### PR TITLE
[Fix] Fixed broken anchor link in the date picker documentation page

### DIFF
--- a/site/docs/components/date_input.mdx
+++ b/site/docs/components/date_input.mdx
@@ -106,7 +106,7 @@ In all other types of services, it is recommended to not disable the confirmatio
 ```
 
 ### Date input without a picker
-It is possible to disable the date picker functionality by supplying a `disableDatePicker` prop to the input. To learn when the date picker should be hidden, see [when to use date picker](http://localhost:3000/components/date-input#when-to-use-the-date-picker) above.
+It is possible to disable the date picker functionality by supplying a `disableDatePicker` prop to the input. To learn when the date picker should be hidden, see [when to use date picker](#when-to-use-the-date-picker) above.
 
 <Playground>
 <div style={{maxWidth: '400px'}}>


### PR DESCRIPTION
## Description
Fixes a broken "When to use date picker" anchor link in the DateInput documentation page.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-854

## How Has This Been Tested?
Tested by running the documentation site locally.
