### PR TITLE
[Change] Add a note about Sketch Assistant link requiring Sketch to be installed

### DIFF
--- a/site/docs/Contributing/design.mdx
+++ b/site/docs/Contributing/design.mdx
@@ -198,10 +198,10 @@ Besides checking HDS library files, this list can also be applied to any Sketch 
   This checklist is (in most parts) also available as a <Link href="https://www.sketch.com/extensions/assistants/" external>Sketch Assistant</Link> that automatically runs a preflight check for Sketch files. If you have Sketch installed on your computer, you may click the following link to automatically install the assistant. 
 </p> 
 <p> 
-  For more information see the <Link href="https://github.com/ronijaakkola/hds-assistant" external>HDS Assistant Github page</Link>. If you have Sketch installed on your computer you can use the following link to automatically install the assistant (the link will not work if you do not have Sketch installed). 
+  For more information see the <Link href="https://github.com/City-of-Helsinki/hds-assistant" external>HDS Assistant Github page</Link>. If you have Sketch installed on your computer you can use the following link to automatically install the assistant (the link will not work if you do not have Sketch installed). 
 </p>
 <p>
-  <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>Add HDS Assistant to your Sketch</Link>
+  <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>Add HDS Assistant to your Sketch (requires Sketch on your computer)</Link>
 </p>
 
 

--- a/site/docs/Contributing/design.mdx
+++ b/site/docs/Contributing/design.mdx
@@ -195,10 +195,13 @@ With the following checklist you can check your design files before merging them
 Besides checking HDS library files, this list can also be applied to any Sketch project for better organisation.
 
 <p>
-  This checklist is (in most parts) also available as a <Link href="https://www.sketch.com/extensions/assistants/" external>Sketch Assistant</Link> that automatically runs a preflight check for Sketch files.
+  This checklist is (in most parts) also available as a <Link href="https://www.sketch.com/extensions/assistants/" external>Sketch Assistant</Link> that automatically runs a preflight check for Sketch files. If you have Sketch installed on your computer, you may click the following link to automatically install the assistant. 
 </p> 
 <p> 
-  For more information see the <Link href="https://github.com/ronijaakkola/hds-assistant" external>HDS Assistant Github page</Link>. You can also <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>add HDS Assistant directly to Sketch by pressing this link</Link>.
+  For more information see the <Link href="https://github.com/ronijaakkola/hds-assistant" external>HDS Assistant Github page</Link>. If you have Sketch installed on your computer you can use the following link to automatically install the assistant (the link will not work if you do not have Sketch installed). 
+</p>
+<p>
+  <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>Add HDS Assistant to your Sketch</Link>
 </p>
 
 

--- a/site/docs/Contributing/design.mdx
+++ b/site/docs/Contributing/design.mdx
@@ -204,7 +204,6 @@ Besides checking HDS library files, this list can also be applied to any Sketch 
   <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>Add HDS Assistant to your Sketch (requires Sketch on your computer)</Link>
 </p>
 
-
 ### Styles
 **Use shared text and layer styles in components**
   - **Text layers** are styled with `HDS Typography` text styles. 

--- a/site/docs/Contributing/design.mdx
+++ b/site/docs/Contributing/design.mdx
@@ -198,10 +198,10 @@ Besides checking HDS library files, this list can also be applied to any Sketch 
   This checklist is (in most parts) also available as a <Link href="https://www.sketch.com/extensions/assistants/" external>Sketch Assistant</Link> that automatically runs a preflight check for Sketch files. If you have Sketch installed on your computer, you may click the following link to automatically install the assistant. 
 </p> 
 <p> 
-  For more information see the <Link href="https://github.com/City-of-Helsinki/hds-assistant" external>HDS Assistant Github page</Link>. If you have Sketch installed on your computer you can use the following link to automatically install the assistant (the link will not work if you do not have Sketch installed). 
+  For more information see the <Link href="https://github.com/City-of-Helsinki/hds-assistant" external>HDS Assistant Github page</Link>. If you have Sketch installed on your computer you can use the following link to automatically install the assistant (the link will not work if you do not have Sketch installed on a Mac computer). 
 </p>
 <p>
-  <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>Add HDS Assistant to your Sketch (requires Sketch on your computer)</Link>
+  <Link href="sketch://add-assistant?url=https://github.com/City-of-Helsinki/hds-assistant/releases/latest/download/hds-assistant.tgz" external>Add HDS Assistant to your Sketch (requires Sketch and a Mac computer)</Link>
 </p>
 
 ### Styles


### PR DESCRIPTION
## Description
The Sketch Assistant add link in the HDS Contributing - Design page is a `sketch://` link - meaning it will only work if the user has Sketch installed on their computer. However, the user cannot know this before activating the link and it can be confusing when the link does not work and just opens an empty tab instead.

To circumvent the issue, this PR adds a clear note that the link will only work if the user has Sketch installed.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-846

## How Has This Been Tested?
Tested by running the documentation site locally.
