### PR TITLE
[FIX] Add missing aria-hidden attribute to navigation dropdown icons

### DIFF
--- a/packages/react/src/components/navigation/navigationDropdown/__snapshots__/NavigationDropdown.test.tsx.snap
+++ b/packages/react/src/components/navigation/navigationDropdown/__snapshots__/NavigationDropdown.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`<Navigation.Dropdown /> spec renders the component 1`] = `
                 Foo
               </span>
               <svg
+                aria-hidden="true"
                 class="icon s"
                 role="img"
                 viewBox="0 0 24 24"

--- a/packages/react/src/components/navigation/navigationLanguageSelector/__snapshots__/NavigationLanguageSelector.test.tsx.snap
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/__snapshots__/NavigationLanguageSelector.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`<Navigation.LanguageSelector /> spec renders the component 1`] = `
                 Foo
               </span>
               <svg
+                aria-hidden="true"
                 class="icon s"
                 role="img"
                 viewBox="0 0 24 24"

--- a/packages/react/src/components/selectionGroup/SelectionGroup.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.tsx
@@ -67,6 +67,7 @@ export const SelectionGroup = ({
       }
     });
     if (hasRadios && !hasCheckedRadios) {
+      // eslint-disable-next-line no-console
       console.warn(
         'All radio buttons in a SelectionGroup are unchecked. One radio button should be checked by default.',
       );

--- a/packages/react/src/internal/menuButton/MenuButton.tsx
+++ b/packages/react/src/internal/menuButton/MenuButton.tsx
@@ -85,7 +85,7 @@ export const MenuButton = ({
       >
         {icon}
         <span className={styles.toggleButtonLabel}>{label}</span>
-        {menuOpen ? <IconAngleUp /> : <IconAngleDown />}
+        {menuOpen ? <IconAngleUp aria-hidden /> : <IconAngleDown aria-hidden />}
       </button>
       <Menu
         id={menuId}

--- a/packages/react/src/internal/menuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/react/src/internal/menuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`<MenuButton /> spec renders the component 1`] = `
         Foo
       </span>
       <svg
+        aria-hidden="true"
         class="icon s"
         role="img"
         viewBox="0 0 24 24"


### PR DESCRIPTION
## Description

Currently the Navigation dropdown menus are using `Icon` components without `aria-hidden` attribute, which leads to a failed accessibility test:

> svg elements with an img role have an alternative text (svg-img-alt)

This PR fixes the issue by adding the missing `aria-hidden` attribute.

## How Has This Been Tested?

Tested locally in Storybook