### PR TITLE
[Fix] Fix stylesheet bundle

### DIFF
--- a/packages/react/src/components/navigation/navigationItem/NavigationItem.module.scss
+++ b/packages/react/src/components/navigation/navigationItem/NavigationItem.module.scss
@@ -56,9 +56,7 @@
 }
 
 // dropdown item styles
-.dropdownItem {
-  composes: dropdownItem from '../navigationDropdown/NavigationDropdown.module.scss';
-}
+@import "../navigationDropdown/NavigationDropdown.module.scss";
 
 .rowItem,
 .dropdownItem {


### PR DESCRIPTION
## Description

Composing classes from `scss` files results to broken styles in the final bundle.

This PR fixes the issue by replacing the composes statement with scss' `@import`.

## How Has This Been Tested?

This has been tested locally in storybook and in a create-react-app.