### PR TITLE
Remove beta texts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Helsinki Design System (beta)</h1>
+<h1 align="center">Helsinki Design System</h1>
 
 <div align="center">
   <strong>Design System for the City of Helsinki</strong>
@@ -12,7 +12,7 @@
 <div align="center">
   <!-- Version -->
   <a href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/latest">
-    <img src="https://img.shields.io/github/v/release/City-of-Helsinki/helsinki-design-system?label=beta-release&style=flat-square"
+    <img src="https://img.shields.io/github/v/release/City-of-Helsinki/helsinki-design-system?label=version&style=flat-square"
       alt="Version" />
   </a>
   <!-- Licence -->
@@ -124,7 +124,7 @@ Helsinki Design System has a public roadmap. For the long-term Roadmap, please r
 
 **Before contributing, it is recommended to read [HDS Contribution - Before contributing page](https://hds.hel.fi/contributing/before-contributing).**
 
-Helsinki Design System is under development, currently in the beta phase. We are accepting new features, feature requests and help with improving the documentation. There are multiple ways you can contribute:
+We are accepting new features, feature requests and help with improving the documentation. There are multiple ways you can contribute:
 
 - Opening [issues](https://github.com/City-of-Helsinki/helsinki-design-system/issues) about bugs/improvements/new features/etc.
 - Opening [pull requests](https://github.com/City-of-Helsinki/helsinki-design-system/pulls) with changes/fixes/new features/etc.

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -29,7 +29,7 @@ In addition to WCAG 2.1 and 2.0, HDS also refers to the following guidelines:
 - <Link href="https://dev.hel.fi/accessibility" external>Develop with Helsinki - accessibility guidelines for developers</Link>.
 
 ## HDS accessibility process
-**After HDS beta release, new components and patterns are not released before their accessibility has been audited by a third party auditor.** If components or patterns are released without an audit, it will be clearly indicated in the documentation. This may happen if the component is quickly needed by some project or if it takes considerably long time to make the component accessible.
+**New components and patterns are not released before their accessibility has been audited by a third party auditor. This includes components marked as Drafts.** If components or patterns are released without an audit, it will be clearly indicated in the documentation. This may happen if the component is quickly needed by some project or if it takes considerably long time to make the component accessible.
 
 Component accessibility is ensured in all stages of HDS design and development. The process is following:
 1. During design phase, auditors will comment the designs from visual perspective. They will also give pointers on which parts of the design may cause challenges for accessibility during implementation.

--- a/site/src/gatsby-theme-docz/components/Sidebar/index.js
+++ b/site/src/gatsby-theme-docz/components/Sidebar/index.js
@@ -46,7 +46,7 @@ export const Sidebar = React.forwardRef((props, ref) => {
           >
             <img src={logo} alt="Helsinki Design System" height="60" />
             <div>
-              <b>Design System</b> (beta)
+              <b>Design System</b>
             </div>
             <div
               style={{


### PR DESCRIPTION
## Description
Removes all references to "beta" from the documentation site and GitHub READMEs.

## How Has This Been Tested?
Tested by running the documentation site locally.
