### PR TITLE
[FIX] Fix a bug related to cleaning of the notification area.

### DIFF
--- a/packages/react/src/components/loadingSpinner/useNotificationArea.ts
+++ b/packages/react/src/components/loadingSpinner/useNotificationArea.ts
@@ -74,7 +74,7 @@ export const useNotificationArea = (loadingTextVal: string, finishedTextVal: str
     if (getActiveIds().length === 0) {
       setFinishedText();
       setTimeout(() => {
-        if (getActiveIds().length === 0) {
+        if (getActiveIds().length === 0 && notificationArea.current.parentNode) {
           notificationArea.current.parentNode.removeChild(notificationArea.current);
         }
       }, 1000);


### PR DESCRIPTION
Caused problems in cypress and jest tests

## Description

Bug fix for the LoadingSpinner component. 

## Motivation and Context

This bug was found by @minevala during the testing of hauki-admin-ui application that applied this component. Cypress and jest tests failed because the program tried to remove a child node that was already removed.

