### PR TITLE
[Fix Fixed broken Storybook links in the Tooltip documentation

### DIFF
--- a/site/docs/components/tooltip.mdx
+++ b/site/docs/components/tooltip.mdx
@@ -114,6 +114,6 @@ _Not included in hds-core!_
 
 ### React
 
-[Tooltips in hds-react](/storybook/react/?path=/story/components-tooltip--regular)
+[Tooltips in hds-react](/storybook/react/?path=/story/components-tooltip--default)
 
-[Tooltip API](/storybook/react/?path=/docs/components-tooltip--regular)
+[Tooltip API](/storybook/react/?path=/docs/components-tooltip--default)


### PR DESCRIPTION
## Description
Fixed broken Storybook links in the Tooltip documentation

## How Has This Been Tested?
Tested by running the documentation site locally.
