### PR TITLE
[Documentation] Date and time guidelines

### DIFF
--- a/site/docs/about/statement.mdx
+++ b/site/docs/about/statement.mdx
@@ -11,7 +11,7 @@ import Link from "../../src/components/Link";
 This accessibility statement applies to the website Helsinki Design System (documentation). The site address is hds.hel.fi.
 
 ### Statutory provisions applicable to the website
-This website was published after 23/09/2018. The website must fulfil statutory accessibility requirements.
+This website was published after 23.09.2018. The website must fulfil statutory accessibility requirements.
 
 ### The objective of the city
 As regards the accessibility of digital services, Helsinki aims to reach at least Level AA or above as set forth in the WCAG guidelines in so far as is reasonably practical.
@@ -20,7 +20,7 @@ As regards the accessibility of digital services, Helsinki aims to reach at leas
 The accessibility compliance of this website has not yet been evaluated. The accessibility will be evaluated before the 1.0 release of the Helsinki Design System.
 
 ### Preparing an accessibility statement
-This statement was prepared on 22/05/2020.
+This statement was prepared on 22.05.2020.
 
 ### Updating the accessibility statement
 The accessibility statement will be updated so that it corresponds with the observations related to accessibility compliance made during an audit.
@@ -42,4 +42,4 @@ The accessibility level of websites is monitored constantly during their mainten
 The city provides counselling and support for the disabled and users of assistive technologies. Support is available on guidance sites announced on the city’s website and through telephone counselling.
 
 ### Approval of the accessibility statement
-This statement was approved on 22/5/2020 by City Executive Office, City of Helsinki
+This statement was approved on 22.5.2020 by City Executive Office, City of Helsinki

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -21,7 +21,7 @@ The WAI contributors maintain <Link href="https://www.w3.org/TR/WCAG21/" externa
 
 
 ### Accessibility in the City of Helsinki digital services
-<p><Link href="https://eur-lex.europa.eu/eli/dir/2016/2102/oj" external>EU directive on web accessibility</Link> mandates that all new public sector websites published by September 23 2019 have to comply with <Link href="https://www.w3.org/TR/WCAG20/#conformance" external>WCAG 2.0 Standard at AA Level</Link>. On 23/09/2020 all websites, new and old, have to meet this criteria. Note, that HDS follows follows WCAG 2.1 instead of WCAG 2.0. The publication of WCAG 2.1 does not deprecate or supersede WCAG 2.0 but W3C advices to use WCAG 2.1.</p> 
+<p><Link href="https://eur-lex.europa.eu/eli/dir/2016/2102/oj" external>EU directive on web accessibility</Link> mandates that all new public sector websites published by 23.09.2019 have to comply with <Link href="https://www.w3.org/TR/WCAG20/#conformance" external>WCAG 2.0 Standard at AA Level</Link>. On 23.09.2020 all websites, new and old, have to meet this criteria. Note, that HDS follows follows WCAG 2.1 instead of WCAG 2.0. The publication of WCAG 2.1 does not deprecate or supersede WCAG 2.0 but W3C advices to use WCAG 2.1.</p> 
 
 <p>The City of Helsinki also has its own <Link href="https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf" external>content accessibility guidelines</Link> for the web.</p>
 

--- a/site/docs/guidelines/data_formats.mdx
+++ b/site/docs/guidelines/data_formats.mdx
@@ -15,22 +15,29 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 ## Date and time
 
 ### Format
-Follow the following suggestions when presenting date and time in your services. It is recommended to use format according to user's locale.
+Follow the following suggestions when presenting date and time in your services. It is recommended to use format depending on user's locale.
 
-Type                          | Format in Finnish/Swedish              | Format in English/other                              | Notes
+Type                          | Format in Finnish/Swedish              | Format in English                                    | Notes
 ------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
 Time                          | 15:00                                  | 03:00 PM                                             | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
+Time (in text)                | 15.00                                  | 03:00 PM                                             | Finnish/Swedish often use single dot instead of colon in written text. Leading zeros can be left out as well.
 Day, month and year           | 24.6.2020                              | 06/24/2020                                           | Note that English locale uses MM/DD/YYYY format rather than DD/MM/YYYY.
 Day, month and year (longer)  | 24. kesäkuuta 2020                     | 24 June 2020                                         | Using the written format of month makes the date easier to understand for different locales.
 Today, tomorrow, yesterday    | Tänään, klo 12:30                      | Today, 12:30 PM                                      | If talking about today, tomorrow or yesterday, written format is used instead of date.
-Time range                    | 12:30-16:30                            | 12:30-4:30 PM                                        | When using 12 hour time format, use only a single AM/PM if times are both AM/PM.
-Date range                    | 2-15. tammikuuta 2020 / 2.1.-5.2.2020  | Jan 2-15, 2020 / Jan 2 - Feb 5, 2020                 | Year and/or month can be only written once if both dates share the same year/month.
+
+### Ranges
+When presenting time or date ranges, consider making information simpler by leaving redundant AM/PM, month and year information out. **Note that when presenting ranges, en dash (–) should be used instead of a standard hyphen (-).**
+
+Type                          | Format in Finnish/Swedish              | Format in English                                    | Notes
+------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
+Time range                    | 12.30–16.30                            | 12:30–4:30 PM                                        | When using 12 hour time format, use only a single AM/PM if times are both AM/PM.
+Date range                    | 2.–15. tammikuuta 2020 / 2.1.–5.2.2020 | Jan 2–15, 2020 / Jan 2 – Feb 5, 2020                 | Year and/or month can be only written once if both dates share the same year/month.
 
 ### Time zones
 **Automatically use user's timezone if possible.** If not available, default to Finnish time and present the time zone as following:
 
-Type       | Format in Finnish/Swedish       | Format in English/other      | Notes
+Type       | Format in Finnish/Swedish       | Format in English            | Notes
 -----------|---------------------------------|------------------------------|---------------------------------------------------------------------------------------------
 Time zone  | UTC+2                           | UTC+2                        | Leading or trailing zeroes are rarely used for timezones.
-Time       | 15:00 UTC+2                     | 03:00 PM UTC+2               | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
+Time       | 15.00 UTC+2                     | 03:00 PM UTC+2               | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
 Date       | 24. kesäkuuta 2020, 15:30 UTC+2 | 24 June 2020, 03:30 PM UTC+2 | -

--- a/site/docs/guidelines/data_formats.mdx
+++ b/site/docs/guidelines/data_formats.mdx
@@ -1,0 +1,36 @@
+---
+name: Data formats
+route: /guidelines/data-formats
+menu: Guidelines
+---
+
+import LargeParagraph from "../../src/components/LargeParagraph";
+
+# Data formats
+
+<LargeParagraph>
+    Helsinki Design System suggests formats for commonly presented data to keep Helsinki services more consistent.
+</LargeParagraph>
+
+## Date and time
+
+### Format
+Follow the following suggestions when presenting date and time in your services. It is recommended to use format according to user's locale.
+
+Type                          | Format in Finnish/Swedish              | Format in English/other                              | Notes
+------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
+Time                          | 15:00                                  | 03:00 PM                                             | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
+Day, month and year           | 24.6.2020                              | 06/24/2020                                           | Note that English locale uses MM/DD/YYYY format rather than DD/MM/YYYY.
+Day, month and year (longer)  | 24. kesäkuuta 2020                     | 24 June 2020                                         | Using the written format of month makes the date easier to understand for different locales.
+Today, tomorrow, yesterday    | Tänään, klo 12:30                      | Today, 12:30 PM                                      | If talking about today, tomorrow or yesterday, written format is used instead of date.
+Time range                    | 12:30-16:30                            | 12:30-4:30 PM                                        | When using 12 hour time format, use only a single AM/PM if times are both AM/PM.
+Date range                    | 2-15. tammikuuta 2020 / 2.1.-5.2.2020  | Jan 2-15, 2020 / Jan 2 - Feb 5, 2020                 | Year and/or month can be only written once if both dates share the same year/month.
+
+### Time zones
+**Automatically use user's timezone if possible.** If not available, default to Finnish time and present the time zone as following:
+
+Type       | Format in Finnish/Swedish       | Format in English/other      | Notes
+-----------|---------------------------------|------------------------------|---------------------------------------------------------------------------------------------
+Time zone  | UTC+2                           | UTC+2                        | Leading or trailing zeroes are rarely used for timezones.
+Time       | 15:00 UTC+2                     | 03:00 PM UTC+2               | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
+Date       | 24. kesäkuuta 2020, 15:30 UTC+2 | 24 June 2020, 03:30 PM UTC+2 | -

--- a/site/docs/guidelines/data_formats.mdx
+++ b/site/docs/guidelines/data_formats.mdx
@@ -20,7 +20,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 Type                            | Format                        | Notes
 --------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Time (in forms, schedules etc.) | 15:00, 02:00                  | When presenting times in forms and schedules, use leading zeros and a colon separator. 24-hour clock is always used.
-Time (in text)                  | 15.00, 2:00                   | When presenting times in written text, use single dot instead of colon separator. Leading zeros can be opted out as well. 24-hour clock is always used.
+Time (in text)                  | 15.00, 2.00                   | When presenting times in written text, use single dot instead of colon separator. Leading zeros can be opted out as well. 24-hour clock is always used.
 Day, month and year             | 24.6.2020                     | Date format is DD.MM.YYYY even if user's locale is something else than Finnish.
 Day, month and year (longer)    | 24. June 2020, 24 June 2020   | Using the written format of month makes the date easier to understand for different locales. Note that technically English translation omits the dot after day number.
 Today, tomorrow, yesterday      | Today, 12:30                  | If talking about today, tomorrow or yesterday, written format is used instead of date.

--- a/site/docs/guidelines/data_formats.mdx
+++ b/site/docs/guidelines/data_formats.mdx
@@ -15,29 +15,30 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 ## Date and time
 
 ### Format
-Follow these guidelines when presenting date and time in your services. It is recommended to use format depending on user's locale.
+**Helsinki services are recommended to follow Finnish date and time locale - even if the user is using some other language.** Follow these guidelines when presenting date and time in your services.
 
-Type                            | Format in Finnish/Swedish              | Format in English                                    | Notes
---------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
-Time (in forms, schedules etc.) | 15:00                                  | 03:00 PM                                             | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
-Time (in text)                  | 15.00                                  | 03:00 PM                                             | Finnish/Swedish often use single dot instead of colon in written text. Leading zeros can be left out as well.
-Day, month and year             | 24.6.2020                              | 24/06/2020                                           | Note that UK English locale uses DD/MM/YYYY format rather than MM/DD/YYYY that US English uses.
-Day, month and year (longer)    | 24. kesäkuuta 2020                     | 24 June 2020                                         | Using the written format of month makes the date easier to understand for different locales.
-Today, tomorrow, yesterday      | Tänään, klo 12:30                      | Today, 12:30 PM                                      | If talking about today, tomorrow or yesterday, written format is used instead of date.
+Type                            | Format                        | Notes
+--------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Time (in forms, schedules etc.) | 15:00, 02:00                  | When presenting times in forms and schedules, use leading zeros and a colon separator. 24-hour clock is always used.
+Time (in text)                  | 15.00, 2:00                   | When presenting times in written text, use single dot instead of colon separator. Leading zeros can be opted out as well. 24-hour clock is always used.
+Day, month and year             | 24.6.2020                     | Date format is DD.MM.YYYY even if user's locale is something else than Finnish.
+Day, month and year (longer)    | 24. June 2020, 24 June 2020   | Using the written format of month makes the date easier to understand for different locales. Note that technically English translation omits the dot after day number.
+Today, tomorrow, yesterday      | Today, 12:30                  | If talking about today, tomorrow or yesterday, written format is used instead of date.
 
 ### Ranges
-When presenting time or date ranges, consider making information simpler by leaving redundant AM/PM, month and year information out. **Note that when presenting ranges, en dash (–) should be used instead of a standard hyphen (-).**
+When presenting time or date ranges, consider making information simpler by leaving redundant month and year information out. **Note that when presenting ranges, en dash (–) should be used instead of a standard hyphen (-).**
 
-Type                          | Format in Finnish/Swedish              | Format in English                                    | Notes
-------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
-Time range                    | 12.30–16.30                            | 12:30–4:30 PM                                        | When using 12 hour time format, use only a single AM/PM if times are both AM/PM.
-Date range                    | 2.–15. tammikuuta 2020 / 2.1.–5.2.2020 | Jan 2–15, 2020 / Jan 2 – Feb 5, 2020                 | Year and/or month can be only written once if both dates share the same year/month.
+Type                                  | Format                                 | Notes
+--------------------------------------|----------------------------------------|---------------------------------------------------------------------------------------
+Time range (in forms, schedules etc.) | 12:30–16:30                            | When presenting times in forms and schedules, use leading zeros and a colon separator. 
+Time range (in text)                  | 12.30–16.30                            | When presenting times in written text, use single dot instead of colon separator.
+Date range                            | 2.–15. January 2020 / 2.1.–5.2.2020    | Year and/or month can be only written once if both dates share the same year/month.
 
 ### Time zones
 **Automatically use user's timezone if possible.** If not available, default to Finnish time and present the time zone as following:
 
-Type       | Format in Finnish/Swedish       | Format in English            | Notes
------------|---------------------------------|------------------------------|---------------------------------------------------------------------------------------------
-Time zone  | UTC+2                           | UTC+2                        | Leading or trailing zeroes are rarely used for timezones.
-Time       | 15.00 UTC+2                     | 03:00 PM UTC+2               | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
-Date       | 24. kesäkuuta 2020, 15:30 UTC+2 | 24 June 2020, 03:30 PM UTC+2 | -
+Type       | Format                          | Notes
+-----------|---------------------------------|---------------------------------------------------------------------------------------------
+Time zone  | UTC+2                           | Leading or trailing zeroes are not recommended to be used for timezones.
+Time       | 15:00 UTC+2                     | -
+Date       | 24. June 2020, 15:30 UTC+2      | -

--- a/site/docs/guidelines/data_formats.mdx
+++ b/site/docs/guidelines/data_formats.mdx
@@ -21,7 +21,7 @@ Type                          | Format in Finnish/Swedish              | Format 
 ------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
 Time                          | 15:00                                  | 03:00 PM                                             | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
 Time (in text)                | 15.00                                  | 03:00 PM                                             | Finnish/Swedish often use single dot instead of colon in written text. Leading zeros can be left out as well.
-Day, month and year           | 24.6.2020                              | 06/24/2020                                           | Note that English locale uses MM/DD/YYYY format rather than DD/MM/YYYY.
+Day, month and year           | 24.6.2020                              | 24/06/2020                                           | Note that English locale uses MM/DD/YYYY format rather than DD/MM/YYYY.
 Day, month and year (longer)  | 24. kesäkuuta 2020                     | 24 June 2020                                         | Using the written format of month makes the date easier to understand for different locales.
 Today, tomorrow, yesterday    | Tänään, klo 12:30                      | Today, 12:30 PM                                      | If talking about today, tomorrow or yesterday, written format is used instead of date.
 

--- a/site/docs/guidelines/data_formats.mdx
+++ b/site/docs/guidelines/data_formats.mdx
@@ -15,15 +15,15 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 ## Date and time
 
 ### Format
-Follow the following suggestions when presenting date and time in your services. It is recommended to use format depending on user's locale.
+Follow these guidelines when presenting date and time in your services. It is recommended to use format depending on user's locale.
 
-Type                          | Format in Finnish/Swedish              | Format in English                                    | Notes
-------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
-Time                          | 15:00                                  | 03:00 PM                                             | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
-Time (in text)                | 15.00                                  | 03:00 PM                                             | Finnish/Swedish often use single dot instead of colon in written text. Leading zeros can be left out as well.
-Day, month and year           | 24.6.2020                              | 24/06/2020                                           | Note that English locale uses MM/DD/YYYY format rather than DD/MM/YYYY.
-Day, month and year (longer)  | 24. kesäkuuta 2020                     | 24 June 2020                                         | Using the written format of month makes the date easier to understand for different locales.
-Today, tomorrow, yesterday    | Tänään, klo 12:30                      | Today, 12:30 PM                                      | If talking about today, tomorrow or yesterday, written format is used instead of date.
+Type                            | Format in Finnish/Swedish              | Format in English                                    | Notes
+--------------------------------|----------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------
+Time (in forms, schedules etc.) | 15:00                                  | 03:00 PM                                             | Use 24-hour clock or AM/PM depending on the locale. Use leading zeros.
+Time (in text)                  | 15.00                                  | 03:00 PM                                             | Finnish/Swedish often use single dot instead of colon in written text. Leading zeros can be left out as well.
+Day, month and year             | 24.6.2020                              | 24/06/2020                                           | Note that UK English locale uses DD/MM/YYYY format rather than MM/DD/YYYY that US English uses.
+Day, month and year (longer)    | 24. kesäkuuta 2020                     | 24 June 2020                                         | Using the written format of month makes the date easier to understand for different locales.
+Today, tomorrow, yesterday      | Tänään, klo 12:30                      | Today, 12:30 PM                                      | If talking about today, tomorrow or yesterday, written format is used instead of date.
 
 ### Ranges
 When presenting time or date ranges, consider making information simpler by leaving redundant AM/PM, month and year information out. **Note that when presenting ranges, en dash (–) should be used instead of a standard hyphen (-).**


### PR DESCRIPTION
## Description
This PR adds requested date and time guidelines to HDS documentation. Guidelines are located in a new page Guidelines/Data formats. Later on more similar guidelines can be added to the same page.

## How Has This Been Tested?
This has been tested working by running the documentation site locally.
