### PR TITLE
Feature/split lokitests

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        loki_configuration: [ 'laptop', 'iphone7' ]
+        loki_configuration: [ 'laptop_Components_[A-M]', 'laptop_Components_[N-Z]', 'iphone7_Components_[A-M]', 'iphone7_Components_[N-Z]' ]
 
     steps:
       - name: download storybook
@@ -88,7 +88,7 @@ jobs:
           yarn add loki@0.26.0
 
       - name: visually test react package with ${{ matrix.loki_configuration }}
-        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static ${{ matrix.loki_configuration }}
+        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static --storiesFilter /${{ matrix.loki_configuration }}/
 
       - name: upload reference and actual images with ${{ matrix.loki_configuration }} in case of failure
         uses: actions/upload-artifact@v2

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -67,7 +67,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        loki_configuration: [ 'laptop_Components_[A-M]', 'laptop_Components_[N-Z]', 'iphone7_Components_[A-M]', 'iphone7_Components_[N-Z]' ]
+        loki_configuration: [ 'laptop', 'iphone7']
+        loki_test_group: [ 'Components/[A-M]', 'Components/[N-Z]']
 
     steps:
       - name: download storybook
@@ -88,11 +89,11 @@ jobs:
           yarn add loki@0.26.0
 
       - name: visually test react package with ${{ matrix.loki_configuration }}
-        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static --storiesFilter /${{ matrix.loki_configuration }}/
+        run: ./node_modules/.bin/loki test --requireReference --verboseRenderer --reactUri file:./storybook-static --storiesFilter ${{ matrix.loki_test_group }} ${{ matrix.loki_configuration }}
 
-      - name: upload reference and actual images with ${{ matrix.loki_configuration }} in case of failure
+      - name: upload reference and actual images with ${{ matrix.loki_configuration }} and ${{ matrix.loki_test_group }} in case of failure
         uses: actions/upload-artifact@v2
         with:
-          name: loki_images_${{ matrix.loki_configuration }}
-          path: .loki/*/*${{ matrix.loki_configuration }}*.*
+          name: loki_images_${{ matrix.loki_configuration }}_${{ matrix.loki_test_group }}
+          path: .loki/*/*${{ matrix.loki_configuration }}/${{ matrix.loki_test_group }}*.*
         if: failure()


### PR DESCRIPTION
## Description
- Split the Lokitests into smaller parallel groups to cut down the build time 

## Closes
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-775

## Motivation and Context
- It can take up to 40 minutes to complete Lokitests at the moment. It makes the release process slow, especially if there is a need for small tweaks during the process.