### PR TITLE
[FIX] Add missing aria-hidden attribute to icon in Notification component

### DIFF
--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -252,7 +252,7 @@ export const Notification = ({
         {autoClose && <animated.div style={autoCloseTransition} className={styles.autoClose} />}
         <div className={styles.content} role={role}>
           <div className={styles.label} role="heading" aria-level={2}>
-            <Icon className={styles.icon} />
+            <Icon className={styles.icon} aria-hidden />
             <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
           </div>
           {children && <div className={styles.body}>{children}</div>}

--- a/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<Notification /> spec renders the component 1`] = `
         role="heading"
       >
         <svg
+          aria-hidden="true"
           class="icon s icon"
           role="img"
           viewBox="0 0 24 24"


### PR DESCRIPTION
## Description

Currently the `Notification` component uses `Icon` component without `aria-hidden` attribute, which leads to a failed accessibility test:

> svg elements with an img role have an alternative text (svg-img-alt)

This PR fixes the issue by adding the missing `aria-hidden` attribute.

## How Has This Been Tested?

Tested locally in Storybook.