### PR TITLE
[Fix] Reference equality comparison in Dropdown multiselect mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### React
+#### Fixed
+- [Dropdown] Reference equality comparison in multiselect mode
+    - Previously a selected option would be labeled as selected only if the selected items contained the exact same object. This could result in unexpected behavior for instance when a multiselect dropdown was used as a controlled component and its options list was not static.
+
 
 ## [0.12.1] - August 19, 2020
 ### Core

--- a/packages/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.stories.tsx
@@ -4,17 +4,21 @@ import { boolean, number, text, withKnobs } from '@storybook/addon-knobs';
 import Dropdown from './Dropdown';
 import Button from '../button/Button';
 
-const options = [
-  { label: 'Plutonium' },
-  { label: 'Americium' },
-  { label: 'Copernicium' },
-  { label: 'Nihonium' },
-  { label: 'Flerovium' },
-  { label: 'Moscovium' },
-  { label: 'Livermorium' },
-  { label: 'Tennessine' },
-  { label: 'Oganesson' },
-];
+function getOptions() {
+  return [
+    { label: 'Plutonium' },
+    { label: 'Americium' },
+    { label: 'Copernicium' },
+    { label: 'Nihonium' },
+    { label: 'Flerovium' },
+    { label: 'Moscovium' },
+    { label: 'Livermorium' },
+    { label: 'Tennessine' },
+    { label: 'Oganesson' },
+  ];
+}
+
+const options = getOptions();
 
 export default {
   component: Dropdown,
@@ -73,6 +77,12 @@ export const Multiselect = () => (
 Multiselect.storyName = 'With multiselect';
 
 export const Controlled = () => {
+  // Initialize options within the render function to ensure that they
+  // are created a new on every render. This way this test case better
+  // ensures that the equality checks the Dropdown component does do not
+  // rely on reference equality.
+  const controlledOptions = getOptions();
+
   const [selectedItem, setSelectedItem] = useState(null);
   const [multiselectSelectedItem, setMultiselectSelectedItem] = useState(null);
 
@@ -85,7 +95,7 @@ export const Controlled = () => {
       {['Dropdown 1', 'Dropdown 2'].map((label) => (
         <Dropdown
           key={label}
-          options={options}
+          options={controlledOptions}
           placeholder="Placeholder"
           label={label}
           onChange={handleSelectedItemChange}
@@ -99,7 +109,7 @@ export const Controlled = () => {
       {['Multiselect 1', 'Multiselect 2'].map((label) => (
         <Dropdown
           key={label}
-          options={options}
+          options={controlledOptions}
           placeholder="Placeholder"
           label={label}
           multiselect

--- a/packages/react/src/components/dropdown/Dropdown.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.tsx
@@ -145,6 +145,15 @@ const Wrapper = ({ filterable, getComboboxProps, children }: WrapperProps) =>
     <div className={styles.wrapper}>{children}</div>
   );
 
+/**
+ * Helper that checks if an item is in the selected options
+ * @param selectedOptions Currently selected options
+ * @param item            Item we want to check
+ */
+function getIsInSelectedOptions(selectedOptions: OptionType[], item: OptionType): boolean {
+  return selectedOptions.some((selectedOption: OptionType) => isEqual(selectedOption, item));
+}
+
 const Dropdown = ({
   circularNavigation = false,
   className,
@@ -347,7 +356,7 @@ const Dropdown = ({
         {isOpen &&
           menuOptions.map((item, index) => {
             const optionLabel = item[optionLabelField];
-            const selected = multiselect ? selectedItems.includes(item) : isEqual(selectedItem, item);
+            const selected = multiselect ? getIsInSelectedOptions(selectedItems, item) : isEqual(selectedItem, item);
             const optionDisabled = typeof isOptionDisabled === 'function' ? isOptionDisabled(item, index) : false;
 
             return (


### PR DESCRIPTION
## Description

Instead of reference equality comparison we use the same `isEqual` helper that's used in single select mode. This implementation uses the [`.some()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) method which traverses the array until it finds a match.

## Related Issue

Closes #228

## Motivation and Context

This change allows the `Dropdown` to be used as a controlled component in `multiselect` mode with "variable" options list.

## How Has This Been Tested?

I changed the current "controlled Dropdown" story so that it broke, applied the fix and tested the behaviour using the story.
