### PR TITLE
[Change] Update color-tram token value

### DIFF
--- a/packages/design-tokens/tokens/color/brand/tram.json
+++ b/packages/design-tokens/tokens/color/brand/tram.json
@@ -1,7 +1,7 @@
 {
   "color": {
     "tram": {
-      "value": "#009246",
+      "value": "#008741",
       "type": "color"
     },
     "tram-light": {

--- a/packages/react/.loki/reference/chrome_iphone7_Components_LoadingSpinner_Custom_theme.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_LoadingSpinner_Custom_theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfd60d10c98c4df4937289cddbae3977da6276786cd715e6c93490fdbc3ce01f
-size 3161
+oid sha256:c049448fe9dc98669fce3a7057feb9b3391ff535cd4d0988f89888b2961e71bf
+size 3165

--- a/packages/react/.loki/reference/chrome_iphone7_Components_ToggleButton_Custom_theme.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_ToggleButton_Custom_theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:515fe90a86721eea079ffb0fdf7d0c658ba2db87be5009e353fd5c3821798d0f
-size 16148
+oid sha256:8df8d155f67781334013353ea6ef6bfece04512225b24a9c2dd55df58d8e968d
+size 16160

--- a/packages/react/.loki/reference/chrome_laptop_Components_LoadingSpinner_Custom_theme.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_LoadingSpinner_Custom_theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa6d898a7460e98666eda103acfbdfe6f99f8238c97172b7394bc4078166f265
-size 1560
+oid sha256:c31226ef6bdbc3e09b42e290aa99d034a5ea6e87cb86d2cd0d85789815cad462
+size 1564

--- a/packages/react/.loki/reference/chrome_laptop_Components_ToggleButton_Custom_theme.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_ToggleButton_Custom_theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77a662eceb439ec9a004ce66bf89d711aebd4fe7c60acca176ff7625fb2f6ec3
-size 6670
+oid sha256:1927369358bb4437ed3ea94e93c011d9cb1156926cccca7fd198a9b8108302ad
+size 6666

--- a/site/docs/design_tokens/colour.mdx
+++ b/site/docs/design_tokens/colour.mdx
@@ -117,7 +117,7 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 | **Tiili**         | white         | **AA** (AAA for large text) `6,1 : 1` | <ColorContrast color="var(--color-white)" background="var(--color-brick)">AA</ColorContrast> |
 | **Metro**         | black 90      | **AA** (AAA for large text) `5,2 : 1` | <ColorContrast color="var(--color-black-90)" background="var(--color-metro)">AA</ColorContrast> |
 | **Vaakuna**       | white         | **AA** (AAA for large text) `5 : 1`   | <ColorContrast color="var(--color-white)" background="var(--color-coat-of-arms)">AA</ColorContrast> | 
-| **Spåra**         | white         | <p style="margin:0; color: var(--color-black-60);">AA for large text `4 : 1`</p>| <ColorContrast color="var(--color-white)" background="var(--color-tram)"><IconError/></ColorContrast> | 
+| **Spåra**         | white         | **AA** (AAA for large text) `4,6 : 1` | <ColorContrast color="var(--color-white)" background="var(--color-tram)">AA</ColorContrast> | 
 
 **For text and other informative elements on white background** it is recommended to only use following brand colours:
 
@@ -126,7 +126,7 @@ Status colours are reserved exclusively for indicating valid, invalid or informa
 | **Bussi**     | **AAA** `12 : 1`| <p style="font-size: var(--fontsize-body-l); color:var(--color-bus); margin: var(--spacing-3-xs);">AAA</p> |
 | **Tiili**     | **AA** (AAA for large text) `6,1 : 1` | <p style="font-size: var(--fontsize-body-l); color: var(--color-brick); margin: var(--spacing-3-xs);">AA</p> |
 | **Vaakuna**   | **AA** (AAA for large text) `5 : 1`   | <p style="font-size: var(--fontsize-body-l); color: var(--color-coat-of-arms); margin: var(--spacing-3-xs);">AA</p> | 
-| **Spåra**     | <p style="margin:0; color: var(--color-black-60);">AA for large text `4 : 1`</p>      | <p style="font-size: var(--fontsize-body-l); color: var(--color-tram); margin: var(--spacing-3-xs);"><IconError/></p> | 
+| **Spåra**     | **AA** (AAA for large text) `4,6 : 1`      | <p style="font-size: var(--fontsize-body-l); color: var(--color-tram); margin: var(--spacing-3-xs);">AA</p> | 
 | **Metro**     | <p style="margin:0; color: var(--color-black-60);">AA for large text `3,3 : 1`</p>  | <p style="font-size: var(--fontsize-body-l); color: var(--color-metro); margin: var(--spacing-3-xs);"><IconError/></p> |
 
 ### Grayscale combinations 
@@ -207,7 +207,7 @@ CSS                                 | SASS                              | Value 
 --color-suomenlinna-light           | $color-suomenlinna-light          | #fff0f7 | <Example color="var(--color-suomenlinna-light)" />           |
 --color-suomenlinna-medium-light    | $color-suomenlinna-medium-light   | #ffdbeb | <Example color="var(--color-suomenlinna-medium-light)" />    |
 --color-suomenlinna-dark            | $color-suomenlinna-dark           | #e673a5 | <Example color="var(--color-suomenlinna-dark)" />           |
---color-tram                        | $color-tram                       | #009246 | <Example color="var(--color-tram)" />                       |
+--color-tram                        | $color-tram                       | #008741 | <Example color="var(--color-tram)" />                       |
 --color-tram-light                  | $color-tram-light                 | #dff7eb | <Example color="var(--color-tram-light)" />                  |
 --color-tram-medium-light           | $color-tram-medium-light          | #a3e3c2 | <Example color="var(--color-tram-medium-light)" />           |
 --color-tram-dark                   | $color-tram-dark                  | #006631 | <Example color="var(--color-tram-dark)" />                  |


### PR DESCRIPTION
## Description
Updates the color token `color-tram` from `#009246` to `#008741`. This ensures better accessibility and the new Tram color can now be used both as a text color (AA contrast) and as a background for white text (AA contrast). Documentation has also been updated to reflect the change.

## Related Issues
https://helsinkisolutionoffice.atlassian.net/browse/HDS-878
https://helsinkisolutionoffice.atlassian.net/browse/HDS-877

Abstract branch: https://share.goabstract.com/8441f799-b728-495b-a910-d692d7664dda

## How Has This Been Tested?
Tested by running the documentation site locally.
