### PR TITLE
[Accessibility] Add warning for non-string checkbox labels

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.stories.tsx
@@ -56,17 +56,6 @@ export const Custom = () => {
 };
 Custom.storyName = 'With custom styles';
 
-export const RichLabel = () => {
-  const label = (
-    <span>
-      I have read city&apos;s {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-      <a style={{ color: 'var(--color-bus)', textDecoration: 'underline' }}>data protection principles</a>.
-    </span>
-  );
-  return <Checkbox id="radio4" label={label} />;
-};
-RichLabel.storyName = 'With rich label';
-
 export const Playground = () => {
   const [checkedItems, setCheckedItems] = useState({});
   const options = ['Option 1', 'Option 2', 'Option 3'];

--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -60,22 +60,30 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       ...rest
     }: CheckboxProps,
     ref: React.Ref<HTMLInputElement>,
-  ) => (
-    <div className={classNames(styles.checkbox, className)} style={style}>
-      <input
-        ref={ref}
-        id={id}
-        className={classNames(styles.input)}
-        onChange={onChange}
-        value={value}
-        type="checkbox"
-        disabled={disabled}
-        checked={checked}
-        {...rest}
-      />
-      <label htmlFor={id} className={classNames(styles.label)}>
-        {label || labelText}
-      </label>
-    </div>
-  ),
+  ) => {
+    if (label && typeof label !== 'string' && typeof label !== 'number') {
+      console.warn(
+        'Using ReactElement as a label is against good usability and accessibility practices. Please prefer plain strings.',
+      );
+    }
+
+    return (
+      <div className={classNames(styles.checkbox, className)} style={style}>
+        <input
+          ref={ref}
+          id={id}
+          className={classNames(styles.input)}
+          onChange={onChange}
+          value={value}
+          type="checkbox"
+          disabled={disabled}
+          checked={checked}
+          {...rest}
+        />
+        <label htmlFor={id} className={classNames(styles.label)}>
+          {label || labelText}
+        </label>
+      </div>
+    );
+  },
 );

--- a/packages/react/src/components/radioButton/RadioButton.stories.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.stories.tsx
@@ -65,19 +65,6 @@ export const Custom = () => {
 };
 Custom.storyName = 'With custom styles';
 
-export const RichLabel = () => {
-  const label = (
-    <span>
-      Label with{' '}
-      <a style={{ color: 'var(--color-bus)' }} href="/?path=/story/components-radiobutton--rich-label">
-        link
-      </a>
-    </span>
-  );
-  return <RadioButton id="radio4" label={label} />;
-};
-RichLabel.storyName = 'With rich label';
-
 export const Playground = () => {
   const [radioValue, setRadioValue] = useState(null);
   const options = ['foo', 'bar', 'baz'];

--- a/packages/react/src/components/radioButton/RadioButton.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.tsx
@@ -60,22 +60,30 @@ export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
       ...rest
     }: RadioButtonProps,
     ref: React.Ref<HTMLInputElement>,
-  ) => (
-    <div className={classNames(styles.radioButton, className)} style={style}>
-      <input
-        ref={ref}
-        id={id}
-        className={classNames(styles.input)}
-        onChange={onChange}
-        value={value}
-        type="radio"
-        disabled={disabled}
-        checked={checked}
-        {...rest}
-      />
-      <label htmlFor={id} className={classNames(styles.label)}>
-        {label || labelText}
-      </label>
-    </div>
-  ),
+  ) => {
+    if (label && typeof label !== 'string' && typeof label !== 'number') {
+      console.warn(
+        'Using ReactElement as a label is against good usability and accessibility practices. Please prefer plain strings.',
+      );
+    }
+
+    return (
+      <div className={classNames(styles.radioButton, className)} style={style}>
+        <input
+          ref={ref}
+          id={id}
+          className={classNames(styles.input)}
+          onChange={onChange}
+          value={value}
+          type="radio"
+          disabled={disabled}
+          checked={checked}
+          {...rest}
+        />
+        <label htmlFor={id} className={classNames(styles.label)}>
+          {label || labelText}
+        </label>
+      </div>
+    );
+  },
 );


### PR DESCRIPTION
## Description

This PR adds warning when using other than strings as a checkbox label.

## Motivation and Context

Links (anchor) embedded in label is poor usability and accessibility practice:

- First, it is very easy for keyboard and screenreader users to accidentally activate the link and/or the checkbox when attempting to click the other one, as users do not necessarily perceive the elements as separate. Secondly, such an unorthodox tag embedding will cause some screenreaders to describe the embedded link in a very unusual manner that is hard to comprehend.

- We recommend that the link be rather placed adjacent but separate to the checkbox. E.g. first the link “City data protection principles”, and below it as a separate checkbox: I have read the city data protection principles (link above).”

## Related Issue

#140 