### PR TITLE
Improve performance by setting font-display to swap

### DIFF
--- a/packages/core/examples/css/example_fonts.css
+++ b/packages/core/examples/css/example_fonts.css
@@ -2,6 +2,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff")
     format("woff");
+  font-display: swap;
   font-weight: 400;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -11,6 +12,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/5bb29e3b7b1d3ef30121229bbe67c3e1.woff")
     format("woff");
+  font-display: swap;
   font-weight: 400;
   font-style: italic;
   text-rendering: optimizeLegibility;
@@ -20,6 +22,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/7c46f288e8133b87e6b12b45dac71865.woff")
     format("woff");
+  font-display: swap;
   font-weight: 500;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -29,6 +32,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/e62dc97e83a385e4d8cdc939cf1e4213.woff")
     format("woff");
+  font-display: swap;
   font-weight: 500;
   font-style: italic;
   text-rendering: optimizeLegibility;
@@ -38,6 +42,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff")
     format("woff");
+  font-display: swap;
   font-weight: 700;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -47,6 +52,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/20d494430c87e15e194932b729d48270.woff")
     format("woff");
+  font-display: swap;
   font-weight: 700;
   font-style: italic;
   text-rendering: optimizeLegibility;
@@ -65,6 +71,7 @@
   font-family: "HelsinkiGrotesk";
   src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/62a1781d8b396fbb025b0552cf6304d2.woff")
     format("woff");
+  font-display: swap;  
   font-weight: 900;
   font-style: italic;
   text-rendering: optimizeLegibility;

--- a/packages/react/.storybook/index.css
+++ b/packages/react/.storybook/index.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
+  font-display: swap;  
   font-weight: 400;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -9,6 +10,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/5bb29e3b7b1d3ef30121229bbe67c3e1.woff') format('woff');
+  font-display: swap;
   font-weight: 400;
   font-style: italic;
   text-rendering: optimizeLegibility;
@@ -17,6 +19,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/7c46f288e8133b87e6b12b45dac71865.woff') format('woff');
+  font-display: swap;
   font-weight: 500;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -25,6 +28,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/e62dc97e83a385e4d8cdc939cf1e4213.woff') format('woff');
+  font-display: swap;
   font-weight: 500;
   font-style: italic;
   text-rendering: optimizeLegibility;
@@ -33,6 +37,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
+  font-display: swap;
   font-weight: 700;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -41,6 +46,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/20d494430c87e15e194932b729d48270.woff') format('woff');
+  font-display: swap;  
   font-weight: 700;
   font-style: italic;
   text-rendering: optimizeLegibility;
@@ -49,6 +55,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/a50a1bd245ce63abcc0d1da80ff790d2.woff') format('woff');
+  font-display: swap;
   font-weight: 900;
   font-style: normal;
   text-rendering: optimizeLegibility;
@@ -57,6 +64,7 @@
 @font-face {
   font-family: 'HelsinkiGrotesk';
   src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/62a1781d8b396fbb025b0552cf6304d2.woff') format('woff');
+  font-display: swap;
   font-weight: 900;
   font-style: italic;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Description

Improve performance of page loads by setting font-display to swap

## Motivation and Context

I ran Lighthouse, Chrome's built in performance audit tool, on the static GitHub site for Helsinki Design System. We get a performance score of 100, with one warning: 

> Ensure text remains visible during webfont load
> Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading

https://web.dev/font-display/

This PR adds "font-display: swap;" to all font-family definitions. 

## How Has This Been Tested?

We are doing the same thing in Kukkuu, and the page opens with no issues. 