### PR TITLE
Fix/time input value on clear

### DIFF
--- a/packages/react/src/components/timeInput/TimeInput.test.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.test.tsx
@@ -43,4 +43,13 @@ describe('<TimeInput /> spec', () => {
     userEvent.type(minutesInput, 'test');
     expect(minutesInput).toHaveValue('');
   });
+
+  it('should remove colon from time value when both minutes and hours are missing', async () => {
+    const { container } = render(
+      <TimeInput id="time" label="timer" hoursLabel="Hours" minutesLabel="Minutes" defaultValue="00:00" />,
+    );
+    userEvent.type(screen.getByLabelText('Hours', { selector: 'input' }), '{backspace}');
+    userEvent.type(screen.getByLabelText('Minutes', { selector: 'input' }), '{backspace}');
+    expect(container.querySelector('#time')).toHaveValue('');
+  });
 });

--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -116,7 +116,7 @@ export const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(
     const updateTimeInput = (newHours: string, newMinutes: string) => {
       setHours(newHours);
       setMinutes(newMinutes);
-      const newTimeValue = `${newHours}:${newMinutes}`;
+      const newTimeValue = newHours.length === 0 && newMinutes.length === 0 ? '' : `${newHours}:${newMinutes}`;
       setTime(newTimeValue);
       const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
       nativeInputValueSetter.call(inputRef.current, newTimeValue);


### PR DESCRIPTION
## Description

Fixes time input to be empty value when both hours and minutes are cleared

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-838

## How Has This Been Tested?

- Manual testing on developers machine
- Automated unit tests
