### PR TITLE
[Content] Links to HDS kits to the documentation

### DIFF
--- a/site/docs/get_started/for_designers.mdx
+++ b/site/docs/get_started/for_designers.mdx
@@ -45,7 +45,8 @@ If you are a newcomer to Sketch or Abstract, they both offer some great tutorial
 - <Link href="https://www.sketchapp.com/docs/" external>Sketch help docs</Link>
 - <Link href="https://www.abstract.com/help/" external>Abstract help docs</Link>
 
-**You do not necessarily need Abstract to use HDS design libraries.** Abstract is a convenient way to get access and update Sketch libraires, but we also offer downloadable HDS design kit. Read below to learn how to download the design kit. 
+<p><b>You do not necessarily need Abstract to use HDS design libraries.</b> Abstract is a convenient way to access and update Sketch libraries, but we also offer a downloadable HDS design kit. <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/latest/download/hds-design-kit.zip" external>Download the latest HDS Design kit from the HDS GitHub repository</Link>. Please note that if you use the design kit outside of Abstract, you need to manually download the kit again to gain access to the newest updates.</p>
+
 
 ### Install fonts
 <p>Make sure that you have the <Link href="https://camelot-typefaces.com/helsinki-grotesk" external>Helsinki Grotesk font</Link> installed.</p>

--- a/site/docs/visual_elements/icons.mdx
+++ b/site/docs/visual_elements/icons.mdx
@@ -6,6 +6,7 @@ menu: Visual assets
 
 import LargeParagraph from "../../src/components/LargeParagraph";
 import Image from "../../src/components/Image";
+import Link from "../../src/components/Link";
 import { StatusLabel } from "hds-react";
 import * as HDS from "hds-react";
 
@@ -20,9 +21,10 @@ The HDS icon library follows the icon style defined in the Helsinki city brand g
 
 See the [Icon component documentation](/components/icons "Icon component") for instructions on using icons in implementation.
 
-## Visual principles
-<StatusLabel>Coming soon</StatusLabel>
+<p>If you need icons outside of HDS Core and React libraries, they are also available as a downloadable ZIP package. <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/latest/download/hds-icon-kit.zip" external>Download the latest HDS Icon kit from the HDS GitHub repository</Link>.</p>
 
+## Visual principles
+To learn more about visual principles behind the City of Helsinki icons, take at look at [the icon contribution guidelines](/contributing/making-icons).
 
 ## Usage
 ### Icon types

--- a/site/docs/visual_elements/logo.mdx
+++ b/site/docs/visual_elements/logo.mdx
@@ -39,7 +39,8 @@ Language version                                                                
 [![Helsinki logo sv](../../static/assets/logo/helsinki-sv.svg)](../../static/assets/logo/helsinki-sv.svg "Helsinki logo sv") | helsinki-sv.svg   | pages in Swedish and Norwegian                |
 
 ### Favicon
-The favicon of City of Helsinki digital services is a minimised version of the Helsinki logo (you may download the favicon by clicking the image below):
+<p>The favicon of City of Helsinki digital services is a minimised version of the Helsinki logo. Different favicons are available as a downloadable ZIP package. <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/latest/download/hds-favicon-kit.zip" external>Download the latest HDS Favicon kit from the HDS GitHub repository</Link>.</p>
+
 
 Favicon                                                                                                                          | File name           |
 -------------------------------------------------------------------------------------------------------------------------------- | ------------------- |


### PR DESCRIPTION
## Description
Adds links to HDS kits to the documentation site. Since the kit files are now named the same in every release, we can point to them directly on the latest release. This also requires that the kit files are present in every release and are named in the same way.

Added the following links:
- Link to the HDS Icon kit to the Icon documentation page (Visual assets)
- Link to the HDS Favicon kit to the Logo documentation page (Visual assets)
- Link to the HDS Design kit to the Designers getting started page

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-707

## How Has This Been Tested?
Tested by running the documentation site locally.
