### PR TITLE
[Fix] Documentation site search placeholder and favicon download

### DIFF
--- a/site/docs/visual_elements/logo.mdx
+++ b/site/docs/visual_elements/logo.mdx
@@ -31,7 +31,7 @@ In other parts of the page, the logo should be used sparingly.
 You can download the logo package provided by Helsinki Visual Guidelines [here](https://brand.hel.fi/wp-content/uploads/2018/11/helsinki_tunnus_paketti.zip).
 
 ### Language versions
-There are two language versions available in HDS:
+There are two language versions available in HDS (you may download the logo files by clicking their images below):
 
 Language version                                                                                                             | File name         | Usage                                         |
 ---------------------------------------------------------------------------------------------------------------------------- |-------------------|-----------------------------------------------|
@@ -39,12 +39,11 @@ Language version                                                                
 [![Helsinki logo sv](../../static/assets/logo/helsinki-sv.svg)](../../static/assets/logo/helsinki-sv.svg "Helsinki logo sv") | helsinki-sv.svg   | pages in Swedish, Danish and Norwegian                        |
 
 ### Favicon
-The favicon of City of Helsinki digital services is a minimised version of the Helsinki logo:
+The favicon of City of Helsinki digital services is a minimised version of the Helsinki logo (you may download the favicon by clicking the image below):
 
-Favicon                                                                                  | File name           |
----------------------------------------------------------------------------------------- | ------------------- |
-<Image src="../../static/assets/logo/favicon.ico" alt="Helsinki favicon" width="16px" /> | favicon.ico         | 
-
+Favicon                                                                                                                          | File name           |
+-------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+[<Image src="../../static/assets/logo/favicon.ico" alt="Helsinki favicon" width="16px" />](../../static/assets/logo/favicon.ico) | favicon.ico         | 
 
 
 ### Colour

--- a/site/src/gatsby-theme-docz/components/Sidebar/index.js
+++ b/site/src/gatsby-theme-docz/components/Sidebar/index.js
@@ -63,7 +63,7 @@ export const Sidebar = React.forwardRef((props, ref) => {
             </div>
           </Link>
         </div>
-        <NavSearch placeholder="Type to search..." value={query} onChange={handleChange} />
+        <NavSearch placeholder="Type to search topics" value={query} onChange={handleChange} />
         {menus &&
           menus.map((menu) => {
             if (!menu.route) return <NavGroup key={menu.id} item={menu} sidebarRef={ref} />;


### PR DESCRIPTION
## Description

This PR fixes to minor issues in the documentation site:
- Search bar placeholder updated to be more clear about what is being searched
- Made favicon downloadable from the Visual assets page

## How Has This Been Tested?
This has been tested by running documentation locally.
