### PR TITLE
[Fix] Add icon to Supplementary button documentation example

### DIFF
--- a/packages/core/src/components/button/button.stories.js
+++ b/packages/core/src/components/button/button.stories.js
@@ -2,6 +2,7 @@ import './button.css';
 import '../../icons/icon.css';
 import '../../icons/ui/icon-share.css';
 import '../../icons/ui/icon-angle-right.css';
+import '../../icons/ui/icon-trash.css';
 
 const getLabel = (label = 'Button') => `<span class="hds-button__label">${label}</span>`;
 
@@ -24,7 +25,7 @@ export const Secondary = () => `
 
 export const Supplementary = () => `
   <button type="button" class="hds-button hds-button--supplementary">
-    <span aria-hidden="true" class="hds-icon hds-icon--share"></span>
+    <span aria-hidden="true" class="hds-icon hds-icon--trash"></span>
     ${getLabel()}
   </button>
 `;

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, radios, text, withKnobs } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
-import { IconShare, IconAngleRight, IconFaceSmile } from '../../icons';
+import { IconShare, IconAngleRight, IconFaceSmile, IconTrash } from '../../icons';
 import { Button } from './Button';
 
 const onClick = action('button-click');
@@ -35,7 +35,7 @@ export const Secondary = () => (
 );
 
 export const Supplementary = () => (
-  <Button onClick={onClick} variant="supplementary" iconLeft={<IconShare />}>
+  <Button onClick={onClick} variant="supplementary" iconLeft={<IconTrash />}>
     Button
   </Button>
 );

--- a/site/docs/components/buttons.mdx
+++ b/site/docs/components/buttons.mdx
@@ -5,7 +5,7 @@ route: /components/button
 ---
 
 import { Playground } from "docz";
-import { Button, IconShare, IconAngleRight, StatusLabel } from "hds-react";
+import { Button, IconShare, IconAngleRight, IconCogwheel, StatusLabel } from "hds-react";
 
 import ColorBox from "../../src/components/ColorBox";
 import LargeParagraph from "../../src/components/LargeParagraph";
@@ -82,8 +82,8 @@ Supplementary buttons can be used in similar cases as secondary buttons. However
 Note! Since supplementary buttons do not have borders, accompanying icon is required to clearly distinguish them from links and passive text elements.
 
 <Playground>
-  <Button variant="supplementary">Supplementary</Button>
-  <Button variant="supplementary" style={{marginLeft: 'var(--spacing-s)'}} disabled>Supplementary disabled</Button>
+  <Button variant="supplementary" iconLeft={<IconCogwheel />}>Supplementary</Button>
+  <Button variant="supplementary" iconLeft={<IconCogwheel />} style={{marginLeft: 'var(--spacing-s)'}} disabled>Supplementary disabled</Button>
 </Playground>
 
 #### Core code example:

--- a/site/docs/components/buttons.mdx
+++ b/site/docs/components/buttons.mdx
@@ -5,7 +5,7 @@ route: /components/button
 ---
 
 import { Playground } from "docz";
-import { Button, IconShare, IconAngleRight, IconCogwheel, StatusLabel } from "hds-react";
+import { Button, IconShare, IconAngleRight, IconTrash, StatusLabel } from "hds-react";
 
 import ColorBox from "../../src/components/ColorBox";
 import LargeParagraph from "../../src/components/LargeParagraph";
@@ -82,8 +82,8 @@ Supplementary buttons can be used in similar cases as secondary buttons. However
 Note! Since supplementary buttons do not have borders, accompanying icon is required to clearly distinguish them from links and passive text elements.
 
 <Playground>
-  <Button variant="supplementary" iconLeft={<IconCogwheel />}>Supplementary</Button>
-  <Button variant="supplementary" iconLeft={<IconCogwheel />} style={{marginLeft: 'var(--spacing-s)'}} disabled>Supplementary disabled</Button>
+  <Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+  <Button variant="supplementary" iconLeft={<IconTrash />} style={{marginLeft: 'var(--spacing-s)'}} disabled>Supplementary disabled</Button>
 </Playground>
 
 #### Core code example:


### PR DESCRIPTION
## Description
The icon was missing from Supplementary button documentation examples. It was added in this PR. Storybook examples for Supplementary button were also updated. They now use IconTrash instead of IconShare since IconTrash is more in line with the documentation on how to use Supplementary buttons.

## How Has This Been Tested?
Tested by running the documention site and Storybooks (both Core and React) locally.
