### PR TITLE
[Fix] Fixed incorrect px value for xs breakpoint documentation

### DIFF
--- a/site/docs/design_tokens/breakpoints.mdx
+++ b/site/docs/design_tokens/breakpoints.mdx
@@ -38,7 +38,7 @@ The breakpoint tokens are divided into two sets;
 ### Breakpoints
 CSS             | SASS           | px value | Scaling method
 ----------------|----------------|----------|----------------------
---breakpoint-xs | $breakpoint-xs | ≤ 320    | Scale columns
+--breakpoint-xs | $breakpoint-xs | ≥ 320    | Scale columns
 --breakpoint-s  | $breakpoint-s  | ≥ 576    | Scale outside margins
 --breakpoint-m  | $breakpoint-m  | ≥ 768    | Scale outside margins
 --breakpoint-l  | $breakpoint-l  | ≥ 992    | Scale outside margins


### PR DESCRIPTION
The table showed "less or equal to" 320 while it should have been "greater or equal to" 320.

## Description

Small correction to breakpoint token documentation. The table showed usecase for breakpoint-xs to be "less or equal to 320" while it should have been "greater or equal to 320". This has been corrected.

## How Has This Been Tested?
Tested working by running the documentation site locally.
