### PR TITLE
Add combobox

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,9 @@
   "module": "./index.js",
   "esnext": "./index.js",
   "types": "./index.d.ts",
-  "sideEffects": ["base.min-*"],
+  "sideEffects": [
+    "base.min-*"
+  ],
   "scripts": {
     "build": "rimraf lib/ && yarn run lint && yarn run tcm && rollup -c",
     "start": "tcm src internal --watch & yarn storybook",
@@ -26,7 +28,7 @@
     "pre-push": "yarn -s test && yarn build",
     "storybook": "start-storybook -p 6006 --quiet",
     "build-storybook": "build-storybook --loglevel error",
-    "test": "jest",
+    "test": "jest --env=jsdom-fourteen",
     "prepublishOnly": "cp -r ./lib/. ."
   },
   "devDependencies": {
@@ -35,6 +37,7 @@
     "@babel/preset-env": "7.11.5",
     "@babel/preset-react": "7.10.4",
     "@babel/preset-typescript": "7.9.0",
+    "@juggle/resize-observer": "^3.2.0",
     "@rollup/plugin-babel": "5.2.1",
     "@rollup/plugin-commonjs": "15.1.0",
     "@rollup/plugin-node-resolve": "9.0.0",

--- a/packages/react/src/components/dropdown/Combobox.module.scss
+++ b/packages/react/src/components/dropdown/Combobox.module.scss
@@ -1,0 +1,57 @@
+.wrapper.wrapper.wrapper {
+  height: unset;
+  min-height: var(--spacing-3-xl);
+}
+
+.buttonInputStack {
+  display: flex;
+  flex-direction: column;
+}
+
+.button.button.button {
+  position: unset;
+  padding: 0;
+}
+
+.noPadding {
+  padding: 0;
+}
+
+.inputWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.inputIcon {
+  padding-left: var(--spacing-s);
+  margin-right: calc((var(--spacing-m) - var(--spacing-s)) * -1);
+}
+
+.input {
+  padding: 0 var(--spacing-s);
+  width: 100%;
+  height: var(--spacing-3-xl);
+  box-sizing: border-box;
+
+  color: var(--input-color-default);
+  font-size: 1.125em;
+
+  background-color: var(--input-background-default);
+  border: none;
+  // The focus is given to the wrapping element instead of this input
+  // so we can hide the outline.
+  outline: none;
+  // Removes the input shadow on iOS
+  -webkit-appearance: none;
+
+  &:not(:focus).hidden {
+    border: 0;
+    clip: "rect(0 0 0 0)";
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    position: absolute;
+  }
+}

--- a/packages/react/src/components/dropdown/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/Combobox.test.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ResizeObserver } from '@juggle/resize-observer';
+
+import { Combobox, ComboboxProps } from './Combobox';
+
+const label = 'Combobox';
+const options = [
+  { label: 'Finland', value: 'FI' },
+  { label: 'Sweden', value: 'SV' },
+  { label: 'Norway', value: 'NO' },
+  { label: 'Botswana', value: 'BW' },
+  { label: 'Bolivia', value: 'BO' },
+];
+const defaultProps: ComboboxProps<{ label: string; value: string }> = {
+  label,
+  options,
+  clearButtonAriaLabel: 'Clear all selections',
+  selectedItemRemoveButtonAriaLabel: 'Remove item {value}',
+  selectedItemSrLabel: 'Selected item {value}',
+};
+
+const getWrapper = (props?: unknown) => render(<Combobox {...defaultProps} {...props} />);
+
+describe('<Combobox />', () => {
+  it('user should be able to search and choose an option ', () => {
+    const onChange = jest.fn();
+    const { getAllByLabelText, getAllByRole, queryByDisplayValue } = getWrapper({ onChange });
+    const input = getAllByLabelText(label)[0];
+
+    fireEvent.change(input, { target: { value: 'Fi' } });
+
+    const visibleOptions = getAllByRole('option');
+
+    // Ensure that options are filtered correctly
+    expect(visibleOptions.length).toBe(1);
+    // Choose one option
+    fireEvent.click(visibleOptions[0]);
+
+    // Ensure that chosen option is shown as value of input
+    expect(queryByDisplayValue(options[0].label)).toBeDefined();
+    // Ensure that chosen option has been sent with the onChange event
+    expect(onChange).toHaveBeenCalledWith(options[0]);
+  });
+
+  describe('in multi select mode', () => {
+    // The version of JSDom we use does not have built in support for
+    // ResizeObserver, so we polyfilling it.
+    let originalResizeObserver;
+
+    beforeEach(() => {
+      // @ts-ignore
+      originalResizeObserver = window.ResizeObserver;
+      // @ts-ignore
+      window.ResizeObserver = ResizeObserver;
+    });
+
+    afterEach(() => {
+      // @ts-ignore
+      window.ResizeObserver = originalResizeObserver;
+    });
+
+    it('user should be able to search and choose multiple options', () => {
+      const onChange = jest.fn();
+      const { getAllByLabelText, getAllByRole, queryAllByText } = getWrapper({
+        onChange,
+        multiselect: true,
+      });
+
+      const input = getAllByLabelText(label)[0];
+
+      fireEvent.change(input, { target: { value: 'Fi' } });
+      const visibleOptions = getAllByRole('option');
+
+      // Ensure that options are filtered correctly
+      expect(visibleOptions.length).toBe(1);
+      // Choose one option
+      fireEvent.click(visibleOptions[0]);
+      // Ensure that it's visible in selected items
+      expect(queryAllByText(options[0].label).length).toEqual(1);
+      // Ensure that it has been passed upwards with onChange
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith([options[0]]);
+
+      fireEvent.change(input, { target: { value: 'bo' } });
+      expect(getAllByRole('option').length).toBe(2);
+      fireEvent.click(getAllByRole('option')[1]);
+      // Ensure that previous and current selection are visible in
+      // selected items
+      expect(queryAllByText(options[0].label).length).toEqual(1);
+      expect(queryAllByText(options[4].label).length).toEqual(1);
+      // Ensure that the current selection is passed correctly with
+      // onChange
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledWith([options[0], options[4]]);
+    });
+  });
+});

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -86,6 +86,8 @@ export const Combobox = <OptionType,>({
   const wrapperRef = useRef<HTMLDivElement>(null);
   // selected items container ref
   const selectedItemsContainerRef = useRef<HTMLDivElement>(null);
+  // combobox input ref
+  const inputRef = useRef<HTMLInputElement>(null);
   // whether active focus is within the dropdown
   const [hasFocus, setFocus] = useState(false);
   // tracks current combobox search value
@@ -115,6 +117,12 @@ export const Combobox = <OptionType,>({
   }, [onFocus, onBlur]);
 
   const getFilteredItems = (items: OptionType[]) => filter(items, search);
+
+  const focusInput = () => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
 
   // init multi-select
   const {
@@ -254,6 +262,16 @@ export const Combobox = <OptionType,>({
       : addSelectedItem(itemToBeSelected);
   };
 
+  const handleWrapperClick = () => {
+    focusInput();
+  };
+
+  // const handleWrapperKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+  //   if (e.key === 'Enter' || e.nativeEvent.code === 'Space') {
+  //     focusInput();
+  //   }
+  // };
+
   const handleMultiSelectInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     // 'keyCode' is deprecated. We can't use 'key', because it does not
     // support space. Alternative would be to use 'code', but it's not
@@ -304,7 +322,32 @@ export const Combobox = <OptionType,>({
     >
       {/* LABEL */}
       {label && <FieldLabel label={label} {...getLabelProps()} />}
-      <div ref={wrapperRef} className={classNames(styles.wrapper, comboboxStyles.wrapper)}>
+      {
+        // This onClick function is used so that mouse users are able to
+        // focus the Combobox without having to use the keyboard. The
+        // design calls for the input to be visually hidden until the
+        // user gives indication of wanting to access it.
+        // Keyboard and screen reader users will move through the
+        // selected items list and the clear button, after which they
+        // will find the input. It's assumed that mouse users can
+        // consume this information all at once and it's hence
+        // convenient to offer direct access to the input by clicking.
+        // In turn, providing this element as a focusable element would
+        // add one more item keyboard/screen reader users would need to
+        // move through.
+      }
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+      <div
+        ref={wrapperRef}
+        onClick={handleWrapperClick}
+        // Enabling these props would make this div accessible. Our
+        // assumption is that we don't want that, but I am not entirely
+        // confident.
+        // onKeyDown={handleWrapperKeyDown}
+        // tabIndex={0}
+        // role="button"
+        className={classNames(styles.wrapper, comboboxStyles.wrapper)}
+      >
         {/* SELECTED ITEMS */}
         {multiselect && selectedItems.length > 0 && (
           <SelectedItems
@@ -348,6 +391,7 @@ export const Combobox = <OptionType,>({
                     // actions in order to ensure that dropdown and
                     // input props don't conflict.
                     onKeyDown: handleMultiSelectInputKeyDown,
+                    ref: inputRef,
                   }),
                 }),
               })}

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -280,9 +280,6 @@ export const Combobox = <OptionType,>({
     // element.
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
       setFocus(false);
-      // If the user "fails" a click, in other words they mouse down on
-      // one element and mouse up on another, isClicking might have been
-      setIsClicking(false);
       onBlur();
     }
   };

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -117,7 +117,7 @@ export const Combobox = <OptionType,>({
     defaultActiveIndex: 0,
     initialActiveIndex: 0,
     // todo: create prop
-    initialSelectedItems: [options[0], options[1], options[2], options[3]],
+    initialSelectedItems: [],
     ...(multiselect && value !== undefined && { selectedItems: (value as OptionType[]) ?? [] }),
     // todo: create a prop for setting the removal message
     getA11yRemovalMessage({ itemToString, removedSelectedItem }) {

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -253,12 +253,6 @@ export const Combobox = <OptionType,>({
     focusInput();
   };
 
-  // const handleWrapperKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-  //   if (e.key === 'Enter' || e.nativeEvent.code === 'Space') {
-  //     focusInput();
-  //   }
-  // };
-
   const ignoreFocusHandlerWhenClickingItem = (handler: FocusEventHandler<HTMLDivElement>) => (
     event: FocusEvent<HTMLDivElement>,
   ) => {
@@ -381,12 +375,6 @@ export const Combobox = <OptionType,>({
         onFocus={ignoreFocusHandlerWhenClickingItem(handleWrapperFocus)}
         onBlur={ignoreFocusHandlerWhenClickingItem(handleWrapperBlur)}
         onClick={handleWrapperClick}
-        // Enabling these props would make this div accessible. Our
-        // assumption is that we don't want that, but I am not entirely
-        // confident.
-        // onKeyDown={handleWrapperKeyDown}
-        // tabIndex={0}
-        // role="button"
         className={classNames(styles.wrapper, comboboxStyles.wrapper)}
       >
         {/* SELECTED ITEMS */}

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -285,11 +285,7 @@ export const Combobox = <OptionType,>({
   };
 
   const handleMultiSelectInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    // 'keyCode' is deprecated. We can't use 'key', because it does not
-    // support space. Alternative would be to use 'code', but it's not
-    // supported by React. Instead we are using the underlying native
-    // element in order to access code.
-    if (e.nativeEvent.code === 'Space') {
+    if (e.key === ' ') {
       // Prevent 'Space' from typing a space into the input.
       // @ts-ignore
       e.nativeEvent.preventDownshiftDefault = true;

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -145,6 +145,7 @@ export const Combobox = <OptionType,>({
       let removedItemIndex;
       let lastItemRemoved;
       switch (type) {
+        case useMultipleSelection.stateChangeTypes.SelectedItemKeyDownBackspace:
         case useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem:
           // get the index of the deleted item
           removedItemIndex = state.selectedItems.findIndex((item) => !changes.selectedItems.includes(item));
@@ -155,7 +156,16 @@ export const Combobox = <OptionType,>({
             ...changes,
             // set the new last item as active if the removed item was last,
             // otherwise set the item succeeding the removed one active
-            activeIndex: lastItemRemoved ? removedItemIndex - 1 : removedItemIndex,
+            // Note: Here activeIndex updates at a different time in comparison
+            // with the Select component. In this component, when 'onStageChange'
+            // is called, the removed item still has a SelectedItem representing
+            // it in the DOM. This means that the succeeding SelectedItem is at
+            // index n + 1 instead of n. This is a concerning difference in
+            // behavior, because I don't know why this discrepancy takes place
+            // or if it can be relied on in all scenarios. It's possible that
+            // this component is just one event loop slower in pushing changes
+            // to the DOM.
+            activeIndex: lastItemRemoved ? removedItemIndex - 1 : removedItemIndex + 1,
           };
         default:
           return changes;

--- a/packages/react/src/components/dropdown/Combobox.tsx
+++ b/packages/react/src/components/dropdown/Combobox.tsx
@@ -291,9 +291,12 @@ export const Combobox = <OptionType,>({
       // @ts-ignore
       e.nativeEvent.preventDownshiftDefault = true;
 
-      const highlightedItem = getFilteredItems(options)[highlightedIndex];
+      // Only select an item if an index is highlighted
+      if (highlightedIndex > -1) {
+        const highlightedItem = getFilteredItems(options)[highlightedIndex];
 
-      setSelectedItems(highlightedItem);
+        setSelectedItems(highlightedItem);
+      }
     }
 
     // If the menu is open, prevent the events for dropdown from firing.

--- a/packages/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.stories.tsx
@@ -178,7 +178,7 @@ export const ComboboxMultiSelectTest = () => {
   };
 
   return (
-    <>
+    <div style={{ width: 400 }}>
       <Combobox
         options={controlledOptions}
         label="Element:"
@@ -194,7 +194,7 @@ export const ComboboxMultiSelectTest = () => {
         onFocus={action('onFocus')}
         onBlur={action('onBlur')}
       />
-    </>
+    </div>
   );
 };
 

--- a/packages/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.stories.tsx
@@ -160,6 +160,8 @@ export const ComboboxTest = () => {
         clearButtonAriaLabel="Clear all selections"
         selectedItemRemoveButtonAriaLabel="Remove item {value}"
         selectedItemSrLabel="Selected item {value}"
+        onFocus={action('onFocus')}
+        onBlur={action('onBlur')}
       />
     </>
   );
@@ -189,6 +191,8 @@ export const ComboboxMultiSelectTest = () => {
         clearButtonAriaLabel="Clear all selections"
         selectedItemRemoveButtonAriaLabel="Remove item {value}"
         selectedItemSrLabel="Selected item {value}"
+        onFocus={action('onFocus')}
+        onBlur={action('onBlur')}
       />
     </>
   );

--- a/packages/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/dropdown/Dropdown.stories.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 // import { Dropdown } from './Dropdown';
 import { Button } from '../button';
 import { Select } from './Select';
 import { IconFaceNeutral, IconFaceSad, IconFaceSmile } from '../../icons';
+import { Combobox } from './Combobox';
 
 function getOptions() {
   return [
@@ -123,6 +125,63 @@ export const SelectTestControlledMultiselect = () => {
         label="Element:"
         helper="Choose an element"
         onChange={setSelectedItems}
+        placeholder="Placeholder"
+        value={selectedItems}
+        style={{ marginTop: 'var(--spacing-s)' }}
+        multiselect
+        clearButtonAriaLabel="Clear all selections"
+        selectedItemRemoveButtonAriaLabel="Remove item {value}"
+        selectedItemSrLabel="Selected item {value}"
+      />
+    </>
+  );
+};
+
+export const ComboboxTest = () => {
+  const controlledOptions = getOptions();
+
+  const [selectedItem, setSelectedItem] = useState(null);
+
+  const handleChange = (item) => {
+    action('onChange')(item);
+    setSelectedItem(item);
+  };
+
+  return (
+    <>
+      <Combobox
+        options={controlledOptions}
+        label="Element:"
+        helper="Choose an element"
+        onChange={handleChange}
+        placeholder="Placeholder"
+        value={selectedItem}
+        style={{ marginTop: 'var(--spacing-s)' }}
+        clearButtonAriaLabel="Clear all selections"
+        selectedItemRemoveButtonAriaLabel="Remove item {value}"
+        selectedItemSrLabel="Selected item {value}"
+      />
+    </>
+  );
+};
+
+export const ComboboxMultiSelectTest = () => {
+  const controlledOptions = getOptions();
+
+  const [selectedItems, setSelectedItems] = useState(null);
+
+  const handleChange = (items) => {
+    action('onChange')(items);
+    setSelectedItems(items);
+  };
+
+  return (
+    <>
+      <Combobox
+        options={controlledOptions}
+        label="Element:"
+        helper="Choose an element"
+        onChange={handleChange}
         placeholder="Placeholder"
         value={selectedItems}
         style={{ marginTop: 'var(--spacing-s)' }}

--- a/packages/react/src/components/dropdown/dropdownUtils.ts
+++ b/packages/react/src/components/dropdown/dropdownUtils.ts
@@ -1,0 +1,10 @@
+import isEqual from 'lodash.isequal';
+
+/**
+ * Helper that checks if an item is in the selected options
+ * @param selectedOptions Currently selected options
+ * @param item            Item we want to check
+ */
+export function getIsInSelectedOptions<T>(selectedOptions: T[], item: T): boolean {
+  return selectedOptions.some((selectedOption: T) => isEqual(selectedOption, item));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,6 +1944,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@juggle/resize-observer@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.2.0.tgz#5e0b448d27fe3091bae6216456512c5904d05661"
+  integrity sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"


### PR DESCRIPTION
## Description

Adds a combobox variant of `Select`. It supports single and multi select usecases and all the other props `Select` does.

## Related Issue

Jira ticket ID: HDS-379

## Motivation and Context

By using a combobox patterns, users are able to search for a specific option from a set of options. This is useful for when the set of options is large.

## How Has This Been Tested?

- One story for single select and multi select combobox
- Happy path test for single and multi select variants

## Screenshots (if appropriate):
<img width="450" alt="Screenshot 2020-10-08 at 12 12 10" src="https://user-images.githubusercontent.com/9090689/95438911-9ddd4800-095f-11eb-9613-8a973d19d569.png">
<img width="482" alt="Screenshot 2020-10-08 at 12 12 00" src="https://user-images.githubusercontent.com/9090689/95438918-9f0e7500-095f-11eb-9907-cc98d69c54e6.png">
