### PR TITLE
Make doc examples more DRY

### DIFF
--- a/packages/react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/dialog/Dialog.stories.tsx
@@ -15,8 +15,6 @@ export default {
   },
   args: {
     id: 'example-dialog',
-    'aria-labelled-by': 'example-dialog-title',
-    'aria-describedby': 'example-dialog-content',
   },
 };
 
@@ -24,6 +22,8 @@ export const Default = (args) => {
   const openButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(false);
   const close = () => setOpen(false);
+  const titleId = 'custom-dialog-title';
+  const descriptionId = 'custom-dialog-content';
 
   return (
     <>
@@ -32,20 +32,16 @@ export const Default = (args) => {
       </Button>
       <Dialog
         id={args.id}
-        aria-labelledby={args['aria-labelledby']}
-        aria-describedby={args['aria-describedby']}
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
         isOpen={open}
         focusAfterCloseRef={openButtonRef}
         close={close}
         closeButtonLabelText="Close"
       >
-        <Dialog.Header
-          id={args['aria-labelledby']}
-          title="Add new item"
-          iconLeft={<IconPlusCircle aria-hidden="true" />}
-        />
+        <Dialog.Header id={titleId} title="Add new item" iconLeft={<IconPlusCircle aria-hidden="true" />} />
         <Dialog.Content>
-          <p id={args['aria-describedby']} className="text-body">
+          <p id={descriptionId} className="text-body">
             Add a new item by filling the information below. All fields are mandatory.
           </p>
           <TextInput
@@ -87,6 +83,8 @@ export const Confirmation = (args) => {
   const openConfirmationButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
+  const titleId = 'confirmation-dialog-title';
+  const descriptionId = 'confirmation-dialog-description';
 
   return (
     <>
@@ -95,19 +93,15 @@ export const Confirmation = (args) => {
       </Button>
       <Dialog
         id={args.id}
-        aria-labelledby={args['aria-labelledby']}
-        aria-describedby={args['aria-describedby']}
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
         isOpen={open}
         focusAfterCloseRef={openConfirmationButtonRef}
         targetElement={dialogTargetElement}
       >
-        <Dialog.Header
-          id={args['aria-labelledby']}
-          title="Confirm dialog"
-          iconLeft={<IconAlertCircle aria-hidden="true" />}
-        />
+        <Dialog.Header id={titleId} title="Confirm dialog" iconLeft={<IconAlertCircle aria-hidden="true" />} />
         <Dialog.Content>
-          <p id={args['aria-describedby']} className="text-body">
+          <p id={descriptionId} className="text-body">
             Are you sure you want to continue?
           </p>
         </Dialog.Content>
@@ -133,8 +127,6 @@ Confirmation.storyName = 'Confirmation';
 
 Confirmation.args = {
   id: 'confirmation-dialog',
-  'aria-labelledby': 'confirmation-dialog-title',
-  'aria-describedby': 'confirmation-dialog-description',
 };
 
 Confirmation.parameters = {
@@ -154,6 +146,8 @@ export const Danger = (args) => {
   const openDangerButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
+  const titleId = 'danger-dialog-title';
+  const descriptionId = 'danger-dialog-description';
 
   return (
     <>
@@ -163,19 +157,15 @@ export const Danger = (args) => {
       <Dialog
         variant="danger"
         id={args.id}
-        aria-labelledby={args['aria-labelledby']}
-        aria-describedby={args['aria-describedby']}
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
         isOpen={open}
         focusAfterCloseRef={openDangerButtonRef}
         targetElement={dialogTargetElement}
       >
-        <Dialog.Header
-          id={args['aria-labelledby']}
-          title="Delete item"
-          iconLeft={<IconAlertCircle aria-hidden="true" />}
-        />
+        <Dialog.Header id={titleId} title="Delete item" iconLeft={<IconAlertCircle aria-hidden="true" />} />
         <Dialog.Content>
-          <p id={args['aria-describedby']} className="text-body">
+          <p id={descriptionId} className="text-body">
             Are you sure you want to delete the item?
           </p>
         </Dialog.Content>
@@ -203,8 +193,6 @@ Danger.storyName = 'Danger';
 
 Danger.args = {
   id: 'danger-dialog',
-  'aria-labelledby': 'danger-dialog-title',
-  'aria-describedby': 'danger-dialog-description',
 };
 
 Danger.parameters = {
@@ -224,6 +212,8 @@ export const ScrollableConfirmation = (args) => {
   const openScrollableConfirmationButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
+  const titleId = 'confirmation-scrollable-title';
+  const descriptionId = 'confirmation-scrollable-description';
 
   return (
     <>
@@ -233,20 +223,16 @@ export const ScrollableConfirmation = (args) => {
       <Dialog
         id={args.id}
         style={{ width: '800px' }}
-        aria-labelledby={args['aria-labelledby']}
-        aria-describedby={args['aria-describedby']}
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
         isOpen={open}
         focusAfterCloseRef={openScrollableConfirmationButtonRef}
         targetElement={dialogTargetElement}
         scrollable
       >
-        <Dialog.Header
-          id={args['aria-labelledby']}
-          title="Confirm dialog"
-          iconLeft={<IconAlertCircle aria-hidden="true" />}
-        />
+        <Dialog.Header id={titleId} title="Confirm dialog" iconLeft={<IconAlertCircle aria-hidden="true" />} />
         <Dialog.Content>
-          <h3 id={args['aria-describedby']}>Are you sure you want to continue?</h3>
+          <h3 id={descriptionId}>Are you sure you want to continue?</h3>
           <p className="text-body">
             Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
             aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
@@ -341,8 +327,6 @@ ScrollableConfirmation.storyName = 'Scrollable confirmation';
 
 ScrollableConfirmation.args = {
   id: 'confirmation-scrollable-dialog',
-  'aria-labelledby': 'confirmation-scrollable-title',
-  'aria-describedby': 'confirmation-scrollable-description',
 };
 
 ScrollableConfirmation.parameters = {
@@ -365,6 +349,10 @@ export const ConfirmationWithTerms = (args) => {
   const openTermsButtonRef = useRef(null);
   const closeTerms = () => setTermsOpen(false);
   const openTermsDialog = () => setTermsOpen(true);
+  const confirmationTitleId = 'confirmation-title';
+  const confirmationDescriptionId = 'confirmation-description';
+  const termsTitleId = 'terms-title';
+  const termsDescriptionId = 'terms-description';
 
   return (
     <>
@@ -374,18 +362,18 @@ export const ConfirmationWithTerms = (args) => {
       <Dialog
         id={args.id}
         style={{ width: '800px' }}
-        aria-labelledby={args['aria-labelledby']}
-        aria-describedby={args['aria-describedby']}
+        aria-labelledby={confirmationTitleId}
+        aria-describedby={confirmationDescriptionId}
         isOpen={open}
         focusAfterCloseRef={openConfirmationButtonRef}
       >
         <Dialog.Header
-          id={args['aria-labelledby']}
+          id={confirmationTitleId}
           title="Accept terms dialog"
           iconLeft={<IconAlertCircle aria-hidden="true" />}
         />
         <Dialog.Content>
-          <p id={args['aria-describedby']} className="text-body">
+          <p id={confirmationDescriptionId} className="text-body">
             Do you want to accept terms of the service?
             <br />
             <br />
@@ -415,16 +403,16 @@ export const ConfirmationWithTerms = (args) => {
       </Dialog>
       <Dialog
         id={args.termsId}
-        aria-labelledby={args.termsLabelId}
-        aria-describedby={args.termsDescriptionId}
+        aria-labelledby={termsTitleId}
+        aria-describedby={termsDescriptionId}
         isOpen={termsOpen}
         focusAfterCloseRef={openTermsButtonRef}
         close={closeTerms}
         closeButtonLabelText="Close terms dialog"
       >
-        <Dialog.Header id={args.termsLabelId} title="Service terms" />
+        <Dialog.Header id={termsTitleId} title="Service terms" />
         <Dialog.Content>
-          <p id={args.termsDescriptionId} className="text-body">
+          <p id={termsDescriptionId} className="text-body">
             These are the terms of the service.
           </p>
           <p className="text-body">
@@ -461,11 +449,7 @@ ConfirmationWithTerms.parameters = {
 
 ConfirmationWithTerms.args = {
   id: 'confirmation-dialog',
-  'aria-labelledby': 'confirmation-title',
-  'aria-describedby': 'confirmation-description',
   termsId: 'terms-dialog',
-  termsLabelId: 'terms-dialog-title',
-  termsDescriptionId: 'terms-dialog-description',
 };
 
 ConfirmationWithTerms.parameters = {

--- a/site/docs/components/dialog.mdx
+++ b/site/docs/components/dialog.mdx
@@ -73,7 +73,7 @@ Info dialogs are used to convey important information to the user. Info dialogs 
           aria-labelledby={titleId}
           aria-describedby={descriptionId}
           isOpen={isOpen}
-          close={() => setIsOpen(false)}
+          close={close}
           closeButtonLabelText="Close info dialog"
           focusAfterCloseRef={openInfoDialogButtonRef}
           targetElement={dialogTargetRef.current}
@@ -116,7 +116,7 @@ Info dialogs are used to convey important information to the user. Info dialogs 
           aria-labelledby={titleId}
           aria-describedby={descriptionId}
           isOpen={isOpen}
-          close={() => setIsOpen(false)}
+          close={close}
           closeButtonLabelText="Close info dialog"
           focusAfterCloseRef={openInfoDialogButtonRef}
         >

--- a/site/docs/components/dialog.mdx
+++ b/site/docs/components/dialog.mdx
@@ -60,6 +60,8 @@ Info dialogs are used to convey important information to the user. Info dialogs 
     const openInfoDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "info-dialog-title";
+    const descriptionId = "info-dialog-content";
     return (
       <>
         <div ref={dialogTargetRef}/>
@@ -68,8 +70,8 @@ Info dialogs are used to convey important information to the user. Info dialogs 
         </Button>
         <Dialog
           id="info-dialog"
-          aria-labelledby="info-dialog-title"
-          aria-describedby="info-dialog-content"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           close={() => setIsOpen(false)}
           closeButtonLabelText="Close info dialog"
@@ -77,12 +79,12 @@ Info dialogs are used to convey important information to the user. Info dialogs 
           targetElement={dialogTargetRef.current}
         >
           <Dialog.Header
-            id="info-dialog-title"
+            id={titleId}
             title="Terms of service have changed"
             iconLeft={<IconInfoCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <p id="info-dialog-content" className="text-body">
+            <p id={descriptionId} className="text-body">
               Please note that the terms of this service have changed. You can review the changes in the user settings.</p>
           </Dialog.Content>
           <Dialog.ActionButtons>
@@ -102,6 +104,8 @@ Info dialogs are used to convey important information to the user. Info dialogs 
     const openInfoDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "info-dialog-title";
+    const descriptionId = "info-dialog-content";
     return (
       <>
         <Button ref={openInfoDialogButtonRef} onClick={() => setIsOpen(true)}>
@@ -109,20 +113,20 @@ Info dialogs are used to convey important information to the user. Info dialogs 
         </Button>
         <Dialog
           id="info-dialog"
-          aria-labelledby="info-dialog-title"
-          aria-describedby="info-dialog-content"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           close={() => setIsOpen(false)}
           closeButtonLabelText="Close info dialog"
           focusAfterCloseRef={openInfoDialogButtonRef}
         >
           <Dialog.Header
-            id="info-dialog-title"
+            id={titleId}
             title="Terms of service have changed"
             iconLeft={<IconInfoCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <p id="info-dialog-content" className="text-body">
+            <p id={descriptionId} className="text-body">
               Please note that the terms of this service have changed. You can review the changes in the user settings.
             </p>
           </Dialog.Content>
@@ -146,6 +150,8 @@ Confirm dialogs are used when an action is required from the user. Confirm dialo
     const openConfirmationDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "confirmation-dialog-title";
+    const descriptionId = "confirmation-dialog-info";
     return (
       <>
         <div ref={confirmationDialogTarget}/>
@@ -154,19 +160,19 @@ Confirm dialogs are used when an action is required from the user. Confirm dialo
         </Button>
         <Dialog
           id="confirmation-dialog"
-          aria-labelledby="confirmation-dialog-title"
-          aria-describedby="confirmation-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openConfirmationDialogButtonRef}
           targetElement={confirmationDialogTarget.current}
         >
           <Dialog.Header
-            id="confirmation-dialog-title"
+            id={titleId}
             title="Are you sure you want to continue?"
             iconLeft={<IconQuestionCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <p id="confirmation-dialog-info" className="text-body">
+            <p id={descriptionId} className="text-body">
               You have not filled all form fields. Do you still want to continue? You can later return to edit this form. Saved forms can be accessed in your personal profile.
             </p>
           </Dialog.Content>
@@ -191,6 +197,8 @@ Confirm dialogs are used when an action is required from the user. Confirm dialo
     const openConfirmationDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "confirmation-dialog-title";
+    const descriptionId = "confirmation-dialog-info";
     return (
       <>
         <Button ref={openConfirmationDialogButtonRef} onClick={() => setIsOpen(true)}>
@@ -198,18 +206,18 @@ Confirm dialogs are used when an action is required from the user. Confirm dialo
         </Button>
         <Dialog
           id="confirmation-dialog"
-          aria-labelledby="confirmation-dialog-title"
-          aria-describedby="confirmation-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openConfirmationDialogButtonRef}
         >
           <Dialog.Header
-            id="confirmation-dialog-title"
+            id={titleId}
             title="Are you sure you want to continue?"
             iconLeft={<IconQuestionCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <p id="confirmation-dialog-info" className="text-body">
+            <p id={descriptionId} className="text-body">
               You have not filled all form fields. Do you still want to continue? You can later return to edit this form. Saved forms can be accessed in your personal profile.
             </p>
           </Dialog.Content>
@@ -236,6 +244,8 @@ Danger dialog is a variant of a confirm dialog. They are used in similar use cas
     const openDeleteDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "delete-dialog-title";
+    const descriptionId = "delete-dialog-info";
     return (
       <>
         <div ref={dangerDialogTargetRef}/>
@@ -245,19 +255,19 @@ Danger dialog is a variant of a confirm dialog. They are used in similar use cas
         <Dialog
           variant="danger"
           id="delete-dialog"
-          aria-labelledby="delete-dialog-title"
-          aria-describedby="delete-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openDeleteDialogButtonRef}
           targetElement={dangerDialogTargetRef.current}
         >
           <Dialog.Header
-            id="delete-dialog-title"
+            id={titleId}
             title="Are you sure you want to delete this blog post?"
             iconLeft={<IconAlertCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <p id="delete-dialog-info" className="text-body">
+            <p id={descriptionId} className="text-body">
               The blog post will be deleted immediately. Deletion is permanent and it cannot be reverted.
             </p>
           </Dialog.Content>
@@ -288,6 +298,8 @@ Danger dialog is a variant of a confirm dialog. They are used in similar use cas
     const openDeleteDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "delete-dialog-title";
+    const descriptionId = "delete-dialog-info";
     return (
       <>
         <Button ref={openDeleteDialogButtonRef} onClick={() => setIsOpen(true)}>
@@ -296,18 +308,18 @@ Danger dialog is a variant of a confirm dialog. They are used in similar use cas
         <Dialog
           variant="danger"
           id="delete-dialog"
-          aria-labelledby="delete-dialog-title"
-          aria-describedby="delete-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openDeleteDialogButtonRef}
         >
           <Dialog.Header
-            id="delete-dialog-title"
+            id={titleId}
             title="Are you sure you want to delete this blog post?"
             iconLeft={<IconAlertCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <p id="delete-dialog-info" className="text-body">
+            <p id={descriptionId} className="text-body">
               The blog post will be deleted immediately. Deletion is permanent and it cannot be reverted.
             </p>
           </Dialog.Content>
@@ -341,6 +353,8 @@ While not recommended, HDS supports scrollable dialogs if there is a large amoun
     const openTermsDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "terms-dialog-title";
+    const descriptionId = "terms-dialog-info";
     return (
       <>
         <div ref={termsDialogTargetRef}/>
@@ -349,20 +363,20 @@ While not recommended, HDS supports scrollable dialogs if there is a large amoun
         </Button>
         <Dialog
           id="terms-dialog"
-          aria-labelledby="terms-dialog-title"
-          aria-describedby="terms-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openTermsDialogButtonRef}
           targetElement={termsDialogTargetRef.current}
           scrollable
         >
           <Dialog.Header
-            id="terms-dialog-title"
+            id={titleId}
             title="Do you accept the terms of service?"
             iconLeft={<IconAlertCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <h3 id="terms-dialog-info">Terms of service</h3>
+            <h3 id={descriptionId}>Terms of service</h3>
             <p className="text-body">
               Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
               aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
@@ -439,6 +453,8 @@ While not recommended, HDS supports scrollable dialogs if there is a large amoun
     const openTermsDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "terms-dialog-title";
+    const descriptionId = "terms-dialog-info";
     return (
       <>
         <Button ref={openTermsDialogButtonRef} onClick={() => setIsOpen(true)}>
@@ -446,19 +462,19 @@ While not recommended, HDS supports scrollable dialogs if there is a large amoun
         </Button>
         <Dialog
           id="terms-dialog"
-          aria-labelledby="terms-dialog-title"
-          aria-describedby="terms-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openTermsDialogButtonRef}
           scrollable
         >
           <Dialog.Header
-            id="terms-dialog-title"
+            id={titleId}
             title="Do you accept the terms of service?"
             iconLeft={<IconAlertCircle aria-hidden="true" />}
           />
           <Dialog.Content>
-            <h3 id="terms-dialog-info">Terms of service</h3>
+            <h3 id={descriptionId}>Terms of service</h3>
             <p className="text-body">
               ...
             </p>
@@ -486,6 +502,8 @@ HDS Dialog elements can be used to build custom dialogs. Using HDS provided elem
     const openCustomDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "custom-dialog-title";
+    const descriptionId = "custom-dialog-info";
     return (
       <>
         <div ref={customDialogTargetRef}/>
@@ -494,18 +512,18 @@ HDS Dialog elements can be used to build custom dialogs. Using HDS provided elem
         </Button>
         <Dialog
           id="custom-dialog"
-          aria-labelledby="custom-dialog-title"
-          aria-describedby="custom-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openCustomDialogButtonRef}
           targetElement={customDialogTargetRef.current}
         >
         <Dialog.Header
-          id="custom-dialog-title"
+          id={titleId}
           title="Add new item"
         />
         <Dialog.Content>
-          <p id="custom-dialog-info" className="text-body">
+          <p id={descriptionId} className="text-body">
             Add a new item by filling the information below. All fields are mandatory.
           </p>
           <TextInput
@@ -548,6 +566,8 @@ HDS Dialog elements can be used to build custom dialogs. Using HDS provided elem
     const openCustomDialogButtonRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
     const close = () => setIsOpen(false);
+    const titleId = "custom-dialog-title";
+    const descriptionId = "custom-dialog-info";
     return (
       <>
         <Button ref={openCustomDialogButtonRef} onClick={() => setIsOpen(true)}>
@@ -555,17 +575,17 @@ HDS Dialog elements can be used to build custom dialogs. Using HDS provided elem
         </Button>
         <Dialog
           id="custom-dialog"
-          aria-labelledby="custom-dialog-title"
-          aria-describedby="custom-dialog-info"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
           isOpen={isOpen}
           focusAfterCloseRef={openCustomDialogButtonRef}
         >
         <Dialog.Header
-          id="custom-dialog-title"
+          id={titleId}
           title="Add new item"
         />
         <Dialog.Content>
-          <p id="custom-dialog-info" className="text-body">
+          <p id={descriptionId} className="text-body">
             Add a new item by filling the information below. All fields are mandatory.
           </p>
           <TextInput


### PR DESCRIPTION
## Description
- Use constants in dialog documentation examples

## Motivation and Context
- Developers often copy-paste examples, so it is good that the examples themselves follow DRY pattern.
- The constants also express the direct linkage between the element ids and the aria-attributes.

## How Has This Been Tested?
- Locally on dev's machine