### PR TITLE
HDS-200 | [Feature] Add option to show selected options as buttons

### DIFF
--- a/packages/react/src/components/dropdown/Dropdown.module.css
+++ b/packages/react/src/components/dropdown/Dropdown.module.css
@@ -35,6 +35,8 @@
   --menu-item-icon-color-selected: var(--color-white);
   --menu-item-icon-color-disabled: var(--color-black-40);
   --placeholder-color: var(--color-black-60);
+  --selected-option-background-color: var(--color-black-10);
+  --selected-option-color: var(--color-black-90);
 
   position: relative;
 }
@@ -120,6 +122,27 @@
 
 .buttonReset {
   composes: button-reset from 'hds-core/lib/utils/helpers.css';
+}
+
+/* MULTISELECT - SELECTED */
+
+.selectedOptionsWrapper .selectedOption {
+  margin-top: var(--spacing-xs);
+  margin-right: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-xs) var(--spacing-m);
+  display: inline-flex;
+  font-size: var(--fontsize-body-m);
+  justify-content: space-between;
+  background-color: var(--selected-option-background-color);
+  color: var(--selected-option-color);
+}
+
+.selectedOptionsWrapper .selectedOption button {
+
+}
+
+.selectedOptionIcon {
+  margin-left: var(--spacing-s);
 }
 
 /* INVALID */

--- a/packages/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.stories.tsx
@@ -5,15 +5,16 @@ import Dropdown from './Dropdown';
 import Button from '../button/Button';
 
 const options = [
-  { label: 'Plutonium' },
+  { key: 'pl', label: 'Plutonium' },
   { label: 'Americium' },
-  { label: 'Copernicium' },
-  { label: 'Nihonium' },
-  { label: 'Flerovium' },
-  { label: 'Moscovium' },
-  { label: 'Livermorium' },
-  { label: 'Tennessine' },
-  { label: 'Oganesson' },
+  { key: 'co', label: 'Copernicium' },
+  { key: 'ni', label: 'Nihonium' },
+  { key: 'fl', label: 'Flerovium' },
+  { key: 'mo', label: 'Moscovium' },
+  { key: 'li', label: 'Livermorium' },
+  { key: 'te', label: 'Tennessine' },
+  { key: 'og', label: 'Oganesson' },
+  { key: 'og2', label: 'Oganesson' }, // Let's test with two items having identical label
 ];
 
 export default {
@@ -133,9 +134,10 @@ Combobox.story = {
   name: 'With filtering (combobox)',
 };
 
-export const MultiSelectCombobox = () => (
+export const MultiSelectFilterCombobox = () => (
   <Dropdown
     options={options}
+    closeMenuOnSelect={false}
     label="Multiselect filterable dropdown (combobox) and buttons below"
     placeholder="Placeholder"
     filterable
@@ -144,7 +146,7 @@ export const MultiSelectCombobox = () => (
   />
 );
 
-MultiSelectCombobox.story = {
+MultiSelectFilterCombobox.story = {
   name: 'Multiselect with filtering (combobox) and buttons below',
 };
 

--- a/packages/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.stories.tsx
@@ -133,6 +133,21 @@ Combobox.story = {
   name: 'With filtering (combobox)',
 };
 
+export const MultiSelectCombobox = () => (
+  <Dropdown
+    options={options}
+    label="Multiselect filterable dropdown (combobox) and buttons below"
+    placeholder="Placeholder"
+    filterable
+    multiselect
+    showSelectedBelow
+  />
+);
+
+MultiSelectCombobox.story = {
+  name: 'Multiselect with filtering (combobox) and buttons below',
+};
+
 export const Playground = () => {
   const multiselect = boolean('Multiselect', false);
   const filterable = boolean('Filterable', false);

--- a/packages/react/src/components/dropdown/Dropdown.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.tsx
@@ -118,6 +118,10 @@ export type DropdownProps = {
    */
   selectedOption?: OptionType | OptionType[];
   /**
+   * Display selected options as buttons below dropdown
+   */
+  showSelectedBelow?: boolean;
+  /**
    * Override or extend the root styles applied to the component
    */
   style?: CSSProperties;
@@ -176,17 +180,11 @@ const Dropdown: FC<DropdownProps> = ({
   placeholder = '',
   required,
   selectedOption,
+  showSelectedBelow = false,
   style,
   toggleButtonId,
   visibleOptions = 5,
 }: DropdownProps) => {
-  // todo: this should be removed when multiselect is supported together with the filterable prop
-  // https://helsinkisolutionoffice.atlassian.net/browse/HDS-200
-  if (filterable && multiselect) {
-    // eslint-disable-next-line no-param-reassign
-    multiselect = false;
-  }
-
   // combobox menu options
   const [inputItems, setInputItems] = useState(options);
 
@@ -290,6 +288,14 @@ const Dropdown: FC<DropdownProps> = ({
     return <span className={styles.buttonLabel}>{buttonLabel || placeholder}</span>;
   };
 
+  const showSelectedItems = (items: OptionType | OptionType[]) => {
+    return items.map((item) => (
+      <button type="button" key={item.key} onClick={() => removeSelectedItem(item)}>
+        {item.label}
+      </button>
+    ));
+  };
+
   // menu items
   const menuOptions = filterable ? inputItems : options;
   // show placeholder if no value is selected
@@ -389,6 +395,7 @@ const Dropdown: FC<DropdownProps> = ({
             );
           })}
       </ul>
+      {showSelectedBelow && showSelectedItems(selectedItems)}
       {helper && <div className={styles.helperText}>{helper}</div>}
     </div>
   );

--- a/packages/react/src/components/dropdown/Dropdown.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.tsx
@@ -4,7 +4,7 @@ import isEqual from 'lodash.isequal';
 
 import styles from './Dropdown.module.css';
 import classNames from '../../utils/classNames';
-import { IconAngleDown, IconCheck, IconAlertCircle } from '../../icons';
+import { IconAngleDown, IconCheck, IconAlertCircle, IconCross } from '../../icons';
 import Checkbox from '../checkbox/Checkbox';
 import FieldLabel from '../../internal/field-label/FieldLabel';
 
@@ -289,11 +289,22 @@ const Dropdown: FC<DropdownProps> = ({
   };
 
   const showSelectedItems = (items: OptionType | OptionType[]) => {
-    return items.map((item) => (
-      <button type="button" key={item.key} onClick={() => removeSelectedItem(item)}>
-        {item.label}
-      </button>
-    ));
+    return (
+      <div className={styles.selectedOptionsWrapper}>
+        {items.map((item) => {
+          return (
+            <button
+              type="button"
+              className={styles.selectedOption}
+              key={item.key || item.label}
+              onClick={() => removeSelectedItem(item)}
+            >
+              {item.label} <IconCross className={styles.selectedOptionIcon} />
+            </button>
+          );
+        })}
+      </div>
+    );
   };
 
   // menu items
@@ -365,7 +376,7 @@ const Dropdown: FC<DropdownProps> = ({
             return (
               <li
                 {...getItemProps({
-                  key: `item-${index}`,
+                  key: `item-${item.key || item.value}`,
                   index,
                   item,
                   disabled: optionDisabled,


### PR DESCRIPTION
## Description

This may or may not solve HDS-200, but at least it could be a step in the right direction. The idea is to show the selected options as buttons (tbd how they look), which makes it easy for the user to see what they have selected and to unselect. 

Closes HDS-200 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

This is in Draft

## Screenshots (if appropriate):
