### PR TITLE
Fix/inline-notification-z-index

### DIFF
--- a/packages/core/src/components/notification/notification.css
+++ b/packages/core/src/components/notification/notification.css
@@ -7,9 +7,10 @@
   --notification-focus-outline-color: var(--color-coat-of-arms);
   --notification-max-width-inline: none;
   --notification-max-width-toast: 21rem;
+  --notification-z-index-inline: auto;
+  --notification-z-index-toast: 99;
   --notification-offset: var(--spacing-layout-s);
   --notification-padding: var(--spacing-s);
-  --notification-z-index: 99;
 
   background-color: var(--notification-background-color);
   border: solid var(--notification-border-color);
@@ -20,7 +21,7 @@
   padding: var(--notification-padding);
   position: relative;
   width: 100%;
-  z-index: var(--notification-z-index);
+  z-index: var(--notification-z-index-inline);
 }
 
 /* CONTENT */
@@ -124,6 +125,7 @@
   max-width: var(--notification-max-width-toast);
   position: fixed;
   width: calc(100% - var(--spacing-l));
+  z-index: var(--notification-z-index-toast);
 }
 
 .hds-notification--top-left {


### PR DESCRIPTION
## Description

Removes z index (sets to default) from the inline version of the notification component. Having a z index for the inline version caused problems with overlapping layouts like navigation menus.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-763

## How Has This Been Tested?

- Local testing on developers machine
