### PR TITLE
Fix #379: Typo in the logo document

### DIFF
--- a/site/docs/visual_elements/logo.mdx
+++ b/site/docs/visual_elements/logo.mdx
@@ -20,7 +20,7 @@ import Link from "../../src/components/Link";
 Official City of Helsinki services must always show the City of Helsinki logo, that is placed: 
 - at the top left corner of the page, in the header component
 - at the bottom of the page, in the footer component
-- at the browser webiste title, as favicon
+- at the browser website title, as favicon
 
 In other parts of the page, the logo should be used sparingly.
 


### PR DESCRIPTION
## Description

Grammatical error in the text.

## Related Issue

Closes #379

## Motivation and Context

Fixes a grammatical error which improves accessibility.

## How Has This Been Tested?

Not applicable.

## Screenshots (if appropriate):

Not applicable. See the linked issue for further details.