### PR TITLE
[Fix] Small documentation site updates

### DIFF
--- a/site/docs/about/support.mdx
+++ b/site/docs/about/support.mdx
@@ -29,7 +29,7 @@ If you’ve got a question or a suggestion, you can get in touch with the team b
 <p>You can submit issues and bug reports to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external>HDS repository in GitHub</Link>.</p>
 
 ### Feature requests
-<p>You can submit feature requests to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external>HDS repository in GitHub</Link> as issues labeled "feature-request". You can also get in touch with HDS team with any of the above-mentioned methods.</p>
+<p>You can submit feature requests to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external>HDS repository in GitHub</Link>. You can also get in touch with HDS team with any of the above-mentioned methods.</p>
 
 ### Contributing
 See [Contributing](/contributing).

--- a/site/docs/about/support.mdx
+++ b/site/docs/about/support.mdx
@@ -21,9 +21,7 @@ If you are making a feature request, please refer to [Contributing](/contributin
 If you’ve got a question or a suggestion, you can get in touch with the team by email. Our address is [hds@hel.fi](mailto:hds@hel.fi). Messages will be answered by the HDS team as soon as possible.
 
 ### Slack channels
-HDS team members can also be reached in two Slack channels in the City of Helsinki Slack.
-- <Link href="https://helsinkicity.slack.com/archives/CHCV3KTHA" external>#designsystem</Link> for design related discussion
-- <Link href="https://helsinkicity.slack.com/archives/CMW0FGFM5" external>#designsystem-dev</Link> for implementation related discussion
+<p>HDS team members can also be reached in the <Link href="https://helsinkicity.slack.com/archives/CHCV3KTHA" external>#designsystem Slack channel</Link> in the City of Helsinki Slack.</p>
 
 ## Issues and features
 

--- a/site/doczrc.js
+++ b/site/doczrc.js
@@ -25,11 +25,11 @@ const menu = [
     name: 'About',
     menu: ['What is new', 'Roadmap', 'Support', 'Accessibility statement'],
   },
-  'Resources',
   {
     name: 'Contributing',
     menu: ['Before contributing', 'Design', 'Implementation', 'Documentation'],
   },
+  'Resources',
 ];
 
 export default {


### PR DESCRIPTION
## Description
A couple of smaller changes to documentation site
- Removed link to #designsystem-dev Slack channel in Support page (does not exist anymore)
- Removed a text about issue labeling in Support page (mentioned label does not exist anymore)
- Moved Contribution category above Resources page in documentation site navigation

## How Has This Been Tested?
Tested by running documentation site locally.