### PR TITLE
[Content] Updated What's new for 0.17.0

### DIFF
--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -13,6 +13,12 @@ import Link from "../../src/components/Link";
     Here you will find summarized patch notes of major releases of HDS. For full patch notes for each release, please refer to the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases" external>GitHub releases</Link>.
 </LargeParagraph>
 
+<p><strong>0.17.0 (beta)</strong> - <em>24.11.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.17.0" external>Release notes</Link></p>
+
+- **Added**: New component Container
+- **Added**: Koros to the Core package
+- **Changed**: Removed non-semantic rounded corners from all of the components
+
 <p><strong>0.16.0 (beta)</strong> - <em>13.11.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.16.0" external>Release notes</Link></p>
 
 - **Added**: New components Loading spinner, Selection group, Tag


### PR DESCRIPTION
## Description
Added missing entry for 0.17.0 version to the What's new section of documentation.

## How Has This Been Tested?
Tested by running the documentation locally.
