### PR TITLE
Spelling error fixes

### DIFF
--- a/site/docs/Contributing/before-contributing.mdx
+++ b/site/docs/Contributing/before-contributing.mdx
@@ -40,7 +40,7 @@ Depending on the feature you want to be working on, you will need access to at l
 
 
 ## Contribution process
-When faced with a need for a component or feature, you can ask yourself a few simple quiestions to decide whether you should propose a new component or feature to be added in HDS, or desing a custom a implementation:
+When faced with a need for a component or feature, you can ask yourself a few simple quiestions to decide whether you should propose a new component or feature to be added in HDS, or design a custom a implementation:
 
 <Image src="../../static/hds-contribution-simple.png" alt="How to contribute to Helsinki Design System" style="max-width:100%" viewable />
 

--- a/site/docs/Contributing/design.mdx
+++ b/site/docs/Contributing/design.mdx
@@ -57,7 +57,7 @@ The symbols and layer styles are sorted into folders by descending order of comp
 
 > Category / Type / Item / Sub item / Variants / State
 
-- ***Category*** defines the primitive nature of a property (for example every property in the category `Color` is always a color).
+- ***Category*** defines the primitive nature of a property (for example every property in the category `Colour` is always a colour).
 - ***Type*** is a sub-category only applied to property tokens. 
 
 > **Example: Two levels of *types* in Colour *category*** 

--- a/site/docs/Contributing/design.mdx
+++ b/site/docs/Contributing/design.mdx
@@ -27,7 +27,7 @@ There are two ways of proposing new designs to be added to HDS.
 
 ### 1. Opening a new branch to Abstract repository
 If you have access to _City of Helsinki_ organisation and _Helsinki Design System_ project in Abstract follow these steps: 
-1. **Create branch from HDS Master branch.** Branch name should follow naming convention _Feature request: [Component name]_. If a related Jira ticet exists, add the number of the ticket in the end of the branch name (for example `Feature request: dropdown-multiselect (HDS-000)`). 
+1. **Create branch from HDS Master branch.** Branch name should follow naming convention _Feature request: [Component name]_. If a related Jira ticket exists, add the number of the ticket in the end of the branch name (for example `Feature request: dropdown-multiselect (HDS-000)`). 
 2. **Add designs** related to your proposals to the component or category library file. If a suitable library for the component does not exist yet, add a new library file named `HDS [component name]` See [Guidelines for HDS design library files](/contributing/design#guidelines-for-naming-hds-design-files "Guidelines for HDS design library files") bellow for more detailed instructions. 
 3. **When the design is done, make a commit** along with a description of what changes were made, your component, how should your component be used and where (give an example layout if possible).
 4. **Submit branch for review** and add HDS designers as reviewers. They will provide feedback and suggest changes if needed.
@@ -121,7 +121,7 @@ The symbols and layer styles are sorted into folders by descending order of comp
 #### Pages
 - **All symbols of one component** are grouped on `[Component name]` page.
   - Symbols are aligned and organised on the page in clear groupings.
-- **Examples of available variations** of the component should be presented with `Example` arboards.
+- **Examples of available variations** of the component should be presented with `Example` artboards.
   - Example artboard name should state the component or feature introduced (for example `Example - Responsive sizes`).
   - Single component libraries, example artboards are grouped on `Examples` page.
   - In libraries with more than one component, example artboards can be grouped in the `[Component name]`  page together with component symbols.

--- a/site/docs/Contributing/making-icons.mdx
+++ b/site/docs/Contributing/making-icons.mdx
@@ -92,7 +92,7 @@ Note that pixel-perfection is less relevant on higher-resolution screens, such a
 ## Line Weight
 A line weight of two pixels is ideal, but three is sometimes necessary. The goal is to provide visual hierarchy and optical accuracy, without introducing too much variety and thus destroying consistency. In most cases, avoid very thin lines, especially in glyph icons.
 
-## Step-by-step instrutions
+## Step-by-step instructions
 > **Animation: How to make the Alert Circle icon using basic shapes.**
 <Image src="../../static/assets/image/AlertCircle_Fill_cropped.gif" alt="How to make the Alert Circle icon using basic shapes." style="max-width:600px;" viewable />
 

--- a/site/docs/about/new.mdx
+++ b/site/docs/about/new.mdx
@@ -25,11 +25,11 @@ import Link from "../../src/components/Link";
 <p><strong>1.1.0</strong> - <em>25.5.2021</em> - <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/tag/v1.1.0" external>Release notes</Link></p>
 
 - **Added**: Password input field
-- **Added**: Examples for color usage
+- **Added**: Examples for colour usage
 - **Added**: Icon variations for labels
-- **Added**: Color usage examples
+- **Added**: colour usage examples
 - **Changed**: Improvements for sizing in tags and labels
-- **Changed**: Improvements for color usage documentation
+- **Changed**: Improvements for colour usage documentation
 - **Fixed**: Date picker positioning
 - **Fixed**: Improvements for Storybook examples loading time
 

--- a/site/docs/about/statement.mdx
+++ b/site/docs/about/statement.mdx
@@ -19,7 +19,7 @@ As regards the accessibility of digital services, Helsinki aims to reach at leas
 ### Compliance status
 The accessibility compliance of this website was evualuated by a third party auditor on 18.9.2020. Most of the critical issues noted in the audit were fixed. However, due to the technical limitations of the website framework, not all issues were possible to be currently fixed. We are looking to change the website framework before the 1.0 release of Helsinki Design System. This upgrade will allow us to fix the rest of the issues.
 
-Currently known accessibity issues are:
+Currently known accessibility issues are:
 - Expandable navigation sub-menus are defined as divs and are missing aria attributes
 - The page is missing a "Skip to content" link
 - The search field is missing a "Search" button

--- a/site/docs/components/accordion.mdx
+++ b/site/docs/components/accordion.mdx
@@ -48,7 +48,7 @@ This style is visually less distracting and it works well when there are multipl
         heading="How to publish data?"
         style={{ maxWidth: '360px' }}
     >
-        To publish your data, open your profile settings and click buttton 'Publish'.
+        To publish your data, open your profile settings and click button 'Publish'.
     </Accordion>
 </Playground>
 
@@ -58,7 +58,7 @@ This style is visually less distracting and it works well when there are multipl
     heading="How to publish data?"
     style={{ maxWidth: '360px' }}
 >
-    To publish your data, open your profile settings and click buttton 'Publish'.
+    To publish your data, open your profile settings and click button 'Publish'.
 </Accordion>
 ```
 
@@ -74,7 +74,7 @@ If you have multiple accordions one below another or many accordions in the same
         heading="How to publish data?"
         style={{ maxWidth: '360px'}}
     >
-        To publish your data, open your profile settings and click buttton 'Publish'.
+        To publish your data, open your profile settings and click button 'Publish'.
     </Accordion>
 </Playground>
 
@@ -86,7 +86,7 @@ If you have multiple accordions one below another or many accordions in the same
     heading="How to publish data?"
     style={{ maxWidth: '360px'}}
 >
-    To publish your data, open your profile settings and click buttton 'Publish'.
+    To publish your data, open your profile settings and click button 'Publish'.
 </Accordion>
 ```
 
@@ -114,7 +114,7 @@ You can easily customize HDS Accordions by giving them a `theme` prop.
             '--content-line-height': 'var(--lineheight-l)',
         }}
     >
-        To publish your data, open your profile settings and click buttton 'Publish'.
+        To publish your data, open your profile settings and click button 'Publish'.
     </Accordion>
 
     <Accordion 
@@ -135,7 +135,7 @@ You can easily customize HDS Accordions by giving them a `theme` prop.
             '--content-line-height': 'var(--lineheight-l)',
         }}
     >
-        To publish your data, open your profile settings and click buttton 'Publish'.
+        To publish your data, open your profile settings and click button 'Publish'.
     </Accordion>
 </Playground>
 
@@ -161,7 +161,7 @@ You can easily customize HDS Accordions by giving them a `theme` prop.
         '--content-line-height': 'var(--lineheight-l)',
     }}
 >
-    To publish your data, open your profile settings and click buttton 'Publish'.
+    To publish your data, open your profile settings and click button 'Publish'.
 </Accordion>
 
 <Accordion 
@@ -182,7 +182,7 @@ You can easily customize HDS Accordions by giving them a `theme` prop.
         '--content-line-height': 'var(--lineheight-l)',
     }}
 >
-    To publish your data, open your profile settings and click buttton 'Publish'.
+    To publish your data, open your profile settings and click button 'Publish'.
 </Accordion>
 ```
 

--- a/site/docs/components/buttons.mdx
+++ b/site/docs/components/buttons.mdx
@@ -162,7 +162,7 @@ It is recommended to use the standard button size in most cases. If there is a b
 ```
 
 ### Utility buttons
-<p>If required, to achieve clearer user interface, you may also use additional utility colors. Different visual styles of these buttons can be used to better inform users of destructive or dangerous actions. To comply with <Link href="https://www.w3.org/TR/WCAG21/#use-of-color" external>WCAG requirement 1.4.1 Use of Color</Link>, these colors are more accessible when paired with an icon.</p>
+<p>If required, to achieve clearer user interface, you may also use additional utility colours. Different visual styles of these buttons can be used to better inform users of destructive or dangerous actions. To comply with <Link href="https://www.w3.org/TR/WCAG21/#use-of-color" external>WCAG requirement 1.4.1 Use of Color</Link>, these colours are more accessible when paired with an icon.</p>
 
 <Playground>
   <Button variant="success">Save</Button>

--- a/site/docs/components/card.mdx
+++ b/site/docs/components/card.mdx
@@ -21,7 +21,7 @@ import Link from "../../src/components/Link";
 
 ## Principles
 - **Use Cards sparingly.** While they can drastically improve service's understandability and readibility, overusing them may result in confusing and complex user interfaces.
-- **Cards work very well for listing heterogenous content** such as news items, blog posts, or upcoming events.
+- **Cards work very well for listing heterogeneous content** such as news items, blog posts, or upcoming events.
 - **Cards can also be used to emphasize important content** such as site CTA (Call To Action).
 - **Default Cards must not be used as interactive elements themselves.** This means that the whole Card should not be clickable. Elements inside the Card can still be interactable.
 - Currently HDS offers base Cards which you can use to build custom Cards for your project's needs. For inspiration and guidelines, you can find custom card examples in <Link href="https://share.goabstract.com/e6aa2ebd-1a49-4cb1-90ef-a44a6486c28b" external>HDS Example Custom Components - Abstract collection</Link>.

--- a/site/docs/components/component_overview.mdx
+++ b/site/docs/components/component_overview.mdx
@@ -28,7 +28,7 @@ The core components and technical documentation are available in [Helsinki Desig
 
 ### React components
 
-Helsinki Design System React library provides a collection of React components for building websites and applications. Using these components will help developers to rapidly create user interfaces that are in line with the Helsinki City Design Language. Components also promote accessible and consistent behavior across applications.
+Helsinki Design System React library provides a collection of React components for building websites and applications. Using these components will help developers to rapidly create user interfaces that are in line with the Helsinki City Design Language. Components also promote accessible and consistent behaviour across applications.
 
 The React components and technical documentation are available in [Helsinki Design System React Storybook](/storybook/react).
 

--- a/site/docs/components/component_overview.mdx
+++ b/site/docs/components/component_overview.mdx
@@ -36,7 +36,7 @@ The React components and technical documentation are available in [Helsinki Desi
 
 ## Component status
 
-HDS uses a simple labeling system for components to communicate their completeness and susceptibility to changes:
+HDS uses a simple labelling system for components to communicate their completeness and susceptibility to changes:
 
 Status                                               | Description
 -----------------------------------------------------|--------------

--- a/site/docs/components/koros.mdx
+++ b/site/docs/components/koros.mdx
@@ -29,7 +29,7 @@ import Link from "../../src/components/Link";
 
 ## Accessibility
 
-- It is allowed to use Koros in all brand colors. When choosing colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
+- It is allowed to use Koros in all brand colours. When choosing colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
 
 ## Usage
 

--- a/site/docs/components/logo.mdx
+++ b/site/docs/components/logo.mdx
@@ -32,7 +32,7 @@ See the [logo visual asset documentation](/visual-assets/logo "City of Helsinki 
 - A text alternative must always be provided for logos using the WAI-ARIA definition `aria-label`. See <Link href="https://www.w3.org/TR/WCAG21/#text-alternatives" external>WCAG 2.1 Text Alternatives guideline</Link> for more information.
     - When using the logo alone without a service name, provide a localised `aria-label` _"City of Helsinki"_.
     - When using the logo with the service name, provide a localised `aria-label` _"City of Helsinki: [Name of the service]"_.
-- The colour contrast between the logo and its background must comply with <Link href="https://www.w3.org/TR/WCAG21/#contrast-minimum" external>AA Level contrast ratios</Link>. You can find more information about accessible color combinations in [Colour design token documentation](/design-tokens/colour).
+- The colour contrast between the logo and its background must comply with <Link href="https://www.w3.org/TR/WCAG21/#contrast-minimum" external>AA Level contrast ratios</Link>. You can find more information about accessible colour combinations in [Colour design token documentation](/design-tokens/colour).
 
 
 ## Usage

--- a/site/docs/components/navigation.mdx
+++ b/site/docs/components/navigation.mdx
@@ -32,7 +32,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 
 ## Accessibility
 
-- HDS Navigation is designed to support many different brand colors. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
+- HDS Navigation is designed to support many different brand colours. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
 - **When designing a menu link hierarchy, always think about keyboard and screen reader users.** First, make sure top-level menu labels are clear, and submenu items contextually fit under it. Next, make sure the menu option order is logical and reasonable. Remember that keyboard users need to manually navigate to each element and thus placing a commonly used menu option last is not optimal.
 
 ## Usage and variations
@@ -113,9 +113,9 @@ A service can opt to use smaller, 1 line navigation if 2 line navigation is too 
 </Navigation>
 ```
 
-### Color variations
+### colour variations
 
-HDS Navigation offers two variations with different background colors - one with white and one with black text elements. Use variation that achieves better contrast with the brand background colour of your choice. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
+HDS Navigation offers two variations with different background colours - one with white and one with black text elements. Use variation that achieves better contrast with the brand background colour of your choice. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
 
 <Playground>
 <Navigation

--- a/site/docs/components/search_input.mdx
+++ b/site/docs/components/search_input.mdx
@@ -175,7 +175,7 @@ Note! This feature is experimental and we are looking to improve it after projec
 
 <Playground>
   {() => {
-    const educations = ['Daycare eduation', 'Preschool education', 'Basic education', 'Upper secondary education', 'Vocational education', 'Polytechnic education', 'University education', 'Adult education centre'].map((education) => ({ value: education }));
+    const educations = ['Daycare education', 'Preschool education', 'Basic education', 'Upper secondary education', 'Vocational education', 'Polytechnic education', 'University education', 'Adult education centre'].map((education) => ({ value: education }));
     
     const getSuggestions = (inputValue) => new Promise((resolve, reject) => {
       const filteredItems = educations.filter((education) => {
@@ -205,7 +205,7 @@ Note! This feature is experimental and we are looking to improve it after projec
 #### React code example:
 ```tsx
 {() => {
-  const educations = ['Daycare eduation', 'Preschool education', 'Basic education', 'Upper secondary education', 'Vocational education', 'Polytechnic education', 'University education', 'Adult education centre'].map((education) => ({ value: education }));
+  const educations = ['Daycare education', 'Preschool education', 'Basic education', 'Upper secondary education', 'Vocational education', 'Polytechnic education', 'University education', 'Adult education centre'].map((education) => ({ value: education }));
   
   const getSuggestions = (inputValue) => new Promise((resolve, reject) => {
     const filteredItems = educations.filter((education) => {

--- a/site/docs/components/spinner.mdx
+++ b/site/docs/components/spinner.mdx
@@ -27,7 +27,7 @@ The loading spinner do not provide details about nature of the processing but it
 
 
 ## Accessibility
-- The colour contrast between the loading spinner and its background must comply with <Link href="https://www.w3.org/TR/WCAG21/#contrast-minimum" external>AA Level contrast ratios</Link>. You can find more information about accessible color combinations in [Colour design token documentation](/design-tokens/colour).
+- The colour contrast between the loading spinner and its background must comply with <Link href="https://www.w3.org/TR/WCAG21/#contrast-minimum" external>AA Level contrast ratios</Link>. You can find more information about accessible colour combinations in [Colour design token documentation](/design-tokens/colour).
 - Multiple simultaneous loading spinners can be very confusing for assistive technologies. **HDS Loading spinner React component is built in a way that only reads one alert for screen readers** - even if there were multiple on the screen. If you are unable to use this feature or it fits your needs poorly (e.g. your project does not use JavaScript), please consider using only one spinner at a time and giving that one spinner the most accurate possible description.
 - HDS Loading spinner must be given labels to describe the loading event. Use `loadingText` prop for description for loading and `loadingFinishedText` prop for description for loading finishing.
   - Descriptions should not be too detailed. You should use generic descriptions such as "_The page content is loading_" and "_The page content loading was finished_".
@@ -72,7 +72,7 @@ The loading spinner comes in two sizes:
 ### Customized loading spinner
 The colour of the spinner can be customised to fit the colour theme of the service. HDS Loading spinner even supports shifting between multiple colours. Colour shifting should be used sparingly and only if the theme of the service calls for it.
 
-Note! When using multicolor loading spinners, at least half of the colors must have sufficient contrast `3:1` against the spinner background.
+Note! When using multicolour loading spinners, at least half of the colours must have sufficient contrast `3:1` against the spinner background.
 
 <Playground>
   <LoadingSpinner
@@ -105,7 +105,7 @@ Note! When using multicolor loading spinners, at least half of the colors must h
   <div></div>
 </div>
 
-<!-- Multi color -->
+<!-- Multi colour -->
 <style>
   .hds-loading-spinner.custom-multi-color {
     --spinner-color-stage1: var(--color-coat-of-arms);

--- a/site/docs/components/tag.mdx
+++ b/site/docs/components/tag.mdx
@@ -36,7 +36,7 @@ import Link from "../../src/components/Link";
 
 ### Which role attribute should be used with Tags?
 - HDS Tags can be clickable. In this case, it needs either a `role=“link”` or  `role=“button”` as an attribute. The role value should be decided as follows:
-  - If the user's focus is moved to another location or another page is opened, the role should be `link`. Example: The user clicks a Tag labeled as "News". The tag takes the user to a new page that lists all items tagged as "News".
+  - If the user's focus is moved to another location or another page is opened, the role should be `link`. Example: The user clicks a Tag labelled as "News". The tag takes the user to a new page that lists all items tagged as "News".
   - If, however, the tag will result in the page's content being dynamically changed (i.e. Tag triggers an action), use `role=“button”`. Example: Clicking the tag will cause a search below to be filtered.
 
 ## Usage and variations

--- a/site/docs/components/toggle.mdx
+++ b/site/docs/components/toggle.mdx
@@ -35,7 +35,7 @@ import Link from '../../src/components/Link';
 
 ## Accessibility
 
-- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colors, refer to [colour guidelines](/design-tokens/colour 'Colour') to ensure accessibility.
+- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to [colour guidelines](/design-tokens/colour 'Colour') to ensure accessibility.
 - If the toggle button makes other elements appear on the view, those elements should be located next to the toggle button - preferably right after or below it.
   - While not recommended, if a toggle button makes elements appear in other parts of the user interface, you need to make sure to notify assistive technologies about the change. You can use [HDS Notification component](/components/notification) for this purpose.
 - HDS Toggle button includes a small animation when the toggle state is changed. However, the animation is considered non-decorative and therefore it does not have to be able to be disabled. See <Link href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html" external>WCAG 2.3.3 Animation from Interactions guideline</Link> for more information.

--- a/site/docs/components/tooltip.mdx
+++ b/site/docs/components/tooltip.mdx
@@ -7,7 +7,7 @@ route: /components/tooltip
 import { Playground } from "docz";
 import { StatusLabel, Tooltip } from "hds-react";
 
-import ColorBox from "../../src/components/ColorBox";
+import Box from "../../src/components/ColorBox";
 import LargeParagraph from "../../src/components/LargeParagraph";
 
 # Tooltip

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -96,7 +96,7 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 
 
 ## Accessible colour combinations
-<p>Here you can find some recommended colour combinations for text and other informative elements. The examples are sorted in order of their contrast ratio. For more examples of accessibile colour combinations, see the <Link href="https://share.goabstract.com/28352b8b-9c51-4346-b249-ff062c5da561" external>Colour accessibility examples - Abstract collection</Link>.</p>
+<p>Here you can find some recommended colour combinations for text and other informative elements. The examples are sorted in order of their contrast ratio. For more examples of accessible colour combinations, see the <Link href="https://share.goabstract.com/28352b8b-9c51-4346-b249-ff062c5da561" external>Colour accessibility examples - Abstract collection</Link>.</p>
 
 - **AA** (contrast ratio at least `4,5 : 1`) and **AAA** (contrast ratio at least `7 : 1`) means you can safely use the color combination on all text sizes
 - **AA for large text** (contrast ratio at least `3 : 1`) means the text size should be at least 18 pt for regular weight or 14 pt for bold weight

--- a/site/docs/design_tokens/typography.mdx
+++ b/site/docs/design_tokens/typography.mdx
@@ -69,7 +69,7 @@ Body font size tokens allow more subtle variations of body text sizes for improv
 
 | Token size  | px value    | rem value | Usage                                                                                |
 | ----------- | ----------- | --------- | ------------------------------------------------------------------------------------ |
-| **Body XL** | 20 px       | 1.25      | Emphasising short introductory texts and other subtiles.                             |
+| **Body XL** | 20 px       | 1.25      | Emphasising short introductory texts and other subtitles.                             |
 | **Body L**  | 18 px       | 1.125     | Improving legibility of essential components, e.g. Text input and other form fields. Can also be used as the default body text size if the layout is not text heavy. |
 | **Body M**  | 16 px       | 1         | **Body text default.**                                                               |
 | **Body S**  | 14 px       | 0.875     | Conserving space in data heavy layouts and small components, e.g. Status label.      |

--- a/site/docs/get_started/for_designers.mdx
+++ b/site/docs/get_started/for_designers.mdx
@@ -74,7 +74,7 @@ You will need permissions to access the City of Helsinki Abstract organisation f
 
 <p><strong>Note! Library versions in Abstract are considered development versions. They can change and things may be unstable.</strong> Using libraries from Abstract allows you to get your hands also on the newest components that are not released yet. If you need more reliable libraries, follow the instructions of option 1. above to download latest stable <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases" external>HDS design kit release</Link>.</p>
 
-1. In Abstract, open up a branch within the project you are working on. You'll either need an invite to a existing project in the City of Helsinki organisation, or permissions to create a new project. See <Link href="https://www.abstract.com/help/getting-started/" external>Abstract documentation</Link> for more information on joining organizations and starting projects.
+1. In Abstract, open up a branch within the project you are working on. You'll either need an invite to a existing project in the City of Helsinki organisation, or permissions to create a new project. See <Link href="https://help.abstract.com/hc/en-us/articles/360050374371-Start-working-in-Abstract" external>Abstract documentation</Link> for more information on joining organizations and starting projects.
 2. From the top of the branch view, select the _Files_ tab
 3. From the top of the file list, select _Add File > Link Library…_  
 4. Select the _Helsinki Design System project_  

--- a/site/docs/get_started/for_designers.mdx
+++ b/site/docs/get_started/for_designers.mdx
@@ -61,7 +61,7 @@ You can start using the HDS design libraries to your project in two ways:
 
 1. Head over to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases" external>HDS GitHub repository releases</Link>.
 2. Download `design-kit` (preferably the newest stable version) to your computer and unzip the package.
-3. Open Sketch and from the top bar thoose _Sketch > Preferences_.
+3. Open Sketch and from the top bar choose _Sketch > Preferences_.
 4. Choose tab _Libraries_ and press the button _Add library_.
 5. Browse to the unzipped folder you just downloaded and select libraries you want to import. Note, you can select multiple libraries by holding the shift key. 
 

--- a/site/docs/get_started/for_developers.mdx
+++ b/site/docs/get_started/for_developers.mdx
@@ -31,7 +31,7 @@ The core package provides Helsinki City brand colors, typography and base styles
 [![https://nodei.co/npm/hds-core.png?downloads=true&downloadRank=true&stars=true](https://nodei.co/npm/hds-core.png?downloads=true&downloadRank=true&stars=true)](https://www.npmjs.com/package/hds-core)
 
 ## React components
-Helsinki Design System React library provides a collection of React component for building websites and applications. Using the components will help developers to rapidly create user interfaces that are in line with the Helsinki City Design Language as well as accessible and consistent in behavior across applications.
+Helsinki Design System React library provides a collection of React component for building websites and applications. Using the components will help developers to rapidly create user interfaces that are in line with the Helsinki City Design Language as well as accessible and consistent in behaviour across applications.
 
 <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react" external>hds-react in GitHub</Link>
 

--- a/site/docs/get_started/for_developers.mdx
+++ b/site/docs/get_started/for_developers.mdx
@@ -24,7 +24,7 @@ import Link from "../../src/components/Link";
 4. Take a look at <Link href="https://dev.hel.fi/" external>Develop with Helsinki site</Link> for practical details for developing open source code for the City of Helsinki.
 
 ## Core styles
-The core package provides Helsinki City brand colors, typography and base styles as css-styles and variables.
+The core package provides Helsinki City brand colours, typography and base styles as css-styles and variables.
 
 <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core" external>hds-core in GitHub</Link>
 

--- a/site/docs/guidelines/accessibility.mdx
+++ b/site/docs/guidelines/accessibility.mdx
@@ -19,7 +19,7 @@ import Link from "../../src/components/Link";
 
 ## Standards behind HDS development
 
-<p>Following the EU directive, HDS aims to fulfill <Link href="https://www.w3.org/TR/WCAG20/" external>WCAG 2.0 Standard at AA Level</Link>.</p>
+<p>Following the EU directive, HDS aims to fulfil <Link href="https://www.w3.org/TR/WCAG20/" external>WCAG 2.0 Standard at AA Level</Link>.</p>
 
 <p>However, HDS follows the newer <Link href="https://www.w3.org/TR/WCAG21/" external>WCAG 2.1 Standard</Link>. The publication of WCAG 2.1 does not deprecate or supersede WCAG 2.0 and W3C advices to use it. Even though the EU directive requires fullfilling the standard at AA level, HDS also implements many requirements from the AAA level.</p>
 

--- a/site/docs/patterns/form_validation.mdx
+++ b/site/docs/patterns/form_validation.mdx
@@ -79,7 +79,7 @@ The advantage of hybrid validation is that because form controls are validated d
 
 ### Form control error/success messages
 
-When a form control has been gone through either dynamic or static validation, the state of the component should change indicating the inputed value has been validated.
+When a form control has been gone through either dynamic or static validation, the state of the component should change indicating the inputted value has been validated.
 
 Depending on the result of the validation, message is displayed below the form field if the value is valid or invalid.
 
@@ -146,7 +146,7 @@ It is better to avoid using success validation if there is not a clear need for 
 
 ### Validation summary pattern
 
-**When using static or hybrid validation methods, HDS recommends using a validation summary to clearly list errors found during the form submit**. Validation summary pattern uses an error summary component which is provided by HDS. The error summary is notification-like element which lists all errors (and their descriptions) found in the form and provides anchor links to each erroneus input for easy access. 
+**When using static or hybrid validation methods, HDS recommends using a validation summary to clearly list errors found during the form submit**. Validation summary pattern uses an error summary component which is provided by HDS. The error summary is notification-like element which lists all errors (and their descriptions) found in the form and provides anchor links to each erroneous input for easy access. 
 
 You can learn more about the error summary component in [HDS React Storybook](/storybook/react/?path=/story/components-errorsummary--default).
 


### PR DESCRIPTION
There are some spelling errors and some american english formats used across the docsite. This is a first batch to fix these errors, found with SiteImprove tool.

## Description
Typo fixes
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue
HDS-855

## Motivation and Context
Spelling errors make reading more complicated and gives a sloppy image of us. 

## How Has This Been Tested?
Running docsite locally.

## Screenshots (if appropriate):
