### PR TITLE
[Accessibility] Button fixes

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -119,6 +119,20 @@ input[type="submit"].hds-button {
   margin: 0 var(--spacing-2-xs);
 }
 
+/* supplementary with right icon */
+.hds-button--supplementary .hds-button__label:first-child {
+  padding-right: var(--spacing-3-xs);
+}
+/* supplementary with left icon */
+.hds-button--supplementary .hds-icon + .hds-button__label:last-child {
+  padding-left: var(--spacing-3-xs);
+}
+/* supplementary with both icons */
+.hds-button--supplementary .hds-icon + .hds-button__label:not(:last-child) {
+  padding-left: var(--spacing-3-xs);
+  padding-right: var(--spacing-3-xs);
+}
+
 /* SMALL */
 .hds-button--small {
   padding: 0;

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -166,14 +166,12 @@ input[type="submit"].hds-button--small {
 
 /* left - small */
 .hds-button--small .hds-icon {
-  height: 1.125em;
-  margin-left: var(--spacing-xs);
-  width: 1.125em;
+  margin-left: var(--spacing-2-xs);
 }
 
 /* right - small */
 .hds-button .hds-button--small .hds-button__label ~ .hds-icon {
-  margin: 0 var(--spacing-xs) 0 0;
+  margin: 0 var(--spacing-2-xs) 0 0;
 }
 
 /* both icons - left */
@@ -188,12 +186,12 @@ input[type="submit"].hds-button--small {
 
 /* both icons - left - small */
 .hds-button--small .hds-icon:first-child:not(:last-of-type) {
-  margin: 0 0 0 var(--spacing-xs);
+  margin: 0 0 0 var(--spacing-2-xs);
 }
 
 /* both icons - right - small */
 .hds-button--small .hds-icon:last-child:not(:first-of-type) {
-  margin: 0 var(--spacing-xs) 0 0;
+  margin: 0 var(--spacing-2-xs) 0 0;
 }
 
 /* PRIMARY */

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -1,6 +1,7 @@
 .hds-button {
   --border-width: 2px;
   --color: inherit;
+  --min-size: 44px;
   --outline-gutter: 2px;
   --outline-width: 3px;
 
@@ -14,6 +15,8 @@
   display: inline-flex;
   font-weight: 500;
   justify-content: center;
+  min-height: var(--min-size);
+  min-width: var(--min-size);
   padding: 0 var(--spacing-2-xs);
   position: relative;
   vertical-align: top;

--- a/packages/core/src/components/button/button.stories.js
+++ b/packages/core/src/components/button/button.stories.js
@@ -24,6 +24,7 @@ export const Secondary = () => `
 
 export const Supplementary = () => `
   <button type="button" class="hds-button hds-button--supplementary">
+    <span aria-hidden="true" class="hds-icon hds-icon--share"></span>
     ${getLabel()}
   </button>
 `;

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -35,7 +35,7 @@ export const Secondary = () => (
 );
 
 export const Supplementary = () => (
-  <Button onClick={onClick} variant="supplementary">
+  <Button onClick={onClick} variant="supplementary" iconLeft={<IconShare />}>
     Button
   </Button>
 );

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -9,7 +9,7 @@ export type ButtonSize = 'default' | 'small';
 export type ButtonTheme = 'default' | 'coat' | 'black';
 export type ButtonVariant = 'primary' | 'secondary' | 'supplementary' | 'success' | 'danger';
 
-export type ButtonProps = React.ComponentPropsWithoutRef<'button'> & {
+export type CommonButtonProps = React.ComponentPropsWithoutRef<'button'> & {
   /**
    * The content of the button
    */
@@ -21,7 +21,7 @@ export type ButtonProps = React.ComponentPropsWithoutRef<'button'> & {
   /**
    * Defines the button variant
    */
-  variant?: ButtonVariant;
+  variant?: Exclude<ButtonVariant, 'supplementary'>;
   /**
    * Defines the button theme
    */
@@ -47,6 +47,20 @@ export type ButtonProps = React.ComponentPropsWithoutRef<'button'> & {
    */
   size?: ButtonSize;
 };
+
+// Supplementary variant requires iconLeft or iconRight
+export type SupplementaryButtonProps = Omit<CommonButtonProps, 'variant'> & {
+  variant: 'supplementary';
+} & (
+    | {
+        iconLeft: React.ReactNode;
+      }
+    | {
+        iconRight: React.ReactNode;
+      }
+  );
+
+export type ButtonProps = CommonButtonProps | SupplementaryButtonProps;
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/packages/react/src/components/navigation/navigationUser/NavigationUser.tsx
+++ b/packages/react/src/components/navigation/navigationUser/NavigationUser.tsx
@@ -63,23 +63,23 @@ export const NavigationUser = ({
     </NavigationDropdown>
   );
 
-  return (
-    <div className={styles.user}>
-      {authenticated ? (
-        userItems
-      ) : (
-        <Button
-          className={styles.signInButton}
-          fullWidth
-          iconLeft={isMobile ? null : <IconSignin aria-hidden />}
-          onClick={onSignIn}
-          theme="black"
-          variant={isMobile ? 'primary' : 'supplementary'}
-        >
-          {label}
-        </Button>
-      )}
-    </div>
+  const signInButton = isMobile ? (
+    <Button className={styles.signInButton} fullWidth onClick={onSignIn} theme="black" variant="primary">
+      {label}
+    </Button>
+  ) : (
+    <Button
+      className={styles.signInButton}
+      fullWidth
+      iconLeft={<IconSignin aria-hidden />}
+      onClick={onSignIn}
+      theme="black"
+      variant="supplementary"
+    >
+      {label}
+    </Button>
   );
+
+  return <div className={styles.user}>{authenticated ? userItems : signInButton}</div>;
 };
 NavigationUser.componentName = 'NavigationUser';

--- a/site/docs/components/buttons.mdx
+++ b/site/docs/components/buttons.mdx
@@ -31,6 +31,7 @@ import Text from "../../src/components/Text";
 
 - **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
 - In most cases, prefer using normal size buttons over small buttons. Default sized buttons are easier for users to notice and press.
+- HDS Buttons (even the Small variant) comply with <Link href="https://www.w3.org/TR/WCAG21/#target-size" external>WCAG 2.5.5 Target Size (AAA) guideline</Link>. Customizing button sizes is not recommended.
 
 ## Usage & variations
 
@@ -76,6 +77,8 @@ Secondary buttons are used for actions which are not mandatory or essential for 
 
 ### Supplementary button
 Supplementary buttons can be used in similar cases as secondary buttons. However, supplementary buttons are meant for actions which are intentionally wanted to be less visible to the user. These kind of actions include i.e. cancel and dismiss functionalities.
+
+Note! Since supplementary buttons do not have borders, accompanying icon is required to clearly distinguish them from links and passive text elements.
 
 <Playground>
   <Button variant="supplementary">Supplementary</Button>


### PR DESCRIPTION
WIP - Requires https://helsinkisolutionoffice.atlassian.net/browse/HDS-449

## Description

Accessibility fixes for the Button component:

- Set button minimum width and height to 44px
- Require `iconLeft` or `iconRight` for supplementary button
- Changed documentation to mention that Supplementary buttons should not be used without an icon
- Added a mention that HDS Buttons comply with WCAG Target Size guideline
- Shortened the spacing between icon and label in Supplementary button to 4px

## How Has This Been Tested?

Tested by running Storybook and documentation site locally.