### PR TITLE
Replace post-css compose with common SASS file

### DIFF
--- a/packages/react/src/components/sideNavigation/SideNavigation.module.scss
+++ b/packages/react/src/components/sideNavigation/SideNavigation.module.scss
@@ -1,5 +1,4 @@
 @value small-down, medium-up from "../../styles/breakpoints.css";
-@import '../../styles/common';
 
 .sideNavigation {
   --side-navigation-background-color: var(--color-white);
@@ -54,65 +53,5 @@
 
   @media medium-up {
     display: block;
-  }
-}
-
-.level {
-  & > button {
-    @extend %buttonReset;
-  }
-
-  & > a,
-  & > button {
-    box-sizing: border-box;
-    display: flex;
-    width: 100%;
-    margin: 0;
-    padding: var(--spacing-2-xs) var(--side-navigation-level-inset);
-    min-height: var(--spacing-2-xl);
-    align-items: center;
-    text-align: left;
-    text-decoration: none;
-    border: var(--side-navigation-level-border-width) solid var(--side-navigation-level-border-color);
-    background-color: var(--side-navigation-level-background-color);
-    color: var(--side-navigation-level-color);
-    outline: none;
-
-    &:hover {
-      background-color: var(--side-navigation-level-background-color-hover);
-      border-color: var(--side-navigation-level-border-color-hover);
-      color: var(--side-navigation-level-color-hover);
-    }
-
-    &:focus {
-      border-color: var(--side-navigation-level-border-color-focus) !important;
-    }
-
-    span {
-      display: flex;
-    }
-  }
-}
-
-.activeLevel {
-  & > a,
-  & > button {
-    position: relative;
-
-    &::before {
-      position: absolute;
-      display: block;
-      content: '';
-      width: var(--spacing-3-xs);
-      background: var(--side-navigation-active-indicator-background-color);
-      top: calc(0px - var(--side-navigation-level-border-width));
-      bottom: calc(0px - var(--side-navigation-level-border-width));
-      left: calc(0px - var(--side-navigation-level-border-width));
-    }
-
-    font-weight: 600;
-    background-color: var(--side-navigation-level-background-color-active);
-    border-color: var(--side-navigation-level-background-color-active);
-    color: var(--side-navigation-level-color-active);
   }
 }

--- a/packages/react/src/components/sideNavigation/_sideNavigation.common.scss
+++ b/packages/react/src/components/sideNavigation/_sideNavigation.common.scss
@@ -1,0 +1,61 @@
+@import '../../styles/common';
+
+%level {
+  & > button {
+    @extend %buttonReset;
+  }
+
+  & > a,
+  & > button {
+    box-sizing: border-box;
+    display: flex;
+    width: 100%;
+    margin: 0;
+    padding: var(--spacing-2-xs) var(--side-navigation-level-inset);
+    min-height: var(--spacing-2-xl);
+    align-items: center;
+    text-align: left;
+    text-decoration: none;
+    border: var(--side-navigation-level-border-width) solid var(--side-navigation-level-border-color);
+    background-color: var(--side-navigation-level-background-color);
+    color: var(--side-navigation-level-color);
+    outline: none;
+
+    &:hover {
+      background-color: var(--side-navigation-level-background-color-hover);
+      border-color: var(--side-navigation-level-border-color-hover);
+      color: var(--side-navigation-level-color-hover);
+    }
+
+    &:focus {
+      border-color: var(--side-navigation-level-border-color-focus) !important;
+    }
+
+    span {
+      display: flex;
+    }
+  }
+}
+
+%activeLevel {
+  & > a,
+  & > button {
+    position: relative;
+
+    &::before {
+      position: absolute;
+      display: block;
+      content: '';
+      width: var(--spacing-3-xs);
+      background: var(--side-navigation-active-indicator-background-color);
+      top: calc(0px - var(--side-navigation-level-border-width));
+      bottom: calc(0px - var(--side-navigation-level-border-width));
+      left: calc(0px - var(--side-navigation-level-border-width));
+    }
+
+    font-weight: 600;
+    background-color: var(--side-navigation-level-background-color-active);
+    border-color: var(--side-navigation-level-background-color-active);
+    color: var(--side-navigation-level-color-active);
+  }
+}

--- a/packages/react/src/components/sideNavigation/mainLevel/MainLevel.module.scss
+++ b/packages/react/src/components/sideNavigation/mainLevel/MainLevel.module.scss
@@ -1,5 +1,8 @@
+@import "../sideNavigation.common";
+
+
 .mainLevel {
-  composes: level from '../SideNavigation.module.scss';
+  @extend %level;
 
   font-size: var(--fontsize-body-m);
 
@@ -10,7 +13,7 @@
 }
 
 .active {
-  composes: activeLevel from '../SideNavigation.module.scss';
+  @extend %activeLevel;
 }
 
 .mainLevelListMenu {

--- a/packages/react/src/components/sideNavigation/subLevel/SubLevel.module.scss
+++ b/packages/react/src/components/sideNavigation/subLevel/SubLevel.module.scss
@@ -1,5 +1,7 @@
+@import "../sideNavigation.common";
+
 .subLevel {
-  composes: level from '../SideNavigation.module.scss';
+  @extend %level;
 
   font-size: var(--fontsize-body-s);
 
@@ -13,5 +15,5 @@
 }
 
 .active {
-  composes: activeLevel from '../SideNavigation.module.scss';
+  @extend %activeLevel;
 }


### PR DESCRIPTION
## Description
- Replace Postcss compose with common SASS file

## Related Issue
- https://helsinkicity.slack.com/archives/CHCV3KTHA/p1631016008034500

## Motivation and Context
- Postcss's compose might generate invalid CSS when including parts of SASS files.  CSS is valid only if it is built in a specific order. This problem occurs when projects are testing their products using the HDS library and Jest, for example.

## How Has This Been Tested?
- locally on dev machine