### PR TITLE
[Content] What's new and Roadmap updates for 0.18.0

### DIFF
--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -13,6 +13,11 @@ import Link from "../../src/components/Link";
     Here you will find summarized patch notes of major releases of HDS. For full patch notes for each release, please refer to the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases" external>GitHub releases</Link>.
 </LargeParagraph>
 
+<p><strong>0.18.0 (beta)</strong> - <em>08.12.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.18.0" external>Release notes</Link></p>
+
+- **Added**: New component Search field
+- **Added**: New pattern Form validation
+
 <p><strong>0.17.0 (beta)</strong> - <em>24.11.2020</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v0.17.0" external>Release notes</Link></p>
 
 - **Added**: New component Container

--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -61,28 +61,28 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 - ~~Component: Tag~~
 - ~~Component: Loading spinner~~
 - ~~Component: Selection group~~
+- ~~Component: Page container~~
+- ~~Component: Search field~~
+- ~~Pattern: Form validation~~
 
 
-- Component: Page container
-- Component: Search field
-- Component: Error template
 - Component: Accordion
 - Component: Tabs
+- Component: Dialog
+- Component: Error template
 - Component: Datepicker
 - Component: Number input field
-- Component: Phone number input field
-- Component: Filter toggle
+- Component: Time input field
 
 
-- Pattern: Form validation
+- Pattern: Multi-step forms
 
 
 **Q1 2021**
 
-- Component: Modal
 - Component: Password input field
-- Component: Time input field
-- Component: Expander
+- Component: Phone number input field
+- Component: Filter toggle
 
 
 - Tokens: Z-index


### PR DESCRIPTION
## Description
This PR updates contents of documentation site What's new and Roadmap sections for the HDS version 0.18.0.

## How Has This Been Tested?
Tested by running the documentation locally.
