### PR TITLE
[Fix] Documentation typos, broken links, streched images

### DIFF
--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -10,11 +10,11 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 # What is new
 
 <LargeParagraph>
-    Here you will find summarized patch notes of HDS. For full patch notes for each release, please refer to the <a href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">GitHub release link</a>.
+    Here you will find summarized patch notes of major releases of HDS. For full patch notes for each release, please refer to the <a href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">GitHub releases</a>.
 </LargeParagraph>
 
-**0.10 (alpha)**
+**0.10.0 (alpha)** - [Release notes](https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.10.0)
 
-- **Added**: New components Button, Checkbox, Dropdown, Koros, Radio button, Text input and Text Area
+- **Added**: New components Button, Checkbox, Dropdown, Koros, Radio button, Text input and Text area
 - **Added**: New design tokens for Colour, Typography and Spacing
 - **Changed**: Updated documentation site with new content for Getting started, Guidelines, Visual elements, About and Contributing sections

--- a/site/docs/about/resources.mdx
+++ b/site/docs/about/resources.mdx
@@ -21,7 +21,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 ## Links & guidelines
 
 - [Helsinki brand guidelines](https://brand.hel.fi/en/)
-- [Helsinki accessibility guidelines](https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf)
+- [Helsinki content accessibility guidelines](https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf)
 
 ## Tools
 

--- a/site/docs/about/statement.mdx
+++ b/site/docs/about/statement.mdx
@@ -18,13 +18,13 @@ As regards the accessibility of digital services, Helsinki aims to reach at leas
 The accessibility compliance of this website has not yet been evaluated. The accessibility will be evaluated before the 1.0 release of the Helsinki Design System.
 
 ### Preparing an accessibility statement
-This statement was prepared on 22.05.2020.
+This statement was prepared on 22/05/2020.
 
 ### Updating the accessibility statement
 The accessibility statement will be updated so that it corresponds with the observations related to accessibility compliance made during an audit.
 
 ### Requesting information in an accessible format
-If a user feels that content on a website is not available in an accessible format, they can request for this information by e-mail at hds@hel.fi or through the feedback form. The aim is to reply to the enquiry within a reasonable time frame.
+If a user feels that content on a website is not available in an accessible format, they can request for this information by e-mail at hds@hel.fi or through the [feedback form](https://www.hel.fi/helsinki/en/administration/participate/feedback). The aim is to reply to the enquiry within a reasonable time frame.
 
 ### Feedback and contact information
 City of Helsinki, City Executive Office, Helsinki Design System team (hds@hel.fi)

--- a/site/docs/about/support.mdx
+++ b/site/docs/about/support.mdx
@@ -33,4 +33,4 @@ You can submit issues and bug reports to [HDS repository in GitHub](https://gith
 You can submit feature requests to [HDS repository in GitHub](https://github.com/City-of-Helsinki/helsinki-design-system) as issues labeled "feature-request". You can also get in touch with HDS team with any of the above-mentioned methods.
 
 ### Contributing
-See [Contribution](/contribution).
+See [Contributing](/contributing).

--- a/site/docs/components/buttons.mdx
+++ b/site/docs/components/buttons.mdx
@@ -92,7 +92,7 @@ Supplementary buttons can be used in similar cases as secondary buttons. However
 ```
 
 ### Icon buttons
-Icons can be added to buttons to make the action easier to understand. Sometimes it can be also beneficial to add icons to make important actions more distinguishable. It is not recommended to use buttons with icons without text label because users interpret icons in different ways. More infomration on icon usage in the [icon guideleines](/visual-assets/icons "Icons").
+Icons can be added to buttons to make the action easier to understand. Sometimes it can be also beneficial to add icons to make important actions more distinguishable. It is not recommended to use buttons with icons without text label because users interpret icons in different ways. More information on icon usage in the [icon guideleines](/visual-assets/icons "Icons").
 
 <Playground>
   <Button iconLeft={<IconShare />}>Button</Button>

--- a/site/docs/components/koros.mdx
+++ b/site/docs/components/koros.mdx
@@ -12,7 +12,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 # Koros
 
 <LargeParagraph>
-  Koros, also known as Wave motifs, are part of the visual identity of City of Helsinki. The Koros can be used as a visual elements, for example as part of the hero image or the footer, and as a divider of content in the user interface.
+  Koros, also known as Wave motifs, are part of the visual identity of City of Helsinki. The Koros can be used as visual elements, for example as part of the hero image or the footer and as a divider of content in the user interface.
 </LargeParagraph>
 
 ## Principles

--- a/site/docs/components/text_fields.mdx
+++ b/site/docs/components/text_fields.mdx
@@ -14,7 +14,7 @@ import Text from "../../src/components/Text";
 # Text fields
 
 <LargeParagraph>
-  A text field is an input field that the user can interact with and input content and data. The user can also be provided with helper text if needed. Text inputs are used for shorter information while Text Areas can be used for multiline answers.
+  A text field is an input field that the user can interact with and input content and data. The user can also be provided with helper text if needed. Text inputs are used for shorter information while Text areas can be used for multiline answers.
 </LargeParagraph>
 
 ## Principles
@@ -24,6 +24,7 @@ import Text from "../../src/components/Text";
 - If possible, add programmatic assistance. Detect and pre-fill inputs to reduce errors and save time. Use sentence-case for default values, detected values, and auto-completion text.
 - If possible, do input validation in client-side real time and provide the user with immediate feedback.
 - If possible, be forgiving of different input formats and small mistakes. It can greatly increase user experience of your product if you can fix common mistakes for the user.
+- To decrease cognitive load of the user, it is recommended to mark all required fields. Remember to provide explanation of the required field indicator at the top of your form.
 
 ## Accessibility
 - Placeholder text can be used to give hints and examples to the user what should be entered to the field. **However, all assistive technologies do not threat placeholder texts as labels and therefore they may ignore them completely.** Aim to provide the sufficient information to fill the input in the label.
@@ -41,6 +42,7 @@ Text input serves in most use cases when the user needs to enter information. Te
     label="Label"
     placeholder="Placeholder"
     helperText="Assistive text"
+    required
   />
   <TextInput
     label="Label"
@@ -103,6 +105,7 @@ Text input serves in most use cases when the user needs to enter information. Te
   label="Label"
   placeholder="Placeholder"
   helperText="Assistive text"
+  required
 />
 
 /* Disabled */
@@ -134,6 +137,7 @@ Text area is meant for situations where inputted text is multiline or contains m
     label="Label"
     placeholder="Placeholder"
     helperText="Assistive text"
+    required
   />
   <TextArea
     label="Label"
@@ -200,6 +204,7 @@ Text area is meant for situations where inputted text is multiline or contains m
   label="Label"
   placeholder="Placeholder"
   helperText="Assistive text"
+  required
 />
 
 /* Disabled */
@@ -309,7 +314,7 @@ Both text input and text area can be provided with additional tooltip. Tooltip i
 
 ### Core
 
-[Text inputs in hds-core](/storybook/core/?path=/story/textinput--default)
+[Text inputs in hds-core](/storybook/core/?path=/story/text-input--default)
 
 [Text areas in hds-core](/storybook/core/?path=/story/textarea--default)
 

--- a/site/docs/contributing.mdx
+++ b/site/docs/contributing.mdx
@@ -21,7 +21,7 @@ Before you start contributing to HDS, please refer to following guidelines.
 Depending on the feature you want to be working on, you will need access at least some of these tools:
 - [Sketch](https://www.sketch.com/)
 - City of Helsinki [Abstract](https://www.abstract.com/)
-- City of Helsinki Slack (channel #designsystem)
+- City of Helsinki Slack (channel [#designsystem](https://helsinkicity.slack.com/archives/CHCV3KTHA))
 - [Git repository](https://github.com/City-of-Helsinki/helsinki-design-system)
 
 ### Process of adding new components
@@ -30,12 +30,12 @@ Answer the following three questions to find out whether you should propose a ne
 #### 1. Does it already exist?
 Before you start working or proposing a new component, it is important to check whether it already exists in HDS or in our roadmap.
 
-- **First**, check if it exists in [HDS components](/components/overview).
+- **First**, check if it exists in [HDS components](/components).
 - **Second**, check if it exists on [HDS roadmap](/about/roadmap).
 - **Third**, check if someone else has already [proposed it](https://github.com/City-of-Helsinki/helsinki-design-system/issues).
 
 #### 2. If not, how easily could the existing component be changed to fulfill new requirements?
-Go through the list of existing [HDS components](/components/overview). See if some of the components could be slightly altered to suit your needs while still fulfilling existing requirements. If yes, move on to [making a proposal for the change]().
+Go through the list of existing [HDS components](/components). See if some of the components could be slightly altered to suit your needs while still fulfilling existing requirements. If yes, move on to [making a proposal for the change]().
 
 #### 3. If not, is this component something that is needed in several projects?
 Think outside of the scope of your project. Can this component be utilized in other projects as well? If not, could you make it something more generic to match needs of other projects? Discuss with other projects and community.

--- a/site/docs/design_tokens/spacing.mdx
+++ b/site/docs/design_tokens/spacing.mdx
@@ -16,7 +16,7 @@ import Spacing from "../../src/components/Spacing";
 Spacing of elements can be used to create visual hierarchy for content and guide focus to certain elements. Too dense information can be hard to digest for a user, so make sure to leave enough space in the user interfaces.
 
 ## Principles
-- **Use small spacing spacing to group elements together and larger spacing separate them.** Elements that are close together appear to be more related than things that are spaced further apart.
+- **Use small spacing to group elements together and larger spacing separate them.** Elements that are close together appear to be more related than things that are spaced further apart.
 - **Use spacing to highlight important elements.** Elements with more spacing around them tend to perceive higher importance than elements that have less space around them.
 - **Use spacing in a way that fits the function and content of the service.** Ample spacing is more fitting for providing mood in branding and communication, denser spacing for performing information heavy tasks efficiently. 
 

--- a/site/docs/design_tokens/typography.mdx
+++ b/site/docs/design_tokens/typography.mdx
@@ -13,7 +13,7 @@ import "../../src/gatsby-theme-docz/assets/index.css";
 # Typography
 
 <LargeParagraph>
-  In Helsinki Design system, typographic style is defined with heading elements and type tokens.
+  In Helsinki Design System, typographic style is defined with heading elements and type tokens.
 </LargeParagraph>
 
 Typography can be used to organise information and help users find their way around our services. 
@@ -25,7 +25,7 @@ Subcontractors can purchase the font licenses from [Camelot Typefaces website](h
 
 ## Principles
 - **Use black or white text colour** depending on the background. Other text colours should be used sparingly if at all.
-- **Use typography consistently** throughout your service, to ensure that the content hierarchy and structure is a clear and easily understandable.
+- **Use typography consistently** throughout your service, to ensure that the content hierarchy and structure is clear and easily understandable.
 - **Use heading levels semantically.** For example after **h1**, next heading on the same page should be **h2**, not **h3**. If needed, the appearance and visual hierarchy of headings can be altered separately from semantic structure with the --fontsize tokens.
 
 
@@ -55,7 +55,7 @@ Subcontractors can purchase the font licenses from [Camelot Typefaces website](h
 
 ### Type styles
 <Playground>
-  <div>Regular (400) is used for body text and Links.</div>
+  <div>Regular (400) is used for body text and links.</div>
   <div className="text-bold">Bold (700) is used in headings, as well as to emphasize body text.</div>
   <div className="text-medium">Medium (500) is used only in button components.</div>
 </Playground>

--- a/site/docs/get_started/for_designers.mdx
+++ b/site/docs/get_started/for_designers.mdx
@@ -99,10 +99,10 @@ The HDS component symbols are _library symbols_. **Do not detach symbols from th
 
 
 ### Adding component symbols to layouts
-Symbols are mainly organised into library files by component, exept form components (checkboxes, radio buttons, dropdowns and text fields), that are grouped into one library HDS Form Components file for convenience. 
+Symbols are mainly organised into library files by component, except form components (checkboxes, radio buttons, dropdowns and text fields), that are grouped into one library HDS Form Components file for convenience. 
 
 **You can add symbols to your layout in two ways:**
-1. from the _Insert_ menu, by selecting _Symbols > HDS [component name]_. After selecting a HDS component, you’ll see the variations and states of that component. Select the desired variant and place it on your artboard.
+1. From the _Insert_ menu, by selecting _Symbols > HDS [component name]_. After selecting a HDS component, you’ll see the variations and states of that component. Select the desired variant and place it on your artboard.
 
 ![Inserting textfield component from Insert menu](../../static/fordesigners-component-textfield-insert.png "Inserting textfield component from Insert menu")
 
@@ -113,7 +113,7 @@ You can also select _All_ and filter the components list by component or variant
 ![Inserting component from Components tab](../../static/fordesigners-component-insert.png "Inserting component from Components tab")
 
 ### Customising component symbols
-The component symbols are use _smart layout_ for easy resizing. You can also configure the content and styling of symbol parts from the in the _Overrides_ section of symbol properties.
+The component symbols use _smart layout_ for easy resizing. You can also configure the content and styling of symbol parts from the _Overrides_ section of symbol properties.
 
 _When changing the colour or other styles of component symbols, be sure your custom design adheres to the design guidelines._ Styles within components are carefully considered. We do not recommend detaching the symbol to change default styles.
 
@@ -124,11 +124,11 @@ _When changing the colour or other styles of component symbols, be sure your cus
 ### Styling text elements
 Linking the HDS Typography library to your project adds the possibility to give HDS text styles to your text elements. You can add text styles to your layout in two ways:
 
-1. You can add a new text element with appropriate text style from the _Insert_ menu, by selecting _HDS Typograhy_ from the a text _Text styles_ section at the bottom part of the insert menu, selecting the desired text style and placing it on your artboard.
+1. You can add a new text element with appropriate text style from the Insert menu: Select the HDS Typography under the a Text styles section, choose the desired text style, and click anywhere on your artboard. This creates a new text element with the chosen style.
 
 ![Inserting header styles](../../static/fordesigners-typography-header-insert.png "Inserting header styles")
 ![Inserting body styles](../../static/fordesigners-typography-body-insert.png "Inserting body styles")
 
-2. You can give text styles to existing text elements, by selecting the text element and changing its style from the _Appearance_ sidebar.
+2. You can give text styles to existing text elements by selecting the text element and changing its style from the _Appearance_ sidebar.
 
 ![Changing text elements style](../../static/fordesigners-typography-textstyle-appearance.png "Changing text elements style")

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -10,6 +10,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 <LargeParagraph>The Helsinki Design System is desgined and built to be accessible for all, regardless of ability or situation.</LargeParagraph>
 
+
 ## Standards
 ### Global accessibility standards
 World Wide Web Consortium (W3C)’s [Web Accessibility Initiative (WAI)](https://www.w3.org/WAI/ "W3C Web Accessibility Initiative") is an effort to improve the accessibility of the World Wide Web for people of all abilities.
@@ -20,25 +21,25 @@ The WAI contributors maintain [The Web Content Accessibility Guidelines (WCAG)](
 ### Accessibility in the City of Helsinki digital services
 [EU directive on web accessibility](https://eur-lex.europa.eu/eli/dir/2016/2102/oj "EU directive on web accessibility") mandates that all new public sector websites published by September 23 2019 have to comply with [WCAG 2.0 Standard at AA Level](https://www.w3.org/TR/WCAG20/#conformance "WCAG 2.0 Standard at AA Level"). On September 23 2020 all websites, new and old, have to meet this criteria. 
 
-The City of Helsinki also has its own [content accessibility guidelines](https://www.hel.fi/static/hki4all/ohjeet/saavutettavuus-opas.pdf) for the web (only in Finnish for now).
+The City of Helsinki also has its own [content accessibility guidelines](https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf) for the web.
+
+[Develop with Helsinki](https://dev.hel.fi/accessibility) site offers quality content about accessibility for developers.
 
 
 ## Principles
 The WCAG 2.0 Accessibility Standard outlines [four principles](https://www.w3.org/TR/WCAG20/#guidelines "WCAG 2.0 Principles") for what an accessible service should be:
 - **Perceivable**: Information and user interface components must be presentable to users in ways they can perceive. For example by providing text alternates to visual and time-based media.
-- **Operable** User interface components and navigation must be operable, for example with keyboard and assistive technologies. It should help users navigate, find content, and determine where they are.
-- **Understandable** the content should be readable and easy to understand, and the services should operate in a predictable way.
-- **Robust** accessible by wide range of technologies, including old and new browsers and assistive technologies.
+- **Operable**: User interface components and navigation must be operable, for example with keyboard and assistive technologies. It should help users navigate, find content, and determine where they are.
+- **Understandable**: the content should be readable and easy to understand, and the services should operate in a predictable way.
+- **Robust**: accessible by wide range of technologies, including old and new browsers and assistive technologies.
 
 A few guidelines for developing accessible services:
 - Write standards compliant, semantic HTML and CSS
 - Support keyboard navigation and other standard accessibility functionalities
-- In [React](https://reactjs.org/docs/accessibility.html "React / Accessibility"), use ARIA when there is no native markup.
-
+- In React, use ARIA when there is no native markup. For more information, see [React accessibility documentation](https://reactjs.org/docs/accessibility.html)
 
 
 ## Further reading
 [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/ "WAI-ARIA Authoring Practices")  
-[Salesforce's accessibility blog posts](https://developer.salesforce.com/blogs/tag/accessibility "Salesforce's accessibility blog posts")  
 [WebAIM](https://webaim.org/ "WebAIM")  
 [Are My Colours Accessible?](https://www.aremycoloursaccessible.com/ "Are My Colours Accessible?")

--- a/site/docs/guidelines/photographs.mdx
+++ b/site/docs/guidelines/photographs.mdx
@@ -10,9 +10,6 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 <LargeParagraph>Photographs can be used for communicating concepts and emotions hard to put in words, and bringing a strong feeling of Helsinki into your service.</LargeParagraph>
 
-The starting point for the Helsinki imagery are people and emotion: what can be experienced and felt in Helsinki. We show the true everyday Helsinki and the good everyday life of the Helsinki resident: people, working together, rejoice and funny details. 
-
-Helsinki is not just the core centre of the City. The neighbourhoods depicting people of different ages and backgrounds are an important part of the cityscape. In the images, we are also bravely showing an incomplete City under construction.
 
 The City of Helsinki’s pictorial narrative is built around four themes:
 - **Changing Helsinki:** Change can be seen not only in the vast area development projects, but also in, for example, the economic structure and in the increasingly international streetscape.
@@ -23,5 +20,5 @@ The City of Helsinki’s pictorial narrative is built around four themes:
 
 In user interfaces, photographs can be used for example in hero elements, text/photo modules or card components.
 
-See the [Visual Identity Guidelines](https://brand.hel.fi/en/photograph-guidelines/ "City of Helsinki Visual Identity Guidelines / Photography guidelines") more information on using photographs.
+See the [Visual Identity Guidelines](https://brand.hel.fi/en/photograph-guidelines/ "City of Helsinki Visual Identity Guidelines / Photography guidelines") for more information on using photographs.
 

--- a/site/docs/visual_elements/icons.mdx
+++ b/site/docs/visual_elements/icons.mdx
@@ -5,6 +5,7 @@ menu: Visual assets
 ---
 
 import LargeParagraph from "../../src/components/LargeParagraph";
+import Image from "../../src/components/Image";
 
 
 # Icons
@@ -39,7 +40,7 @@ The default size of the HDS icons is 24 × 24 px.
 - When using the icons in 16 × 16 px, make sure the icon is still clear and legible.
 - Larger sizes than 64 × 64 px are not recommended
 
-![HDS icon sizes](../../static/icon-sizes.png "HDS icon sizes")
+<Image src="../../static/icon-sizes@2x.png" alt="HDS icon sizes" width="40%" />
 
 ### Colour
 The default colour of the HDS icons is black or white, depending on the background. 

--- a/site/docs/visual_elements/logo.mdx
+++ b/site/docs/visual_elements/logo.mdx
@@ -5,6 +5,7 @@ menu: Visual assets
 ---
 
 import LargeParagraph from "../../src/components/LargeParagraph";
+import Image from "../../src/components/Image";
 
 # Logo
 
@@ -16,7 +17,7 @@ The City of Helsinki logo consists of the text _Helsinki_ framed by the shape de
 
 
 ## Principles 
-Official City of Helsinki services must always show the City of Helsinki the logo, that is placed: 
+Official City of Helsinki services must always show the City of Helsinki logo, that is placed: 
 - at the top left corner of the page, in the header component
 - at the bottom of the page, in the footer component
 
@@ -29,15 +30,16 @@ There are two language versions available in HDS:
 Language version                                                                                                             | File name         | Usage                                         |
 ---------------------------------------------------------------------------------------------------------------------------- |-------------------|-----------------------------------------------|
 [![Helsinki logo fi](../../static/assets/logo/helsinki-fi.svg)](../../static/assets/logo/helsinki-fi.svg "Helsinki logo fi") | helsinki-fi.svg   | pages in Finnish, English and other languages |
-[![Helsinki logo sv](../../static/assets/logo/helsinki-sv.svg)](../../static/assets/logo/helsinki-sv.svg "Helsinki logo sv") | helsinki-sv.svg   | pages pages in Swedish                        |
+[![Helsinki logo sv](../../static/assets/logo/helsinki-sv.svg)](../../static/assets/logo/helsinki-sv.svg "Helsinki logo sv") | helsinki-sv.svg   | pages in Swedish                        |
 
 
 ### Favicon
 The favicon of City of Helsinki digital services is a minimised version of the Helsinki logo:
 
-Favicon                                                                                                              | File name           |
--------------------------------------------------------------------------------------------------------------------- | ------------------- |
-[![Helsinki logo sv](../../static/assets/logo/favicon.ico)](../../static/assets/logo/favicon.ico "Helsinki favicon") | favicon.ico         | 
+Favicon                                                                                  | File name           |
+---------------------------------------------------------------------------------------- | ------------------- |
+<Image src="../../static/assets/logo/favicon.ico" alt="Helsinki favicon" width="16px" /> | favicon.ico         | 
+
 
 
 ### Colour

--- a/site/src/components/Image.js
+++ b/site/src/components/Image.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Image = ({ src, alt = 'Image', style = {}, ...rest }) => <img alt={alt} src={src} style={style} {...rest} />;
+
+Image.propTypes = {
+    alt: PropTypes.string.isRequired,
+    src: PropTypes.string.isRequired,
+    style: PropTypes.object,
+};
+
+export default Image;


### PR DESCRIPTION
## Description

- Fixed multiple typos in most page sections
- Fixed multiple broken links in most page sections
- Clarified link label naming
- Fixed wrong version number in "What is new" section and added link to full release notes
- Added new component, Image, which allows setting image size manually
- Swapped certain images in Logo and Icons pages to use the new Image component to ensure that images do not stretch

## Motivation and Context

Fixes based on proofreading done by Antti Pakarinen.

## How Has This Been Tested?

This has been tested working by running the documentation site locally.
