### PR TITLE
[Fix] Added aria-label to documentation site external link icon

### DIFF
--- a/site/src/components/Link.js
+++ b/site/src/components/Link.js
@@ -20,7 +20,7 @@ const Link = ({
       {...rest}
     >
       {children}
-      {external && <IconLinkExternal style={{ marginLeft: 'var(--spacing-3-xs)' }} size="xs" />}
+      {external && <IconLinkExternal style={{ marginLeft: 'var(--spacing-3-xs)' }} size="xs" aria-label="Opens in a new window." />}
     </a>
   );
 };


### PR DESCRIPTION
## Description
Aria-label tells the user that the link opens in a new window. 

## Related Issue
This fixes issue 5.4 of the accessibility audit of the documentation website.

## How Has This Been Tested?
Tested by running the documentation site locally.
