### PR TITLE
[Fix] Changed Localisation page URL to use BR English

### DIFF
--- a/site/docs/guidelines/localisation.mdx
+++ b/site/docs/guidelines/localisation.mdx
@@ -1,6 +1,6 @@
 ---
 name: Localisation
-route: /guidelines/localization
+route: /guidelines/localisation
 menu: Guidelines
 ---
 


### PR DESCRIPTION
## Description
Documentation site Localisation page was using the US English spelling. Changed it to use BR English spelling as the HDS localisation guideline suggests.

## How Has This Been Tested?
Tested by running the documentation site locally.