### PR TITLE
[Fix] Documentation templates

### DIFF
--- a/site/examples/component.mdx
+++ b/site/examples/component.mdx
@@ -17,9 +17,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 # <COMPONENT_NAME>
 
 <LargeParagraph>
-    <!---
     With a couple of sentences, describe the component and its main use cases.
-    -->
 </LargeParagraph>
 
 <!---
@@ -27,7 +25,6 @@ If you want to add more introductory content, you can do that below LargeParagra
 -->
 
 ## Principles
-
 <!---
 Principles section lists the most important fundamentals about using the component. Generally, HDS documentation tends not to list basic level usability principles in component documentation. Instead, try to provide concise principles on how to and how not to use the component in real world user interfaces. A good starting point is to check other components' documentation for examples.
 
@@ -46,65 +43,68 @@ Accessibility principles are listed as separate bullet points. You may bold part
 -->
 
 ## Usage and variations
-
 <!---
 In the following subchapters, list all notable variants of the component. For example, a button component includes variants such as Primary, Secondary, Supplementary, Icon, Small and Utility.
 -->
 
 ### <COMPONENT_VARIANT>
-
 <!---
 Add a short description about the variant. What it is and when it should be used over other variants? Keep this relatively short, maximum of 5 sentences.
 -->
 
+<!---
+Add React code here to provide interactive examples of the component variant.
+-->
 <Playground>
-    <!---
-    Add React code here to provide interactive examples of the component variant.
-    -->
+
 </Playground>
 
 ##### Core:
-```html
 <!---
 Add HTML (HDS Core package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 
 Note! This section should be left out if this component is not included in the Core package.
 -->
+```html
+
 ```
 
 ##### React:
-```tsx
 <!---
 Add React (HDS React package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 -->
+```tsx
+
 ```
 
 ### <COMPONENT_VARIANT2>
-
 <!---
 Add a short description about the variant. What it is and when it should be used over other variants? Keep this relatively short, maximum of 5 sentences.
 -->
 
+<!---
+Add React code here to provide interactive examples of the component variant.
+-->
 <Playground>
-    <!---
-    Add React code here to provide interactive examples of the component variant.
-    -->
+
 </Playground>
 
 ##### Core:
-```html
 <!---
 Add HTML (HDS Core package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 
 Note! This section should be left out if this component is not included in the Core package.
 -->
+```html
+
 ```
 
 ##### React:
-```tsx
 <!---
 Add React (HDS React package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 -->
+```tsx
+
 ```
 
 ## Demos & API

--- a/site/examples/component.mdx
+++ b/site/examples/component.mdx
@@ -6,8 +6,11 @@ route: /components/<COMPONENT_NAME>
 
 <!---
 Import all the needed components from HDS libraries.
--->
+
+For example:
 import { <COMPONENT_NAME> } from "hds-react";
+-->
+
 
 <!---
 Import documentation specific components. You can view what is available in /site/src/components/ folder.
@@ -59,7 +62,7 @@ Add React code here to provide interactive examples of the component variant.
 
 </Playground>
 
-##### Core:
+#### Core:
 <!---
 Add HTML (HDS Core package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 
@@ -69,7 +72,7 @@ Note! This section should be left out if this component is not included in the C
 
 ```
 
-##### React:
+#### React:
 <!---
 Add React (HDS React package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 -->
@@ -89,7 +92,7 @@ Add React code here to provide interactive examples of the component variant.
 
 </Playground>
 
-##### Core:
+#### Core:
 <!---
 Add HTML (HDS Core package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 
@@ -99,7 +102,7 @@ Note! This section should be left out if this component is not included in the C
 
 ```
 
-##### React:
+#### React:
 <!---
 Add React (HDS React package) code example here. This code should try to match the Playground code above. You may add comments in the code to make it more understandable.
 -->

--- a/site/examples/design_token.mdx
+++ b/site/examples/design_token.mdx
@@ -6,8 +6,10 @@ route: /components/<COMPONENT_NAME>
 
 <!---
 Import all the needed components from HDS libraries.
--->
+
+For example:
 import { <COMPONENT_NAME> } from "hds-react";
+-->
 
 <!---
 Import documentation specific components. You can view what is available in /site/src/components/ folder.

--- a/site/examples/design_token.mdx
+++ b/site/examples/design_token.mdx
@@ -17,9 +17,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 # <TOKEN_NAME>
 
 <LargeParagraph>
-    <!---
     With a couple of sentences, describe what this set of tokens are used for. 
-    -->
 </LargeParagraph>
 
 <!---
@@ -27,7 +25,6 @@ If you want to add more introductory content, you can do that below LargeParagra
 -->
 
 ## Principles
-
 <!---
 Principles section lists the most important fundamentals about using the set of tokens. List cases where the correct usage of this set of tokens is important. A good starting point is to check other tokens' documentation for examples.
 
@@ -48,7 +45,6 @@ Accessibility principles are listed as separate bullet points. You may bold part
 -->
 
 ## Usage
-
 <!---
 In this section, aim to list all subsets of this token set. Provide a short definition for each subset. What are the tokens for? When this set should be used over others? 
 
@@ -60,7 +56,6 @@ This section can also include other rules or tips on using this set of tokens. T
 -->
 
 ## Tokens
-
 <!---
 In this section, list all tokens of the set in a table format.
 -->

--- a/site/examples/page.mdx
+++ b/site/examples/page.mdx
@@ -9,8 +9,10 @@ With the above settings, page name will be "Example page", its path will be hds.
 
 <!---
 Import all the needed components from HDS libraries.
--->
+
+For example:
 import { <COMPONENT_NAME> } from "hds-react";
+-->
 
 <!---
 Import documentation specific components. You can view what is available in /site/src/components/ folder.

--- a/site/examples/page.mdx
+++ b/site/examples/page.mdx
@@ -20,9 +20,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 # <PAGE_NAME>
 
 <LargeParagraph>
-    <!---
     With a couple of sentences, describe the page content and its meaning for the reader.
-    -->
 </LargeParagraph>
 
 <!---
@@ -30,19 +28,16 @@ If you want to add more introductory content, you can do that below LargeParagra
 -->
 
 ## Header level 2
-
 <!---
 Add your content here. Note, to comply with site accessibility requirements, do not skip heading levels. After header level 2, the next should be header level 3, and so on.
 -->
 
 ### Header level 3
-
 <!---
 Add your content here. Note, to comply with site accessibility requirements, do not skip heading levels. After header level 2, the next should be header level 3, and so on.
 -->
 
 #### Header level 4
-
 <!---
 Add your content here. Note, to comply with site accessibility requirements, do not skip heading levels. After header level 2, the next should be header level 3, and so on.
 -->


### PR DESCRIPTION
## Description
This PR fixes documentation page templates. There were two issues related to them:
- There were HTML comment tags inside React/Playground tags. These were removed.
- There were example import which yielded errors during `yarn build`. It was moved into comments to avoid errors.

## How Has This Been Tested?
Tested by copying template files into doc folders, building and starting site locally.
