### PR TITLE
v0.18.0 release

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-test:
+    if: ${{ !contains('hotfix/', github.ref) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,10 +2,12 @@ name: development
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build-test:
-    if: ${{ !contains('hotfix/', github.ref) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +53,7 @@ jobs:
           path: |
             packages/react/.loki
             packages/react/storybook-static
-            packages/react/package.json
+            packages/react/.lokirc.json
           retention-days: 1
 
   visual-tests:
@@ -80,10 +82,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install graphicsmagick -y
-          yarn add loki
+          yarn add loki@0.26.0
 
       - name: visually test react package with ${{ matrix.loki_configuration }}
-        run: yarn visual-test ${{ matrix.loki_configuration }}
+        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static visual-test ${{ matrix.loki_configuration }}
 
       - name: upload reference and actual images with ${{ matrix.loki_configuration }} in case of failure
         uses: actions/upload-artifact@v2

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,9 +2,6 @@ name: development
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
 
 jobs:
   build-test:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -85,7 +85,7 @@ jobs:
           yarn add loki@0.26.0
 
       - name: visually test react package with ${{ matrix.loki_configuration }}
-        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static visual-test ${{ matrix.loki_configuration }}
+        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static ${{ matrix.loki_configuration }}
 
       - name: upload reference and actual images with ${{ matrix.loki_configuration }} in case of failure
         uses: actions/upload-artifact@v2

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -58,7 +58,7 @@ jobs:
 
   visual-tests:
     needs: build-test
-    if: ${{ !contains('hotfix/', github.ref) }}
+    if: "!contains(github.ref, 'hotfix')"
     runs-on: ubuntu-latest
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - December 8, 2020
+### Design kit
+#### Added
+- [Form Components] Search field input symbols
+- [Form Components] Search suggestion symbols
+- [Form Components] Error summary symbols. These can be used to list all errors in a form when using a static validation approach.
+- [Form Components] Error state for Checkbox, Radio button and Selection group symbols
+- [Form Components] Success state for Text Input and Text Area symbols
+- [Typography] Default link style for small sized medium body text
+
+#### Changed
+- Updated all HDS library files to Sketch 70 file version
+- [Form Components] Renamed “Text field/01 Input/06 Fixed” to “Text field/01 Input/07 Fixed”
+- [Typography] Default link text style colour from #0072c6 to #0000bf to ensure better contrast on varying backgrounds
+
+#### Fixed
+- [Form Components] Incorrect order numbering in TextInput example artboards
+
+#### Removed
+- [Form Components] Redundant internal symbols
+
+### Documentation
+#### Added
+- Documentation for the SearchInput component
+- Documentation for the Form validation pattern
+
+#### Changed
+- Updated Roapmap to reflect the current state and plans of the project
+
+### Core
+#### Changed
+- [TextInput, TextArea] Error icon moved below the input next to the error text (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+
+#### Added
+- New component: Error summary (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- [Text input, textarea, checkbox, selection group] Added error text for validation error message (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- [Text input, textArea] Added success text (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+
+### React
+#### Changed
+- [TextInput, TextArea] Error icon moved below the input next to the error text (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+
+#### Removed
+- Removed `aria-hidden` attribute from input required indicator ("*") (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+
+#### Added
+- New component: ErrorSummary (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- New component: SearchInput (in [#317](https://github.com/City-of-Helsinki/helsinki-design-system/pull/317))
+- Added examples of form validation using Yup and Formik (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- [TextInput, TextArea] Added `successText` prop for success state message (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- [TextInput, TextArea, Checkbox, SelectionGroup] Added `errorText` prop for validation error message (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- [TextInput, TextArea] Added `aria-describedby` input attribute to reference error text, success text and assistive text (in [#320](https://github.com/City-of-Helsinki/helsinki-design-system/pull/320))
+- Visual regression tests using [Loki](https://loki.js.org/) (in [#323](https://github.com/City-of-Helsinki/helsinki-design-system/pull/323))
+- Accessibility tests using `jest-axe` (in [#334](https://github.com/City-of-Helsinki/helsinki-design-system/pull/323))
+
 ## [0.17.0] - November 24, 2020
 ### Design kit
 #### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-core",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Core styles for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "contributors": [
@@ -29,7 +29,7 @@
     "@storybook/html": "6.0.19",
     "copyfiles": "2.2.0",
     "cssnano": "4.1.10",
-    "hds-design-tokens": "0.17.0",
+    "hds-design-tokens": "0.18.0",
     "normalize.css": "8.0.1",
     "postcss": "7.0.30",
     "postcss-cli": "7.1.1",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-design-tokens",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Design tokens for the Helsinki Design System",
   "author": "Niclas Liimatainen <niclas.liimatainen@gmail.com>",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",

--- a/packages/react/.lokirc.json
+++ b/packages/react/.lokirc.json
@@ -1,0 +1,16 @@
+{
+  "chromeRetries": 2,
+  "configurations": {
+    "chrome.laptop": {
+      "target": "chrome.docker",
+      "width": 1366,
+      "height": 768,
+      "mobile": false
+    },
+    "chrome.iphone7": {
+      "target": "chrome.docker",
+      "preset": "iPhone 7"
+    }
+  },
+  "skipStories": "Icons/.*"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "React components for the Helsinki Design System",
   "author": "Anssi Lehtonen <lehtovaaralainen@gmail.com>",
   "contributors": [
@@ -102,7 +102,7 @@
     "@popperjs/core": "2.5.3",
     "@react-aria/visually-hidden": "3.2.0",
     "downshift": "6.0.6",
-    "hds-core": "0.17.0",
+    "hds-core": "0.18.0",
     "lodash.isequal": "4.5.0",
     "lodash.uniqueid": "4.0.1",
     "react-merge-refs": "1.1.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -114,21 +114,5 @@
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
-  },
-  "loki": {
-    "chromeRetries": 2,
-    "configurations": {
-      "chrome.laptop": {
-        "target": "chrome.docker",
-        "width": 1366,
-        "height": 768,
-        "mobile": false
-      },
-      "chrome.iphone7": {
-        "target": "chrome.docker",
-        "preset": "iPhone 7"
-      }
-    },
-    "skipStories": "Icons/.*"
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "description": "Documentation for Helsinki Design System",
   "license": "MIT",
@@ -22,9 +22,9 @@
   "devDependencies": {
     "gatsby-cli": "2.12.29",
     "gatsby-plugin-matomo": "0.8.3",
-    "hds-core": "0.17.0",
-    "hds-design-tokens": "0.17.0",
-    "hds-react": "0.17.0",
+    "hds-core": "0.18.0",
+    "hds-design-tokens": "0.18.0",
+    "hds-react": "0.18.0",
     "react-helmet": "6.0.0",
     "rimraf": "3.0.2"
   }


### PR DESCRIPTION
## v0.18.0 release

- Temporarily disable visual regression tests on push to master
- Update CHANGELOG
- Bump HDS version to 0.18.0