### PR TITLE
Fix/Allow reseting number input to an empty value

### DIFF
--- a/packages/react/src/components/numberInput/NumberInput.test.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
@@ -71,5 +71,31 @@ describe('<NumberInput /> spec', () => {
       userEvent.click(screen.getByRole('button', { name: 'Decrease 10 euros' }));
     });
     expect(onChange.mock.calls.length).toBe(1);
+  });
+
+  it'should be able to reset a controlled NumberInput to an empty value', async () => {
+    const TestComponent = () => {
+      const [value, setValue] = useState<'' | number>(10);
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => {
+              setValue('');
+            }}
+          >
+            Reset number input
+          </button>
+          <NumberInput step={10} value={value} {...numberInputProps} />
+        </div>
+      );
+    };
+
+    render(<TestComponent />);
+    await act(async () => {
+      userEvent.click(screen.getByRole('button', { name: 'Reset number input' }));
+    });
+    const numberInput = screen.getByLabelText('Test label number input', { selector: 'input' });
+    expect(numberInput).toHaveValue(null); // Empty string is converted to null by react/html
   });
 });

--- a/packages/react/src/components/numberInput/NumberInput.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.tsx
@@ -49,7 +49,7 @@ export type NumberInputProps = Omit<
   /**
    * The value of the input element, required for a controlled component
    */
-  value?: number;
+  value?: number | '';
 };
 
 function combineLabelAndUnit(label: string, unit: string | undefined): string | undefined {


### PR DESCRIPTION
## Description

NumberInput did not allow reseting the component to an empty value when used as a controlled component. This PR fixes it by allowing users reset to an empty value for controlled component.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1013

## How Has This Been Tested?

- Locally on developers machine
- Automated unit test
