### PR TITLE
Omit unused props from the time-input

### DIFF
--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -8,7 +8,7 @@ import textInputStyles from '../textInput/TextInput.module.css';
 import styles from './TimeInput.module.scss';
 import classNames from '../../utils/classNames';
 
-export type TimeInputProps = TextInputProps & {
+export type TimeInputProps = Omit<TextInputProps, 'buttonIcon' | 'buttonAriaLabel' | 'onButtonClick'> & {
   /**
    * A visually hidden label for the hours. Helps to navigate the component with screen readers.
    */

--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -8,7 +8,7 @@ import textInputStyles from '../textInput/TextInput.module.css';
 import styles from './TimeInput.module.scss';
 import classNames from '../../utils/classNames';
 
-export type TimeInputProps = Omit<TextInputProps, 'buttonIcon' | 'buttonAriaLabel' | 'onButtonClick'> & {
+export type TimeInputProps = Omit<TextInputProps, 'children' | 'buttonIcon' | 'buttonAriaLabel' | 'onButtonClick'> & {
   /**
    * A visually hidden label for the hours. Helps to navigate the component with screen readers.
    */


### PR DESCRIPTION
## Description
Remove unused props from the time-input component. 

## Motivation and Context
Documented but unused properties will confuse library users. Removed  'children', 'buttonIcon', 'buttonAriaLabel' and 'onButtonClick' properties from time-input.

## How Has This Been Tested?
On local machine by building the storybook