### PR TITLE
[Content] Documentation site accessibility guidelines and statement

### DIFF
--- a/site/docs/about/statement.mdx
+++ b/site/docs/about/statement.mdx
@@ -17,13 +17,22 @@ This website was published after 23.09.2018. The website must fulfil statutory a
 As regards the accessibility of digital services, Helsinki aims to reach at least Level AA or above as set forth in the WCAG guidelines in so far as is reasonably practical.
 
 ### Compliance status
-The accessibility compliance of this website has not yet been evaluated. The accessibility will be evaluated before the 1.0 release of the Helsinki Design System.
+The accessibility compliance of this website was evualuated by a third party auditor on 18.9.2020. Most of the critical issues noted in the audit were fixed. However, due to the technical limitations of the website framework, not all issues were possible to be currently fixed. We are looking to change the website framework before the 1.0 release of Helsinki Design System. This upgrade will allow us to fix the rest of the issues.
+
+Currently known accessibity issues are:
+- Expandable navigation sub-menus are defined as divs and are missing aria attributes
+- The page is missing a "Skip to content" link
+- The search field is missing a "Search" button
+- The search field is missing a label
+- In some cases, navigation links do not correctly move the view into the content
+- Code example (Playground) buttons are missing aria labels
+- Mobile menu icon ("hamburger") is missing an aria label and focus indicator
 
 ### Preparing an accessibility statement
-This statement was prepared on 22.05.2020.
+This statement was originally prepared on 22.05.2020. The statement has been updated on 15.10.2020.
 
 ### Updating the accessibility statement
-The accessibility statement will be updated so that it corresponds with the observations related to accessibility compliance made during an audit.
+The accessibility statement will be updated so that it corresponds with the most recent compliance status of the website.
 
 ### Requesting information in an accessible format
 <p>If a user feels that content on a website is not available in an accessible format, they can request for this information by e-mail at hds@hel.fi or through the <Link href="https://www.hel.fi/helsinki/en/administration/participate/feedback" external>feedback form</Link>. The aim is to reply to the enquiry within a reasonable time frame.</p>
@@ -42,4 +51,4 @@ The accessibility level of websites is monitored constantly during their mainten
 The city provides counselling and support for the disabled and users of assistive technologies. Support is available on guidance sites announced on the city’s website and through telephone counselling.
 
 ### Approval of the accessibility statement
-This statement was approved on 22.5.2020 by City Executive Office, City of Helsinki
+This statement was approved on 15.10.2020 by City Executive Office, City of Helsinki

--- a/site/docs/about/statement.mdx
+++ b/site/docs/about/statement.mdx
@@ -8,7 +8,7 @@ import Link from "../../src/components/Link";
 
 # Accessibility statement
 
-This accessibility statement applies to the website Helsinki Design System (documentation). The site address is hds.hel.fi.
+This accessibility statement applies to the website Helsinki Design System (documentation). The site address is [hds.hel.fi](http://hds.hel.fi).
 
 ### Statutory provisions applicable to the website
 This website was published after 23.09.2018. The website must fulfil statutory accessibility requirements.
@@ -35,10 +35,14 @@ This statement was originally prepared on 22.05.2020. The statement has been upd
 The accessibility statement will be updated so that it corresponds with the most recent compliance status of the website.
 
 ### Requesting information in an accessible format
-<p>If a user feels that content on a website is not available in an accessible format, they can request for this information by e-mail at hds@hel.fi or through the <Link href="https://www.hel.fi/helsinki/en/administration/participate/feedback" external>feedback form</Link>. The aim is to reply to the enquiry within a reasonable time frame.</p>
+If a user feels that content on a website is not available in an accessible format, they can request for this information by e-mail at [hds@hel.fi](mailto:hds@hel.fi).
+
+<p>It is also possible to send requests through a <Link href="https://www.hel.fi/helsinki/en/administration/participate/feedback" external>feedback form</Link>.</p>
+
+The aim is to reply to the enquiry within a reasonable time frame.
 
 ### Feedback and contact information
-City of Helsinki, City Executive Office, Helsinki Design System team (hds@hel.fi)
+City of Helsinki, City Executive Office, Helsinki Design System team ([hds@hel.fi](mailto:hds@hel.fi))
 
 ### The City of Helsinki and accessibility
 The objective of the city of Helsinki is to be an accessible city to all. Helsinki aims to ensure that all residents are able to move about and act as effortlessly as possible and that all content and services are accessible to all.

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -4,6 +4,8 @@ route: /guidelines/accessibility
 menu: Guidelines
 ---
 
+import { StatusLabel } from "hds-react";
+
 import LargeParagraph from "../../src/components/LargeParagraph";
 import Link from "../../src/components/Link";
 
@@ -12,37 +14,34 @@ import Link from "../../src/components/Link";
 <LargeParagraph>The Helsinki Design System is designed and built to be accessible for all, regardless of ability or situation.</LargeParagraph>
 
 
-## Standards
-### Global accessibility standards
-<p>World Wide Web Consortium (W3C)’s <Link href="https://www.w3.org/WAI/" external>Web Accessibility Initiative (WAI)</Link> is an effort to improve the accessibility of the World Wide Web for people of all abilities.
-The WAI contributors maintain <Link href="https://www.w3.org/TR/WCAG21/" external>The Web Content Accessibility Guidelines 2.1 (WCAG)</Link>, which is the global accessibility standard.</p>
+## Accessibility in the City of Helsinki digital services
+<p>The basis of HDS accessibility is <Link href="https://eur-lex.europa.eu/eli/dir/2016/2102/oj" external>an EU directive on web accessibility</Link> which mandates that all new public sector websites published by 23.09.2019 have to comply with <Link href="https://www.w3.org/TR/WCAG20/" external>WCAG 2.0 Standard at AA Level</Link>. On 23.09.2020 all websites, new and old, have to meet this criteria. HDS aims to make the life of projects easier by providing components, patterns and guidelines that meet these requirements.</p>
 
-<p><Link href="https://a11yproject.com/" external>The international A11Y Project</Link> is a community-driven effort to make web accessibility easier.</p>
+## Standards behind HDS development
 
+<p>Following the EU directive, HDS aims to fulfill <Link href="https://www.w3.org/TR/WCAG20/" external>WCAG 2.0 Standard at AA Level</Link>.</p>
 
-### Accessibility in the City of Helsinki digital services
-<p><Link href="https://eur-lex.europa.eu/eli/dir/2016/2102/oj" external>EU directive on web accessibility</Link> mandates that all new public sector websites published by 23.09.2019 have to comply with <Link href="https://www.w3.org/TR/WCAG20/#conformance" external>WCAG 2.0 Standard at AA Level</Link>. On 23.09.2020 all websites, new and old, have to meet this criteria. Note, that HDS follows follows WCAG 2.1 instead of WCAG 2.0. The publication of WCAG 2.1 does not deprecate or supersede WCAG 2.0 but W3C advices to use WCAG 2.1.</p> 
+<p>However, HDS follows the newer <Link href="https://www.w3.org/TR/WCAG21/" external>WCAG 2.1 Standard</Link>. The publication of WCAG 2.1 does not deprecate or supersede WCAG 2.0 and W3C advices to use it. Even though the EU directive requires fullfilling the standard at AA level, HDS also implements many requirements from the AAA level.</p>
 
-<p>The City of Helsinki also has its own <Link href="https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf" external>content accessibility guidelines</Link> for the web.</p>
+In addition to WCAG 2.1 and 2.0, HDS also refers to the following guidelines:
+- <Link href="https://www.w3.org/TR/WCAG22/" external>WCAG 2.2 Standard (draft) at AA level</Link>. This is done for future-proofing reasons even though the requirements are not part of the official WCAG requirements yet.
+- <Link href="https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf" external>The City of Helsinki content accessibility guidelines</Link>. They are heavily based on WCAG requirements but still include good extra practices.
+- <Link href="https://dev.hel.fi/accessibility" external>Develop with Helsinki - accessibility for developers</Link>.
 
-<p><Link href="https://dev.hel.fi/accessibility" external>Develop with Helsinki</Link> site offers quality content about accessibility for developers.</p>
+## HDS accessibility process
+**After HDS beta release, new components and patterns are not released before their accessibility has been audited by a third party auditor.** If components or patterns are released without an audit, it will be clearly indicated in the documentation. This may happen if the component is quickly needed by some project or if it takes considerably long time to make the component accessible.
 
+Component accessibility is ensured in all stages of HDS design and development. The process is following:
+1. During design phase, auditors will comments the designs from visual perspective. They will also give pointers on which parts of the design may cause challenges for accessibility during implementation.
+2. During implementation specification phase, auditors will comment on the specifications from the accessibility point of view. Specifications will include things like keyboard navigation, usage of aria features etc.
+3. During implementation, auditors will actively test the component and suggest changes if needed.
+4. During documentation phase, auditors will read through the documentation and suggest changes and clarifications if needed.
+5. After all phases have been accepted by the auditors, the component will be marked with the following status label in the HDS documentation: <StatusLabel type="success">Accessible</StatusLabel> 
 
-## Principles
-<p>The WCAG 2.1 Accessibility Standard outlines <Link href="https://www.w3.org/WAI/WCAG21/Understanding/intro#understanding-the-four-principles-of-accessibility" external>four principles</Link> for what an accessible service should be:</p>
+## Accessibility in projects using HDS
+HDS promises to ensure component and pattern level accessibility. This means that a project that uses HDS components and patterns and follows HDS guidelines can trust that these parts of the service are accessible. However, if the components are used in other ways or use cases than specified in the HDS documentation, HDS cannot promise accessibility. **It is good to keep in mind that using HDS does not alone make the service accessible!**
 
-- **Perceivable**: Information and user interface components must be presentable to users in ways they can perceive. For example by providing text alternates to visual and time-based media.
-- **Operable**: User interface components and navigation must be operable, for example with keyboard and assistive technologies. It should help users navigate, find content, and determine where they are.
-- **Understandable**: the content should be readable and easy to understand, and the services should operate in a predictable way.
-- **Robust**: accessible by wide range of technologies, including old and new browsers and assistive technologies.
-
-A few guidelines for developing accessible services:
-- Write standards compliant, semantic HTML and CSS
-- Support keyboard navigation and other standard accessibility functionalities
-- In React, use ARIA when there is no native markup. For more information, see <Link href="https://reactjs.org/docs/accessibility.html" external>React accessibility documentation</Link>
-
-
-## Further reading
-- <Link href="https://www.w3.org/TR/wai-aria-practices-1.1/" external>WAI-ARIA Authoring Practices</Link>
-- <Link href="https://webaim.org/" external>WebAIM</Link>
-- <Link href="https://www.aremycoloursaccessible.com/" external>Are My Colours Accessible?</Link>
+Here are some things projects should take into account when designing accessible services using HDS:
+- Get at least a basic level familiarity of <Link href="https://www.w3.org/TR/WCAG20/" external>WCAG 2.0 Standard at AA Level</Link>. Your service is required to follow WCAG guidelines at A and AA levels.
+- HDS components allow a lot of customisation. When customising component colours, ensure accessibility. For more information, refer to <Link href="/design-tokens/colour#accessible-colour-combinations">HDS Colours - Accessible colour combination documentation</Link>.
+- When designing components that are not part of the HDS, you are required to ensure the accessibility by yourself. It may help to refer to HDS components for good accessibility design and implementation practices. You may also contact the HDS team if you need assistance.

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -32,7 +32,7 @@ In addition to WCAG 2.1 and 2.0, HDS also refers to the following guidelines:
 **After HDS beta release, new components and patterns are not released before their accessibility has been audited by a third party auditor.** If components or patterns are released without an audit, it will be clearly indicated in the documentation. This may happen if the component is quickly needed by some project or if it takes considerably long time to make the component accessible.
 
 Component accessibility is ensured in all stages of HDS design and development. The process is following:
-1. During design phase, auditors will comments the designs from visual perspective. They will also give pointers on which parts of the design may cause challenges for accessibility during implementation.
+1. During design phase, auditors will comment the designs from visual perspective. They will also give pointers on which parts of the design may cause challenges for accessibility during implementation.
 2. During implementation specification phase, auditors will comment on the specifications from the accessibility point of view. Specifications will include things like keyboard navigation, usage of aria features etc.
 3. During implementation, auditors will actively test the component and suggest changes if needed.
 4. During documentation phase, auditors will read through the documentation and suggest changes and clarifications if needed.

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -26,7 +26,7 @@ import Link from "../../src/components/Link";
 In addition to WCAG 2.1 and 2.0, HDS also refers to the following guidelines:
 - <Link href="https://www.w3.org/TR/WCAG22/" external>WCAG 2.2 Standard (draft) at AA level</Link>. This is done for future-proofing reasons even though the requirements are not part of the official WCAG requirements yet.
 - <Link href="https://www.hel.fi/static/liitteet/kanslia/TPR/opas_saavutettavaan_sisaltoon_EN.pdf" external>The City of Helsinki content accessibility guidelines</Link>. They are heavily based on WCAG requirements but still include good extra practices.
-- <Link href="https://dev.hel.fi/accessibility" external>Develop with Helsinki - accessibility for developers</Link>.
+- <Link href="https://dev.hel.fi/accessibility" external>Develop with Helsinki - accessibility guidelines for developers</Link>.
 
 ## HDS accessibility process
 **After HDS beta release, new components and patterns are not released before their accessibility has been audited by a third party auditor.** If components or patterns are released without an audit, it will be clearly indicated in the documentation. This may happen if the component is quickly needed by some project or if it takes considerably long time to make the component accessible.

--- a/site/docs/resources.mdx
+++ b/site/docs/resources.mdx
@@ -28,6 +28,7 @@ import Link from "../src/components/Link";
 - <Link href="https://www.getstark.co/" external>Stark Sketch plugin</Link>
 - <Link href="https://cluse.cc/" external>Cluse Sketch plugin</Link>
 - <Link href="https://webaim.org/resources/contrastchecker/" external>WebAIM Contrast checker</Link>
+- <Link href="https://www.aremycoloursaccessible.com/" external>Are My Colours Accessible?</Link>
 
 ## HDS repositories
 


### PR DESCRIPTION
## Description
This PR updates the documentation site accessibility guidelines and statement:
- Guidelines were updated to describe the basis of HDS accessibility as well as the process of ensuring accessibility.
- The accessibility statement was updated to list all currently known accessibility issues of the HDS documentation site. The reason for not fixing the issues was also stated.

## How Has This Been Tested?
Tested by running the documentation site locally.
