### PR TITLE
Fixed punctuation and improved content on doc site Getting started section

### DIFF
--- a/site/docs/get_started/for_designers.mdx
+++ b/site/docs/get_started/for_designers.mdx
@@ -9,21 +9,21 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 # For designers
 
 <LargeParagraph>
-    The HDS design kit contains all the resources you need to get started designing beautiful and accessible user experiences, that follow the City of Helsinki brand.
+    The HDS design kit contains all the resources you need to get started designing beautiful and accessible user experiences that follow the City of Helsinki brand.
 </LargeParagraph>
 
-The HDS design libraries are the single point of reference for your design. When you connect your design files with the design system libraries, you can use ready designed components and have them synced whenever the design system is updated.
+The HDS design libraries are the single point of reference for your design. When you connect your design files with the design system libraries, you can have the components synced whenever the design system is updated.
 
 ## Principles
 
-Always keep these core principles in mind, when making design decisions:
-- **Modular and flexible:** All components are designed to work as reusable, customisable building blocks and help people work smarter, better and faster.
+Always keep these core principles in mind when making design decisions:
+- **Modular and flexible:** All components are designed to work as reusable, customisable building blocks to help people work smarter, better and faster.
 - **Consistent:** All components are designed to fit together seamlessly to ensure consistent and cohesive user experience.
 - **Accessibility baked-in:** Accessibility is part of the process from start to end. It is designed to be accessible to all, regardless of ability or situation.
 
 ## Getting started
 1. Explore the City of Helsinki [Visual Identity Guidelines](https://brand.hel.fi/ "City of Helsinki Visual Identity Guidelines") to learn the design principles of the brand.
-2. Take a look at the [Components documentation](/components "Components"), to see what’s there and how you can incorporate those into your designs.
+2. Take a look at the [Components documentation](/components "Components") to see what’s there and how you can incorporate those into your designs.
 3. The design assets are available either via direct design kit download or via the City of Helsinki Abstract. To use HDS libraries, you will need to install Sketch. See more on downloading and setting up the libraries below.
 4. If you have a an idea for improvements or a component that could be useful addition to the Design System, see the [Contributing](/contributing "Contributing") page for more information.
 
@@ -32,18 +32,18 @@ Always keep these core principles in mind, when making design decisions:
 ### Install the tools
 The HDS design workflow is based on **Sketch** and **Abstract** (if you have access to Helsinki organisation):
 - [Sketch](https://www.sketch.com/ "Sketch - The digital design toolkit") is a **vector graphics editor** and is widely adopted by designers to create user interface designs for web and mobile services.
-- [Abstract](https://www.abstract.com/ "Abstract: Design Version Control, Collaboration & Handoff for teams") **design collaboration and version and managegement tool**, that enables designers to share Sketch files and libraries easily. By leveraging and extends the technology of Git, Abstract provides design teams with a lightweight workflow and stable tools so designers can work together with confidence.
+- [Abstract](https://www.abstract.com/ "Abstract: Design Version Control, Collaboration & Handoff for teams") **design collaboration and version and managegement tool** that enables designers to share Sketch files and libraries easily. By leveraging and extends the technology of Git, Abstract provides design teams with a lightweight workflow and stable tools so designers can work together with confidence.
 
 If you’re a newcomer to Sketch or Abstract, they offer both some great tutorials and help docs
 - [Sketch help docs](https://www.sketchapp.com/docs/ "Sketch help docs")
 - [Abstract help docs](https://www.abstract.com/help/ "Abstract help docs")
 
-**You do not necessarily need Abstract to use HDS design libraries.** Abstract is a convenient way to get access and update Sketch libraires but we also offer downloadable HDS design kit. Read below to learn how to download the design kit. 
+**You do not necessarily need Abstract to use HDS design libraries.** Abstract is a convenient way to get access and update Sketch libraires, but we also offer downloadable HDS design kit. Read below to learn how to download the design kit. 
 
 ### Install fonts
 Make sure that you have the [Helsinki Grotesk](https://camelot-typefaces.com/helsinki-grotesk "Camelot Typefaces / Helsinki Grotesk") font installed.
 
-Subcontractors can purchase the font licenses from [Camelot Typefaces website](https://camelot-typefaces.com/helsinki-grotesk "Camelot Typefaces / Helsinki Grotesk").
+Helsinki Grotesk font can be purchased from [Camelot Typefaces website](https://camelot-typefaces.com/helsinki-grotesk "Camelot Typefaces / Helsinki Grotesk").
 
 ### Downloading HDS Design kit and linking libraries
 
@@ -51,13 +51,13 @@ Subcontractors can purchase the font licenses from [Camelot Typefaces website](h
 2. Download `design-kit` (preferably the newest stable version) to your computer and unzip the package.
 3. Open Sketch and from the top bar thoose _Sketch > Preferences_.
 4. Choose tab _Libraries_ and press the button _Add library_.
-5. Browse to the unzipped folder you just downloaded and select libraries you want to import. Note, you can select multiple libraries by holding shift key. **You can import only part of the libraries but we recommend to import all for best experience.**
+5. Browse to the unzipped folder you just downloaded and select libraries you want to import. Note, you can select multiple libraries by holding shift key. **You can choose what libraries you want to import, but we recommend importing all of them for best experience.**
 
 ![Linking libraries in Sketch preferences](../../static/fordesigners-hds-designkit.png "Linking libraries in Sketch preferences")
 
 ### Setting up Abstract
 
-If you have access to the City of Helsinki Abstract organisation. You can use and link libraries directly from Abstract. **Note! Library versions in Abstract are considered development versions. They can change and things may be unstable.** Using libraries from Abstract allows you to get your hands on the newest components that are not necessarily released yet. If you need reliable libraries, download latest stable design kit release from the [GitHub repository](https://github.com/City-of-Helsinki/helsinki-design-system/releases).
+If you have access to the City of Helsinki Abstract organisation, you can use and link libraries directly from Abstract. **Note! Library versions in Abstract are considered development versions. They can change and things may be unstable.** Using libraries from Abstract allows you to get your hands on the newest components that are not necessarily released yet. If you need reliable libraries, download latest stable design kit release from the [GitHub repository](https://github.com/City-of-Helsinki/helsinki-design-system/releases).
 
 #### Create a project in Abstract
 

--- a/site/docs/get_started/get_started.mdx
+++ b/site/docs/get_started/get_started.mdx
@@ -8,12 +8,12 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 # Introduction
 
-<LargeParagraph>The Helsinki Design System is a shared point of reference for designers and developers, that helps teams work and communicate more efficiently</LargeParagraph>
+<LargeParagraph>The Helsinki Design System is a shared point of reference for designers and developers that helps teams work and communicate more efficiently</LargeParagraph>
 
-The system provides working code, design resources and guidelines, that bring predictability to the product development process and help keep the City of Helsinki brand more cohesive throughout all digital services.
+The system provides working code, design resources and guidelines that bring predictability to the product development process and help keep the City of Helsinki brand more cohesive throughout all digital services.
 
 The Helsinki Design System consists of several parts:
 - **Component library** provides front-end developers modular, accessible components for building scalable digital services efficiently.
-- **Design kit** includes design files of all components in the HDS component library. It helps designers create beautiful, usable and accessible user experiences, that follow the City of Helsinki brand guidelines.
+- **Design kit** includes design files of all components in the HDS component library. It helps designers create beautiful, usable and accessible user experiences that follow the City of Helsinki brand guidelines.
 - **Visual assets** like icons and logos help keeping the visual language consistent.
 - **Documentation site** collects detailed information on how to use the HDS components, design tokens and visual assets in practice, including design principles, accessibility and usage guidelines, examples, interactive demos and API descriptions.


### PR DESCRIPTION
## Description
- Fixed minor punctuation errors and sentence structures in _Getting started_ section
- Improved _For designers_ instructions for setting up HDS libraries
- Added an image of linking HDS libraries in Abstract

## Motivation and Context
Antti proofread the _Getting started_ section and suggested improvements