### PR TITLE
Fix/number input on change

### DIFF
--- a/packages/react/src/components/numberInput/NumberInput.test.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import { act } from 'react-dom/test-utils';
 
 import { NumberInput } from './NumberInput';
 
@@ -37,5 +38,23 @@ describe('<NumberInput /> spec', () => {
     userEvent.click(screen.getByRole('button', { name: 'Decrease 10 euros' }));
     const numberInput = screen.getByLabelText('Test label number input', { selector: 'input' });
     expect(numberInput).toHaveValue(0);
+  });
+  it('should call onChange when input value is changed directly from input field', async () => {
+    const onChange = jest.fn();
+    render(<NumberInput onChange={onChange} step={10} {...numberInputProps} />);
+    const numberInput = screen.getByLabelText('Test label number input', { selector: 'input' });
+    await act(async () => {
+      userEvent.type(numberInput, '20');
+    });
+    expect(numberInput).toHaveValue(20);
+    expect(onChange.mock.calls.length).toBe(2);
+  });
+  it('should call onChange when user clicks step up button', async () => {
+    const onChange = jest.fn();
+    render(<NumberInput onChange={onChange} defaultValue={10} step={10} {...numberInputProps} />);
+    await act(async () => {
+      userEvent.click(screen.getByRole('button', { name: 'Add 10 euros' }));
+    });
+    expect(onChange.mock.calls.length).toBe(1);
   });
 });

--- a/packages/react/src/components/numberInput/NumberInput.test.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.test.tsx
@@ -18,27 +18,32 @@ describe('<NumberInput /> spec', () => {
     const { asFragment } = render(<NumberInput {...numberInputProps} />);
     expect(asFragment()).toMatchSnapshot();
   });
+
   it('renders the component with steppers', () => {
     const { asFragment } = render(<NumberInput step={10} {...numberInputProps} />);
     expect(asFragment()).toMatchSnapshot();
   });
+
   it('should not have basic accessibility issues', async () => {
     const { container } = render(<NumberInput step={10} {...numberInputProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
   it('should increase value correct amount when user clicks step up button', async () => {
     render(<NumberInput defaultValue={10} step={10} {...numberInputProps} />);
     userEvent.click(screen.getByRole('button', { name: 'Add 10 euros' }));
     const numberInput = screen.getByLabelText('Test label number input', { selector: 'input' });
     expect(numberInput).toHaveValue(20);
   });
+
   it('should decrease value correct amount when user clicks step down button', async () => {
     render(<NumberInput defaultValue={10} step={10} {...numberInputProps} />);
     userEvent.click(screen.getByRole('button', { name: 'Decrease 10 euros' }));
     const numberInput = screen.getByLabelText('Test label number input', { selector: 'input' });
     expect(numberInput).toHaveValue(0);
   });
+
   it('should call onChange when input value is changed directly from input field', async () => {
     const onChange = jest.fn();
     render(<NumberInput onChange={onChange} step={10} {...numberInputProps} />);
@@ -49,6 +54,7 @@ describe('<NumberInput /> spec', () => {
     expect(numberInput).toHaveValue(20);
     expect(onChange.mock.calls.length).toBe(2);
   });
+
   it('should call onChange when user clicks step up button', async () => {
     const onChange = jest.fn();
     render(<NumberInput onChange={onChange} defaultValue={10} step={10} {...numberInputProps} />);
@@ -57,6 +63,7 @@ describe('<NumberInput /> spec', () => {
     });
     expect(onChange.mock.calls.length).toBe(1);
   });
+
   it('should call onChange when user clicks step down button', async () => {
     const onChange = jest.fn();
     render(<NumberInput onChange={onChange} defaultValue={10} step={10} {...numberInputProps} />);

--- a/packages/react/src/components/numberInput/NumberInput.test.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.test.tsx
@@ -57,4 +57,12 @@ describe('<NumberInput /> spec', () => {
     });
     expect(onChange.mock.calls.length).toBe(1);
   });
+  it('should call onChange when user clicks step down button', async () => {
+    const onChange = jest.fn();
+    render(<NumberInput onChange={onChange} defaultValue={10} step={10} {...numberInputProps} />);
+    await act(async () => {
+      userEvent.click(screen.getByRole('button', { name: 'Decrease 10 euros' }));
+    });
+    expect(onChange.mock.calls.length).toBe(1);
+  });
 });

--- a/packages/react/src/components/numberInput/NumberInput.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.tsx
@@ -120,6 +120,13 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
       }
     }, [inputRef, ref]);
 
+    const dispatchNativeOnChangeEvent = (): void => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      nativeInputValueSetter.call(inputRef.current, inputRef.current.value);
+      const onChangeEvent = new Event('input', { bubbles: true });
+      inputRef.current.dispatchEvent(onChangeEvent);
+    };
+
     // Compose aria-describedby attribute
     const ariaDescribedBy = comboseAriaDescribedBy(id, helperText, errorText, successText);
 
@@ -152,6 +159,7 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
                     // Prevent default to not submit form if we happen to be inside form
                     event.preventDefault();
                     inputRef.current.stepDown();
+                    dispatchNativeOnChangeEvent();
                   }}
                   aria-label={minusStepButtonAriaLabel || 'Decrease by one'}
                 >
@@ -167,6 +175,7 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
                     // Prevent default to not submit form if we happen to be inside form
                     event.preventDefault();
                     inputRef.current.stepUp();
+                    dispatchNativeOnChangeEvent();
                   }}
                   aria-label={plusStepButtonAriaLabel || 'Increase by one'}
                 >


### PR DESCRIPTION
## Description

Fix a bug in number input where onChange was not triggered when user changes value through stepper buttons

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-947
https://github.com/facebook/react/issues/22212

## How Has This Been Tested?

- Locally on developers machine
- Through automated unit tests
