### PR TITLE
[Content] Added links to Abstract collection to Designers getting started page

### DIFF
--- a/site/docs/get_started/for_designers.mdx
+++ b/site/docs/get_started/for_designers.mdx
@@ -111,6 +111,16 @@ You can also select _All_ and filter the components list by component or variant
 
 <Image src="../../static/fordesigners-component-insert.png" alt="Inserting component from Components tab" style="width: 100%; max-width:850px" />
 
+## Get familiar with HDS
+Before you start designing, it is a good idea to get familiar with HDS offering.
+
+For designers, a good place to start is to browse through design collections in the HDS Abstract project. 
+- <Link href="https://share.goabstract.com/7b92ffce-5566-4aa1-be7a-3555b8d7a11c" external>Abstract Collection - Components</Link>
+- <Link href="https://share.goabstract.com/1dd17c91-0b9e-463a-9492-66af1301e52a" external>Abstract Collection - Design Tokens</Link>
+- <Link href="https://share.goabstract.com/cd813835-b6de-42a7-8686-0ea8aec21663" external>Abstract Collection - Patterns</Link>
+- <Link href="https://share.goabstract.com/1dd17c91-0b9e-463a-9492-66af1301e52a" external>Abstract Collection - Design Tokens</Link>
+- <Link href="https://share.goabstract.com/34245a50-f1a5-4160-9059-c4ccf320c7d2" external>Abstract Collection - Icons</Link>
+- <Link href="https://share.goabstract.com/e6aa2ebd-1a49-4cb1-90ef-a44a6486c28b" external>Abstract Collection - Example Custom Components</Link>
 
 ### Customising component symbols
 The component symbols use _smart layout_ for easy resizing. You can also configure the content and styling of symbol parts from the _Overrides_ section of symbol properties.


### PR DESCRIPTION
## Description
This PR adds links to Abstract collections to the designer getting started page. All Abstract collections also have now been set public.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-331

## How Has This Been Tested?
Tested by running the documentation site locally.