### PR TITLE
[FIX] Optimize focus outline animation to prevent glitches

### DIFF
--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -85,6 +85,7 @@
   line-height: normal;
   padding: 0 var(--spacing-s);
   width: 100%;
+  will-change: transform, box-shadow;
 }
 
 .hds-text-input textarea.hds-text-input__input {


### PR DESCRIPTION
## Description

In TextInput and TextArea, there's a slight visual glitch with the focus outline when the component is used directly inside a grid layout:

https://codesandbox.io/s/spring-meadow-lnz4k?file=/src/App.tsx

This can be fixed with a simple `will-change: transform, box-shadow;` CSS rule, which tells browsers to optimize the outline animation:

https://codesandbox.io/s/stupefied-hoover-wterr?file=/src/styles.css