### PR TITLE
New release

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Core styles for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
@@ -69,7 +69,7 @@
     "webpack-cli": "^3.3.9"
   },
   "dependencies": {
-    "hds-core": "^0.4.1",
+    "hds-core": "^0.4.2",
     "lodash.uniqueid": "^4.0.1",
     "react-spring": "^8.0.27"
   },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "description": "Documentation for Helsinki Design System",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "react-dom": "^16.11.0"
   },
   "devDependencies": {
-    "hds-core": "^0.4.1",
-    "hds-react": "^0.5.4",
+    "hds-core": "^0.4.2",
+    "hds-react": "^0.5.5",
     "react-helmet": "^5.2.1",
     "rimraf": "^3.0.0"
   }


### PR DESCRIPTION
## Release 0.5.5

New versions:
- hds-react, site: 0.5.5
- hds-core: 0.4.2

Includes new icons and fixes to hds-react dependencies.