### PR TITLE
Fix: broken CSS link in core examples

### DIFF
--- a/packages/core/examples/icons.html
+++ b/packages/core/examples/icons.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>HDS Icons</title>
     <link rel="stylesheet" href="../lib/helsinki.css" />
-    <link rel="stylesheet" href="../lib/icons.css" />
+    <link rel="stylesheet" href="../lib/icons/all.css" />
     <style>
       body > span {
         display: inline-block;


### PR DESCRIPTION
- icons example html page was linking to icons.css instead of icons/all.css