### PR TITLE
Added a linebreak after index imports to please the linter

### DIFF
--- a/packages/react/scripts/scaffold.js
+++ b/packages/react/scripts/scaffold.js
@@ -49,7 +49,7 @@ const createComponentFiles = (templatePath, destination, name) => {
 
 const addExport = name => {
   const nameCapital = `${name[0].toUpperCase()}${name.slice(1)}`;
-  const exportString = `export { default as ${nameCapital} } from './components/${name.toLowerCase()}/${nameCapital}';`;
+  const exportString = `export { default as ${nameCapital} } from './components/${name.toLowerCase()}/${nameCapital}';\n`;
   try {
     fs.appendFileSync('src/index.ts', exportString, 'utf-8');
   } catch (error) {


### PR DESCRIPTION
index.ts now has a linebreak at the end. ESLint was not happy it was missing.