### PR TITLE
[Fix] Content overlap in the Select component with long labels

### DIFF
--- a/packages/react/src/components/dropdown/select/Select.module.scss
+++ b/packages/react/src/components/dropdown/select/Select.module.scss
@@ -44,6 +44,13 @@
 }
 
 /**
+ * THE BUTTON LABEL (SELECTED VALUE OR PLACEHOLDER)
+ */
+.buttonLabel {
+  padding-right: var(--spacing-layout-xs);
+}
+
+/**
  * ICON
  */
 

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -445,7 +445,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   const getButtonLabel = (): React.ReactNode => {
     let buttonLabel = selectedItem?.[optionLabelField] || placeholder;
     if (props.multiselect) buttonLabel = selectedItems.length > 0 ? null : placeholder;
-    return buttonLabel;
+    return buttonLabel && <span className={styles.buttonLabel}>{buttonLabel}</span>;
   };
 
   // screen readers should read the labels in the following order:


### PR DESCRIPTION
## Description

This PR fixes the small layout bug in the `Select` component with labels of a specific length. Before this PR, the label text could overlap with the dropdown caret icon. See screenshots below for more details.

## Related Issue

The issue was briefly discussed in Slack: https://helsinkicity.slack.com/archives/CHCV3KTHA/p1617287264046900

## Motivation and Context

We encountered this bug in Kasko Asti.

## How Has This Been Tested?

This has been tested by hand in Storybook: I verified that the change fixes the bug in question. I also verified that this change does not affect the `Combobox` component or the multi-select variant of the `Select` component.

## Screenshots

### Before

<img width="459" alt="Screenshot 2021-04-06 at 9 00 13" src="https://user-images.githubusercontent.com/631969/113666045-3f4b1980-96b7-11eb-85ce-5e50da8afff7.png">

### After

<img width="459" alt="Screenshot 2021-04-06 at 9 00 23" src="https://user-images.githubusercontent.com/631969/113666063-496d1800-96b7-11eb-828b-b83262b81a0c.png">
