### PR TITLE
[bug fixing] Fix github template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug.
 title: ''
-labels: 'i: bug'
+labels: [bug]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -2,7 +2,7 @@
 name: Enhancement
 about: Request a change to an existing component, pattern, token or documentation.
 title: ''
-labels: 'i: enhancement'
+labels: [enhancement]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question
 about: Post a question and ask help from the community.
 title: ''
-labels: 'i: question'
+labels: [question]
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description

Apply correct syntax for github template labels, which should fix the problem with labels.

Cyntax taken from here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-593

