### PR TITLE
[Content] Roadmap update

### DIFF
--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -28,6 +28,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 - Component: Notification & toast
 - Component: Status label
 - Component: Tooltip
+- Component: Footer
 
 
 - Update: Cleaning typography styles
@@ -36,7 +37,6 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 **Q3 2020**
 
 - Component: Loading placeholder
-- Component: Footer
 - Component: Card
 - Component: Loading spinner
 - Component: Search field

--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -25,6 +25,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 
 - Component: Navigation
+- Component: Logo
 - Component: Notification & toast
 - Component: Status label
 - Component: Tooltip

--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -21,20 +21,54 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 - ~~Component: Text area~~
 - ~~Tokens: Spacing~~
 - ~~Tokens: Line heights~~
+- ~~Tokens: Breakpoints and maximum content width~~
+
+
 - Component: Navigation
-- Component: Footer
-- Component: Notifications & toasts
-- Component: Status labels
-- Tokens: Breakpoints
+- Component: Notification & toast
+- Component: Status label
+- Component: Tooltip
+
+
+- Update: Cleaning typography styles
+- Update: Cleaning color styles
 
 **Q3 2020**
 
-_Coming soon!_
+- Component: Loading placeholder
+- Component: Footer
+- Component: Card
+- Component: Loading spinner
+- Component: Search field
+- Component: Filter toggle
+- Component: Datepicker
+- Component: Number input field
+- Component: Phone number input field
+- Component: Tag
+
+
+- Tokens: Z-index
+- Tokens: Media queries
+
+
+- Icons: Next set of icons
+
+
+- Update: Better scaling for mobile (typography and components)
+
 
 **Q4 2020**
 
-_Coming soon!_
 
-**2021**
+- Pattern: First patterns (TBD)
 
-_Coming soon!_
+
+- Component: Modal
+- Component: Password input field
+- Component: Time input field
+- Component: Expander
+
+
+**Q1 2021**
+
+- HDS 1.0 Release


### PR DESCRIPTION
## Description
Documentation site Roadmap page updated to match the current plan. Content also now matches the GitHub repo Project board: https://github.com/City-of-Helsinki/helsinki-design-system/projects/1

## How Has This Been Tested?
Tested working by running documentation site locally.
