### PR TITLE
[Fix] Documentation site paragraph margins

### DIFF
--- a/site/src/gatsby-theme-docz/theme/styles.js
+++ b/site/src/gatsby-theme-docz/theme/styles.js
@@ -36,6 +36,8 @@ const styles = {
   },
   p: {
     maxWidth: 600,
+    marginTop: 'var(--spacing-l)',
+    marginBottom: 'var(--spacing-l)',
   },
   li: {
     marginBottom: 1,


### PR DESCRIPTION
## Description
This PR fixes incorrect paragraph margins on the documentation site that were introduced in 0.12.0 release.

## How Has This Been Tested?
Tested by running the documentation site locally.
