### PR TITLE
[Content] Add missing components to the form pattern documentation

### DIFF
--- a/site/docs/patterns/forms.mdx
+++ b/site/docs/patterns/forms.mdx
@@ -93,13 +93,25 @@ Forms *should* be designed to be as clear and straightforward as possible, to al
 Different form controls have all different functionalities and specific use cases. Here are some guidelines on when each form control *should* be used.
 
 ### Entering text
-Enable the user to **input a freeform string of text or numbers.**
+
+#### Text inputs
+Enable the user to **input a freeform string of text that does not have a specific format.**
 
 | Control   | Name        | Usage         | Examples      |
 | --------- | ----------- | ------------- | ------------- |
 | <Image src="../../static/patterns/form/form-choosing-textinput@2x.png" alt="Text input" style="max-width:250px;" viewable />  | Text input                | Entering short strings of texts or numbers no more than a few words long.               |  |
-| <Image src="../../static/patterns/form/form-choosing-textarea@2x.png" alt="Text area" style="max-width:250px;" viewable />    | Text area                 | Entering multiple lines of text | Messages, descriptions, feedback, support requests  |  |
-| <p style="margin: var(--spacing-2-xs) 0;"><StatusLabel type="error">Coming soon</StatusLabel></p>                             | *Text input data types*   | <p>Text fields come in several varieties for different data types (date, password etc.) and specific purposes (e.g. search).</p><p style="margin-bottom:0"><strong>Separate components for most common input data types coming soon to HDS.</strong></p>| Names, phone numbers, addresses, search. |  |
+| <Image src="../../static/patterns/form/form-choosing-textarea@2x.png" alt="Text area" style="max-width:250px;" viewable />    | Text area                 | Entering multiple lines of text. | Messages, descriptions, feedback, support requests  |  |
+
+#### Data inputs for specific types and formats
+Enable user to **input textual data of a specific type**. While this kind of data could be inputted to a text input, it is always recommended to use a data-specific input if it is available.
+
+| Control   | Name        | Usage         | Examples      |
+| --------- | ----------- | ------------- | ------------- |
+| <Image src="../../static/patterns/form/form-choosing-numberinput@2x.png" alt="Number input" style="max-width:250px;" viewable />            | Number input              | Entering a number. | Prices, amounts, numbers with units  |  |
+| <Image src="../../static/patterns/form/form-choosing-dateinput@2x.png" alt="Date input" style="max-width:250px;" viewable />                | Date input                | Entering a date. | Event dates, birthdays, dates as filters  |  |
+| <Image src="../../static/patterns/form/form-choosing-timeinput@2x.png" alt="Time input" style="max-width:250px;" viewable />                | Time input                | Entering a time in a clock format. | Event start time, parking end time  |  |
+| <Image src="../../static/patterns/form/form-choosing-phonenumberinput@2x.png" alt="Phone number input" style="max-width:250px;" viewable /> | Phone number input        | Entering a phone number. | Phone numbers in different locale formats  |  |
+| <Image src="../../static/patterns/form/form-choosing-passwordinput@2x.png" alt="Password input" style="max-width:250px;" viewable />        | Password input            | Entering a password or other sensitive data. | Passwords, passphrases, sensitive personal data |  |
 
 <div class="guideline-do" style="background: var(--color-success-light); padding: var(--spacing-s); margin-bottom: var(--spacing-layout-2-xs); max-width:600px;">
     <div class="guideline-do-label" style="color:var(--color-success); margin-bottom:var(--spacing-s);"><IconCheck style={{ marginRight: 'var(--spacing-3-xs)', verticalAlign: 'middle'}} size="s"/><strong>Do</strong></div>
@@ -111,6 +123,7 @@ Enable the user to **input a freeform string of text or numbers.**
                 <li>If an input is too long to be fully displayed in the field, truncate the value with ellipsis.</li>
             </ul>
         </li>
+        <li>Always use a dedicated input type if it is available. E.g. use the phone number input for inputting phone numbers.</li>
         <li>Make sure users can enter their information even on smaller screen sizes and mobile devices.</li>
     </ul>
 </div>
@@ -120,17 +133,15 @@ Enable the user to **input a freeform string of text or numbers.**
 ### Selecting from pre-defined options 
 Enable the user to enter an input by **selecting from a set of pre-defined options**.
 
-Each selection control has a specific use case. The main factors that determine which one is the appropriate for the given situation are:
-- how many options you need to present?
-- can the user select only one or multiple options at the same time?
+Each selection control has a specific use case. To learn which one to use, see [HDS Guideline Checkboxes, radio buttons, or toggles documentation page](/guidelines/checkboxes-radiobuttons-toggles).
 
 #### Short lists of choices
 | Control   | Name        | Usage         | Examples      |
 | --------- | ----------- | ------------- | ------------- |
-| <Image src="../../static/patterns/form/form-choosing-select-checkbox@2x.png" alt="Checkbox" style="max-width:250px;" viewable />              | Checkbox              | Selecting a single option.                        | Agreeing to terms and conditions |
+| <Image src="../../static/patterns/form/form-choosing-select-checkbox@2x.png" alt="Checkbox" style="max-width:250px;" viewable />              | Checkbox              | Selecting a single option.                                    | Agreeing to terms and conditions |
 | <Image src="../../static/patterns/form/form-choosing-select-checkboxgroup@2x.png" alt="Checkbox group" style="max-width:250px;" viewable />   | Checkbox group        | Selecting one or more options from a short list.              | <ul style="margin-bottom:0"><li>Adding optional items</li><li>Selecting all that apply</li></ul> |
 | <Image src="../../static/patterns/form/form-choosing-select-radio@2x.png" alt="Radio button group" style="max-width:250px;" viewable />       | Radio button group    | Selecting a single option from mutually exclusive choices.    | Picking a type |
-| <StatusLabel type="error">Coming soon</StatusLabel>                                                                                           | Toggle                | Choosing between binary options.                              | <ul style="margin-bottom:0"><li>On/off</li><li>Show/hide</li></ul> |
+| <Image src="../../static/patterns/form/form-choosing-select-togglebutton@2x.png" alt="Toggle button" style="max-width:250px;" viewable />     | Toggle button         | Choosing between binary options.                              | Changing a setting, switching a theme |
 
 <div class="guideline-do" style="background: var(--color-success-light); padding: var(--spacing-s); margin-bottom: var(--spacing-layout-2-xs); max-width:600px;">
     <div class="guideline-do-label" style="color:var(--color-success); margin-bottom:var(--spacing-s);"><IconCheck style={{ marginRight: 'var(--spacing-3-xs)', verticalAlign: 'middle'}} size="s"/><strong>Do</strong></div>

--- a/site/static/patterns/form/form-choosing-combobox-multi@2x.png
+++ b/site/static/patterns/form/form-choosing-combobox-multi@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9102517be412dc29367bbcd5711d101264d1754dadefbfa6ba0d5c4778ca4d3a
-size 33593
+oid sha256:7db83e99c5ea8fe8e169549d6e5a193f31e89973d62e3752b97ef6624b28a9cc
+size 31807

--- a/site/static/patterns/form/form-choosing-combobox@2x.png
+++ b/site/static/patterns/form/form-choosing-combobox@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0b12ed424db5a1fbea022a3fecfdf2fbff6103074226f483581883c2a4171ee
-size 23171
+oid sha256:1d9cb2fe84afa337fcb5662302a0bd4c430e4de78a86fc494c281c7d077ff6a1
+size 22685

--- a/site/static/patterns/form/form-choosing-dateinput@2x.png
+++ b/site/static/patterns/form/form-choosing-dateinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f2c5266416aa92e437451c3f4b02dac9ec967f88176fd5a7d3e52745d16aab4
+size 8340

--- a/site/static/patterns/form/form-choosing-dropdown-multi@2x.png
+++ b/site/static/patterns/form/form-choosing-dropdown-multi@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f709c47dc0a34b260f5ab51f34082e1758d02df381f1ee784204b98c5cb3e4f
-size 29945
+oid sha256:545fc448d69b46a0db3e841e324301702bdc5068ec187dcc6d4c1574284f1f13
+size 28210

--- a/site/static/patterns/form/form-choosing-dropdown@2x.png
+++ b/site/static/patterns/form/form-choosing-dropdown@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7fc8f091cb0d1869f3f3853ef78eb43f07b2e021cb5212f4b33954c37abb189
-size 24506
+oid sha256:b147d088ed920e9ad9aaca9e0d555706d130986767e6187766d72d1aa6840a8c
+size 23753

--- a/site/static/patterns/form/form-choosing-numberinput@2x.png
+++ b/site/static/patterns/form/form-choosing-numberinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3206a6ad3084a14c02d227e9926fc0314ff1e10f86e228f68504d88c7f062a7a
+size 7455

--- a/site/static/patterns/form/form-choosing-passwordinput@2x.png
+++ b/site/static/patterns/form/form-choosing-passwordinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f60093afcd83a364b3d925881edeb0d2c16e30946f1f19e8b8f26a8258af6f3
+size 10165

--- a/site/static/patterns/form/form-choosing-phonenumberinput copy@2x.png
+++ b/site/static/patterns/form/form-choosing-phonenumberinput copy@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d265ec4dc544379852b735b597ea529a8b70a43fa8069ecadd5e72954de9556
+size 11895

--- a/site/static/patterns/form/form-choosing-phonenumberinput copy@2x.png
+++ b/site/static/patterns/form/form-choosing-phonenumberinput copy@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d265ec4dc544379852b735b597ea529a8b70a43fa8069ecadd5e72954de9556
-size 11895

--- a/site/static/patterns/form/form-choosing-phonenumberinput@2x.png
+++ b/site/static/patterns/form/form-choosing-phonenumberinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d265ec4dc544379852b735b597ea529a8b70a43fa8069ecadd5e72954de9556
+size 11895

--- a/site/static/patterns/form/form-choosing-select-togglebutton@2x.png
+++ b/site/static/patterns/form/form-choosing-select-togglebutton@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:418d6d416f7977fd3fc1574c07486d8bb8611e7e97a96369273c1e35725c63fe
+size 8888

--- a/site/static/patterns/form/form-choosing-textarea@2x.png
+++ b/site/static/patterns/form/form-choosing-textarea@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f06b39496139a86d01b10aa55865c0c3773902de9b76fa1360517df61b779661
-size 7978
+oid sha256:2f9ecc89f5a4bb31ff0e64dd07ccee09574cc2cc3f0d16e6640bc016d875792d
+size 11492

--- a/site/static/patterns/form/form-choosing-textinput@2x.png
+++ b/site/static/patterns/form/form-choosing-textinput@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d6488060b34307b3c8db9b82e2aae4184f18abf91e270b37fce74906a8e73ba5
-size 5664
+oid sha256:47e3c32e87b9c691799bbf5a35e549fe201f3a141e5e1e7bd29df2afa51b1a69
+size 7248

--- a/site/static/patterns/form/form-choosing-timeinput@2x.png
+++ b/site/static/patterns/form/form-choosing-timeinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:325dee2ffa16e466591f5c85d0e754c5d1a9d739420c108dc19561d1f330e577
+size 7715

--- a/site/static/patterns/form/form-states-focus@2x.png
+++ b/site/static/patterns/form/form-states-focus@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a56214fa4e77f144e844e5ac857657b6b1e1590c662ecd9eadc436835bbadc8
-size 14966
+oid sha256:d3681317bb3dd66a4d291abd022f48eaaa59830065088b9e642bd04908003c32
+size 14416


### PR DESCRIPTION
## Description
Form pattern documentation lists all HDS form components in a table and explains their usage. These tables have not been updated for a while and they are missing some components. This PR adds the missing components to the documentation:
- Number input
- Date input
- Time input
- Phone number input
- Password input
- Toggle button

This PR also updates images that have the component focus styling visible. Since the pattern documentation uses static screenshots, some of the images still had the old focus style with rounded corners. These images have been updated.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-874

## How Has This Been Tested?
Tested by running the documentation site locally.
