### PR TITLE
Fix rollup TypeScript config

### DIFF
--- a/packages/react/.storybook/webpack.config.js
+++ b/packages/react/.storybook/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = ({ config, mode }) => {
     enforce: 'pre',
   });
   // we need an alias for hds-core to point webpack to the package as we can't use tilde (~) with rollup
-  config.resolve.alias['./hds-core'] = require('path').resolve(__dirname, '../../../node_modules/hds-core')
+  config.resolve.alias['./hds-core'] = require('path').resolve(__dirname, '../../../node_modules/hds-core');
   config.resolve.extensions.push('.ts', '.tsx');
   return config;
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,13 +1,11 @@
 {
   "name": "hds-react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "scripts": {
     "build": "yarn run lint && yarn run tcm && rollup -c",
-    "postbuild": "yarn run copy-css-modules",
-    "copy-css-modules": "copyfiles -u 1 src/**/*.module.css** lib && copyfiles -u 1 src/**/*.module.css** lib-esm",
     "start": "rollup -c --watch & tcm src --watch & yarn storybook",
     "scaffold": "node scripts/scaffold.js",
     "tsc:es5": "tsc",
@@ -40,7 +38,6 @@
     "@typescript-eslint/parser": "^2.3.3",
     "babel-plugin-require-context-hook": "^1.0.0",
     "chalk": "^2.4.2",
-    "copyfiles": "^2.1.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.4.0",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "ES2015",
+    "moduleResolution": "Node",
     "target": "es5",
     "lib": ["dom", "es2015"],
     "outDir": "lib",


### PR DESCRIPTION
## Description
Fixes the TS config as it wasn't able to resolve modules correctly resulting in failing static storybook builds. Also removed CSS module copying post build as it is no longer needed.