### PR TITLE
[Fix] Cast style value as any

### DIFF
--- a/packages/react/src/components/navigation/navigation-search/NavigationSearch.tsx
+++ b/packages/react/src/components/navigation/navigation-search/NavigationSearch.tsx
@@ -88,7 +88,11 @@ export const NavigationSearch = ({
             onBlur={handleBlur}
             onFocus={onFocus}
           />
-          {transition((values, item) => item && <AnimatedSearchIcon style={values} className={styles.inputIcon} />)}
+          {transition(
+            // there is an issue with react-spring -rc3 and a new version of @types/react: https://github.com/react-spring/react-spring/issues/1102
+            // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+            (values, item) => item && <AnimatedSearchIcon style={values as any} className={styles.inputIcon} />,
+          )}
         </>
       )}
       <button

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -235,7 +235,9 @@ export const Notification = ({
   return (
     <ConditionalVisuallyHidden visuallyHidden={invisible}>
       <animated.div
-        style={{ ...notificationTransition, ...style }}
+        // there is an issue with react-spring -rc3 and a new version of @types/react: https://github.com/react-spring/react-spring/issues/1102
+        // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+        style={{ ...(style as any), ...notificationTransition }}
         className={classNames(
           styles[position],
           styles.notification,


### PR DESCRIPTION
There is [an issue](https://github.com/react-spring/react-spring/issues/1102) with react-spring v9-rc3 and newer versions of `@types/react` causing TS compile-time errors for the style prop.

Changes in this PR temporarily casts the prop value as `any` until the issue is fixed.