### PR TITLE
Add npm-script to update library versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "lerna publish from-package --yes",
     "husky:pre-commit": "lerna run --concurrency 1 --stream pre-commit",
     "husky:pre-push": "lerna run --concurrency 1 --stream pre-push",
-    "update-versions": "lerna version --no-git-tag-version --no-push --amend --yes"
+    "update-versions": "lerna version --exact --no-git-tag-version --no-push --amend --yes"
   },
   "devDependencies": {
     "husky": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start:react": "lerna run --scope hds-react start",
     "release": "lerna publish from-package --yes",
     "husky:pre-commit": "lerna run --concurrency 1 --stream pre-commit",
-    "husky:pre-push": "lerna run --concurrency 1 --stream pre-push"
+    "husky:pre-push": "lerna run --concurrency 1 --stream pre-push",
+    "update-versions": "lerna version --no-git-tag-version --no-push --amend --yes"
   },
   "devDependencies": {
     "husky": "^3.1.0",


### PR DESCRIPTION
## Description
Add npm script to update version numbers. The script utilizes  [Lerna's version](https://github.com/lerna/lerna/tree/main/commands/version) command. The script parameter can either be release version string or [Lerna's positional](https://github.com/lerna/lerna/tree/main/commands/version#positionals) (major, minor, patch,.. ).

For example: 
- bump up minor `yarn run update-versions minor`
- with version string `yarn run update-versions 0.22.0`

## Motivation and Context
At the moment, each library version and cross dependencies are manually updated. 
This process takes some time and is prone to errors.

## How Has This Been Tested?
- Locally on dev's machine
