### PR TITLE
Add tip into documentation for solving missing styles

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -17,3 +17,28 @@ Import components:
 ```
 import { TextInput } from "hds-react";
 ```
+
+**I am not seeing any styles**  
+`hds-react` uses CSS modules under the hood. If your tooling, for instance webpack, is missing support for CSS modules, components may be left without styles altogether. Here's a quick example of how you can declare support for CSS modules without changing behavior for regular CSS files. These rules assume that the files meant for CSS module support have been named like so: `*.module.css`.
+
+```js
+{
+  test: /\.css$/,
+  exclude: /\.module\.css$/,
+  use: [
+    'style-loader',
+    'css-loader',
+  ],
+},
+{
+  test: /\.css$/,
+  include: /\.module\.css$/,
+  use: [
+    'style-loader',
+    {
+      loader: 'css-loader',
+      options: { importLoaders: 1, modules: true },
+    },
+  ],
+},
+```

--- a/site/docs/get_started/for_developers.mdx
+++ b/site/docs/get_started/for_developers.mdx
@@ -49,6 +49,31 @@ Import components:
 import { TextInput } from "hds-react";
 ```
 
+**I am not seeing any styles**  
+`hds-react` uses CSS modules under the hood. If your tooling, for instance webpack, is missing support for CSS modules, components may be left without styles altogether. Here's a quick example of how you can declare support for CSS modules without changing behavior for regular CSS files. These rules assume that the files meant for CSS module support have been named like so: `*.module.css`.
+
+```js
+{
+  test: /\.css$/,
+  exclude: /\.module\.css$/,
+  use: [
+    'style-loader',
+    'css-loader',
+  ],
+},
+{
+  test: /\.css$/,
+  include: /\.module\.css$/,
+  use: [
+    'style-loader',
+    {
+      loader: 'css-loader',
+      options: { importLoaders: 1, modules: true },
+    },
+  ],
+},
+```
+
 ## Contributing
 
 ### Github


### PR DESCRIPTION
## Description

Adds tips into README and site for developers seeking to integrate this library into their project. Currently the documentation doesn't mention any dependencies, but there's at least one requirement for the environment where this package is used: `*.module.css` files should be loaded with CSS modules toggled on.

I do not know if this is by design. If it is and the idea is that this project is only guaranteed to work with Ratkis preferred tooling, the better fix may be to state that the `hds-react` lib is compatible with `create-react-app` based projects.

## Motivation and Context

I attempted to integrate this project with [Varaamo](https://github.com/City-of-Helsinki/varaamo), but failed to get components showing correctly based on the instructions in the documentation.
