### PR TITLE
Use useEffect to fix time-input rendering on server-side

### DIFF
--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEventHandler, useLayoutEffect, useRef, useState } from 'react';
+import React, { FocusEventHandler, useEffect, useRef, useState } from 'react';
 import 'hds-core';
 import isFunction from 'lodash.isfunction';
 
@@ -128,7 +128,7 @@ export const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(
     /**
      * Merge props.ref to the internal ref
      */
-    useLayoutEffect(() => {
+    useEffect(() => {
       if (ref) {
         if (isFunction(ref)) {
           (ref as (instance: HTMLInputElement) => void)(inputRef.current);


### PR DESCRIPTION
## Description
When rendering time-input on the server-side Next.js throws a warning:
`Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.`

## Motivation and Context
UseLayoutEffect is replaced with useEffect to ensure the time-input component works correctly also on the server-side

## How Has This Been Tested?
On local machine in next.js environment, with [hds-next](https://github.com/City-of-Helsinki/hds-next).