### PR TITLE
Add "upcoming breaking changes"-page

### DIFF
--- a/site/docs/about/breaking_changes.mdx
+++ b/site/docs/about/breaking_changes.mdx
@@ -10,7 +10,7 @@ import Link from "../../src/components/Link";
 # Upcoming breaking changes
 
 <LargeParagraph>
-  Here you will find summarized notes of breaking changes of HDS. The source can be found here, <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/issues/495" external>Github breaking changes issue</Link>.
+  Here you will find summarized notes of upcoming breaking changes of HDS. The source can be found here, <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/issues/495" external>Github upcoming breaking changes issue</Link>.
 </LargeParagraph>
 
 <BreakingChangesComments />

--- a/site/docs/about/breaking_changes.mdx
+++ b/site/docs/about/breaking_changes.mdx
@@ -1,0 +1,16 @@
+---
+name: Upcoming breaking changes
+route: /about/breaking
+menu: About
+---
+import BreakingChangesComments from '../../src/components/BreakingChangesComments';
+import LargeParagraph from "../../src/components/LargeParagraph";
+import Link from "../../src/components/Link";
+
+# Upcoming breaking changes
+
+<LargeParagraph>
+  Here you will find summarized notes of breaking changes of HDS. The source can be found here, <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/issues/495" external>Github breaking changes issue</Link>.
+</LargeParagraph>
+
+<BreakingChangesComments />

--- a/site/package.json
+++ b/site/package.json
@@ -20,12 +20,14 @@
     "react-dom": "16.13.1"
   },
   "devDependencies": {
+    "date-fns": "^2.23.0",
     "gatsby-cli": "2.12.29",
     "gatsby-plugin-matomo": "0.8.3",
     "hds-core": "1.2.0",
     "hds-design-tokens": "1.2.0",
     "hds-react": "1.2.0",
     "react-helmet": "6.0.0",
+    "react-markdown": "^6.0.3",
     "rimraf": "3.0.2"
   }
 }

--- a/site/src/components/BreakingChangesComments.js
+++ b/site/src/components/BreakingChangesComments.js
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { format, parseJSON } from 'date-fns'
+
+const BreakingChangesComments = () => {
+  const [comments, setComments] = useState([]);
+
+  useEffect(() => {
+    fetch('https://api.github.com/repos/City-of-Helsinki/helsinki-design-system/issues/495/comments')
+      .then((response) => response.json())
+      .then((resultData) => {
+        setComments(resultData);
+      }); // set data for the number of stars
+  }, []);
+
+  return (
+    <ul style={{ margin: '2rem 1rem 0', padding: '0px' }}>
+      {comments.map(
+        (comment) =>
+          console.log(parseJSON(comment.updated_at)) || (
+            <li key={comment.id} style={{ margin: '0 0 3rem', padding: '0px' }}>
+              <ReactMarkdown>{comment.body && comment.body}</ReactMarkdown>
+              <p><time dateTime={comment.updated_at}>{format(parseJSON(comment.updated_at),  'd.M.yyyy')}</time>
+              </p>
+            </li>
+          ),
+      )}
+    </ul>
+  );
+};
+
+export default BreakingChangesComments;

--- a/site/src/components/BreakingChangesComments.js
+++ b/site/src/components/BreakingChangesComments.js
@@ -16,7 +16,7 @@ const BreakingChangesComments = () => {
       .then((response) => response.json())
       .then((resultData) => {
         setComments(resultData);
-      }); // set data for the number of stars
+      });
   }, []);
 
   return (

--- a/site/src/components/BreakingChangesComments.js
+++ b/site/src/components/BreakingChangesComments.js
@@ -1,6 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { format, parseJSON } from 'date-fns'
+import { format, parseJSON } from 'date-fns';
+
+const DateText = ({ label, date }) => (
+  <p style={{ fontStyle: 'italic' }}>
+    {label}: <time dateTime={date}>{format(parseJSON(date), 'd.M.yyyy')}</time>
+  </p>
+);
 
 const BreakingChangesComments = () => {
   const [comments, setComments] = useState([]);
@@ -14,17 +20,17 @@ const BreakingChangesComments = () => {
   }, []);
 
   return (
-    <ul style={{ margin: '2rem 1rem 0', padding: '0px' }}>
-      {comments.map(
-        (comment) =>
-          console.log(parseJSON(comment.updated_at)) || (
-            <li key={comment.id} style={{ margin: '0 0 3rem', padding: '0px' }}>
-              <ReactMarkdown>{comment.body && comment.body}</ReactMarkdown>
-              <p><time dateTime={comment.updated_at}>{format(parseJSON(comment.updated_at),  'd.M.yyyy')}</time>
-              </p>
-            </li>
-          ),
-      )}
+    <ul style={{ margin: 'var(--spacing-xl) var(--spacing-l) 0', padding: '0' }}>
+      {comments.map((comment) => (
+        <li key={comment.id} style={{ margin: '0 0 var(--spacing-2-xl)', padding: '0' }}>
+          <ReactMarkdown>{comment.body && comment.body}</ReactMarkdown>
+          {comment.created_at === comment.updated_at ? (
+            <DateText label="Published" date={comment.created_at} />
+          ) : (
+            <DateText label="Updated" date={comment.updated_at} />
+          )}
+        </li>
+      ))}
     </ul>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11656,6 +11656,11 @@ date-fns@2.16.1, date-fns@^2.0.1, date-fns@^2.14.0, date-fns@^2.8.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
+date-fns@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -11686,6 +11691,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.0.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.2.0"
@@ -19717,6 +19729,17 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
@@ -19762,6 +19785,20 @@ mdast-util-to-hast@9.1.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+mdast-util-to-hast@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz#61875526a017d8857b71abc9333942700b2d3604"
+  integrity sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    mdast-util-definitions "^4.0.0"
+    mdurl "^1.0.0"
+    unist-builder "^2.0.0"
+    unist-util-generated "^1.0.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^2.0.0"
+
 mdast-util-to-nlcst@^3.2.0:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/mdast-util-to-nlcst/-/mdast-util-to-nlcst-3.2.3.tgz#dcd0f51b59515b11a0700aeb40f168ed7ba9ed3d"
@@ -19776,6 +19813,11 @@ mdast-util-to-string@^1.0.0, mdast-util-to-string@^1.0.5, mdast-util-to-string@^
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdast-util-toc@^3.1.0:
   version "3.1.0"
@@ -19956,6 +19998,14 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -23584,15 +23634,15 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.0, react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
-react-is@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-layout-effect@^1.0.1:
   version "1.0.5"
@@ -23617,6 +23667,25 @@ react-live@^2.2.1:
     prop-types "^15.5.8"
     react-simple-code-editor "^0.10.0"
     unescape "^1.0.1"
+
+react-markdown@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-6.0.3.tgz#625ec767fa321d91801129387e7d31ee0cb99254"
+  integrity sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/unist" "^2.0.3"
+    comma-separated-tokens "^1.0.0"
+    prop-types "^15.7.2"
+    property-information "^5.3.0"
+    react-is "^17.0.0"
+    remark-parse "^9.0.0"
+    remark-rehype "^8.0.0"
+    space-separated-tokens "^1.1.0"
+    style-to-object "^0.3.0"
+    unified "^9.0.0"
+    unist-util-visit "^2.0.0"
+    vfile "^4.0.0"
 
 react-merge-refs@1.1.0:
   version "1.1.0"
@@ -24588,6 +24657,20 @@ remark-parse@^6.0.0, remark-parse@^6.0.2, remark-parse@^6.0.3:
     unist-util-remove-position "^1.0.0"
     vfile-location "^2.0.0"
     xtend "^4.0.1"
+
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+  dependencies:
+    mdast-util-from-markdown "^0.8.0"
+
+remark-rehype@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-8.1.0.tgz#610509a043484c1e697437fa5eb3fd992617c945"
+  integrity sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==
+  dependencies:
+    mdast-util-to-hast "^10.2.0"
 
 remark-retext@^3.1.3:
   version "3.1.3"
@@ -25899,7 +25982,7 @@ sourcemap-codec@^1.4.4:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-space-separated-tokens@^1.0.0:
+space-separated-tokens@^1.0.0, space-separated-tokens@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
@@ -27525,6 +27608,18 @@ unified@^8.3.2, unified@^8.4.2:
   dependencies:
     bail "^1.0.0"
     extend "^3.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
+unified@^9.0.0:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
+  integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
     is-plain-obj "^2.0.0"
     trough "^1.0.0"
     vfile "^4.0.0"


### PR DESCRIPTION
## Description
- Add new "Upcoming breaking changes" - page

## Motivation and Context
- HDS library users can see planned breaking changes from the documentation site too (in addition to Github)

## How Has This Been Tested?
- Locally on dev's machine

## Screenshots (if appropriate):
<img width="988" alt="Näyttökuva 2021-8-5 kello 12 13 07" src="https://user-images.githubusercontent.com/1610860/128324934-9ade706a-a5db-4c71-8580-741ff2edaed2.png">
