### PR TITLE
TextInput style tweaks, template updates

### DIFF
--- a/packages/react/.templates/new-component/NewComponent.test.tsx
+++ b/packages/react/.templates/new-component/NewComponent.test.tsx
@@ -5,6 +5,7 @@ import [-replace-name-capital-] from './[-replace-name-capital-]';
 
 describe('<[-replace-name-capital-] /> spec', () => {
   it('renders the component', () => {
-    render(<[-replace-name-capital-] />);
+    const { asFragment } = render(<[-replace-name-capital-] />);
+    expect(asFragment()).toMatchSnapshot(); 
   });
 });

--- a/packages/react/.templates/new-component/NewComponent.tsx
+++ b/packages/react/.templates/new-component/NewComponent.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import styles from './[-replace-name-capital-].module.css';
 
-type Props = React.PropsWithChildren<{}>;
+export type [-replace-name-capital-]Props = React.PropsWithChildren<{}>;
 
-export default ({ children }: Props) => {
+export default ({ children }: [-replace-name-capital-]Props) => {
   return <div className={styles.[-replace-name-camel-]}>{children}</div>;
 };

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -150,7 +150,7 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ['.templates/'],
+  testPathIgnorePatterns: ['.templates/', 'lib/', 'lib-esm/'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/packages/react/scripts/scaffold.js
+++ b/packages/react/scripts/scaffold.js
@@ -49,7 +49,7 @@ const createComponentFiles = (templatePath, destination, name) => {
 
 const addExport = name => {
   const nameCapital = `${name[0].toUpperCase()}${name.slice(1)}`;
-  const exportString = `export { default as ${nameCapital} } from './components/${name.toLowerCase()}/${nameCapital}';\n`;
+  const exportString = `export { default as ${nameCapital}, ${nameCapital}Props } from './components/${name.toLowerCase()}/${nameCapital}';\n`;
   try {
     fs.appendFileSync('src/index.ts', exportString, 'utf-8');
   } catch (error) {

--- a/packages/react/src/components/textinput/TextInput.module.css
+++ b/packages/react/src/components/textinput/TextInput.module.css
@@ -55,11 +55,12 @@
 
 .inputIcon {
   border: solid 2px var(--hds-ui-color-black-20);
+  border-width: 0 2px;
   width: 3.5em;
-  height: 100%;
   position: absolute;
-  right: -0;
-  top: 0;
+  right: 0;
+  top: 2px;
+  bottom: 2px;
   background: no-repeat center center;
   background-color: inherit;
   z-index: 10;
@@ -80,6 +81,10 @@
 
 .alternative.readOnly .input {
   background-color: var(--hds-theme-color-secondary-light);
+}
+
+.alternative.readOnly .input:focus {
+  border-color: var(--hds-theme-color-secondary);
 }
 
 /* INPUT FOCUS */

--- a/packages/react/src/components/textinput/TextInput.module.css
+++ b/packages/react/src/components/textinput/TextInput.module.css
@@ -9,7 +9,6 @@
 }
 
 .inputWrapper {
-  display: inline-block;
   position: relative;
 }
 
@@ -27,8 +26,7 @@
 
 .input {
   composes: text-md from '~hds-core/lib/helsinki.css';
-  min-width: 18em;
-  height: 3.11em;
+  width: 100%;
   border: 2px solid var(--hds-ui-color-black-20);
   border-radius: 1px;
   padding: 0.888em 0.72em;
@@ -57,8 +55,8 @@
 
 .inputIcon {
   border: solid 2px var(--hds-ui-color-black-20);
-  height: 3.5em;
   width: 3.5em;
+  height: 100%;
   position: absolute;
   right: -0;
   top: 0;

--- a/packages/react/src/components/textinput/TextInput.module.css
+++ b/packages/react/src/components/textinput/TextInput.module.css
@@ -13,6 +13,18 @@
   position: relative;
 }
 
+.helperText {
+  composes: text-sm from '~hds-core/lib/helsinki.css';
+  color: var(--hds-ui-color-black-70);
+}
+
+.invalidText {
+  composes: text-sm from '~hds-core/lib/helsinki.css';
+  color: var(--hds-ui-color-error);
+}
+
+/* INPUT */
+
 .input {
   composes: text-md from '~hds-core/lib/helsinki.css';
   min-width: 18em;
@@ -22,19 +34,8 @@
   padding: 0.888em 0.72em;
 }
 
-.input:focus {
-  outline-color: var(--hds-ui-color-black-90);
-  outline-style: solid;
-  outline-width: 2px;
-}
-
 .input::placeholder {
   color: var(--hds-ui-color-black-30);
-}
-
-.helperText {
-  composes: text-sm from '~hds-core/lib/helsinki.css';
-  color: var(--hds-ui-color-black-70);
 }
 
 .disabled .input {
@@ -50,17 +51,8 @@
   border-color: var(--hds-ui-color-error);
 }
 
-.invalidText {
-  composes: text-sm from '~hds-core/lib/helsinki.css';
-  color: var(--hds-ui-color-error);
-}
-
 .readOnly .input {
   background-color: var(--hds-ui-color-black-5);
-}
-
-.readOnly .input:focus {
-  outline-color: var(--hds-ui-color-black-20);
 }
 
 .inputIcon {
@@ -78,6 +70,8 @@
   justify-content: center;
 }
 
+/* ALT STYLE */
+
 .alternative .input {
   border-color: var(--hds-theme-color-secondary);
 }
@@ -88,4 +82,14 @@
 
 .alternative.readOnly .input {
   background-color: var(--hds-theme-color-secondary-light);
+}
+
+/* INPUT FOCUS */
+
+.input:focus {
+  border-color: var(--hds-ui-color-black-90);
+}
+
+.readOnly .input:focus {
+  border-color: var(--hds-ui-color-black-20);
 }

--- a/packages/react/src/components/textinput/TextInput.stories.tsx
+++ b/packages/react/src/components/textinput/TextInput.stories.tsx
@@ -3,6 +3,9 @@ import { storiesOf } from '@storybook/react';
 
 import TextInput from './TextInput';
 
+// A simple Wrapper to control max-width and the spacing around inputs.
+const WrapperDecorator = storyFn => <div style={{ padding: '10px', maxWidth: '400px' }}> {storyFn()}</div>;
+
 (TextInput as React.FC).displayName = 'TextInput';
 
 const textInputProps = {
@@ -11,22 +14,50 @@ const textInputProps = {
   placeholder: 'A placeholder text',
 };
 
-storiesOf('TextInput', module).add('default', () => <TextInput {...textInputProps} />);
-storiesOf('TextInput', module).add('disabled', () => <TextInput {...textInputProps} disabled />);
-storiesOf('TextInput', module).add('read only', () => (
-  <TextInput {...textInputProps} readOnly defaultValue="This is the default value" />
-));
-storiesOf('TextInput', module).add('alternative', () => <TextInput {...textInputProps} alternative />);
-storiesOf('TextInput', module).add('alternative read only', () => (
-  <TextInput {...textInputProps} alternative readOnly defaultValue="This is the default value" />
-));
-storiesOf('TextInput', module).add('with label hidden', () => <TextInput {...textInputProps} hideLabel />);
-storiesOf('TextInput', module).add('with tooltip', () => (
-  <TextInput {...textInputProps} tooltipText="Tooltip goes here" />
-));
-storiesOf('TextInput', module).add('with helper text', () => (
-  <TextInput {...textInputProps} helperText="Helper text goes here" />
-));
-storiesOf('TextInput', module).add('with invalid input', () => (
-  <TextInput {...textInputProps} invalid invalidText="This explains why the value is invalid" />
-));
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('default', () => <TextInput {...textInputProps} />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('with default value', () => <TextInput {...textInputProps} defaultValue="This is the default value" />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('without placeholder', () => <TextInput {...textInputProps} placeholder={undefined} />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('disabled', () => <TextInput {...textInputProps} disabled />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('read only', () => <TextInput {...textInputProps} readOnly defaultValue="This is the default value" />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('alternative', () => <TextInput {...textInputProps} alternative />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('alternative read only', () => (
+    <TextInput {...textInputProps} alternative readOnly defaultValue="This is the default value" />
+  ));
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('with label hidden', () => <TextInput {...textInputProps} hideLabel />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('with tooltip', () => <TextInput {...textInputProps} tooltipText="Tooltip goes here" />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('with helper text', () => <TextInput {...textInputProps} helperText="Helper text goes here" />);
+
+storiesOf('TextInput', module)
+  .addDecorator(WrapperDecorator)
+  .add('with invalid input', () => (
+    <TextInput {...textInputProps} invalid invalidText="This explains why the value is invalid" />
+  ));

--- a/packages/react/src/components/textinput/TextInput.test.tsx
+++ b/packages/react/src/components/textinput/TextInput.test.tsx
@@ -11,6 +11,7 @@ const textInputProps = {
 
 describe('<TextInput /> spec', () => {
   it('renders the component', () => {
-    render(<TextInput {...textInputProps} />);
+    const { asFragment } = render(<TextInput {...textInputProps} />);
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/react/src/components/textinput/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/components/textinput/__snapshots__/TextInput.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TextInput /> spec renders the component 1`] = `
+<DocumentFragment>
+  <div
+    class="
+      
+      
+      
+      
+      "
+  >
+    <label
+      class="label "
+      for="hdsInput"
+    >
+      HDS input field
+    </label>
+    <div
+      class="inputWrapper"
+    >
+      <input
+        class="input"
+        id="hdsInput"
+        placeholder="A placeholder text"
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
- tweaked TextInput
  - focus styles simplified
  - removed set width and height styles
  - fixed color issues with alternative readonly input
  - added snapshot to tests
  - added story without default text
- updated scaffold template
  - added prop-types export to component template
  - added prop-types export to index
  - added snapshot to tests