### PR TITLE
[Documentation] Doc site updates for beta release

### DIFF
--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -20,7 +20,8 @@ import Link from "../../src/components/Link";
 - **Added**: New icons, fill variants for notification icons
 - **Changed**: Colour token names and values of light/dark variants
 - **Reworked**: Visual style of some icons to more accessible
-- **Fixed**: Multiple bug fixes accessibility improvements to existing components
+- **Fixed**: Multiple accessibility improvements to existing components. *All released components have now passed accessibility audit.*
+- **Fixed**: Multiple bug fixes existing components. 
 
 <p><strong>0.14.0 (alpha)</strong> - <em>15.10.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.14.0" external>Release notes</Link></p>
 

--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -18,7 +18,7 @@ import Link from "../../src/components/Link";
 - **Added**: First pattern Forms
 - **Added**: New components Tooltip, Card
 - **Added**: New icons, fill variants for notification icons
-- **Reworked**: Colour token names and values of light/dark variants
+- **Changed**: Colour token names and values of light/dark variants
 - **Reworked**: Visual style of some icons to more accessible
 - **Fixed**: Multiple bug fixes accessibility improvements to existing components
 

--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -13,6 +13,15 @@ import Link from "../../src/components/Link";
     Here you will find summarized patch notes of major releases of HDS. For full patch notes for each release, please refer to the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases" external>GitHub releases</Link>.
 </LargeParagraph>
 
+<p><strong>0.15.0 (beta)</strong> - <em>29.10.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.15.0" external>Release notes</Link></p>
+
+- **Added**: First pattern Forms
+- **Added**: New components Tooltip, Card
+- **Added**: New components icons and fill variant for notification icons
+- **Reworked**: Colour token names and values of light/dark variants
+- **Reworked**: Visual style of some icons to more accessible
+- **Fixed**: Multiple bug fixes accessibility improvements to existing components
+
 <p><strong>0.14.0 (alpha)</strong> - <em>15.10.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.14.0" external>Release notes</Link></p>
 
 - **Added**: New component Footer

--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -17,7 +17,7 @@ import Link from "../../src/components/Link";
 
 - **Added**: First pattern Forms
 - **Added**: New components Tooltip, Card
-- **Added**: New components icons and fill variant for notification icons
+- **Added**: New icons, fill variants for notification icons
 - **Reworked**: Colour token names and values of light/dark variants
 - **Reworked**: Visual style of some icons to more accessible
 - **Fixed**: Multiple bug fixes accessibility improvements to existing components

--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -14,7 +14,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 **Q2 2020**
 
-- ~~Release of the first design kit~~
+- ~~**Release of the first design kit**~~
 - ~~Component: Dropdown~~
 - ~~Component: Radio button~~
 - ~~Component: Checkbox~~
@@ -28,42 +28,36 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 **Q3 2020**
 
 - ~~Update: Cleaning typography styles~~
+
+
 - ~~Component: Navigation~~
 - ~~Component: Notification~~
 - ~~Component: Logo~~
-
-
-- Update: Multiselect dropdown update
-
-
-- Component: Footer
-- Component: Tag
-- Component: Empty content placeholders
+- ~~Component: Footer~~
+- ~~Visual assets: Empty content placeholders~~
 
 
 **Q4 2020**
 
-- **Accessibility: Audit for all released components**
+- ~~Update: Cleaning color styles~~
+- ~~Update: Multiselect dropdown update (Combobox and Select)~~
 
 
-- Pattern: Form guidelines
+- ~~Component: Tooltip~~
+- ~~Component: Card~~
+- ~~Pattern: Forms~~
+- ~~Visual assets: New and updated icons~~
 
 
-- Component: Tooltip
+- ~~**Accessibility: Audit for all released components**~~
+
+
+- **HDS Beta release 29.10.2020**
+
+
+- Component: Tag
 - Component: Loading spinner
-- Component: Card
 - Component: Error template
-
-
-- Icons: Next set of icons
-
-
-- Update: Cleaning color styles
-
-
-- **HDS Beta release during November**
-
-
 - Component: Search field
 - Component: Datepicker
 - Component: Number input field

--- a/site/src/gatsby-theme-docz/components/Sidebar/index.js
+++ b/site/src/gatsby-theme-docz/components/Sidebar/index.js
@@ -46,7 +46,7 @@ export const Sidebar = React.forwardRef((props, ref) => {
           >
             <img src={logo} alt="Helsinki Design System" height="60" />
             <div>
-              <b>Design System</b> (alpha)
+              <b>Design System</b> (beta)
             </div>
             <div
               style={{


### PR DESCRIPTION
## Description
- Updated documentation Roadmap and What's new pages to beta
- Changed designs system logo in doc site sidebar from alpha to beta

## How Has This Been Tested?
Tested by running the documentation site locally.