### PR TITLE
0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - November 13, 2020
+### Design kit
+#### Added
+- New library HDS Loaders
+    - New component: Loading spinner
+    - New component: Loading skeleton (implementation still missing)
+- [Form Components] Added horizontal version of selection groups (both for checkbox and radio button)
+
+#### Changed
+- [Form Components] Checkbox + label symbols to use Smart layout
+- [Form Componenst] Radio button + label symbols to use Smart layout
+
+#### Fixed
+- [Form Components] Disabled state radio button borders now use shared styles
+
+### Documentation
+#### Added
+- Documentation for Loading spinner component
+- Documentation for Tag component
+- Documentation for Selection group component
+
+#### Changed
+- Added a link to Container component Storybook examples to Grid and Breakpoint documentation
+
+#### Fixed
+- Small fixes to Notification documentation subtitles
+- Checkbox Playground examples are now interactable
+- Radio button Playground examples are now interactable
+
+### Core
+#### Added
+- New component: Loading spinner (in [#311](https://github.com/City-of-Helsinki/helsinki-design-system/pull/311))
+- New component: Selection group (in [#292](https://github.com/City-of-Helsinki/helsinki-design-system/pull/292))
+
+### React
+#### Added
+- New component: LoadingSpinner (in [#311](https://github.com/City-of-Helsinki/helsinki-design-system/pull/311))
+- New component: SelectionGroup (in [#292](https://github.com/City-of-Helsinki/helsinki-design-system/pull/292))
+- New component: Tag (in [#308](https://github.com/City-of-Helsinki/helsinki-design-system/pull/308))
+
+#### Fixed
+- [Accessibility] Added missing `aria-hidden` attribute to the icon in `Notification` component (in [#313](https://github.com/City-of-Helsinki/helsinki-design-system/pull/313))
+
 ## [0.15.1] - November 3, 2020
 ### Documentation
 #### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-core",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Core styles for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "contributors": [

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-design-tokens",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Design tokens for the Helsinki Design System",
   "author": "Niclas Liimatainen <niclas.liimatainen@gmail.com>",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "React components for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "contributors": [
@@ -94,7 +94,7 @@
     "@popperjs/core": "2.5.3",
     "@react-aria/visually-hidden": "3.2.0",
     "downshift": "6.0.6",
-    "hds-core": "0.15.1",
+    "hds-core": "0.16.0",
     "lodash.isequal": "4.5.0",
     "lodash.uniqueid": "4.0.1",
     "react-merge-refs": "1.1.0",

--- a/packages/react/src/components/loadingSpinner/LoadingSpinner.stories.tsx
+++ b/packages/react/src/components/loadingSpinner/LoadingSpinner.stories.tsx
@@ -8,7 +8,31 @@ export default {
   title: 'Components/LoadingSpinner',
 };
 
-export const Default = (args) => {
+export const Default = (args) => <LoadingSpinner {...args} />;
+
+export const Small = (args) => <LoadingSpinner {...args} />;
+Small.args = {
+  small: true,
+};
+
+export const CustomTheme = (args) => (
+  <>
+    <LoadingSpinner {...args} multicolor={false} />
+    <br />
+    <LoadingSpinner {...args} multicolor />
+  </>
+);
+CustomTheme.storyName = 'Custom theme';
+CustomTheme.args = {
+  theme: {
+    '--spinner-color': 'var(--color-tram)',
+    '--spinner-color-stage1': 'var(--color-coat-of-arms)',
+    '--spinner-color-stage2': 'var(--color-tram)',
+    '--spinner-color-stage3': 'var(--color-metro)',
+  },
+};
+
+export const MultipleSpinners = (args) => {
   const [showSpinner1, setShowSpinner1] = useState(false);
   const [showSpinner2, setShowSpinner2] = useState(false);
   const [showSpinner3, setShowSpinner3] = useState(false);
@@ -36,25 +60,4 @@ export const Default = (args) => {
     </>
   );
 };
-
-export const Small = (args) => <LoadingSpinner {...args} />;
-Small.args = {
-  small: true,
-};
-
-export const CustomTheme = (args) => (
-  <>
-    <LoadingSpinner {...args} multicolor={false} />
-    <br />
-    <LoadingSpinner {...args} multicolor />
-  </>
-);
-CustomTheme.storyName = 'Custom theme';
-CustomTheme.args = {
-  theme: {
-    '--spinner-color': 'var(--color-tram)',
-    '--spinner-color-stage1': 'var(--color-coat-of-arms)',
-    '--spinner-color-stage2': 'var(--color-tram)',
-    '--spinner-color-stage3': 'var(--color-metro)',
-  },
-};
+MultipleSpinners.storyName = 'Multiple spinners';

--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -13,6 +13,11 @@ import Link from "../../src/components/Link";
     Here you will find summarized patch notes of major releases of HDS. For full patch notes for each release, please refer to the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases" external>GitHub releases</Link>.
 </LargeParagraph>
 
+<p><strong>0.16.0 (beta)</strong> - <em>13.11.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.16.0" external>Release notes</Link></p>
+
+- **Added**: New components Loading spinner, Selection group, Tag
+- **Fixed**: Accessibility issues in Notification component
+
 <p><strong>0.15.0 (beta)</strong> - <em>29.10.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.15.0" external>Release notes</Link></p>
 
 - **Added**: First pattern Forms

--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -25,6 +25,9 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 - ~~Tokens: Breakpoints and maximum content width~~
 
 
+- **HDS Alpha release 26.05.2020**
+
+
 **Q3 2020**
 
 - ~~Update: Cleaning typography styles~~
@@ -55,11 +58,16 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 - **HDS Beta release 29.10.2020**
 
 
-- Component: Tag
-- Component: Loading spinner
+- ~~Component: Tag~~
+- ~~Component: Loading spinner~~
+- ~~Component: Selection group~~
+
+
+- Component: Page container
+- Component: Search field
 - Component: Error template
 - Component: Accordion
-- Component: Search field
+- Component: Tabs
 - Component: Datepicker
 - Component: Number input field
 - Component: Phone number input field

--- a/site/docs/components/spinner.mdx
+++ b/site/docs/components/spinner.mdx
@@ -51,13 +51,13 @@ The loading spinner comes in two sizes:
 
 ##### Core:
 ```html
-<div class="hds-loading-spinner" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+<div class="hds-loading-spinner">
   <div></div>
   <div></div>
   <div></div>
 </div>
 
-<div class="hds-loading-spinner hds-loading-spinner--small" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+<div class="hds-loading-spinner hds-loading-spinner--small">
   <div></div>
   <div></div>
   <div></div>
@@ -100,7 +100,7 @@ Note! When using multicolor loading spinners, at least half of the colors must h
     --spinner-color: var(--color-tram);
   }
 </style>
-<div class="hds-loading-spinner custom-single-color" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+<div class="hds-loading-spinner custom-single-color">
   <div></div>
   <div></div>
   <div></div>
@@ -114,7 +114,7 @@ Note! When using multicolor loading spinners, at least half of the colors must h
     --spinner-color-stage3: var(--color-metro);
   }
 </style>
-<div class="hds-loading-spinner hds-loading-spinner--multicolor custom-multi-color" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+<div class="hds-loading-spinner hds-loading-spinner--multicolor custom-multi-color">
   <div></div>
   <div></div>
   <div></div>

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": true,
   "description": "Documentation for Helsinki Design System",
   "license": "MIT",
@@ -22,9 +22,9 @@
   "devDependencies": {
     "gatsby-cli": "2.12.29",
     "gatsby-plugin-matomo": "0.8.3",
-    "hds-core": "0.15.1",
-    "hds-design-tokens": "0.15.1",
-    "hds-react": "0.15.1",
+    "hds-core": "0.16.0",
+    "hds-design-tokens": "0.16.0",
+    "hds-react": "0.16.0",
     "react-helmet": "6.0.0",
     "rimraf": "3.0.2"
   }


### PR DESCRIPTION
## Description

0.16.0 release
- Updated documentation site Roadmap
- Updated documentation site What's new section
- Updated CHANGELOG
- Bumped version number to 0.16.0