### PR TITLE
Fix style issues on iOS

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Core styles for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "contributors": [

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -11,6 +11,7 @@
   align-items: center;
   background-color: var(--background-color, transparent);
   border: var(--border-width) solid var(--border-color, transparent);
+  border-radius: 0;
   color: var(--color);
   display: inline-flex;
   fill: currentColor;

--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -63,6 +63,8 @@
 }
 
 .hds-text-input .hds-text-input__input {
+  /* removes the input shadow on iOS */
+  -webkit-appearance: none;
   background-color: var(--input-background-default);
   border: var(--border-width) solid var(--input-border-color-default);
   border-radius: var(--border-radius);
@@ -133,6 +135,7 @@
   height: var(--icon-size);
   mask-image: svg-inline(icon);
   -webkit-mask-image: svg-inline(icon);
+  pointer-events: none;
   position: absolute;
   right: var(--border-width);
   top: 0;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
@@ -72,7 +72,7 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "hds-core": "0.6.2",
+    "hds-core": "0.6.3",
     "lodash": "^4.17.15",
     "react-spring": "^8.0.27"
   },

--- a/site/package.json
+++ b/site/package.json
@@ -21,9 +21,9 @@
   },
   "devDependencies": {
     "gatsby-cli": "^2.11.5",
-    "hds-core": "0.6.2",
+    "hds-core": "0.6.3",
     "hds-design-tokens": "^0.2.0",
-    "hds-react": "^0.7.0",
+    "hds-react": "^0.7.2",
     "react-helmet": "^6.0.0",
     "rimraf": "^3.0.2"
   }


### PR DESCRIPTION
## Description

- Fixed button border-radius for `type="submit"` inputs on iOS
- Removed shadow for text-inputs on iOS
- Clicking the invalid icon on text-inputs now focuses the field

## Related Issue

Closes: #138 

## How Has This Been Tested?
Tested links provided in [issue](https://github.com/City-of-Helsinki/helsinki-design-system/issues/138) using BrowserStack
