### PR TITLE
Flexible labeling for TextInput

### DIFF
--- a/packages/react/src/components/textinput/TextInput.module.css
+++ b/packages/react/src/components/textinput/TextInput.module.css
@@ -63,7 +63,7 @@
   outline-color: var(--hds-ui-color-black-20);
 }
 
-.lock {
+.inputIcon {
   border: solid 2px var(--hds-ui-color-black-20);
   height: 3.5em;
   width: 3.5em;
@@ -82,10 +82,10 @@
   border-color: var(--hds-theme-color-secondary);
 }
 
-.alternative.readOnly .input {
-  background-color: var(--hds-theme-color-secondary-light);
+.alternative .inputIcon {
+  border-color: var(--hds-theme-color-secondary);
 }
 
-.alternative.readOnly .lock {
-  border-color: var(--hds-theme-color-secondary);
+.alternative.readOnly .input {
+  background-color: var(--hds-theme-color-secondary-light);
 }

--- a/packages/react/src/components/textinput/TextInput.stories.tsx
+++ b/packages/react/src/components/textinput/TextInput.stories.tsx
@@ -6,8 +6,8 @@ import TextInput from './TextInput';
 (TextInput as React.FC).displayName = 'TextInput';
 
 const textInputProps = {
-  id: 'myInput',
-  label: 'A text input',
+  id: 'hdsInput',
+  labelText: 'HDS input field',
   placeholder: 'A placeholder text',
 };
 

--- a/packages/react/src/components/textinput/TextInput.tsx
+++ b/packages/react/src/components/textinput/TextInput.tsx
@@ -67,7 +67,7 @@ export default ({
         value={value}
       />
       {readOnly && (
-        <div className={styles.lock}>
+        <div className={styles.inputIcon}>
           <IconLock fill={`var(${alternative ? '--hds-theme-color-secondary' : '--hds-ui-color-black-80'})`} />
         </div>
       )}

--- a/packages/react/src/components/textinput/TextInput.tsx
+++ b/packages/react/src/components/textinput/TextInput.tsx
@@ -41,41 +41,53 @@ export default ({
   tooltipText = undefined,
   type = 'text',
   value = undefined,
-}: TextInputProps) => (
-  <div
-    className={`
+}: TextInputProps) => {
+  const label = labelText ? (
+    <label htmlFor={id} className={`${styles.label} ${hideLabel ? styles.hiddenLabel : ''}`}>
+      {labelText}
+    </label>
+  ) : null;
+
+  const tooltip = tooltipText ? <div> {tooltipText}</div> : null;
+
+  const helper = helperText ? <div className={styles.helperText}>{helperText}</div> : null;
+
+  const invalidMsg = invalidText ? <div className={styles.invalidText}>{invalidText}</div> : null;
+
+  const inputIcon = readOnly ? (
+    <div className={styles.inputIcon}>
+      <IconLock fill={`var(${alternative ? '--hds-theme-color-secondary' : '--hds-ui-color-black-80'})`} />
+    </div>
+  ) : null;
+
+  return (
+    <div
+      className={`
       ${alternative ? styles.alternative : ''}
       ${disabled ? styles.disabled : ''}
       ${readOnly ? styles.readOnly : ''}
       ${invalid ? styles.invalid : ''}
       ${className}`}
-  >
-    {labelText && (
-      <label htmlFor={id} className={`${styles.label} ${hideLabel ? styles.hiddenLabel : ''}`}>
-        {labelText}
-      </label>
-    )}
-    {tooltipText && <p>{tooltipText}</p>}
-    <div className={styles.inputWrapper}>
-      <input
-        className={styles.input}
-        defaultValue={defaultValue}
-        aria-labelledby={labelledBy}
-        disabled={disabled}
-        id={id}
-        readOnly={readOnly}
-        onChange={onChange}
-        placeholder={placeholder}
-        type={type}
-        value={value}
-      />
-      {readOnly && (
-        <div className={styles.inputIcon}>
-          <IconLock fill={`var(${alternative ? '--hds-theme-color-secondary' : '--hds-ui-color-black-80'})`} />
-        </div>
-      )}
+    >
+      {label}
+      {tooltip}
+      <div className={styles.inputWrapper}>
+        <input
+          className={styles.input}
+          defaultValue={defaultValue}
+          aria-labelledby={labelledBy}
+          disabled={disabled}
+          id={id}
+          readOnly={readOnly}
+          onChange={onChange}
+          placeholder={placeholder}
+          type={type}
+          value={value}
+        />
+        {inputIcon}
+      </div>
+      {helper}
+      {invalidMsg}
     </div>
-    {helperText && <div className={styles.helperText}>{helperText}</div>}
-    {invalid && <div className={styles.invalidText}>{invalidText}</div>}
-  </div>
-);
+  );
+};

--- a/packages/react/src/components/textinput/TextInput.tsx
+++ b/packages/react/src/components/textinput/TextInput.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent } from 'react';
 import IconLock from '../../icons/IconLock';
 import styles from './TextInput.module.css';
 
-type Props = {
+export type TextInputProps = {
   id: string;
   labelText: string;
   alternative?: boolean;
@@ -39,7 +39,7 @@ export default ({
   tooltipText = undefined,
   type = 'text',
   value = undefined,
-}: Props) => (
+}: TextInputProps) => (
   <div
     className={`
       ${alternative ? styles.alternative : ''}

--- a/packages/react/src/components/textinput/TextInput.tsx
+++ b/packages/react/src/components/textinput/TextInput.tsx
@@ -5,8 +5,7 @@ import styles from './TextInput.module.css';
 
 type Props = {
   id: string;
-  label: string;
-
+  labelText: string;
   alternative?: boolean;
   className?: string;
   defaultValue?: string;
@@ -25,8 +24,7 @@ type Props = {
 
 export default ({
   id,
-  label,
-
+  labelText = undefined,
   alternative = false,
   className = '',
   defaultValue = undefined,
@@ -50,9 +48,11 @@ export default ({
       ${invalid ? styles.invalid : ''}
       ${className}`}
   >
-    <label htmlFor={id} className={`${styles.label} ${hideLabel ? styles.hiddenLabel : ''}`}>
-      {label}
-    </label>
+    {labelText && (
+      <label htmlFor={id} className={`${styles.label} ${hideLabel ? styles.hiddenLabel : ''}`}>
+        {labelText}
+      </label>
+    )}
     {tooltipText && <p>{tooltipText}</p>}
     <div className={styles.inputWrapper}>
       <input

--- a/packages/react/src/components/textinput/TextInput.tsx
+++ b/packages/react/src/components/textinput/TextInput.tsx
@@ -5,7 +5,8 @@ import styles from './TextInput.module.css';
 
 export type TextInputProps = {
   id: string;
-  labelText: string;
+  labelText?: string;
+  labelledBy?: string;
   alternative?: boolean;
   className?: string;
   defaultValue?: string;
@@ -25,6 +26,7 @@ export type TextInputProps = {
 export default ({
   id,
   labelText = undefined,
+  labelledBy = undefined,
   alternative = false,
   className = '',
   defaultValue = undefined,
@@ -58,6 +60,7 @@ export default ({
       <input
         className={styles.input}
         defaultValue={defaultValue}
+        aria-labelledby={labelledBy}
         disabled={disabled}
         id={id}
         readOnly={readOnly}


### PR DESCRIPTION
`label` is renamed to `labelText` and no more required for TextInput. If not given, no label will be created and will have to be handled outside of the component. For this, added an optional `labelledBy` prop.

Did some code readability improvements for render while at it.