### PR TITLE
Add loading-button aria-label

### DIFF
--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -117,6 +117,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         disabled={disabled}
         aria-disabled={isLoading || disabled || undefined}
+        aria-label={isLoading ? loadingText : undefined}
         type="button"
         className={classNames(
           styles.button,

--- a/packages/react/src/components/button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/components/button/__snapshots__/Button.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`<Button /> spec renders the loading button component 1`] = `
 <DocumentFragment>
   <button
     aria-disabled="true"
+    aria-label="foo"
     class="button primary theme-default size-default isLoading"
     type="button"
   >


### PR DESCRIPTION
## Description
Add aria-label when the button is in a loading state. 

## Motivation and Context
Aria-label will help screen readers to notify the user about the button's state changes.

## How Has This Been Tested?
- locally on developer's machine
- snapshot test

👉   [Storybook demo](https://city-of-helsinki.github.io/hds-demo/loading-button/iframe.html?id=components-button--loading)