### PR TITLE
[Fix] Remove redundant LockOpen icon rows from the icon docs table

### DIFF
--- a/site/docs/visual_elements/icons.mdx
+++ b/site/docs/visual_elements/icons.mdx
@@ -121,8 +121,6 @@ Icon                         | Core               | React             | Usage
 <HDS.IconEyeCrossed />       | eye-crossed        | EyeCrossed        | Hide content
 <HDS.IconLock />             | lock               | Lock              | Content locked
 <HDS.IconLockOpen />         | lock-open          | LockOpen          | Content unlocked
-<HDS.IconLockOpen />         | lock-open          | LockOpen          | Content unlocked
-<HDS.IconLockOpen />         | lock-open          | LockOpen          | Content unlocked
 <HDS.IconSaveDiskette />     | save-diskette      | SaveDiskette      | Saving
 <HDS.IconSaveDisketteFill /> | save-diskette-fill | SaveDisketteFill  | Saving alternative
 <HDS.IconShare />            | share              | Share             | Share content or link


### PR DESCRIPTION
## Description
Remove redundant LockOpen icon rows from the icon docs table.

## How Has This Been Tested
Tested by running the documentation site locally.
