### PR TITLE
[bug-fixing] Fix Navigation component render when optional label property is missing

### DIFF
--- a/packages/react/src/components/notification/Notification.test.tsx
+++ b/packages/react/src/components/notification/Notification.test.tsx
@@ -13,11 +13,18 @@ describe('<Notification /> spec', () => {
     const { asFragment } = render(<Notification label={label}>{body}</Notification>);
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('renders the component without optional label', () => {
+    const { asFragment } = render(<Notification>{body}</Notification>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('should not have basic accessibility issues', async () => {
     const { container } = render(<Notification label={label}>{body}</Notification>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
   it('adds className prop to notification classes', () => {
     const { container } = render(
       <Notification label={label} className="testClass">
@@ -26,6 +33,7 @@ describe('<Notification /> spec', () => {
     );
     expect((container.firstChild as HTMLElement).classList.contains('testClass')).toBe(true);
   });
+
   it('should be closable', () => {
     const { getByRole } = render(
       <Notification label={label} dismissible closeButtonLabelText="test">
@@ -34,6 +42,7 @@ describe('<Notification /> spec', () => {
     );
     expect(getByRole('button')).toBeDefined();
   });
+
   it('adds role="alert" for non-inline notifications', () => {
     const { getByRole } = render(
       <Notification label={label} position="bottom-center">

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -255,10 +255,12 @@ export const Notification = React.forwardRef<HTMLDivElement, NotificationProps>(
         >
           {autoClose && <animated.div style={autoCloseTransition} className={styles.autoClose} />}
           <div className={styles.content} role={role} ref={ref}>
-            <div className={styles.label} role="heading" aria-level={2}>
-              <Icon className={styles.icon} aria-hidden />
-              <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
-            </div>
+            {label && (
+              <div className={styles.label} role="heading" aria-level={2}>
+                <Icon className={styles.icon} aria-hidden />
+                <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
+              </div>
+            )}
             {children && <div className={styles.body}>{children}</div>}
           </div>
           {dismissible && (

--- a/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -47,3 +47,23 @@ exports[`<Notification /> spec renders the component 1`] = `
   </section>
 </DocumentFragment>
 `;
+
+exports[`<Notification /> spec renders the component without optional label 1`] = `
+<DocumentFragment>
+  <section
+    aria-atomic="true"
+    aria-label="Notification"
+    class="inline notification default info"
+  >
+    <div
+      class="content"
+    >
+      <div
+        class="body"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Description
- Notification component does not render successfully when the optional label property is missing

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-847

## How Has This Been Tested?
- Locally on dev's machine
- In an unit (component snapshot) test
