### PR TITLE
[Content] Added documentation for Dropdown component

### DIFF
--- a/site/docs/components/dropdown.mdx
+++ b/site/docs/components/dropdown.mdx
@@ -17,21 +17,25 @@ import LargeParagraph from "../../src/components/LargeParagraph";
   Dropdown offers user a list of options which one or multiple can be selected. Dropsdowns are often used as part of forms and filters.
 </LargeParagraph>
 
-> **Work in progress!**
-> 
-> The documentation of this component is still work in progress and subject to change.
-
 ## Principles
 
-> Coming soon!
+- **Label should be always provided with dropdowns.** Aim for labels that are short, concise and easy to understand.
+- Dropdowns usually have four (4) or more options. When having only 2-4 options, it is usually better to use [radio button group](/components/radio-button). Also, if options need to be easily comparable (for example, product pricing), prefer radio buttons over dropdown.
+- It is recommended to set default option for the dropdown. If the default option is also the recommended option, you can mark the option with text "_(recommended)_".
+- If your dropdown has 8 or more options, consider using the [filterable](/components/dropdown#filterable) variant so the user can locate the wanted option easier.
+- Dropdown options should not span over one line. Aim for short texts for all options.
+- If possible, do input validation in client-side real time and provide the user with immediate feedback after selection.
 
 ## Accessibility
 
-> Coming soon!
+- Placeholder text can be used to give hints and examples to the user what is being selected with the dropdown. **However, all assistive technologies do not threat placeholder texts as labels and therefore they may ignore them completely.** Aim to provide the sufficient information to fill the input in the label. Also if possible, set default option for the dropdown so the placeholder is not needed.
+- In the case of an erroneous selection, aim to provide clear instructions to the user how to correct the mistake. Always provide text description of the error. In dropdowns it is usually possible to filter selectable options for the user to avoid errors completely.
 
 ## Usage
 
 ### Default
+
+Default dropdown serves in most use cases when the user needs to select one from 4 to 7 options. If there are 8 or more options available, consider using [filterable](/components/dropdown#filterable) variant.
 
 <Playground>
 <Dropdown
@@ -118,6 +122,10 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 ### Filterable
 
+**NOTE! Accessibility of this component is still in validation.**
+
+Filterable dropdown variant works exactly like the default one except it allows filtering the options by typing while component is focused. This variant can increase usability when there are 8 or more options available.
+
 <Playground>
 <Dropdown
   id="example3"
@@ -150,6 +158,10 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 ```
 
 ### Multi-select
+
+**NOTE! This component is work in progress and is subject to change in the future versions of HDS!**
+
+Multi-select variant allows the user to select one or more options simultaneously.
 
 <Playground>
 <Dropdown

--- a/site/docs/components/radio_button.mdx
+++ b/site/docs/components/radio_button.mdx
@@ -22,6 +22,7 @@ import Text from "../../src/components/Text";
 - If the user can select more than one option from a list, use [checkboxes](/components/checkbox) instead.
 - Radio button label should always describe clearly what will happen if the specific option is chosen. A good practice is to keep labels at maximum of three words long.
 - Radio button groups should have a default option selected.
+- When there are more than 4 options, consider switching to [dropdown](/components/dropdown) component.
 - If possible, align radio button groups vertically rather than horizontally. Vertical radio button groups are easier to read.
 
 ## Accessibility


### PR DESCRIPTION
## Description

- Added Dropdown documentation page content
- Added note about option amount to radio button page

## Motivation and Context

Dropdown component (which is already implemented and part of HDS) had lacking documentation.

## How Has This Been Tested?

This has been tested working by running the documentation site locally.
