### PR TITLE
Fix/dateinput min width

### DIFF
--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
@@ -28,6 +28,7 @@
   display: inline-block;
   width: 100%;
   max-width: calc(var(--table-width) + 2 * var(--horizontal-spacing));
+  min-width: var(--container-width-xs);
   padding: var(--vertical-spacing) var(--horizontal-spacing);
 }
 

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
@@ -24,7 +24,7 @@
   background: #fff;
   position: relative;
   box-sizing: border-box;
-  box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
   display: inline-block;
   width: 100%;
   max-width: calc(var(--table-width) + 2 * var(--horizontal-spacing));


### PR DESCRIPTION
## Description
- Add min-width for dateinput's datepicker

## Closes
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-782

## Motivation and Context
- The width of the datepicker is based on the width of the dateinput. With min-width, the datepicker won’t get too narrow with a narrow dateinput.

## How Has This Been Tested?
- Locally on dev's machine

## Screenshots (if appropriate):

Before: 
<img width="264" alt="Näyttökuva 2021-4-23 kello 15 49 14" src="https://user-images.githubusercontent.com/1610860/116088679-c2560300-a6aa-11eb-93f1-1bd604d6ba3f.png">

After:
<img width="472" alt="Näyttökuva 2021-4-26 kello 15 46 52" src="https://user-images.githubusercontent.com/1610860/116088701-c71ab700-a6aa-11eb-90d5-3a91f1b306b2.png">
