### PR TITLE
Ignore visual tests on hotfixes

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -43,10 +43,12 @@ jobs:
         working-directory: ./packages/react
       
       - name: build storybook for react
+        if: ${{ !(contains(github.head_ref, 'hotfix') || contains(github.ref, 'hotfix')) }}
         run: yarn build-storybook
         working-directory: ./packages/react
 
       - name: Store storybook as artifact
+        if: ${{ !(contains(github.head_ref, 'hotfix') || contains(github.ref, 'hotfix')) }}
         uses: actions/upload-artifact@v2
         with:
           name: storybook-${{ github.sha }}
@@ -56,9 +58,10 @@ jobs:
             packages/react/.lokirc.json
           retention-days: 1
 
-  visual-tests:
+  visual-tests: 
     needs: build-test
-    if: "!contains(github.ref, 'hotfix')"
+    # No visual testing in hotfixes
+    if: ${{ !(contains(github.head_ref, 'hotfix') || contains(github.ref, 'hotfix')) }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Description
Fixes ignore that allows getting hotfixes quicker through the pipeline. 

Branches where name contains `hotfix` are not tested with Loki's visual testing.

## How Has This Been Tested?
GHA


