### PR TITLE
Fix navigation logout SSR-bug

### DIFF
--- a/packages/react/src/internal/menuButton/MenuButton.tsx
+++ b/packages/react/src/internal/menuButton/MenuButton.tsx
@@ -62,8 +62,10 @@ export const MenuButton = ({
   useEffect(() => {
     // closes the menu when a user clicks outside the container element
     const handleOutsideClick = (e: MouseEvent) => {
-      if (menuOpen && !containerRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
+      if (containerRef.current) {
+        if (menuOpen && !containerRef.current.contains(e.target as Node)) {
+          setMenuOpen(false);
+        }
       }
     };
 


### PR DESCRIPTION
## Description
When the user logouts, the server-side rendered Navigation throws an error. A menu button is missing the component ref. 

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):
