### PR TITLE
[Content] Documentation guidelines

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -56,7 +56,7 @@ The documentation is written as `.mdx` files in the `docs/` folder. To keep thin
 
 ### Using example page templates
 
-HDS offers example page templates for the most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are:
+HDS offers example page templates for the most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are (note that GitHub Markdown viewer does not show file comments. Use raw format or read files with your code editor.):
 - [Component page template](examples/component.mdx)
 - [Design token page template](examples/design_token.mdx)
 - [General page template](examples/page.mdx)
@@ -80,8 +80,11 @@ route: /components/<COMPONENT_NAME>
 ---
 ```
 `name` specifies the page name shown in the browser. 
+
 `menu` specifies the category page is under in the menu hierarchy. 
+
 `route` specifies the URL format of the page. It should follow the naming of the category the page belongs to.
+
 For full documentation about document settings, refer to [Docz documentation - Document settings](https://www.docz.site/docs/document-settings).
 
 ### Adding new categories

--- a/site/README.md
+++ b/site/README.md
@@ -1,24 +1,45 @@
 # Helsinki Design System documentation site
 
-Built with [docz](https://www.docz.site/).
+This is the public documentation site of Helsinki Design System ([hds.hel.fi](https://hds.hel.fi/)). It is built with [docz](https://www.docz.site/) which is powered by [Gatsby](https://www.gatsbyjs.com/). Documentation site includes:
+
+- Getting started section for designers and developers
+- Guidelines for accessibility, grid, localisation and more
+- Guidelines for visual assets such as icons and Helsinki logo
+- Design token documentation
+- Component documentation
+- About section with news, release notes and road map
+- Resources section
+- Contribution guidelines
 
 ## Getting started
 
-### Run the dev env
+When making changes to the documentation website, recommended way to get it running locally. This way you can review and see your changes in real time like they would show up in production. 
 
+### Setting up local development environment
+
+1. Clone the HDS repository.
 ```
-# Clone the repo
 git clone https://github.com/City-of-Helsinki/helsinki-design-system.git
-cd helsinki-design-system/site
+```
 
-# Install dependencies
+2. Go to the root of the project and install dependencies with `yarn`.
+```
+cd helsinki-design-system
 yarn
+```
 
-# Start dev server, watch for changes
+3. Build packages with `yarn`. Note, you need to build all HDS packages since the documentation site uses those as well.
+```
+yarn build
+```
+
+4. Start the development server. It will watch for file changes automatically.
+```
+cd site
 yarn start
 ```
 
-With your dev server up, you can access the documentation at http://localhost:3000/ start writing your documentation.
+You may need to rerun `yarn build` if you make changes to `doczrc.js` config file or if other HDS packages are updated.
 
 ### Writing documentation
 
@@ -29,15 +50,6 @@ In addition to the markdown, the file contains a frontmatter header that will be
 [Example page documentation file](examples/page.mdx)
 
 [Example component documentation file](examples/component.mdx)
-
-### Deployment
-
-```
-# generate static site
-yarn build
-```
-
-If everything goes well, you'll find the static site at `public/`.
 
 ### App configuration
 

--- a/site/README.md
+++ b/site/README.md
@@ -48,14 +48,24 @@ yarn start
 The documentation is written as `.mdx` files in the `docs/` folder. To keep things tidy, the folder structure should always mirror the site menu hierarchy.
 
 ### General guidelines
-TODO
+- HDS documentation is written in British English.
+- The audience of the documentation includes every one at the City of Helsinki organisation with the main focus on developers, designers and product owners. Try to avoid technical jargon to keep documentation understandable for everyone.
+- HDS documentation aims to guide designers and developer and not restrict them. Most of the time the last word is left to the user of the design system. Keep this in mind - especially when writing component and token principles.
+- Documentation in Components and Design tokens sections always should have their counterpart both in design kit and implementation. HDS aims not to release documentation before implementation is released.
+- Documentation site styles take care of most of the accessibility issues. You mostly need to ensure that heading levels are used semantically (refer to [HDS typography documentation](https://hds.hel.fi/design-tokens/typography)) and external links are correctly visualized (you can use the HDS provided [Link component](src/components/Link.js)).
 
 ### Using example page templates
 
-HDS offers example page templates for most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are:
+HDS offers example page templates for the most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are:
 - [Component page template](examples/component.mdx)
 - [Design token page template](examples/design_token.mdx)
 - [General page template](examples/page.mdx)
+
+You can use the following command line command to quickly copy example templates to the right folder:
+```
+cd site/docs/<category_folder>
+cp ../../examples/<example_template>.mdx ./<component_name>.mdx
+```
 
 ### Adding new pages
 
@@ -78,20 +88,16 @@ For full documentation about document settings, refer to [Docz documentation - D
 
 Generally new pages will be added to the documentation page automatically without restarting the development server. However, if you are adding a completely new category you need to add it to the `doczrc.js` configuration file and build the site package again. For more info on how to configure docz, refer to [Docz documentation - Project configuration](https://www.docz.site/docs/project-configuration).
 
-## App configuration
-
-Docz configuration is handled via the [`doczrc.js`](doczrc.js). Follow the [Project Configuration reference](https://www.docz.site/docs/project-configuration).
-
 ## Troubleshooting
 
-* Most compiling errors when running `yarn start`
+### Most compiling errors when running `yarn start`
   
-    Try running the following in the project root `rm -rf node_modules/ yarn.lock && yarn && yarn build && cd site && yarn start`
+Try running the following in the project root folder:
+`rm -rf node_modules/ yarn.lock && yarn && yarn build && cd site && yarn start`
 
-* Error after running `yarn start` and opening http://localhost:3000/
+### Error after running `yarn start` and opening http://localhost:3000/
+```
+TypeError: Cannot read property 'find' of undefined
+```
 
-    ```
-    TypeError: Cannot read property 'find' of undefined
-    ```
-  
-    Make a change to any of the documentation `.mdx` files and refresh the page.
+Make a change to any of the documentation `.mdx` files and refresh the page. You can also try to clear browser's cache or doing a hard refresh.

--- a/site/README.md
+++ b/site/README.md
@@ -56,7 +56,7 @@ The documentation is written as `.mdx` files in the `docs/` folder. To keep thin
 
 ### Using example page templates
 
-HDS offers example page templates for the most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are (note that GitHub Markdown viewer does not show file comments. Use raw format or read files with your code editor.):
+HDS offers example page templates for the most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are (Note that GitHub Markdown viewer does not show file comments. Use raw format or read files with your code editor.):
 - [Component page template](examples/component.mdx)
 - [Design token page template](examples/design_token.mdx)
 - [General page template](examples/page.mdx)

--- a/site/README.md
+++ b/site/README.md
@@ -93,12 +93,12 @@ Generally new pages will be added to the documentation page automatically withou
 
 ## Troubleshooting
 
-### Most compiling errors when running `yarn start`
+**Most compiling errors when running `yarn start`**
   
 Try running the following in the project root folder:
 `rm -rf node_modules/ yarn.lock && yarn && yarn build && cd site && yarn start`
 
-### Error after running `yarn start` and opening http://localhost:3000/
+**Error after running `yarn start` and opening http://localhost:3000/**
 ```
 TypeError: Cannot read property 'find' of undefined
 ```

--- a/site/README.md
+++ b/site/README.md
@@ -108,4 +108,4 @@ Make a change to any of the documentation `.mdx` files and refresh the page. You
 
 **After changes the page renders completely empty or some of the content does not show on the page**
 
-If you have used custom React components inlined (like the Link component), Gatsby does not render those paragraphs correctly. The fix is to wrap the text into paragraph tags. This way Gatsby 
+If you have used custom React components inlined (like the Link component), Gatsby does not render those paragraphs correctly. The fix is to wrap the text into paragraph tags. This way Gatsby correctly recognizes and renders React components.

--- a/site/README.md
+++ b/site/README.md
@@ -2,6 +2,7 @@
 
 This is the public documentation site of Helsinki Design System ([hds.hel.fi](https://hds.hel.fi/)). It is built with [docz](https://www.docz.site/) which is powered by [Gatsby](https://www.gatsbyjs.com/). Documentation site includes:
 
+- General introduction of Helsinki Design System
 - Getting started section for designers and developers
 - Guidelines for accessibility, grid, localisation and more
 - Guidelines for visual assets such as icons and Helsinki logo
@@ -13,7 +14,7 @@ This is the public documentation site of Helsinki Design System ([hds.hel.fi](ht
 
 ## Getting started
 
-When making changes to the documentation website, recommended way to get it running locally. This way you can review and see your changes in real time like they would show up in production. 
+When making changes to the documentation website, recommended way is to get it running locally. This way you can review and see your changes in real time like they would show up in production. 
 
 ### Setting up local development environment
 
@@ -104,3 +105,7 @@ TypeError: Cannot read property 'find' of undefined
 ```
 
 Make a change to any of the documentation `.mdx` files and refresh the page. You can also try to clear browser's cache or doing a hard refresh.
+
+**After changes the page renders completely empty or some of the content does not show on the page**
+
+If you have used custom React components inlined (like the Link component), Gatsby does not render those paragraphs correctly. The fix is to wrap the text into paragraph tags. This way Gatsby 

--- a/site/README.md
+++ b/site/README.md
@@ -39,39 +39,54 @@ cd site
 yarn start
 ```
 
-You may need to rerun `yarn build` if you make changes to `doczrc.js` config file or if other HDS packages are updated.
+5. Open the browser of your choice (Chrome recommended) and navigate to http://localhost:3000/. You should now see the documentation site.
 
-### Writing documentation
+**Note!** You may need to rerun `yarn build` if you make changes to `doczrc.js` config file or if other HDS packages are updated.
 
-The documentation is written as md/mdx files in the `docs/` folder. Docz doesn't care for the subfolders, but for the sake of clarity, the folder structure should mirror the menu hierarchy. Once you create a new markdown file under `docs` it will be added in the documentation automatically (given it's valid of course).
+## Writing documentation
 
-In addition to the markdown, the file contains a frontmatter header that will be used to give the page it's settings (see [Document settings](https://www.docz.site/docs/document-settings)).
+The documentation is written as `.mdx` files in the `docs/` folder. To keep things tidy, the folder structure should always mirror the site menu hierarchy.
 
-[Example page documentation file](examples/page.mdx)
+### General guidelines
+TODO
 
-[Example component documentation file](examples/component.mdx)
+### Using example page templates
 
-### App configuration
+HDS offers example page templates for most common pages such as component and design token documentation. If an example template is available for the page you are writing, it should be used. Example templates include basic title structure and general guidelines for content for each section. Currently available example template pages are:
+- [Component page template](examples/component.mdx)
+- [Design token page template](examples/design_token.mdx)
+- [General page template](examples/page.mdx)
+
+### Adding new pages
+
+To add new pages to documentation, simply add a new `.mdx` under the `docs/` folder inside a corresponding menu category. For example, if you are adding documentation for a new component, create a `<component name>.mdx` file to `docs/components/` folder. It is recommended to use example page templates provided in `site/examples/` folder.
+
+All docz pages should include a following frontmatter settings header at the top of the file:
+```
+---
+name: <COMPONENT_NAME>
+menu: Components
+route: /components/<COMPONENT_NAME>
+---
+```
+`name` specifies the page name shown in the browser. 
+`menu` specifies the category page is under in the menu hierarchy. 
+`route` specifies the URL format of the page. It should follow the naming of the category the page belongs to.
+For full documentation about document settings, refer to [Docz documentation - Document settings](https://www.docz.site/docs/document-settings).
+
+### Adding new categories
+
+Generally new pages will be added to the documentation page automatically without restarting the development server. However, if you are adding a completely new category you need to add it to the `doczrc.js` configuration file and build the site package again. For more info on how to configure docz, refer to [Docz documentation - Project configuration](https://www.docz.site/docs/project-configuration).
+
+## App configuration
 
 Docz configuration is handled via the [`doczrc.js`](doczrc.js). Follow the [Project Configuration reference](https://www.docz.site/docs/project-configuration).
 
-### Troubleshooting
+## Troubleshooting
 
-* Compiling error when running `yarn start`
-
-    ```
-    ERROR #98123 WEBPACK
-
-    Generating development JavaScript bundle failed
-
-    Failed to load config "react-app" to extend from.
-    Referenced from: BaseConfig
-    
-    File: .cache/app.js
-    ```
+* Most compiling errors when running `yarn start`
   
     Try running the following in the project root `rm -rf node_modules/ yarn.lock && yarn && yarn build && cd site && yarn start`
-
 
 * Error after running `yarn start` and opening http://localhost:3000/
 

--- a/site/docs/contributing.mdx
+++ b/site/docs/contributing.mdx
@@ -84,10 +84,10 @@ _Coming soon!_
 
 ### Cloning repository and setting up local environment
 
-<p>When contributing for documentation, it is recommended to set up a local development environment. This allows you to view changes you make in real time. Refer to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site#setting-up-local-development-environment" external>site project GitHub README</Link> for easy instructions how to set up the local development envinroment.</p>
+<p>When contributing for documentation, it is recommended to set up a local development environment. This allows you to view changes you make in real time. Refer to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site#setting-up-local-development-environment" external>site project GitHub README</Link> for easy instructions how to set up the local development environment.</p>
 
 ### Guidelines for writing documentation
 
-<p>After the local deveopment environment is set up, editing documentation and adding new pages is simple. Refer to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site#writing-documentation" external>site project GitHub README</Link> for general documentation guidelines and instructions on how to create new pages and categories.</p>
+<p>After the local development environment is set up, editing documentation and adding new pages is simple. Refer to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site#writing-documentation" external>site project GitHub README</Link> for general documentation guidelines and instructions on how to create new pages and categories.</p>
 
 

--- a/site/docs/contributing.mdx
+++ b/site/docs/contributing.mdx
@@ -82,18 +82,12 @@ _Coming soon!_
 
 ## Documentation
 
-When contributing for documentation, there are a couple of ways of doing it
+### Cloning repository and setting up local environment
 
-### Editing pages directly in GitHub website
-
-The easiest way to edit a page is with the Edit this page on Github link that appears at the bottom of every page on the site. The link opens the specific Github page where you can edit the content and propose the change with a pull request.
-
-### Forking repository and setting up local environment
-
-<p>If you are planning regular or more comprehensive content updates, you will want to fork the repository and install some of the tools we use to build the website. This will create an easier workflow for you long term. Follow README in <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site" external>documentation site package</Link> to get you started setting up local development environment.</p>
+<p>When contributing for documentation, it is recommended to set up a local development environment. This allows you to view changes you make in real time. Refer to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site#setting-up-local-development-environment" external>site project GitHub README</Link> for easy instructions how to set up the local development envinroment.</p>
 
 ### Guidelines for writing documentation
 
-_Coming soon!_
+<p>After the local deveopment environment is set up, editing documentation and adding new pages is simple. Refer to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/site#writing-documentation" external>site project GitHub README</Link> for general documentation guidelines and instructions on how to create new pages and categories.</p>
 
 

--- a/site/examples/component.mdx
+++ b/site/examples/component.mdx
@@ -4,25 +4,118 @@ menu: Components
 route: /components/<COMPONENT_NAME>
 ---
 
+<!---
+Import all the needed components from HDS libraries.
+-->
+import { <COMPONENT_NAME> } from "hds-react";
+
+<!---
+Import documentation specific components. You can view what is available in /site/src/components/ folder.
+-->
+import LargeParagraph from "../../src/components/LargeParagraph";
+
 # <COMPONENT_NAME>
 
-<DESCRIPTION>
+<LargeParagraph>
+    <!---
+    With a couple of sentences, describe the component and its main use cases.
+    -->
+</LargeParagraph>
+
+<!---
+If you want to add more introductory content, you can do that below LargeParagraph section. Keep this relatively short and simple.
+-->
+
+## Principles
+
+<!---
+Principles section lists the most important fundamentals about using the component. Generally, HDS documentation tends not to list basic level usability principles in component documentation. Instead, try to provide concise principles on how to and how not to use the component in real world user interfaces. A good starting point is to check other components' documentation for examples.
+
+Principles are listed as separate bullet points. You may bold part of the sentences to highlight the most important principles.
+- <ADD PRINCIPLE HERE>
+- <ADD PRINCIPLE HERE>
+-->
 
 ## Accessibility
+<!---
+Accessibility section lists the most important principles related to accessibility. A good rule of thumb is that every principle in this section should have a point of reference in WCAG 2.1 documentation and provide a link to that reference. If you do not have experience about accessibility, you can contact the HDS team and we will guide you forward.
 
-## How to use
+Accessibility principles are listed as separate bullet points. You may bold part of the sentences to highlight the most important principles.
+- <ADD ACCESSIBILITY PRINCIPLE HERE>
+- <ADD ACCESSIBILITY PRINCIPLE HERE>
+-->
 
-## <COMPONENT_VARIANT>
+## Usage and variations
 
-## <COMPONENT_VARIANT2>
+<!---
+In the following subchapters, list all notable variants of the component. For example, a button component includes variants such as Primary, Secondary, Supplementary, Icon, Small and Utility.
+-->
+
+### <COMPONENT_VARIANT>
+
+<!---
+Add a short description about the variant. What it is and when it should be used over other variants? Keep this relatively short, maximum of 5 sentences.
+-->
+
+<Playground>
+    <!---
+    Add React code here to provide interactive examples of the component variant.
+    -->
+</Playground>
+
+##### Core:
+```html
+<!---
+Add HTML (HDS Core package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
+
+Note! This section should be left out if this component is not included in the Core package.
+-->
+```
+
+##### React:
+```tsx
+<!---
+Add React (HDS React package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
+-->
+```
+
+### <COMPONENT_VARIANT2>
+
+<!---
+Add a short description about the variant. What it is and when it should be used over other variants? Keep this relatively short, maximum of 5 sentences.
+-->
+
+<Playground>
+    <!---
+    Add React code here to provide interactive examples of the component variant.
+    -->
+</Playground>
+
+##### Core:
+```html
+<!---
+Add HTML (HDS Core package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
+
+Note! This section should be left out if this component is not included in the Core package.
+-->
+```
+
+##### React:
+```tsx
+<!---
+Add React (HDS React package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
+-->
+```
 
 ## Demos & API
 
 ### Core
 
-[Link to core storybook](<LINK>)
+[<COMPONENT_NAME> in hds-core](/storybook/core/?path=/story/<COMPONENT_PATH>)
 
 ### React
 
-[Link to react storybook](<LINK>)
+[<COMPONENT_NAME> in hds-react](/storybook/react/?path=/story/<COMPONENT_PATH>)
+
+[<COMPONENT_NAME> API](/storybook/react/?path=/docs/<COMPONENT_PATH>)
 

--- a/site/examples/design_token.mdx
+++ b/site/examples/design_token.mdx
@@ -1,0 +1,70 @@
+---
+name: <COMPONENT_NAME>
+menu: Components
+route: /components/<COMPONENT_NAME>
+---
+
+<!---
+Import all the needed components from HDS libraries.
+-->
+import { <COMPONENT_NAME> } from "hds-react";
+
+<!---
+Import documentation specific components. You can view what is available in /site/src/components/ folder.
+-->
+import LargeParagraph from "../../src/components/LargeParagraph";
+
+# <TOKEN_NAME>
+
+<LargeParagraph>
+    <!---
+    With a couple of sentences, describe what this set of tokens are used for. 
+    -->
+</LargeParagraph>
+
+<!---
+If you want to add more introductory content, you can do that below LargeParagraph section. Keep this relatively short and simple.
+-->
+
+## Principles
+
+<!---
+Principles section lists the most important fundamentals about using the set of tokens. List cases where the correct usage of this set of tokens is important. A good starting point is to check other tokens' documentation for examples.
+
+Principles are listed as separate bullet points. You may bold part of the sentences to highlight the most important principles.
+- <ADD PRINCIPLE HERE>
+- <ADD PRINCIPLE HERE>
+-->
+
+## Accessibility
+<!---
+Accessibility section lists the most important principles related to accessibility. A good rule of thumb is that every principle in this section should have a point of reference in WCAG 2.1 documentation and provide a link to that reference. If you do not have experience about accessibility, you can contact the HDS team and we will guide you forward.
+
+If there are no accessibility principles related to this set of tokens, this section can be omitted.
+
+Accessibility principles are listed as separate bullet points. You may bold part of the sentences to highlight the most important principles.
+- <ADD ACCESSIBILITY PRINCIPLE HERE>
+- <ADD ACCESSIBILITY PRINCIPLE HERE>
+-->
+
+## Usage
+
+<!---
+In this section, aim to list all subsets of this token set. Provide a short definition for each subset. What are the tokens for? When this set should be used over others? 
+
+The recommended way to list all the subsets is to use bullet points. See other design token pages for reference.
+- <ADD A DESCRIPTION OF A TOKEN SUBSET HERE>
+- <ADD A DESCRIPTION OF A TOKEN SUBSET HERE>
+
+This section can also include other rules or tips on using this set of tokens. These rules often include 
+-->
+
+## Tokens
+
+<!---
+In this section, list all tokens of the set in a table format.
+-->
+
+CSS                   | SASS                  | token value   | Example                            |
+--------------------- | --------------------- | ---------     | -----------------------------------|
+CSS token name        | SASS token name       | token value   | If applicable, token example       |

--- a/site/examples/page.mdx
+++ b/site/examples/page.mdx
@@ -1,11 +1,48 @@
 ---
 name: Example page
-route: /doc-example
-menu: Examples
+menu: Example category
+route: /page
 ---
+<!---
+With the above settings, page name will be "Example page", its path will be hds.hel.fi/page and it will be a subitem of the "Example category" in the site navigation.
+-->
 
-# Example page
+<!---
+Import all the needed components from HDS libraries.
+-->
+import { <COMPONENT_NAME> } from "hds-react";
 
-Hello, I'm an example of a mdx file!
+<!---
+Import documentation specific components. You can view what is available in /site/src/components/ folder.
+-->
+import LargeParagraph from "../../src/components/LargeParagraph";
 
-Here the page's name is _Example page_, it's path will be site-url/_doc-example_ and it will be a subitem of the _Examples_ menu item in the site navigation.
+# <PAGE_NAME>
+
+<LargeParagraph>
+    <!---
+    With a couple of sentences, describe the page content and its meaning for the reader.
+    -->
+</LargeParagraph>
+
+<!---
+If you want to add more introductory content, you can do that below LargeParagraph section. Keep this relatively short and simple.
+-->
+
+## Header level 2
+
+<!---
+Add your content here. Note, to comply with site accessibility requirements, do not skip heading levels. After header level 2, the next should be header level 3, and so on.
+-->
+
+### Header level 3
+
+<!---
+Add your content here. Note, to comply with site accessibility requirements, do not skip heading levels. After header level 2, the next should be header level 3, and so on.
+-->
+
+#### Header level 4
+
+<!---
+Add your content here. Note, to comply with site accessibility requirements, do not skip heading levels. After header level 2, the next should be header level 3, and so on.
+-->


### PR DESCRIPTION
## Description
This PR adds documentation guidelines and basic instructions to site package README. The easiest way to review these changes is to browse the README directly in GitHub: https://github.com/City-of-Helsinki/helsinki-design-system/tree/content/documentation-guidelines-and-readme/site

Apart from the README, only very minor changes were done to the Contribution page (mainly linking to the new README).

## How Has This Been Tested?
This has been tested by running the documentation site locally. README has been checked in GitHub directly.
