### PR TITLE
[Fix] Incorrect px value of spacing-xs token in documentation page

### DIFF
--- a/site/docs/design_tokens/spacing.mdx
+++ b/site/docs/design_tokens/spacing.mdx
@@ -34,8 +34,8 @@ CSS                   | SASS                  | rem value | px value  | Example 
 --------------------- | --------------------- | --------- | --------- | --------------------------------------------- |
 --spacing-4-xs        | $spacing-4-xs         | 0.125     | 2         | <Spacing size="var(--spacing-4-xs)" />        |
 --spacing-3-xs        | $spacing-3-xs         | 0.25      | 4         | <Spacing size="var(--spacing-3-xs)" />        |
---spacing-2-xs        | $spacing-2-xs         | 0.5       | 4         | <Spacing size="var(--spacing-2-xs)" />        |
---spacing-xs          | $spacing-xs           | 0.75      | 8         | <Spacing size="var(--spacing-xs)" />          |
+--spacing-2-xs        | $spacing-2-xs         | 0.5       | 8         | <Spacing size="var(--spacing-2-xs)" />        |
+--spacing-xs          | $spacing-xs           | 0.75      | 12        | <Spacing size="var(--spacing-xs)" />          |
 --spacing-s           | $spacing-s            | 1         | 16        | <Spacing size="var(--spacing-s)" />           |
 --spacing-m           | $spacing-m            | 1.5       | 24        | <Spacing size="var(--spacing-m)" />           |
 --spacing-l           | $spacing-l            | 2         | 32        | <Spacing size="var(--spacing-l)" />           |


### PR DESCRIPTION
## Description

Documentation of spacing tokens listed both `--spacing-xs` and `--spacing-2xs` as 8px. This has been corrected and `--spacing-xs` is now 12px in documentation.

## How Has This Been Tested?

This has been tested by running the documentation site locally.