### PR TITLE
[Fix]: Fix Language Selector not closing after language is selected

### DIFF
--- a/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
@@ -4,7 +4,7 @@ import styles from './NavigationLanguageSelector.module.scss';
 import { MenuButton, MenuButtonProps } from '../../../internal/menuButton/MenuButton';
 
 export const NavigationLanguageSelector = ({ children, id = 'languageSelector', label, ...rest }: MenuButtonProps) => (
-  <MenuButton className={styles.languageDropdown} id={id} label={label} menuOffset={10} {...rest}>
+  <MenuButton className={styles.languageDropdown} id={id} label={label} menuOffset={10} {...rest} closeOnItemClick>
     {children}
   </MenuButton>
 );

--- a/packages/react/src/internal/menuButton/MenuButton.tsx
+++ b/packages/react/src/internal/menuButton/MenuButton.tsx
@@ -21,6 +21,10 @@ export type MenuButtonProps = React.PropsWithChildren<{
    */
   className?: string;
   /**
+   * Should the menu close after item is clicked
+   */
+  closeOnItemClick?: boolean;
+  /**
    * Used to generate the first part of the id on the elements
    */
   id?: string;
@@ -42,6 +46,7 @@ export const MenuButton = ({
   buttonAriaLabel,
   children,
   className,
+  closeOnItemClick = false,
   icon,
   id: _id,
   label,
@@ -88,6 +93,7 @@ export const MenuButton = ({
         menuContainerSize={menuContainerSize}
         menuOffset={menuOffset}
         menuOpen={menuOpen}
+        onItemClick={closeOnItemClick ? () => setMenuOpen(false) : undefined}
       >
         {children}
       </Menu>

--- a/packages/react/src/internal/menuButton/menu/Menu.tsx
+++ b/packages/react/src/internal/menuButton/menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, isValidElement, useEffect, useRef, useState } from 'react';
+import React, { cloneElement, isValidElement, useEffect, useRef, useState, MouseEvent } from 'react';
 import { RectReadOnly } from 'react-use-measure';
 
 import classNames from '../../../utils/classNames';
@@ -13,11 +13,12 @@ type MenuProps = React.ComponentPropsWithoutRef<'div'> & {
   menuContainerSize: RectReadOnly;
   menuOffset?: number;
   menuOpen: boolean;
+  onItemClick?: (event: MouseEvent<HTMLElement>) => void;
 };
 
 const MENU_MIN_WIDTH = 190;
 
-export const Menu = ({ children, menuContainerSize, menuOffset = 0, menuOpen, ...rest }: MenuProps) => {
+export const Menu = ({ children, menuContainerSize, menuOffset = 0, menuOpen, onItemClick, ...rest }: MenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const [menuStyles, setMenuStyles] = useState<MenuStyles>({});
 
@@ -42,6 +43,17 @@ export const Menu = ({ children, menuContainerSize, menuOffset = 0, menuOpen, ..
           ? cloneElement(child, {
               // add class name(s) to child
               className: `${styles.item} ${child.props.className || ''}`,
+              // add onclick handler(s) to child
+              onClick: (event: MouseEvent<HTMLElement>) => {
+                // Call the individual child onClick function
+                if (typeof child.props.onClick === 'function') {
+                  child.props.onClick(event);
+                }
+                // Call the common onItemClick function
+                if (typeof onItemClick === 'function') {
+                  onItemClick(event);
+                }
+              },
             })
           : child;
       })}


### PR DESCRIPTION
## Description

This PR contains fix for Navigation Language Selector not closing after language is selected.

## How Has This Been Tested?

- Locally on Storybook
- In a `create-react-app`
- In the project from which this issue was raised 
