### PR TITLE
[Accessibility] Removed aria-checked from Checkbox and Radio button

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -71,7 +71,6 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         type="checkbox"
         disabled={disabled}
         checked={checked}
-        aria-checked={checked}
         {...rest}
       />
       <label htmlFor={id} className={classNames(styles.label)}>

--- a/packages/react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`<Checkbox /> spec renders the component 1`] = `
     class="checkbox"
   >
     <input
-      aria-checked="false"
       class="input"
       id="test"
       type="checkbox"

--- a/packages/react/src/components/radioButton/RadioButton.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.tsx
@@ -71,7 +71,6 @@ export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
         type="radio"
         disabled={disabled}
         checked={checked}
-        aria-checked={checked}
         {...rest}
       />
       <label htmlFor={id} className={classNames(styles.label)}>

--- a/packages/react/src/components/radioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/react/src/components/radioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`<RadioButton /> spec renders the component 1`] = `
     class="radioButton"
   >
     <input
-      aria-checked="false"
       class="input"
       id="test"
       type="radio"


### PR DESCRIPTION
## Description
This PR removed `aria-checked` from Checkbox and Radio button components. 

## Related Issue
Changes are based on accessibility audit report done for HDS. `aria-checked` was mentioned to be redundant since `type` property was already used in Checkbox and Radio button.

## How Has This Been Tested?
Tested by running Storybook and documentation site locally.