### PR TITLE
Fix/text field error and success text alignments

### DIFF
--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -120,6 +120,7 @@
 .hds-text-input__helper-text {
   color: var(--helper-color-default);
   display: block;
+  line-height: var(--lineheight-l);
   font-size: var(--fontsize-body-m);
   margin-top: var(--spacing-3-xs);
 }

--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -130,6 +130,7 @@
   color: var(--helper-color-invalid);
   display: block;
   font-size: var(--fontsize-body-m);
+  line-height: var(--lineheight-l);
   margin-top: var(--spacing-3-xs);
   padding-left: calc(var(--icon-size) + var(--spacing-2-xs));
 }
@@ -170,6 +171,7 @@
   color: var(--helper-color-success);
   display: block;
   font-size: var(--fontsize-body-m);
+  line-height: var(--lineheight-l);
   margin-top: var(--spacing-3-xs);
   padding-left: calc(var(--icon-size) + var(--spacing-2-xs));
 }


### PR DESCRIPTION
## Description

Fix text field error and success text alignments by specifying explicit line height

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-703
https://github.com/City-of-Helsinki/helsinki-design-system/issues/467

Closes #

https://github.com/City-of-Helsinki/helsinki-design-system/issues/467

## How Has This Been Tested?

- Locally on developers machine
- Automated loki tests to ensure no breaking visual changes to the components itself

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2777633/121178475-2f8eb380-c867-11eb-9d0a-b30d46d61b4b.png)

->

![image](https://user-images.githubusercontent.com/2777633/121178275-fce4bb00-c866-11eb-9efe-23732839d847.png)

The issue can be reproduced by setting a line height of 15px to the whole component container. The error text (and success text) will inherit that line height which will break the vertical alignment. 


