### PR TITLE
Quickfix: broken tests

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,7 +15,7 @@
     "tcm": "tcm src",
     "lint": "yarn eslint \"src/**/*.{ts,tsx}\"",
     "pre-commit": "yarn -s lint",
-    "pre-push": "yarn -s test",
+    "pre-push": "yarn -s test && yarn build",
     "storybook": "start-storybook -p 6006 --quiet",
     "build-storybook": "build-storybook",
     "test": "jest"

--- a/packages/react/src/components/textinput/TextInput.test.tsx
+++ b/packages/react/src/components/textinput/TextInput.test.tsx
@@ -3,8 +3,14 @@ import { render } from '@testing-library/react';
 
 import TextInput from './TextInput';
 
+const textInputProps = {
+  id: 'hdsInput',
+  labelText: 'HDS input field',
+  placeholder: 'A placeholder text',
+};
+
 describe('<TextInput /> spec', () => {
   it('renders the component', () => {
-    render(<TextInput id="myInput" label="My Input" />);
+    render(<TextInput {...textInputProps} />);
   });
 });


### PR DESCRIPTION
Fixed changed properties for TextInput in tests. Running build pre-push to prevent broken tests from slipping to the repo again.