### PR TITLE
Fix/input submit and select height

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Core styles for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "contributors": [

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -87,10 +87,16 @@
 
 /* LABEL */
 
+input[type="submit"].hds-button,
 .hds-button__label {
   font-weight: 500;
   line-height: 1.25em;
   padding: var(--spacing-s);
+}
+
+input[type="submit"].hds-button {
+  cursor: pointer;
+  padding: var(--spacing-s) var(--spacing-l);
 }
 
 /* no icons */
@@ -103,9 +109,14 @@
   padding: 0;
 }
 
+input[type="submit"].hds-button--small,
 .hds-button--small .hds-button__label {
-  line-height: 1em;
+  line-height: var(--lineheight-s);
   padding: var(--spacing-2-xs) var(--spacing-xs);
+}
+
+input[type="submit"].hds-button--small {
+  padding: var(--spacing-2-xs) var(--spacing-m);
 }
 
 /* no icons */

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -4,6 +4,8 @@
 .hds-button {
   --border-width: 2px;
   --color: inherit;
+  --outline-gutter: 2px;
+  --outline-width: 3px;
 
   align-content: flex-start;
   align-items: center;
@@ -15,7 +17,6 @@
   justify-content: center;
   padding: 0 var(--spacing-2-xs);
   position: relative;
-  text-align: left;
   vertical-align: top;
 }
 
@@ -69,8 +70,6 @@
 /* FOCUS OUTLINE */
 
 .hds-button::after {
-  --gutter: 2px;
-  --outline-width: 3px;
   --size: 100%;
 
   border: var(--outline-width) solid transparent;
@@ -81,8 +80,13 @@
 }
 
 .hds-button:focus::after {
-  --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--gutter) * 2));
+  --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
   border-color: var(--focus-outline-color);
+}
+
+/* submit input */
+input[type="submit"].hds-button:focus {
+  box-shadow: 0 0 0 var(--outline-gutter) var(--submit-input-focus-gutter-color), 0 0 0 calc(var(--outline-gutter) + var(--outline-width)) var(--focus-outline-color);
 }
 
 /* LABEL */
@@ -204,6 +208,7 @@ input[type="submit"].hds-button--small {
   --color-disabled: var(--color-label-button-primary-disabled);
 
   --focus-outline-color: var(--color-focus-outline-button-primary);
+  --submit-input-focus-gutter-color: var(--color-white);
 }
 
 /* SECONDARY */
@@ -229,6 +234,7 @@ input[type="submit"].hds-button--small {
   --color-disabled: var(--color-label-button-secondary-disabled);
 
   --focus-outline-color: var(--color-focus-outline-button-secondary);
+  --submit-input-focus-gutter-color: var(--color-white);
 }
 
 /* SUPPLEMENTARY */
@@ -253,6 +259,7 @@ input[type="submit"].hds-button--small {
   --color-disabled: var(--color-label-button-supplementary-disabled);
 
   --focus-outline-color: var(--color-focus-outline-button-supplementary);
+  --submit-input-focus-gutter-color: transparent;
 }
 
 /* UTILITY */

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -33,9 +33,7 @@
   --label-color: var(--color-label-checkbox-default);
   --label-color-disabled: var(--color-label-checkbox-disabled);
 
-  align-items: center;
   display: flex;
-  height: var(--size);
   position: relative;
 }
 
@@ -89,8 +87,7 @@
   content: "";
   left: 0;
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
 }
 
 /* checkbox icon */
@@ -106,14 +103,14 @@
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-size: calc(var(--size) * var(--icon-scale));
   width: var(--size);
-  transform: translate3d(0, -50%, 0) scale(0.6);
+  transform: scale(0.6);
   z-index: 1;
 }
 
 /* checkbox icon - selected */
 .hds-checkbox .hds-checkbox__input:checked::before {
   background-color: var(--icon-color-selected);
-  transform: translate3d(0, -50%, 0) scale(1);
+  transform: scale(1);
 }
 
 /* focus outline */
@@ -125,7 +122,7 @@
 /* focus outline - focus */
 .hds-checkbox .hds-checkbox__input:focus + .hds-checkbox__label::before {
   box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
-  transform: translate3d(0, -50%, 0);
+  transform: translate3d(0, 0, 0);
 }
 
 /* background */

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -34,6 +34,7 @@
   --label-color-disabled: var(--color-label-checkbox-disabled);
 
   display: flex;
+  min-height: var(--size);
   position: relative;
 }
 

--- a/packages/core/src/components/radio-button/radio-button.css
+++ b/packages/core/src/components/radio-button/radio-button.css
@@ -33,6 +33,7 @@
   --label-color-disabled: var(--color-label-radio-button-disabled);
 
   display: flex;
+  min-height: var(--size);
   position: relative;
 }
 

--- a/packages/core/src/components/radio-button/radio-button.css
+++ b/packages/core/src/components/radio-button/radio-button.css
@@ -32,9 +32,7 @@
   --label-color: var(--color-label-radio-button-default);
   --label-color-disabled: var(--color-label-radio-button-disabled);
 
-  align-items: center;
   display: flex;
-  height: var(--size);
   position: relative;
 }
 
@@ -82,8 +80,7 @@
   content: "";
   left: 0;
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
 }
 
 /* background & focus outline */
@@ -101,7 +98,7 @@
 /* background - focus */
 .hds-radio-button .hds-radio-button__input:focus + .hds-radio-button__label::before {
   box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
-  transform: translate3d(0, -50%, 0);
+  transform: translate3d(0, 0, 0);
 }
 
 /* inner circle */

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,7 +72,7 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "hds-core": "0.6.1",
+    "hds-core": "0.6.2",
     "lodash": "^4.17.15",
     "react-spring": "^8.0.27"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Documentation for Helsinki Design System",
   "license": "MIT",

--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "gatsby-cli": "^2.11.5",
-    "hds-core": "0.6.1",
+    "hds-core": "0.6.2",
     "hds-design-tokens": "^0.2.0",
     "hds-react": "^0.7.0",
     "react-helmet": "^6.0.0",


### PR DESCRIPTION
## Description
This fixes the issue where the height for the `Checkbox` and `RadioButton` components was fixed, causing problems with long labels.
This also adds support for `type="submit"` inputs to be styled as buttons using `hds-core` classes.

## Related Issues

Fixes #135 
Closes #134 

## How Has This Been Tested?
Tested on storybook
