### PR TITLE
[Examples] Add autocomplete attributes to form examples

### DIFF
--- a/packages/react/src/examples/forms/validationDynamic.stories.tsx
+++ b/packages/react/src/examples/forms/validationDynamic.stories.tsx
@@ -135,6 +135,7 @@ export const Dynamic = () => {
                 invalid={!!getErrorMessage('firstName')}
                 aria-invalid={!!getErrorMessage('firstName')}
                 errorText={getErrorMessage('firstName')}
+                autoComplete="given-name"
                 required
               />
             </div>
@@ -149,6 +150,7 @@ export const Dynamic = () => {
                 invalid={!!getErrorMessage('lastName')}
                 aria-invalid={!!getErrorMessage('lastName')}
                 errorText={getErrorMessage('lastName')}
+                autoComplete="family-name"
                 required
               />
             </div>
@@ -184,6 +186,7 @@ export const Dynamic = () => {
                 invalid={!!getErrorMessage('postalCode')}
                 aria-invalid={!!getErrorMessage('postalCode')}
                 errorText={getErrorMessage('postalCode')}
+                autoComplete="postal-code"
                 required
               />
             </div>
@@ -199,6 +202,7 @@ export const Dynamic = () => {
               invalid={!!getErrorMessage('email')}
               aria-invalid={!!getErrorMessage('email')}
               errorText={getErrorMessage('email')}
+              autoComplete="email"
               required
               tooltipButtonLabel="Tooltip: Email address"
               tooltipText="We will send a confirmation to this email address. You may also receive important updates about your parking permit via email."

--- a/packages/react/src/examples/forms/validationHybrid.stories.tsx
+++ b/packages/react/src/examples/forms/validationHybrid.stories.tsx
@@ -174,6 +174,7 @@ export const Hybrid = () => {
                 invalid={!!getErrorMessage('firstName')}
                 aria-invalid={!!getErrorMessage('firstName')}
                 errorText={getErrorMessage('firstName')}
+                autoComplete="given-name"
                 required
               />
             </div>
@@ -188,6 +189,7 @@ export const Hybrid = () => {
                 invalid={!!getErrorMessage('lastName')}
                 aria-invalid={!!getErrorMessage('lastName')}
                 errorText={getErrorMessage('lastName')}
+                autoComplete="family-name"
                 required
               />
             </div>
@@ -223,6 +225,7 @@ export const Hybrid = () => {
                 invalid={!!getErrorMessage('postalCode')}
                 aria-invalid={!!getErrorMessage('postalCode')}
                 errorText={getErrorMessage('postalCode')}
+                autoComplete="postal-code"
                 required
               />
             </div>
@@ -238,6 +241,7 @@ export const Hybrid = () => {
               invalid={!!getErrorMessage('email')}
               aria-invalid={!!getErrorMessage('email')}
               errorText={getErrorMessage('email')}
+              autoComplete="email"
               required
               tooltipButtonLabel="Tooltip: Email address"
               tooltipText="We will send a confirmation to this email address. You may also receive important updates about your parking permit via email."

--- a/packages/react/src/examples/forms/validationStatic.stories.tsx
+++ b/packages/react/src/examples/forms/validationStatic.stories.tsx
@@ -151,6 +151,7 @@ export const Static = () => {
                 value={formik.values.firstName}
                 invalid={!!getErrorMessage('firstName')}
                 errorText={getErrorMessage('firstName')}
+                autoComplete="given-name"
                 required
               />
             </div>
@@ -164,6 +165,7 @@ export const Static = () => {
                 value={formik.values.lastName}
                 invalid={!!getErrorMessage('lastName')}
                 errorText={getErrorMessage('lastName')}
+                autoComplete="family-name"
                 required
               />
             </div>
@@ -198,6 +200,7 @@ export const Static = () => {
                 value={formik.values.postalCode}
                 invalid={!!getErrorMessage('postalCode')}
                 errorText={getErrorMessage('postalCode')}
+                autoComplete="postal-code"
                 required
               />
             </div>
@@ -212,6 +215,7 @@ export const Static = () => {
               value={formik.values.email}
               invalid={!!getErrorMessage('email')}
               errorText={getErrorMessage('email')}
+              autoComplete="email"
               required
               tooltipButtonLabel="Tooltip: Email address"
               tooltipText="We will send a confirmation to this email address. You may also receive important updates about your parking permit via email."


### PR DESCRIPTION
## Description

This PR adds HTML `autocomplete` attributes to applicable fields in form examples.