### PR TITLE
Silence Babel warning

### DIFF
--- a/packages/react/babel.config.json
+++ b/packages/react/babel.config.json
@@ -9,5 +9,8 @@
   ],
   "plugins": [["@babel/plugin-transform-runtime", {
     "useESModules": true
-  }]]
+  }],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }],
+    ["@babel/plugin-proposal-private-methods", { "loose": true }],
+    ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,9 @@
   },
   "devDependencies": {
     "@babel/core": "7.11.6",
+    "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-proposal-private-methods": "^7.13.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.14.0",
     "@babel/plugin-transform-runtime": "7.11.5",
     "@babel/preset-env": "7.11.5",
     "@babel/preset-react": "7.10.4",


### PR DESCRIPTION
## Description
- There are multiple configuration warnings when running `yarn build-storybook`. Warnings are related to upgraded babel-plugins which are used in the new Storybook version
`The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]`

## Motivation and Context
- All the unnecessary logging or warnings should be removed or suppressed for better maintainability
