### PR TITLE
[Accessibility] Fix notification accessibility issues

### DIFF
--- a/packages/core/src/components/notification/notification.css
+++ b/packages/core/src/components/notification/notification.css
@@ -15,13 +15,18 @@
   border-width: 0 0 0 var(--notification-border-width);
   box-sizing: border-box;
   color: var(--notification-color);
-  display: grid;
-  gap: var(--spacing-s);
   max-width: var(--notification-max-width-inline);
   padding: var(--notification-padding);
   position: relative;
   width: 100%;
   z-index: var(--notification-z-index);
+}
+
+/* CONTENT */
+
+.hds-notification__content {
+  display: grid;
+  gap: var(--spacing-s);
 }
 
 /* LABEL */
@@ -42,6 +47,9 @@
 
 .hds-notification--small {
   --notification-padding: var(--spacing-2-xs);
+}
+
+.hds-notification--small .hds-notification__content {
   display: flex;
   gap: 0;
 }
@@ -99,7 +107,7 @@
 }
 
 .hds-notification__close-button:focus {
-  box-shadow: 0 0 0 3px var(--notification-focus-outline-color)
+  box-shadow: 0 0 0 3px var(--notification-focus-outline-color);
 }
 
 /* TOAST POSITIONS */

--- a/packages/core/src/components/notification/notification.stories.js
+++ b/packages/core/src/components/notification/notification.stories.js
@@ -16,7 +16,7 @@ const iconMapping = {
 const getLabel = (type = 'info') => {
   const label = type[0].toUpperCase() + type.substring(1);
   return `
-    <div class="hds-notification__label">
+    <div class="hds-notification__label" role="heading">
       <span class="hds-icon hds-icon--${iconMapping[type]}" aria-hidden="true"></span>
       <span>${label}</span>
     </div>`;
@@ -39,31 +39,39 @@ export default {
 };
 
 export const Default = () => `
-    <div class="hds-notification">
-      ${getLabel()}
-      ${text}
-    </div>
+    <section aria-label="Notification" class="hds-notification">
+      <div role="alert" class="hds-notification__content">
+        ${getLabel()}
+        ${text}
+      </div>
+    </section>
 `;
 
 export const Success = () => `
-    <div class="hds-notification hds-notification--success">
-      ${getLabel('success')}
-      ${text}
-    </div>
+    <section aria-label="Notification" class="hds-notification hds-notification--success">
+      <div role="alert" class="hds-notification__content">
+        ${getLabel('success')}
+        ${text}
+      </div>
+    </section>
 `;
 
 export const Alert = () => `
-    <div class="hds-notification hds-notification--alert">
-      ${getLabel('alert')}
-      ${text}
-    </div>
+    <section aria-label="Notification" class="hds-notification hds-notification--alert">
+      <div role="alert" class="hds-notification__content">
+        ${getLabel('alert')}
+        ${text}
+      </div>
+    </section>
 `;
 
 export const Error = () => `
-    <div class="hds-notification hds-notification--error">
-      ${getLabel('error')}
-      ${text}
-    </div>
+    <section aria-label="Notification" class="hds-notification hds-notification--error">
+      <div role="alert" class="hds-notification__content">
+        ${getLabel('error')}
+        ${text}
+      </div>
+    </section>
 `;
 
 export const Toast = () =>
@@ -71,10 +79,12 @@ export const Toast = () =>
     .map(
       (position) =>
         `
-        <div class="hds-notification hds-notification--${position}">
-          ${getLabel()}
-          ${position}
-        </div>
+        <section aria-label="Notification" class="hds-notification hds-notification--${position}">
+          <div role="alert" class="hds-notification__content">
+            ${getLabel()}
+            ${position}
+          </div>
+        </section>
     `,
     )
     .join('');
@@ -84,12 +94,16 @@ export const Small = () =>
     .map(
       (type) =>
         `
-        <div class="hds-notification hds-notification--small ${type ? `hds-notification--${type}` : ''}">
-          <div class="hds-notification__label">
-            <span class="hds-icon hds-icon--${iconMapping[type]}" aria-hidden="true"></span>
+        <section aria-label="Notification" class="hds-notification hds-notification--small ${
+          type ? `hds-notification--${type}` : ''
+        }">
+          <div role="alert" class="hds-notification__content">
+            <div class="hds-notification__label">
+              <span class="hds-icon hds-icon--${iconMapping[type]}" aria-hidden="true"></span>
+            </div>
+            <div class="hds-notification__body">${type[0].toUpperCase() + type.substring(1)}</div>
           </div>
-          <div class="hds-notification__body">${type[0].toUpperCase() + type.substring(1)}</div>
-        </div>
+        </section>
     `,
     )
     .join('');
@@ -99,42 +113,54 @@ export const Large = () =>
     .map(
       (type) =>
         `
-        <div class="hds-notification hds-notification--large ${type ? `hds-notification--${type}` : ''}">
-          ${getLabel(type)}
-          ${text}
-        </div>
+        <section aria-label="Notification" class="hds-notification hds-notification--large ${
+          type ? `hds-notification--${type}` : ''
+        }">
+          <div role="alert" class="hds-notification__content">
+            ${getLabel(type)}
+            ${text}
+          </div>
+        </section>
     `,
     )
     .join('');
 
 export const Invisible = () => `
     <div class="hiddenFromScreen" aria-atomic="true" aria-live="assertive" role="status">
-        <div class="hds-notification">
+      <section aria-label="Notification" class="hds-notification">
+        <div role="alert" class="hds-notification__content">
           ${getLabel()}
           This notification is only visible to screen readers
         </div>
+      </section>
     </div>
 `;
 
 export const WithClose = () => `
-    <div class="hds-notification">
-      ${getLabel('info')}
-      ${text}
-      ${closeButton}
-    </div>
-    <br>
-    <div class="hds-notification hds-notification--small">
-      <div class="hds-notification__label">
-        <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+    <section aria-label="Notification" class="hds-notification">
+      <div role="alert" class="hds-notification__content">
+        ${getLabel('info')}
+        ${text}
       </div>
-      <div class="hds-notification__body">Info</div>
       ${closeButton}
-    </div>
+    </section>
     <br>
-    <div class="hds-notification hds-notification--large">
-      ${getLabel('info')}
-      ${text}
+    <section aria-label="Notification" class="hds-notification hds-notification--small">
+      <div role="alert" class="hds-notification__content">
+        <div class="hds-notification__label">
+          <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+        </div>
+        <div class="hds-notification__body">Info</div>
+      </div>
       ${closeButton}
-    </div>
+    </section>
+    <br>
+    <section aria-label="Notification" class="hds-notification hds-notification--large">
+      <div role="alert" class="hds-notification__content">
+        ${getLabel('info')}
+        ${text}
+      </div>
+      ${closeButton}
+    </section>
 `;
 WithClose.storyName = 'With close button';

--- a/packages/core/src/components/notification/notification.stories.js
+++ b/packages/core/src/components/notification/notification.stories.js
@@ -16,7 +16,7 @@ const iconMapping = {
 const getLabel = (type = 'info') => {
   const label = type[0].toUpperCase() + type.substring(1);
   return `
-    <div class="hds-notification__label" role="heading">
+    <div class="hds-notification__label" role="heading" aria-level="2">
       <span class="hds-icon hds-icon--${iconMapping[type]}" aria-hidden="true"></span>
       <span>${label}</span>
     </div>`;

--- a/packages/core/src/components/notification/notification.stories.js
+++ b/packages/core/src/components/notification/notification.stories.js
@@ -40,7 +40,7 @@ export default {
 
 export const Default = () => `
     <section aria-label="Notification" class="hds-notification">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         ${getLabel()}
         ${text}
       </div>
@@ -49,7 +49,7 @@ export const Default = () => `
 
 export const Success = () => `
     <section aria-label="Notification" class="hds-notification hds-notification--success">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         ${getLabel('success')}
         ${text}
       </div>
@@ -58,7 +58,7 @@ export const Success = () => `
 
 export const Alert = () => `
     <section aria-label="Notification" class="hds-notification hds-notification--alert">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         ${getLabel('alert')}
         ${text}
       </div>
@@ -67,7 +67,7 @@ export const Alert = () => `
 
 export const Error = () => `
     <section aria-label="Notification" class="hds-notification hds-notification--error">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         ${getLabel('error')}
         ${text}
       </div>
@@ -97,7 +97,7 @@ export const Small = () =>
         <section aria-label="Notification" class="hds-notification hds-notification--small ${
           type ? `hds-notification--${type}` : ''
         }">
-          <div role="alert" class="hds-notification__content">
+          <div class="hds-notification__content">
             <div class="hds-notification__label">
               <span class="hds-icon hds-icon--${iconMapping[type]}" aria-hidden="true"></span>
             </div>
@@ -116,7 +116,7 @@ export const Large = () =>
         <section aria-label="Notification" class="hds-notification hds-notification--large ${
           type ? `hds-notification--${type}` : ''
         }">
-          <div role="alert" class="hds-notification__content">
+          <div class="hds-notification__content">
             ${getLabel(type)}
             ${text}
           </div>
@@ -128,7 +128,7 @@ export const Large = () =>
 export const Invisible = () => `
     <div class="hiddenFromScreen" aria-atomic="true" aria-live="assertive" role="status">
       <section aria-label="Notification" class="hds-notification">
-        <div role="alert" class="hds-notification__content">
+        <div class="hds-notification__content">
           ${getLabel()}
           This notification is only visible to screen readers
         </div>
@@ -138,7 +138,7 @@ export const Invisible = () => `
 
 export const WithClose = () => `
     <section aria-label="Notification" class="hds-notification">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         ${getLabel('info')}
         ${text}
       </div>
@@ -146,7 +146,7 @@ export const WithClose = () => `
     </section>
     <br>
     <section aria-label="Notification" class="hds-notification hds-notification--small">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         <div class="hds-notification__label">
           <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
         </div>
@@ -156,7 +156,7 @@ export const WithClose = () => `
     </section>
     <br>
     <section aria-label="Notification" class="hds-notification hds-notification--large">
-      <div role="alert" class="hds-notification__content">
+      <div class="hds-notification__content">
         ${getLabel('info')}
         ${text}
       </div>

--- a/packages/react/src/components/notification/Notification.module.css
+++ b/packages/react/src/components/notification/Notification.module.css
@@ -21,6 +21,10 @@
   width: 100%;
 }
 
+.content {
+  composes: hds-notification__content from 'hds-core/lib/components/notification/notification.css';
+}
+
 .icon {
   composes: hds-icon from 'hds-core/lib/components/notification/notification.css';
 }

--- a/packages/react/src/components/notification/Notification.test.tsx
+++ b/packages/react/src/components/notification/Notification.test.tsx
@@ -28,4 +28,12 @@ describe('<Notification /> spec', () => {
     );
     expect(getByRole('button')).toBeDefined();
   });
+  it('adds role="alert" for non-inline notifications', () => {
+    const { getByRole } = render(
+      <Notification label={label} position="bottom-center">
+        {body}
+      </Notification>,
+    );
+    expect(getByRole('alert')).toBeDefined();
+  });
 });

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -228,13 +228,9 @@ export const Notification = ({
   const notificationTransition = useSpring(open ? openTransitionProps : closeTransitionProps);
   const autoCloseTransition = useSpring(autoCloseTransitionProps);
 
-  // a11y attributes
-  const ariaLive: React.AriaAttributes['aria-live'] = type === 'error' ? 'assertive' : 'polite';
-  const role = type === 'error' ? 'alert' : 'status';
-
   return (
     <ConditionalVisuallyHidden visuallyHidden={invisible}>
-      <animated.div
+      <animated.section
         // there is an issue with react-spring -rc3 and a new version of @types/react: https://github.com/react-spring/react-spring/issues/1102
         // eslint-disable-next-line  @typescript-eslint/no-explicit-any
         style={{ ...notificationTransition, ...(style as any) }}
@@ -246,17 +242,18 @@ export const Notification = ({
           autoClose && styles.noBorder,
           className,
         )}
-        role={role}
-        aria-live={ariaLive}
+        aria-label="Notification"
         aria-atomic="true"
         data-testid={dataTestId}
       >
         {autoClose && <animated.div style={autoCloseTransition} className={styles.autoClose} />}
-        <div className={styles.label}>
-          <Icon className={styles.icon} />
-          <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
+        <div className={styles.content} role="alert">
+          <div className={styles.label} role="heading">
+            <Icon className={styles.icon} />
+            <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
+          </div>
+          {children && <div className={styles.body}>{children}</div>}
         </div>
-        {children && <div className={styles.body}>{children}</div>}
         {dismissible && (
           <button
             className={classNames(styles.close, styles[type])}
@@ -268,7 +265,7 @@ export const Notification = ({
             <IconCross aria-hidden />
           </button>
         )}
-      </animated.div>
+      </animated.section>
     </ConditionalVisuallyHidden>
   );
 };

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -228,6 +228,9 @@ export const Notification = ({
   const notificationTransition = useSpring(open ? openTransitionProps : closeTransitionProps);
   const autoCloseTransition = useSpring(autoCloseTransitionProps);
 
+  // Set role="alert" for non-inline notifications
+  const role = position !== 'inline' ? 'alert' : null;
+
   return (
     <ConditionalVisuallyHidden visuallyHidden={invisible}>
       <animated.section
@@ -247,7 +250,7 @@ export const Notification = ({
         data-testid={dataTestId}
       >
         {autoClose && <animated.div style={autoCloseTransition} className={styles.autoClose} />}
-        <div className={styles.content} role="alert">
+        <div className={styles.content} role={role}>
           <div className={styles.label} role="heading" aria-level={2}>
             <Icon className={styles.icon} />
             <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -248,7 +248,7 @@ export const Notification = ({
       >
         {autoClose && <animated.div style={autoCloseTransition} className={styles.autoClose} />}
         <div className={styles.content} role="alert">
-          <div className={styles.label} role="heading">
+          <div className={styles.label} role="heading" aria-level={2}>
             <Icon className={styles.icon} />
             <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
           </div>

--- a/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`<Notification /> spec renders the component 1`] = `
       role="alert"
     >
       <div
+        aria-level="2"
         class="label"
         role="heading"
       >

--- a/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`<Notification /> spec renders the component 1`] = `
   >
     <div
       class="content"
-      role="alert"
     >
       <div
         aria-level="2"

--- a/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -2,41 +2,46 @@
 
 exports[`<Notification /> spec renders the component 1`] = `
 <DocumentFragment>
-  <div
+  <section
     aria-atomic="true"
-    aria-live="polite"
+    aria-label="Notification"
     class="inline notification default info"
-    role="status"
   >
     <div
-      class="label"
+      class="content"
+      role="alert"
     >
-      <svg
-        class="icon s icon"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="label"
+        role="heading"
       >
-        <g
-          fill="none"
-          fill-rule="evenodd"
+        <svg
+          class="icon s icon"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M0 0h24v24H0z"
-          />
-          <path
-            d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm0 2a8 8 0 100 16 8 8 0 000-16zm1 6v6.5h2V18H9v-1.5h2v-5H9V10h4zm-1.187-4a1.312 1.312 0 110 2.625 1.312 1.312 0 010-2.625z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
-      This is the label text
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M0 0h24v24H0z"
+            />
+            <path
+              d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm0 2a8 8 0 100 16 8 8 0 000-16zm1 6v6.5h2V18H9v-1.5h2v-5H9V10h4zm-1.187-4a1.312 1.312 0 110 2.625 1.312 1.312 0 010-2.625z"
+              fill="currentColor"
+            />
+          </g>
+        </svg>
+        This is the label text
+      </div>
+      <div
+        class="body"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+      </div>
     </div>
-    <div
-      class="body"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
-    </div>
-  </div>
+  </section>
 </DocumentFragment>
 `;

--- a/site/docs/components/notification.mdx
+++ b/site/docs/components/notification.mdx
@@ -58,40 +58,48 @@ Note! Inline notifications should not be added to the page dynamically. For this
 #### Core code example:
 ```html
 <!-- Default -->
-<div class="hds-notification">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
-    <span>New messages</span>
+<section aria-label="Notification" class="hds-notification">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+      <span>New messages</span>
+    </div>
+    <div class="hds-notification__body">You have received new messages.</div>
   </div>
-  <div class="hds-notification__body">You have received new messages.</div>
-</div>
+</section>
 
 <!-- Success -->
-<div class="hds-notification hds-notification--success">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--check" aria-hidden="true"></span>
-    <span>Form done</span>
+<section aria-label="Notification" class="hds-notification hds-notification--success">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--check" aria-hidden="true"></span>
+      <span>Form done</span>
+    </div>
+    <div class="hds-notification__body">Form submit was successful!</div>
   </div>
-  <div class="hds-notification__body">Form submit was successful!</div>
-</div>
+</section>
 
 <!-- Alert -->
-<div class="hds-notification hds-notification--alert">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--alert-circle" aria-hidden="true"></span>
-    <span>Slow loading</span>
+<section aria-label="Notification" class="hds-notification hds-notification--alert">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--alert-circle" aria-hidden="true"></span>
+      <span>Slow loading</span>
+    </div>
+    <div class="hds-notification__body">Loading is taking longer than expected.</div>
   </div>
-  <div class="hds-notification__body">Loading is taking longer than expected.</div>
-</div>
+</section>
 
 <!-- Error -->
-<div class="hds-notification hds-notification--error">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--error" aria-hidden="true"></span>
-    <span>Missing information</span>
+<section aria-label="Notification" class="hds-notification hds-notification--error">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--error" aria-hidden="true"></span>
+      <span>Missing information</span>
+    </div>
+    <div class="hds-notification__body">Form is missing critical information.</div>
   </div>
-  <div class="hds-notification__body">Form is missing critical information.</div>
-</div>
+</section>
 ```
 
 #### React code example:
@@ -132,16 +140,18 @@ Toasts notifications provide lightweight feedback for changes in system status s
 
 #### Core code example:
 ```html
-<div class="hds-notification hds-notification--top-right">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
-    <span>New messages</span>
-    <button class="hds-notification__close-button" aria-label="Close toast" type="button" onclick="">
-      <span class="hds-icon hds-icon--cross" aria-hidden="true"></span>
-    </button>
+<section aria-label="Notification" class="hds-notification hds-notification--top-right">
+  <div role="alert" class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+      <span>New messages</span>
+    </div>
+    <div class="hds-notification__body">You have received new messages.</div>
   </div>
-  <div class="hds-notification__body">You have received new messages.</div>
-</div>
+  <button class="hds-notification__close-button" aria-label="Close toast" type="button" onclick="">
+    <span class="hds-icon hds-icon--cross" aria-hidden="true"></span>
+  </button>
+</section>
 ```
 
 #### React code example:
@@ -167,30 +177,36 @@ HDS notifications come in three different sizes, allowing the designer to choose
 #### Core code example:
 ```html
 <!-- Large -->
-<div class="hds-notification hds-notification--large">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
-    <span>New messages</span>
+<section aria-label="Notification" class="hds-notification hds-notification--large">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+      <span>New messages</span>
+    </div>
+    <div class="hds-notification__body">You have received new messages.</div>
   </div>
-  <div class="hds-notification__body">You have received new messages.</div>
-</div>
+</section>
 
 <!-- Default -->
-<div class="hds-notification">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
-    <span>New messages</span>
+<section aria-label="Notification" class="hds-notification">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+      <span>New messages</span>
+    </div>
+    <div class="hds-notification__body">You have received new messages.</div>
   </div>
-  <div class="hds-notification__body">You have received new messages.</div>
-</div>
+</section>
 
 <!-- Small -->
-<div class="hds-notification hds-notification--small">
-  <div class="hds-notification__label">
-    <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+<section aria-label="Notification" class="hds-notification hds-notification--small">
+  <div class="hds-notification__content">
+    <div class="hds-notification__label" role="heading" aria-level="2">
+      <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+    </div>
+    <div class="hds-notification__body">You have received new messages.</div>
   </div>
-  <div class="hds-notification__body">You have received new messages.</div>
-</div>
+</section>
 ```
 
 #### React code example:
@@ -206,13 +222,15 @@ Invisible notifications do not show up on screen and they are meant to aid scree
 #### Core code example:
 ```html
 <div class="hiddenFromScreen" aria-atomic="true" aria-live="assertive" role="status">
-  <div class="hds-notification">
-    <div class="hds-notification__label">
-      <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
-      <span>New messages</span>
+  <section aria-label="Notification" class="hds-notification">
+    <div class="hds-notification__content">
+      <div class="hds-notification__label" role="heading" aria-level="2">
+        <span class="hds-icon hds-icon--info-circle" aria-hidden="true"></span>
+        <span>New messages</span>
+      </div>
+      <div class="hds-notification__body">You have received new messages. This notification is invisible.</div>
     </div>
-    <div class="hds-notification__body">You have received new messages. This notification is invisible.</div>
-  </div>
+  </section>
 </div>
 ```
 

--- a/site/docs/components/notification.mdx
+++ b/site/docs/components/notification.mdx
@@ -28,7 +28,7 @@ import Text from "../../src/components/Text";
 - **If you use automatically disappearing notifications, make sure the information is accessible elsewhere in case the user misses the notification.**
 
 ### When to use each notification type?
-- **Use inline notifications when information is related to the content or if you want to keep information visible at all times.** Inline notifications are part of the content and should therefore be placed as close as possible to the related part of the content.
+- **Use inline notifications when information is related to the content or if you want to keep information visible at all times.** Inline notifications are part of the content and should therefore be placed as close as possible to the related part of the content. Inline notifications should not be added to the page dynamically.
 - **Use toast notifications to inform the user about a specific event or change in the system status.** Toast notifications do not relate to any specific object on the page and are therefore placed on top of the content (usually top right or bottom center).
 - **Use invisible notifications to make system state changes more apparent for screen reader users.** Some features (such as moving a product to the shopping cart) are apparent for regular users but screen readers may need extra assist.
 
@@ -39,16 +39,19 @@ import Text from "../../src/components/Text";
 - Avoid using automatically disappearing toast notifications for critical information or very long messages. It is possible that the notification disappears before the user or screen reader can react to the message. Refer to <Link href="https://www.w3.org/WAI/WCAG21/Understanding/no-timing.html" external>WCAG 2.1 No timing requirement</Link> for more information.
 - Remember that colour should never be the only way of conveying information. Make sure the meaning of the notification is clearly described by the title and body. Refer to <Link href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html" external>WCAG 2.1 Use of Colour guideline</Link> for more information.
 - It is recommended (but not required) to offer a way to turn off less important notifications. Refer to <Link href="https://www.w3.org/WAI/WCAG21/Understanding/interruptions.html" external>WCAG 2.1 Interruptions guideline</Link> for more information.
+- HDS Toast notifications use `role="alert"` which means they are immediately announced to the screen reader as the node is inserted to the DOM. Inline notifications do not need this role since they are created during page load.
 
 ## Usage & variations
 
 ### Inline
 Inline notifications are used as part of the content. They closely relate to the part of the content and work best when placed as close as the related content as possible. Inline notifications are often used to provide or emphasise key information related to the content of the page. It is recommended not to make them closable - unless their information is not important or can be accessed somewhere else. Inline notifications greatly emphasise the information so they should be used sparingly in order not to dilute their effect. A good rule of thumb is to limit the number of simultaneous inline notifications to one.
 
+Note! Inline notifications should not be added to the page dynamically. For this use case, use [Toast notifications](#toast).
+
 <Playground>
-    <Notification label="New messages" dismissible>You have received new messages.</Notification>
-    <Notification label="Form done" type="success" dismissible style={{marginTop: 'var(--spacing-s)'}}>Form submit was successful!</Notification>
-    <Notification label="Slow loading" type="alert" dismissible style={{marginTop: 'var(--spacing-s)'}}>Loading is taking longer than expected.</Notification>
+    <Notification label="New messages">You have received new messages.</Notification>
+    <Notification label="Form done" type="success" style={{marginTop: 'var(--spacing-s)'}}>Form submit was successful!</Notification>
+    <Notification label="Slow loading" type="alert" style={{marginTop: 'var(--spacing-s)'}}>Loading is taking longer than expected.</Notification>
     <Notification label="Missing information" type="error" style={{marginTop: 'var(--spacing-s)'}}>Form is missing critical information.</Notification>
 </Playground>
 


### PR DESCRIPTION
## Description

This PR improves accessibility of the Notification component, based on HDS accessibility audit:

- Changed the wrapping HTML element from `div` to `section`
- Use `role="alert"` only for toast notifications
- Add `role="heading"` and `aria-level="2"` to the notification label element

## Related Issues

https://helsinkisolutionoffice.atlassian.net/browse/HDS-439
https://helsinkisolutionoffice.atlassian.net/browse/HDS-438
https://helsinkisolutionoffice.atlassian.net/browse/HDS-440

## How Has This Been Tested?

Tested by running Storybook locally.
