### PR TITLE
[bug-fixing] Add lang-attributes to Navigation.LanguageSelector examples

### DIFF
--- a/packages/react/src/components/navigation/Navigation.stories.tsx
+++ b/packages/react/src/components/navigation/Navigation.stories.tsx
@@ -84,12 +84,12 @@ export const Default = ({ searchLabel, searchPlaceholder, authenticated, userNam
 
       {/* LANGUAGE SELECTOR */}
       <Navigation.LanguageSelector label="FI">
-        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="Suomeksi" />
-        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="På svenska" />
-        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="In English" />
-        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="En français" />
-        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="Auf deutsch" />
-        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="По-русски" />
+        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="fi" label="Suomeksi" />
+        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="sv" label="På svenska" />
+        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="en" label="In English" />
+        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="fr" label="En français" />
+        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="de" label="Auf deutsch" />
+        <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="ru" label="По-русски" />
       </Navigation.LanguageSelector>
     </Navigation.Actions>
   </Navigation>
@@ -130,12 +130,12 @@ export const Inline = ({ searchLabel, searchPlaceholder, authenticated, userName
 
         {/* LANGUAGE SELECTOR */}
         <Navigation.LanguageSelector label="FI">
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="Suomeksi" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="På svenska" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="In English" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="En français" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="Auf deutsch" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="По-русски" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="fi" label="Suomeksi" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="sv" label="På svenska" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="en" label="In English" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="fr" label="En français" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="de" label="Auf deutsch" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="ru" label="По-русски" />
         </Navigation.LanguageSelector>
       </Navigation.Actions>
     </Navigation>
@@ -179,12 +179,12 @@ export const CustomTheme = ({ searchLabel, searchPlaceholder, authenticated, use
 
         {/* LANGUAGE SELECTOR */}
         <Navigation.LanguageSelector label="FI">
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="Suomeksi" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="På svenska" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="In English" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="En français" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="Auf deutsch" />
-          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} label="По-русски" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="fi" label="Suomeksi" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="sv" label="På svenska" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="en" label="In English" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="fr" label="En français" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="de" label="Auf deutsch" />
+          <Navigation.Item href="#" onClick={(e) => e.preventDefault()} lang="ru" label="По-русски" />
         </Navigation.LanguageSelector>
       </Navigation.Actions>
     </Navigation>
@@ -408,6 +408,7 @@ export const Example = ({ userName, ...args }) => {
                     e.preventDefault();
                     setLanguage(lang.value);
                   }}
+                  lang={lang.value}
                   label={lang.label}
                 />
               );

--- a/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
@@ -7,6 +7,7 @@ export const NavigationLanguageSelector = ({ children, id = 'languageSelector', 
   React.useEffect(() => {
     React.Children.forEach(children, (child:React.ReactElement) => {
       if (!child.props.lang) {
+        // eslint-disable-next-line no-console
         console.warn(`NavigationLanguageSelector item "${child.props.label}" is missing a lang property.`);
       }
     });

--- a/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
@@ -5,7 +5,7 @@ import { MenuButton, MenuButtonProps } from '../../../internal/menuButton/MenuBu
 
 export const NavigationLanguageSelector = ({ children, id = 'languageSelector', label, ...rest }: MenuButtonProps) => {
   React.useEffect(() => {
-    React.Children.forEach(children, (child:React.ReactElement) => {
+    React.Children.forEach(children, (child: React.ReactElement) => {
       if (!child.props.lang) {
         // eslint-disable-next-line no-console
         console.warn(`NavigationLanguageSelector item "${child.props.label}" is missing a lang property.`);

--- a/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
@@ -3,9 +3,19 @@ import React from 'react';
 import styles from './NavigationLanguageSelector.module.scss';
 import { MenuButton, MenuButtonProps } from '../../../internal/menuButton/MenuButton';
 
-export const NavigationLanguageSelector = ({ children, id = 'languageSelector', label, ...rest }: MenuButtonProps) => (
-  <MenuButton className={styles.languageDropdown} id={id} label={label} menuOffset={10} {...rest} closeOnItemClick>
-    {children}
-  </MenuButton>
-);
+export const NavigationLanguageSelector = ({ children, id = 'languageSelector', label, ...rest }: MenuButtonProps) => {
+  React.useEffect(() => {
+    React.Children.forEach(children, (child:React.ReactElement) => {
+      if (!child.props.lang) {
+        console.warn(`NavigationLanguageSelector item "${child.props.label}" is missing a lang property.`);
+      }
+    });
+  });
+
+  return (
+    <MenuButton className={styles.languageDropdown} id={id} label={label} menuOffset={10} {...rest} closeOnItemClick>
+      {children}
+    </MenuButton>
+  );
+};
 NavigationLanguageSelector.componentName = 'NavigationLanguageSelector';

--- a/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
@@ -11,7 +11,7 @@ export const NavigationLanguageSelector = ({ children, id = 'languageSelector', 
         console.warn(`NavigationLanguageSelector item "${child.props.label}" is missing a lang property.`);
       }
     });
-  });
+  }, [children]);
 
   return (
     <MenuButton className={styles.languageDropdown} id={id} label={label} menuOffset={10} {...rest} closeOnItemClick>

--- a/site/docs/components/navigation.mdx
+++ b/site/docs/components/navigation.mdx
@@ -26,7 +26,7 @@ import LargeParagraph from "../../src/components/LargeParagraph";
 - Always position navigation to the top of the page. Keep the navigation in place so the user can always easily locate it. It is recommended to include navigation on every page of the service.
 - Navigation component is built to follow HDS [breakpoint tokens](/design-tokens/breakpoints). While it is recommended to follow HDS breakpoint tokens, you may alter navigation width to fit your service's needs.
 - **Try to keep the order of actions (search, user, language select) consistent in navigation.** Do not change the default order without a good reason.
-  - If there are less than three available languages and the services navigation is simple, available languages can be listed as links in the action row instead of a language select dropdown for better usability.
+  - If there are less than three available languages and the services navigation is simple, available languages can be listed as links in the action row instead of a language select dropdown for better usability. **Remember to provide a lang-attribute for each language option to help assistive technology to read the language correctly**.
 - Keep navigation menu link labels clear and concise. Prefer max 1-2 word long labels. Avoid starting multiple menu link labels with the same word.
 
 
@@ -233,9 +233,9 @@ HDS Navigation component supports many commonly used features out of the box. Th
     <Navigation.Search searchLabel="Search" searchPlaceholder="Search page" />
     <Navigation.User label="Sign in" />
     <Navigation.LanguageSelector label="FI">
-      <Navigation.Item label="Suomeksi" />
-      <Navigation.Item label="På svenska" />
-      <Navigation.Item label="In English" />
+      <Navigation.Item lang="fi" label="Suomeksi" />
+      <Navigation.Item lang="sv" label="På svenska" />
+      <Navigation.Item lang="en" label="In English" />
     </Navigation.LanguageSelector>
   </Navigation.Actions>
 </Navigation>
@@ -253,9 +253,9 @@ HDS Navigation component supports many commonly used features out of the box. Th
     <Navigation.Search searchLabel="Search" searchPlaceholder="Search page" />
     <Navigation.User label="Sign in" />
     <Navigation.LanguageSelector label="FI">
-      <Navigation.Item label="Suomeksi" />
-      <Navigation.Item label="På svenska" />
-      <Navigation.Item label="In English" />
+      <Navigation.Item lang="fi" label="Suomeksi" />
+      <Navigation.Item lang="sv" label="På svenska" />
+      <Navigation.Item lang="en" label="In English" />
     </Navigation.LanguageSelector>
   </Navigation.Actions>
 </Navigation>


### PR DESCRIPTION
## Description
- Add lang-attributes to Navigation.LanguageSelector examples
- Log warn if LanguageSelector option is missing a lang-attribute.

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-753

## Motivation and Context
- The fix helps assistive technology to read the language options

## How Has This Been Tested?
- Locally on dev's machine
