### PR TITLE
[Content] Colour accessibility examples

### DIFF
--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -98,45 +98,45 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 
 ### Brand colour combinations
 
-| Brand Colour      | Text Colour   | Colour contrast   | Example           |
-| ----------------- | ------------- | ----------------- | ----------------- |
-| **Engel**         | black 90      | AAA (14,3 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-engel)">AAA</ColorContrast> |
-| **Hopea**         | black 90      | AAA (13,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
-| **Bussi**         | white         | AAA (12 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
-| **Kesä**          | black 90      | AAA (11,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-summer)">AAA</ColorContrast> |
-| **Sumu**          | black 90      | AAA (10 : 1)      | <ColorContrast color="var(--color-black-90)" background="var(--color-fog)">AAA</ColorContrast> |
-| **Kupari**        | black 90      | AAA (9,4 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-copper)">AAA</ColorContrast> |
-| **Suomenlinna**   | black 90      | AAA (9,1 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
-| **Kulta**         | black 90      | AAA (7,1 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
-| **Tiili**         | white         | AA (6,1 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
-| **Metro**         | black 90      | AA (5,2 : 1)      | <ColorContrast color="var(--color-black-90)" background="var(--color-metro)">AA</ColorContrast> |
-| **Vaakuna**       | white         | AA (5 : 1)        | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
-| **Spåra**         | white         | AA for large text (4 : 1) | <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
+| Brand Colour      | Text Colour   | Colour contrast       | Example           |
+| ----------------- | ------------- | --------------------- | ----------------- |
+| **Engel**         | black 90      | **AAA** `14,3 : 1`  | <ColorContrast color="var(--color-black-90)" background="var(--color-engel)">AAA</ColorContrast> |
+| **Hopea**         | black 90      | **AAA** `13,1 : 1`  | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
+| **Bussi**         | white         | **AAA** `12 : 1`    | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
+| **Kesä**          | black 90      | **AAA** `11,1 : 1`  | <ColorContrast color="var(--color-black-90)" background="var(--color-summer)">AAA</ColorContrast> |
+| **Sumu**          | black 90      | **AAA** `10 : 1`    | <ColorContrast color="var(--color-black-90)" background="var(--color-fog)">AAA</ColorContrast> |
+| **Kupari**        | black 90      | **AAA** `9,4 : 1`   | <ColorContrast color="var(--color-black-90)" background="var(--color-copper)">AAA</ColorContrast> |
+| **Suomenlinna**   | black 90      | **AAA** `9,1 : 1`   | <ColorContrast color="var(--color-black-90)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
+| **Kulta**         | black 90      | **AAA** `7,1 : 1`   | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
+| **Tiili**         | white         | **AA** (AAA for large text) `6,1 : 1` | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
+| **Metro**         | black 90      | **AA** (AAA for large text) `5,2 : 1` | <ColorContrast color="var(--color-black-90)" background="var(--color-metro)">AA</ColorContrast> |
+| **Vaakuna**       | white         | **AA** (AAA for large text) `5 : 1`   | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
+| **Spåra**         | white         | <p style="margin:0; color: var(--color-black-60);">AA for large text `4 : 1`</p>| <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
 
 **For text and other informative elements on white background** it is recommended to only use following brand colours:
 
 | Brand Colour  | Colour contrast   | Example           |
 | --------------| ----------------- | ----------------- |
-| **Bussi**     | AAA (12 : 1)   | <p style="font-size: var(--fontsize-body-l); color:var(--color-bus); margin: var(--spacing-3-xs);">AAA</p> |
-| **Tiili**     | AA (6,1 : 1)     | <p style="font-size: var(--fontsize-body-l); color: var(--color-brick); margin: var(--spacing-3-xs);">AA</p> |
-| **Vaakuna**   | AA (5 : 1)     | <p style="font-size: var(--fontsize-body-l); color: var(--color-coat-of-arms-blue); margin: var(--spacing-3-xs);">AA</p> | 
-| **Spåra**     | AA for large text (4 : 1)  | <p style="font-size: var(--fontsize-body-l); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
-| **Metro**     | AA for large text (3,3 : 1)  | <p style="font-size: var(--fontsize-body-l); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
+| **Bussi**     | **AAA** `12 : 1`| <p style="font-size: var(--fontsize-body-l); color:var(--color-bus); margin: var(--spacing-3-xs);">AAA</p> |
+| **Tiili**     | **AA** (AAA for large text) `6,1 : 1` | <p style="font-size: var(--fontsize-body-l); color: var(--color-brick); margin: var(--spacing-3-xs);">AA</p> |
+| **Vaakuna**   | **AA** (AAA for large text) `5 : 1`   | <p style="font-size: var(--fontsize-body-l); color: var(--color-coat-of-arms-blue); margin: var(--spacing-3-xs);">AA</p> | 
+| **Spåra**     | <p style="margin:0; color: var(--color-black-60);">AA for large text `4 : 1`</p>      | <p style="font-size: var(--fontsize-body-l); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
+| **Metro**     | <p style="margin:0; color: var(--color-black-60);">AA for large text `3,3 : 1`</p>  | <p style="font-size: var(--fontsize-body-l); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
 
 ### Grayscale combinations 
 
-| Brand Colour  | Text Colour   | Colour contrast   | Example           | Text on white
+| Brand Colour  | Text Colour   | Colour contrast   | As background     | As text on white  |
 | --------------| ------------- | ----------------- | ----------------- | ----------------- |
-| **Black**     | white         | AAA (21 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-black)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black); margin: var(--spacing-3-xs);">AAA</p> |
-| **Black 90**  | white         | AAA (17,4 : 1)    | <ColorContrast color="var(--color-white)" background="var(--color-black-90)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-90); margin: var(--spacing-3-xs);">AAA</p> |
-| **Black 80**  | white         | AAA (12,6 : 1)    | <ColorContrast color="var(--color-white)" background="var(--color-black-80)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-80); margin: var(--spacing-3-xs);">AAA</p> |
-| **Black 70**  | white         | AAA (8,6 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-black-70)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-70); margin: var(--spacing-3-xs);">AAA</p> |
-| **Black 60**  | white         | AA (5,7 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-black-60)">AA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-60); margin: var(--spacing-3-xs);">AA</p> |
-| **Black 50**  | black 90      | AA for large text (4,3 : 1 / 4 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-black-50)"><IconError/></ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-50); margin: var(--spacing-3-xs);"><IconError/></p> |
-| **Black 40**  | black 90      | AA (6,1 : 1)      | <ColorContrast color="var(--color-black-90)" background="var(--color-black-40)">AA</ColorContrast> | |
-| **Black 30**  | black 90      | AAA (10,9 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-30)">AAA</ColorContrast> | |
-| **Black 20**  | black 90      | AAA (13,8 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-20)">AAA</ColorContrast> | |
-| **Black 10**  | black 90      | AAA (15,6 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-10)">AAA</ColorContrast> | |
+| **Black**     | white         | **AAA** `21 : 1`      | <ColorContrast color="var(--color-white)" background="var(--color-black)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 90**  | white         | **AAA** `17,4 : 1`    | <ColorContrast color="var(--color-white)" background="var(--color-black-90)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-90); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 80**  | white         | **AAA** `12,6 : 1`    | <ColorContrast color="var(--color-white)" background="var(--color-black-80)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-80); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 70**  | white         | **AAA** `8,6 : 1`     | <ColorContrast color="var(--color-white)" background="var(--color-black-70)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-70); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 60**  | white         | **AA** (AAA for large text) `5,7 : 1`     | <ColorContrast color="var(--color-white)" background="var(--color-black-60)">AA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-60); margin: var(--spacing-3-xs);">AA</p> |
+| **Black 50**  | black 90      | <p style="margin:0; color: var(--color-black-60);">AA for large text `4,3 : 1`/`4 : 1`</p>    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-50)"><IconError/></ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-50); margin: var(--spacing-3-xs);"><IconError/></p> |
+| **Black 40**  | black 90      | **AA** (AAA for large text) `6,1 : 1`     | <ColorContrast color="var(--color-black-90)" background="var(--color-black-40)">AA</ColorContrast> | |
+| **Black 30**  | black 90      | **AAA** `10,9 : 1`    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-30)">AAA</ColorContrast> | |
+| **Black 20**  | black 90      | **AAA** `13,8 : 1`    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-20)">AAA</ColorContrast> | |
+| **Black 10**  | black 90      | **AAA** `15,6 : 1`    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-10)">AAA</ColorContrast> | |
 
 ## Tokens
 The colour tokens are provided as CSS and SASS variables in [hds-design-tokens](https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/design-tokens).

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -94,35 +94,47 @@ Here you can find recommended colour combinatios for different brand colours and
 
 - **AA** and **AAA** means you can safely use the color combination on all text sizes
 - **AA for large text** means the text size should be at least 18 pt for regular weight or 14 pt for bold weight
+- **Black 90** is the default text colour in HDS
 
 | Brand Colour      | Text Colour   | Colour contrast       | Example           |
 | ----------------- | ------------- | --------------------- | ----------------- |
-| **Engel**         | black         | AAA (14,26 : 1)   | <ColorContrast color="var(--color-black)" background="var(--color-engel)">AAA</ColorContrast> |
-| **Hopea**         | black         | AAA (13,08 : 1)   | <ColorContrast color="var(--color-black)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
-| **Bussi**         | white         | AAA (11,98 : 1)   | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
-| **Kesä**          | black         | AAA (11,08 : 1)   | <ColorContrast color="var(--color-black)" background="var(--color-summer)">AAA</ColorContrast> |
-| **Sumu**          | black         | AAA (9,99 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-fog)">AAA</ColorContrast> |
-| **Kupari**        | black         | AAA (9,37 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-copper)">AAA</ColorContrast> |
-| **Suomenlinna**   | black         | AAA (9,09 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
-| **Kulta**         | black         | AAA (7,13 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
-| **Tiili**         | white         | AA (6,06 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
-| **Metro**         | black         | AA (5,23 : 1)     | <ColorContrast color="var(--color-black)" background="var(--color-metro)">AA</ColorContrast> |
-| **Vaakuna**       | white         | AA (4,97 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
-| **Spåra**         | white         | AA for large text (4,04 : 1) | <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
+| **Engel**         | black 90      | AAA (14,3 : 1)   | <ColorContrast color="var(--color-black-90)" background="var(--color-engel)">AAA</ColorContrast> |
+| **Hopea**         | black 90      | AAA (13,1 : 1)   | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
+| **Bussi**         | white         | AAA (12 : 1)   | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
+| **Kesä**          | black 90      | AAA (11,1 : 1)   | <ColorContrast color="var(--color-black-90)" background="var(--color-summer)">AAA</ColorContrast> |
+| **Sumu**          | black 90      | AAA (10 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-fog)">AAA</ColorContrast> |
+| **Kupari**        | black 90      | AAA (9,4 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-copper)">AAA</ColorContrast> |
+| **Suomenlinna**   | black 90      | AAA (9,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
+| **Kulta**         | black 90      | AAA (7,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
+| **Tiili**         | white         | AA (6,1 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
+| **Metro**         | black 90      | AA (5,2 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-metro)">AA</ColorContrast> |
+| **Vaakuna**       | white         | AA (5 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
+| **Spåra**         | white         | AA for large text (4 : 1) | <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
 
 For text and other informative elements on white background it is recommended to only use following brand colours:
 
 | Brand Colour  | Colour contrast   | Example           |
 | --------------| ----------------- | ----------------- |
-| **Bussi**     | AAA (11,98 : 1)   | <p style="font-size: var(--fontsize-body-xl); color:var(--color-bus); margin: var(--spacing-3-xs);">AAA</p> |
-| **Tiili**     | AA (6,06 : 1)     | <p style="font-size: var(--fontsize-body-xl); color: var(--color-brick); margin: var(--spacing-3-xs);">AA</p> |
-| **Vaakuna**   | AA (4,97 : 1)     | <p style="font-size: var(--fontsize-body-xl); color: var(--color-coat-of-arms-blue); margin: var(--spacing-3-xs);">AA</p> | 
-| **Spåra**     | AA for large text (4,04 : 1)  | <p style="font-size: var(--fontsize-body-xl); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
-| **Metro**     | AA for large text (3,34 : 1)  | <p style="font-size: var(--fontsize-body-xl); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
+| **Bussi**     | AAA (12 : 1)   | <p style="font-size: var(--fontsize-body-l); color:var(--color-bus); margin: var(--spacing-3-xs);">AAA</p> |
+| **Tiili**     | AA (6,1 : 1)     | <p style="font-size: var(--fontsize-body-l); color: var(--color-brick); margin: var(--spacing-3-xs);">AA</p> |
+| **Vaakuna**   | AA (5 : 1)     | <p style="font-size: var(--fontsize-body-l); color: var(--color-coat-of-arms-blue); margin: var(--spacing-3-xs);">AA</p> | 
+| **Spåra**     | AA for large text (4 : 1)  | <p style="font-size: var(--fontsize-body-l); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
+| **Metro**     | AA for large text (3,3 : 1)  | <p style="font-size: var(--fontsize-body-l); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
 
+Recommended combinations for grayscale colours: 
 
-
-
+| Brand Colour  | Text Colour   | Colour contrast   | Example           | Text on white
+| --------------| ------------- | ----------------- | ----------------- | ----------------- |
+| **Black**     | white         | AAA (21 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-black)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 90**  | white         | AAA (17,4 : 1)    | <ColorContrast color="var(--color-white)" background="var(--color-black-90)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-90); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 80**  | white         | AAA (12,6 : 1)    | <ColorContrast color="var(--color-white)" background="var(--color-black-80)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-80); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 70**  | white         | AAA (8,6 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-black-70)">AAA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-70); margin: var(--spacing-3-xs);">AAA</p> |
+| **Black 60**  | white         | AA (5,7 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-black-60)">AA</ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-60); margin: var(--spacing-3-xs);">AA</p> |
+| **Black 50**  | black 90      | AA for large text (4,3 : 1 / 4 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-black-50)"><IconError/></ColorContrast> | <p style="font-size: var(--fontsize-body-l); color:var(--color-black-50); margin: var(--spacing-3-xs);"><IconError/></p> |
+| **Black 40**  | black 90      | AA (6,1 : 1)      | <ColorContrast color="var(--color-black-90)" background="var(--color-black-40)">AA</ColorContrast> | |
+| **Black 30**  | black 90      | AAA (10,9 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-30)">AAA</ColorContrast> | |
+| **Black 20**  | black 90      | AAA (13,8 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-20)">AAA</ColorContrast> | |
+| **Black 10**  | black 90      | AAA (15,6 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-black-10)">AAA</ColorContrast> | |
 
 ## Tokens
 The colour tokens are provided as CSS and SASS variables in [hds-design-tokens](https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/design-tokens).

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -7,6 +7,7 @@ route: /design-tokens/colour
 import LargeParagraph from "../../src/components/LargeParagraph";
 import Colors from "../../src/components/Colors";
 import ColorBox from "../../src/components/ColorBox";
+import ColorContrast from "../../src/components/ColorContrast";
 import Example from "../../src/components/Example";
 import Link from "../../src/components/Link";
 
@@ -85,6 +86,17 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 | black                                  |  90                                       | 80                                        | 70                                        | 60                                        | 50                                        | 40                                        | 30                                        | 20                                        | 10                                        | 5                                        | white                                   |
 | -------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ----------------------------------------- | ---------------------------------------- | --------------------------------------- |
 | <ColorBox color="var(--color-black)"/> | <ColorBox color="var(--color-black-90)"/> | <ColorBox color="var(--color-black-80)"/> | <ColorBox color="var(--color-black-70)"/> | <ColorBox color="var(--color-black-60)"/> | <ColorBox color="var(--color-black-50)"/> | <ColorBox color="var(--color-black-40)"/> | <ColorBox color="var(--color-black-30)"/> | <ColorBox color="var(--color-black-20)"/> | <ColorBox color="var(--color-black-10)"/> | <ColorBox color="var(--color-black-5)"/> | <ColorBox color="var(--color-white)" /> |
+
+
+## Recommended colour combinations
+Here you can find recommended colours for text and other informative elements on different background colours and their contrast accessibility level
+- **AA** and **AAA** means you can safely use the color combination on all text sizes
+- **AA for large text** means the text size should be at least 18 pt for regular weight or 14 pt for bold weight
+
+
+<ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast>
+
+
 
 
 ## Tokens

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -92,8 +92,8 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 ## Accessible colour combinations
 <p>Here you can find some recommended colour combinations for text and other informative elements. The examples are sorted in order of their contrast ratio. For more examples of accessibile colour combinations, see the <Link href="https://share.goabstract.com/28352b8b-9c51-4346-b249-ff062c5da561" external>Colour accessibility examples - Abstract collection</Link>.</p>
 
-- **AA** and **AAA** means you can safely use the color combination on all text sizes
-- **AA for large text** means the text size should be at least 18 pt for regular weight or 14 pt for bold weight
+- **AA** (contrast ratio at least `4,5 : 1`) and **AAA** (contrast ratio at least `7 : 1`) means you can safely use the color combination on all text sizes
+- **AA for large text** (contrast ratio at least `3 : 1`) means the text size should be at least 18 pt for regular weight or 14 pt for bold weight
 - **Black 90** is the default text colour in HDS
 
 ### Brand colour combinations

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -10,6 +10,8 @@ import ColorBox from "../../src/components/ColorBox";
 import ColorContrast from "../../src/components/ColorContrast";
 import Example from "../../src/components/Example";
 import Link from "../../src/components/Link";
+import { IconError } from 'hds-react';
+
 
 # Colour
 
@@ -20,7 +22,6 @@ import Link from "../../src/components/Link";
 Colour can be used for branding, providing visual hierarchy and giving visual cues for action.
 
 <p>The Helsinki Design system colour tokens are based on the City of Helsinki brand colour palette. More information on using and combining the brand colours in the <Link href="https://brand.hel.fi/en/colours/" external>City of Helsinki Visual Identity Guidelines - Colours</Link>.</p>
-
 
 ## Principles
 - **Use bold colours to attract users attention** to most important content and primary actions.
@@ -57,18 +58,18 @@ Brand colours are used for primary, secondary and tertiary colours. They should 
 
 | Colour name (en)    |  Colour name (fi) | Base colour                                          | Dark 50                                                      | Light 50                                                      | Light 20                                                      | Light 5                                                      |
 | ------------------- | ----------------- | ---------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------|
-| Coat of Arms Blue   |  Vaakuna          | <ColorBox color="var(--color-coat-of-arms-blue)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-dark-50)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-light-50)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-light-20)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-light-5)"/>   |
-| Coat of Arms Gold   |  Kulta            | <ColorBox color="var(--color-coat-of-arms-gold)"/>   | <ColorBox color="var(--color-coat-of-arms-gold-dark-50)"/>   | <ColorBox color="var(--color-coat-of-arms-gold-light-50)"/>   | <ColorBox color="var(--color-coat-of-arms-gold-light-20)"/>   |                                                              |
-| Coat of Arms Silver |  Hopea            | <ColorBox color="var(--color-coat-of-arms-silver)"/> | <ColorBox color="var(--color-coat-of-arms-silver-dark-50)"/> | <ColorBox color="var(--color-coat-of-arms-silver-light-50)"/> | <ColorBox color="var(--color-coat-of-arms-silver-light-20)"/> |                                                              |
-| Brick               |  Tiili            | <ColorBox color="var(--color-brick)"/>               | <ColorBox color="var(--color-brick-dark-50)"/>               | <ColorBox color="var(--color-brick-light-50)"/>               | <ColorBox color="var(--color-brick-light-20)"/>               |                                                              |
-| Bus                 |  Bussi            | <ColorBox color="var(--color-bus)"/>                 | <ColorBox color="var(--color-bus-dark-50)"/>                 | <ColorBox color="var(--color-bus-light-50)"/>                 | <ColorBox color="var(--color-bus-light-20)"/>                 | <ColorBox color="var(--color-bus-light-5)"/>                 |
-| Copper              |  Kupari           | <ColorBox color="var(--color-copper)"/>              | <ColorBox color="var(--color-copper-dark-50)"/>              | <ColorBox color="var(--color-copper-light-50)"/>              | <ColorBox color="var(--color-copper-light-20)"/>              |                                                              |
-| Engel               |  Engel            | <ColorBox color="var(--color-engel)"/>               | <ColorBox color="var(--color-engel-dark-50)"/>               | <ColorBox color="var(--color-engel-light-50)"/>               | <ColorBox color="var(--color-engel-light-20)"/>               |                                                              |
-| Fog                 |  Sumu             | <ColorBox color="var(--color-fog)"/>                 | <ColorBox color="var(--color-fog-dark-50)"/>                 | <ColorBox color="var(--color-fog-light-50)"/>                 | <ColorBox color="var(--color-fog-light-20)"/>                 |                                                              |
-| Metro               |  Metro            | <ColorBox color="var(--color-metro)"/>               | <ColorBox color="var(--color-metro-dark-50)"/>               | <ColorBox color="var(--color-metro-light-50)"/>               | <ColorBox color="var(--color-metro-light-20)"/>               |                                                              |
-| Summer              |  Kesä             | <ColorBox color="var(--color-summer)"/>              | <ColorBox color="var(--color-summer-dark-50)"/>              | <ColorBox color="var(--color-summer-light-50)"/>              | <ColorBox color="var(--color-summer-light-20)"/>              |                                                              |
-| Suomenlinna         |  Suomenlinna      | <ColorBox color="var(--color-suomenlinna)"/>         | <ColorBox color="var(--color-suomenlinna-dark-50)"/>         | <ColorBox color="var(--color-suomenlinna-light-50)"/>         | <ColorBox color="var(--color-suomenlinna-light-20)"/>         |                                                              |
-| Tram                |  Spåra            | <ColorBox color="var(--color-tram)"/>                | <ColorBox color="var(--color-tram-dark-50)"/>                | <ColorBox color="var(--color-tram-light-50)"/>                | <ColorBox color="var(--color-tram-light-20)"/>                |                                                              |
+| Coat of Arms Blue   | Vaakuna           | <ColorBox color="var(--color-coat-of-arms-blue)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-dark-50)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-light-50)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-light-20)"/>   | <ColorBox color="var(--color-coat-of-arms-blue-light-5)"/>   |
+| Coat of Arms Gold   | Kulta             | <ColorBox color="var(--color-coat-of-arms-gold)"/>   | <ColorBox color="var(--color-coat-of-arms-gold-dark-50)"/>   | <ColorBox color="var(--color-coat-of-arms-gold-light-50)"/>   | <ColorBox color="var(--color-coat-of-arms-gold-light-20)"/>   |                                                              |
+| Coat of Arms Silver | Hopea             | <ColorBox color="var(--color-coat-of-arms-silver)"/> | <ColorBox color="var(--color-coat-of-arms-silver-dark-50)"/> | <ColorBox color="var(--color-coat-of-arms-silver-light-50)"/> | <ColorBox color="var(--color-coat-of-arms-silver-light-20)"/> |                                                              |
+| Brick               | Tiili             | <ColorBox color="var(--color-brick)"/>               | <ColorBox color="var(--color-brick-dark-50)"/>               | <ColorBox color="var(--color-brick-light-50)"/>               | <ColorBox color="var(--color-brick-light-20)"/>               |                                                              |
+| Bus                 | Bussi             | <ColorBox color="var(--color-bus)"/>                 | <ColorBox color="var(--color-bus-dark-50)"/>                 | <ColorBox color="var(--color-bus-light-50)"/>                 | <ColorBox color="var(--color-bus-light-20)"/>                 | <ColorBox color="var(--color-bus-light-5)"/>                 |
+| Copper              | Kupari            | <ColorBox color="var(--color-copper)"/>              | <ColorBox color="var(--color-copper-dark-50)"/>              | <ColorBox color="var(--color-copper-light-50)"/>              | <ColorBox color="var(--color-copper-light-20)"/>              |                                                              |
+| Engel               | Engel             | <ColorBox color="var(--color-engel)"/>               | <ColorBox color="var(--color-engel-dark-50)"/>               | <ColorBox color="var(--color-engel-light-50)"/>               | <ColorBox color="var(--color-engel-light-20)"/>               |                                                              |
+| Fog                 | Sumu              | <ColorBox color="var(--color-fog)"/>                 | <ColorBox color="var(--color-fog-dark-50)"/>                 | <ColorBox color="var(--color-fog-light-50)"/>                 | <ColorBox color="var(--color-fog-light-20)"/>                 |                                                              |
+| Metro               | Metro             | <ColorBox color="var(--color-metro)"/>               | <ColorBox color="var(--color-metro-dark-50)"/>               | <ColorBox color="var(--color-metro-light-50)"/>               | <ColorBox color="var(--color-metro-light-20)"/>               |                                                              |
+| Summer              | Kesä              | <ColorBox color="var(--color-summer)"/>              | <ColorBox color="var(--color-summer-dark-50)"/>              | <ColorBox color="var(--color-summer-light-50)"/>              | <ColorBox color="var(--color-summer-light-20)"/>              |                                                              |
+| Suomenlinna         | Suomenlinna       | <ColorBox color="var(--color-suomenlinna)"/>         | <ColorBox color="var(--color-suomenlinna-dark-50)"/>         | <ColorBox color="var(--color-suomenlinna-light-50)"/>         | <ColorBox color="var(--color-suomenlinna-light-20)"/>         |                                                              |
+| Tram                | Spåra             | <ColorBox color="var(--color-tram)"/>                | <ColorBox color="var(--color-tram-dark-50)"/>                | <ColorBox color="var(--color-tram-light-50)"/>                | <ColorBox color="var(--color-tram-light-20)"/>                |                                                              |
 
 
 ### UI colours
@@ -88,13 +89,37 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 | <ColorBox color="var(--color-black)"/> | <ColorBox color="var(--color-black-90)"/> | <ColorBox color="var(--color-black-80)"/> | <ColorBox color="var(--color-black-70)"/> | <ColorBox color="var(--color-black-60)"/> | <ColorBox color="var(--color-black-50)"/> | <ColorBox color="var(--color-black-40)"/> | <ColorBox color="var(--color-black-30)"/> | <ColorBox color="var(--color-black-20)"/> | <ColorBox color="var(--color-black-10)"/> | <ColorBox color="var(--color-black-5)"/> | <ColorBox color="var(--color-white)" /> |
 
 
-## Recommended colour combinations
-Here you can find recommended colours for text and other informative elements on different background colours and their contrast accessibility level
+## Colour contrast accessibility
+Here you can find recommended colour combinatios for different brand colours and text or other informative elements in order of their contrast ratio.
+
 - **AA** and **AAA** means you can safely use the color combination on all text sizes
 - **AA for large text** means the text size should be at least 18 pt for regular weight or 14 pt for bold weight
 
+| Brand Colour      | Text Colour   | Colour contrast       | Example           |
+| ----------------- | ------------- | --------------------- | ----------------- |
+| **Engel**         | black         | AAA (14,26 : 1)   | <ColorContrast color="var(--color-black)" background="var(--color-engel)">AAA</ColorContrast> |
+| **Hopea**         | black         | AAA (13,08 : 1)   | <ColorContrast color="var(--color-black)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
+| **Bussi**         | white         | AAA (11,98 : 1)   | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
+| **Kesä**          | black         | AAA (11,08 : 1)   | <ColorContrast color="var(--color-black)" background="var(--color-summer)">AAA</ColorContrast> |
+| **Sumu**          | black         | AAA (9,99 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-fog)">AAA</ColorContrast> |
+| **Kupari**        | black         | AAA (9,37 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-copper)">AAA</ColorContrast> |
+| **Suomenlinna**   | black         | AAA (9,09 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
+| **Kulta**         | black         | AAA (7,13 : 1)    | <ColorContrast color="var(--color-black)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
+| **Tiili**         | white         | AA (6,06 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
+| **Metro**         | black         | AA (5,23 : 1)     | <ColorContrast color="var(--color-black)" background="var(--color-metro)">AA</ColorContrast> |
+| **Vaakuna**       | white         | AA (4,97 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
+| **Spåra**         | white         | AA for large text (4,04 : 1) | <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
 
-<ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast>
+For text and other informative elements on white background it is recommended to only use following brand colours:
+
+| Brand Colour  | Colour contrast   | Example           |
+| --------------| ----------------- | ----------------- |
+| **Bussi**     | AAA (11,98 : 1)   | <p style="font-size: var(--fontsize-body-xl); color:var(--color-bus); margin: var(--spacing-3-xs);">AAA</p> |
+| **Tiili**     | AA (6,06 : 1)     | <p style="font-size: var(--fontsize-body-xl); color: var(--color-brick); margin: var(--spacing-3-xs);">AA</p> |
+| **Vaakuna**   | AA (4,97 : 1)     | <p style="font-size: var(--fontsize-body-xl); color: var(--color-coat-of-arms-blue); margin: var(--spacing-3-xs);">AA</p> | 
+| **Spåra**     | AA for large text (4,04 : 1)  | <p style="font-size: var(--fontsize-body-xl); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
+| **Metro**     | AA for large text (3,34 : 1)  | <p style="font-size: var(--fontsize-body-xl); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
+
 
 
 

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -89,29 +89,31 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 | <ColorBox color="var(--color-black)"/> | <ColorBox color="var(--color-black-90)"/> | <ColorBox color="var(--color-black-80)"/> | <ColorBox color="var(--color-black-70)"/> | <ColorBox color="var(--color-black-60)"/> | <ColorBox color="var(--color-black-50)"/> | <ColorBox color="var(--color-black-40)"/> | <ColorBox color="var(--color-black-30)"/> | <ColorBox color="var(--color-black-20)"/> | <ColorBox color="var(--color-black-10)"/> | <ColorBox color="var(--color-black-5)"/> | <ColorBox color="var(--color-white)" /> |
 
 
-## Colour contrast accessibility
-Here you can find recommended colour combinatios for different brand colours and text or other informative elements in order of their contrast ratio.
+## Accessible colour combinations
+<p>Here you can find some recommended colour combinations for text and other informative elements. The examples are sorted in order of their contrast ratio. For more examples of accessibile colour combinations, see the <Link href="https://share.goabstract.com/28352b8b-9c51-4346-b249-ff062c5da561" external>Colour accessibility examples - Abstract collection</Link>.</p>
 
 - **AA** and **AAA** means you can safely use the color combination on all text sizes
 - **AA for large text** means the text size should be at least 18 pt for regular weight or 14 pt for bold weight
 - **Black 90** is the default text colour in HDS
 
-| Brand Colour      | Text Colour   | Colour contrast       | Example           |
-| ----------------- | ------------- | --------------------- | ----------------- |
-| **Engel**         | black 90      | AAA (14,3 : 1)   | <ColorContrast color="var(--color-black-90)" background="var(--color-engel)">AAA</ColorContrast> |
-| **Hopea**         | black 90      | AAA (13,1 : 1)   | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
-| **Bussi**         | white         | AAA (12 : 1)   | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
-| **Kesä**          | black 90      | AAA (11,1 : 1)   | <ColorContrast color="var(--color-black-90)" background="var(--color-summer)">AAA</ColorContrast> |
-| **Sumu**          | black 90      | AAA (10 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-fog)">AAA</ColorContrast> |
-| **Kupari**        | black 90      | AAA (9,4 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-copper)">AAA</ColorContrast> |
-| **Suomenlinna**   | black 90      | AAA (9,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
-| **Kulta**         | black 90      | AAA (7,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
-| **Tiili**         | white         | AA (6,1 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
-| **Metro**         | black 90      | AA (5,2 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-metro)">AA</ColorContrast> |
-| **Vaakuna**       | white         | AA (5 : 1)     | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
+### Brand colour combinations
+
+| Brand Colour      | Text Colour   | Colour contrast   | Example           |
+| ----------------- | ------------- | ----------------- | ----------------- |
+| **Engel**         | black 90      | AAA (14,3 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-engel)">AAA</ColorContrast> |
+| **Hopea**         | black 90      | AAA (13,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-silver)">AAA</ColorContrast> |
+| **Bussi**         | white         | AAA (12 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-bus)">AAA</ColorContrast> |
+| **Kesä**          | black 90      | AAA (11,1 : 1)    | <ColorContrast color="var(--color-black-90)" background="var(--color-summer)">AAA</ColorContrast> |
+| **Sumu**          | black 90      | AAA (10 : 1)      | <ColorContrast color="var(--color-black-90)" background="var(--color-fog)">AAA</ColorContrast> |
+| **Kupari**        | black 90      | AAA (9,4 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-copper)">AAA</ColorContrast> |
+| **Suomenlinna**   | black 90      | AAA (9,1 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-suomenlinna)">AAA</ColorContrast> |
+| **Kulta**         | black 90      | AAA (7,1 : 1)     | <ColorContrast color="var(--color-black-90)" background="var(--color-coat-of-arms-gold)">AAA</ColorContrast> |
+| **Tiili**         | white         | AA (6,1 : 1)      | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
+| **Metro**         | black 90      | AA (5,2 : 1)      | <ColorContrast color="var(--color-black-90)" background="var(--color-metro)">AA</ColorContrast> |
+| **Vaakuna**       | white         | AA (5 : 1)        | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms-blue)">AA</ColorContrast> | 
 | **Spåra**         | white         | AA for large text (4 : 1) | <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
 
-For text and other informative elements on white background it is recommended to only use following brand colours:
+**For text and other informative elements on white background** it is recommended to only use following brand colours:
 
 | Brand Colour  | Colour contrast   | Example           |
 | --------------| ----------------- | ----------------- |
@@ -121,7 +123,7 @@ For text and other informative elements on white background it is recommended to
 | **Spåra**     | AA for large text (4 : 1)  | <p style="font-size: var(--fontsize-body-l); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
 | **Metro**     | AA for large text (3,3 : 1)  | <p style="font-size: var(--fontsize-body-l); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
 
-Recommended combinations for grayscale colours: 
+### Grayscale combinations 
 
 | Brand Colour  | Text Colour   | Colour contrast   | Example           | Text on white
 | --------------| ------------- | ----------------- | ----------------- | ----------------- |
@@ -139,7 +141,6 @@ Recommended combinations for grayscale colours:
 ## Tokens
 The colour tokens are provided as CSS and SASS variables in [hds-design-tokens](https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/design-tokens).
 
-### Brand colours
 CSS                                | SASS                              | Value   | Example
 ---------------------------------- | --------------------------------- | ------- | ----------------------------------------------------------- |
 --color-brick                      | $color-brick                      | #bd2719 | <Example color="var(--color-brick)" />                      |

--- a/site/src/components/ColorContrast.js
+++ b/site/src/components/ColorContrast.js
@@ -9,9 +9,8 @@ const ColorContrast = ({
 }) => (
   <div
     style={{
-      display: 'inline-block',
-      width: 'var(--spacing-layout-m)',
-      height: 'var(--spacing-layout-m)',
+      width: 'var(--spacing-xl)',
+      height: 'var(--spacing-xl)',
       alignItems: 'center',
       justifyContent: 'center',
       display: 'flex',
@@ -26,6 +25,8 @@ const ColorContrast = ({
 
 ColorContrast.propTypes = {
   color: PropTypes.string.isRequired,
+  background: PropTypes.string.isRequired,
+  style: PropTypes.object,
 };
 
 export default ColorContrast;

--- a/site/src/components/ColorContrast.js
+++ b/site/src/components/ColorContrast.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ColorContrast = ({ 
+  color, 
+  background, 
+  style = {},
+  children
+}) => (
+  <div
+    style={{
+      display: 'inline-block',
+      width: 'var(--spacing-layout-m)',
+      height: 'var(--spacing-layout-m)',
+      alignItems: 'center',
+      justifyContent: 'center',
+      display: 'flex',
+      background: `${background}`,
+      color: `${color}`,
+      ...style,
+    }}
+  >
+      {children}
+  </div>
+);
+
+ColorContrast.propTypes = {
+  color: PropTypes.string.isRequired,
+};
+
+export default ColorContrast;

--- a/site/src/components/ColorContrast.js
+++ b/site/src/components/ColorContrast.js
@@ -9,8 +9,9 @@ const ColorContrast = ({
 }) => (
   <div
     style={{
-      width: 'var(--spacing-xl)',
-      height: 'var(--spacing-xl)',
+      fontSize: 'var(--fontsize-body-l)',
+      width: 'var(--spacing-2-xl)',
+      height: 'var(--spacing-2-xl)',
       alignItems: 'center',
       justifyContent: 'center',
       display: 'flex',

--- a/site/src/gatsby-theme-docz/theme/styles.js
+++ b/site/src/gatsby-theme-docz/theme/styles.js
@@ -88,8 +88,8 @@ const styles = {
     borderSpacing: 0,
     [['th', 'td']]: {
       textAlign: 'left',
-      py: '4px',
-      pr: '4px',
+      py: 'var(--spacing-3-xs)',
+      pr: 'var(--spacing-m)',
       pl: 0,
       borderColor: 'muted',
       borderBottomStyle: 'solid',
@@ -100,7 +100,7 @@ const styles = {
     borderBottomWidth: '2px',
   },
   td: {
-    verticalAlign: 'top',
+    verticalAlign: 'middle',
     borderBottomWidth: '1px',
   },
   hr: {


### PR DESCRIPTION
## Description
Adds examples of accessible colour combinations to colour token documentation.

## How Has This Been Tested?
Tested by running the documentation site locally.