### PR TITLE
[FIX] Add logoLanguage prop to Footer component

### DIFF
--- a/packages/react/src/components/footer/Footer.tsx
+++ b/packages/react/src/components/footer/Footer.tsx
@@ -3,7 +3,7 @@ import React, { useReducer } from 'react';
 // import core base styles
 import 'hds-core';
 import styles from './Footer.module.scss';
-import { Logo } from '../logo';
+import { Logo, LogoLanguage } from '../logo';
 import { Koros, KorosType } from '../koros';
 import classNames from '../../utils/classNames';
 import { FooterNavigation } from './footerNavigation/FooterNavigation';
@@ -30,6 +30,11 @@ export type FooterProps = React.PropsWithChildren<{
    * Koros type to use in the footer
    */
   korosType?: KorosType;
+  /**
+   * The language of the Helsinki-logo
+   * @default 'fi'
+   */
+  logoLanguage?: LogoLanguage;
   /**
    * Defines the footer theme
    */
@@ -58,6 +63,7 @@ export const Footer = ({
   className,
   footerProps,
   korosType = 'basic',
+  logoLanguage = 'fi',
   theme = 'light',
   title,
 }: FooterProps) => {
@@ -86,7 +92,7 @@ export const Footer = ({
         <Koros className={classNames(styles.koros, styles[korosType])} type={korosType} />
         <section className={classNames(styles.navigationContainer, styles[navigationVariant])}>
           <div className={styles.titleWrapper}>
-            <Logo size="medium" aria-hidden />
+            <Logo size="medium" language={logoLanguage} aria-hidden />
             {title && <h2 className={styles.title}>{title}</h2>}
           </div>
           {navigation}


### PR DESCRIPTION
## Description

This PR adds `logoLanguage` prop to the `Footer` component.

## How Has This Been Tested?

Tested locally in storybook.