### PR TITLE
Update roadmap.mdx

### DIFF
--- a/site/docs/about/roadmap.mdx
+++ b/site/docs/about/roadmap.mdx
@@ -21,8 +21,8 @@ For previously released features, see changelogs in the [What is new section](/a
 
 **Q1 2021**
 
+~~- Component: Datepicker and date field~~
 - Component: Error template
-- Component: Datepicker and date field
 - Component: Dialog
 - Component: Time input field
 - Component: Number input field


### PR DESCRIPTION
Mark datepicker as done (with overline) on roadmap as well

## Description

After the release last week, the roadmap should also show the datepicker as done.

## How Has This Been Tested?
Running docsite locally
