### PR TITLE
Try to fix lsf-bandwidth issue in development

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -11,11 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v2
+        id: lfs-cache
         with:
-          lfs: true
-          
-      - name: Checkout LFS objects
-        run: git lfs checkout
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+
+      - name: Git LFS Pull
+        run: git lfs pull
 
       - name: setup node
         uses: actions/setup-node@v2.1.5

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,11 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v2
+        id: lfs-cache
         with:
-          lfs: true
-          
-      - name: Checkout LFS objects
-        run: git lfs checkout
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+
+      - name: Git LFS Pull
+        run: git lfs pull
 
       - name: setup node
         uses: actions/setup-node@v2.1.5

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  hooks: {
-    "pre-commit": "yarn run husky:pre-commit",
-    "pre-push": "yarn run husky:pre-push"
-  }
-};


### PR DESCRIPTION
## Description
- Decrease the bandwidth size of Github actions by replacing the file comparison with a file name-hash-based cache key.

## Closes
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-858

## Motivation and Context
- All Github actions are failing with error:  
  `batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data  packs to restore access`
- We create a file name-hash-based cache key without pulling the actual images every time. We can use the ones in Github's actions cache instead
- The solution: https://github.com/actions/checkout/issues/165#issuecomment-657673315
- The origin for solution: https://www.develer.com/en/avoiding-git-lfs-bandiwdth-waste-with-github-and-circleci/ 

