### PR TITLE
[bug fixing] Pass native event to onTitleClick

### DIFF
--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -54,7 +54,7 @@ export type NavigationProps = React.PropsWithChildren<{
   /**
    * Callback fired when the title or logo is clicked
    */
-  onTitleClick?: () => void;
+  onTitleClick?: (e?: Event) => void;
   /**
    * ID of the element to jump to when the "skip to content" accessibility shortcut is clicked
    */

--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -136,9 +136,9 @@ const HeaderWrapper = ({ children, logoLanguage, onTitleClick, title, titleAriaL
         href={titleUrl}
         aria-label={titleAriaLabel}
         onKeyPress={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') onTitleClick(e);
+          if ((e.key === 'Enter' || e.key === ' ') && onTitleClick) onTitleClick(e);
         }}
-        onClick={(event) => onTitleClick(event)}
+        onClick={(event) => onTitleClick && onTitleClick(event)}
         {...(!titleUrl && onTitleClick && { tabIndex: 0 })}
       >
         <Logo className={styles.logo} language={logoLanguage} aria-hidden />

--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -136,9 +136,9 @@ const HeaderWrapper = ({ children, logoLanguage, onTitleClick, title, titleAriaL
         href={titleUrl}
         aria-label={titleAriaLabel}
         onKeyPress={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') onTitleClick();
+          if (e.key === 'Enter' || e.key === ' ') onTitleClick(e);
         }}
-        onClick={onTitleClick}
+        onClick={(event) => onTitleClick(event)}
         {...(!titleUrl && onTitleClick && { tabIndex: 0 })}
       >
         <Logo className={styles.logo} language={logoLanguage} aria-hidden />


### PR DESCRIPTION
## Description

Pass native event to onTitleClick. This is to prevent page reload which happens because of anchor tag

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-919

