### PR TITLE
[Fix] TextInput error state examples (HDS-658)

### DIFF
--- a/site/docs/components/text_fields.mdx
+++ b/site/docs/components/text_fields.mdx
@@ -60,7 +60,8 @@ Text input serves in most use cases when the user needs to enter information. Te
     id="input-invalid"
     label="Label"
     defaultValue="Text input value"
-    helperText="Error text"
+    errorText="Error text"
+    helperText="Assistive text"
     style={{marginTop: 'var(--spacing-s)'}}
     invalid
   />
@@ -99,7 +100,8 @@ Text input serves in most use cases when the user needs to enter information. Te
   <div class="hds-text-input__input-wrapper">
     <input id="input" class="hds-text-input__input" type="text" value="Text input value" />
   </div>
-  <span class="hds-text-input__helper-text">Error text</span>
+  <span class="hds-text-input__error-text">Error text</span>
+  <span class="hds-text-input__helper-text">Assistive text</span>
 </div>
 ```
 
@@ -128,7 +130,8 @@ Text input serves in most use cases when the user needs to enter information. Te
   id="input"
   label="Label"
   defaultValue="Text input value"
-  helperText="Error text"
+  errorText="Error text"
+  helperText="Assistive text"
   invalid
 />
 ```
@@ -156,7 +159,8 @@ Text area is meant for situations where inputted text is multiline or contains m
     id="textarea-invalid"
     label="Label"
     defaultValue="Text area value"
-    helperText="Error text"
+    errorText="Error text"
+    helperText="Assistive text"
     style={{marginTop: 'var(--spacing-s)'}}
     invalid
 />
@@ -199,7 +203,8 @@ Text area is meant for situations where inputted text is multiline or contains m
       Text area value
     </textarea>
   </div>
-  <span class="hds-text-input__helper-text">Error text</span>
+  <span class="hds-text-input__error-text">Error text</span>
+  <span class="hds-text-input__helper-text">Assistive text</span>
 </div>
 ```
 
@@ -228,7 +233,8 @@ Text area is meant for situations where inputted text is multiline or contains m
   id="textarea"
   label="Label"
   defaultValue="Text input value"
-  helperText="Error text"
+  errorText="Error text"
+  helperText="Assistive text"
   invalid
 />
 ```


### PR DESCRIPTION
## Description
Examples had an incorrect styling for the error text. This PR fixes this and also adds assistive text to those examples (because in HDS the assistive text stays visible even during the error state).

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-658

## How Has This Been Tested?
Tested by running the documentation site locally.

## Screenshots (if appropriate):
Current:
![image](https://user-images.githubusercontent.com/4214671/111633136-da11b000-87fd-11eb-8f7c-8283ac25a3b0.png)

Fixed:
![image](https://user-images.githubusercontent.com/4214671/111633181-e4cc4500-87fd-11eb-891c-e414935650be.png)

