### PR TITLE
[Fix] Removed HTML Title from Gatsby wrapper.jsx

### DIFF
--- a/site/src/gatsby-theme-docz/wrapper.jsx
+++ b/site/src/gatsby-theme-docz/wrapper.jsx
@@ -7,8 +7,6 @@ import './assets/index.css';
 const Wrapper = ({ children }) => (
   <React.Fragment>
     <Helmet>
-      <title>Helsinki Design System</title>
-
       <link rel="apple-touch-icon" sizes="57x57" href={require('./assets/apple-icon-57x57.png')} />
       <link rel="apple-touch-icon" sizes="60x60" href={require('./assets/apple-icon-60x60.png')} />
       <link rel="apple-touch-icon" sizes="72x72" href={require('./assets/apple-icon-72x72.png')} />


### PR DESCRIPTION
## Description
Removing the HTML title makes the title dynamic. The fixes the issue that documentation pages lacked a descriptive title.

## Related Issue
Documentation pages lacking descriptive titles came up in the doc site accessibility audit.

## How Has This Been Tested?
Tested by running the documentation site locally.
