### PR TITLE
[FIX] Fix placeholders in firefox

### DIFF
--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -105,6 +105,7 @@
 
 .hds-text-input .hds-text-input__input::placeholder {
   color: var(--placeholder-color);
+  opacity: 1;
 }
 
 /* FOCUS OUTLINE */

--- a/packages/react/src/components/dropdown/combobox/Combobox.module.scss
+++ b/packages/react/src/components/dropdown/combobox/Combobox.module.scss
@@ -68,7 +68,7 @@
 
   &::placeholder {
     color: var(--placeholder-color);
-    line-height: normal;
+    opacity: 1;
   }
 
   &:disabled::placeholder {


### PR DESCRIPTION
## Description

Fixed placeholder issues in Firefox browser:

- Fixed placeholder text alignment
- Fixed placeholder text opacity in Combobox, TextInput and TextArea

Closes #340 

## How Has This Been Tested?

Tested in [storybook](https://aleksik.github.io/react/iframe.html?id=components-dropdowns-combobox--default)