### PR TITLE
[Fix] Removed unnecessary dot from HDS mail address

### DIFF
--- a/site/docs/about/support.mdx
+++ b/site/docs/about/support.mdx
@@ -18,7 +18,7 @@ import Link from "../../src/components/Link";
 If you are making a feature request, please refer to [Contributing](/contributing) page. If you are making a bug report, read about issues below.
 
 ### Email
-If you’ve got a question or a suggestion, you can get in touch with the team by email. Our address is hds@hel.fi. Messages will be answered by the HDS team as soon as possible.
+If you’ve got a question or a suggestion, you can get in touch with the team by email. Our address is [hds@hel.fi](mailto:hds@hel.fi). Messages will be answered by the HDS team as soon as possible.
 
 ### Slack channels
 HDS team members can also be reached in two Slack channels in the City of Helsinki Slack.


### PR DESCRIPTION
## Description
Removed unnecessary dot from HDS email address which was listed on the Support documentation page. Email link did not work correctly with the trailing dot.

## How Has This Been Tested?
This has been tested working by running the documentation site locally.
