### PR TITLE
Fix/combobox select deselect on tab

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Combobox, ComboboxProps } from './Combobox';
@@ -29,14 +30,17 @@ describe('<Combobox />', () => {
     const { getAllByLabelText, getAllByRole, queryByDisplayValue } = getWrapper({ onChange });
     const input = getAllByLabelText(label)[0];
 
-    fireEvent.change(input, { target: { value: 'Fi' } });
+    userEvent.type(input, 'Fi');
 
     const visibleOptions = getAllByRole('option');
 
     // Ensure that options are filtered correctly
     expect(visibleOptions.length).toBe(1);
-    // Choose one option
-    fireEvent.click(visibleOptions[0]);
+
+    act(() => {
+      // Choose one option
+      userEvent.click(visibleOptions[0]);
+    });
 
     // Ensure that chosen option is shown as value of input
     expect(queryByDisplayValue(options[0].label)).toBeDefined();
@@ -54,22 +58,28 @@ describe('<Combobox />', () => {
 
       const input = getAllByLabelText(label)[0];
 
-      fireEvent.change(input, { target: { value: 'Fi' } });
+      // Search an option
+      userEvent.type(input, 'Fi');
       const visibleOptions = getAllByRole('option');
 
       // Ensure that options are filtered correctly
       expect(visibleOptions.length).toBe(1);
-      // Choose one option
-      fireEvent.click(visibleOptions[0]);
+      act(() => {
+        // Choose one option
+        userEvent.click(visibleOptions[0]);
+      });
       // Ensure that it's visible in selected items
       expect(queryAllByText(options[0].label).length).toEqual(2);
       // Ensure that it has been passed upwards with onChange
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith([options[0]]);
 
-      fireEvent.change(input, { target: { value: 'bo' } });
+      // Search another option
+      userEvent.type(input, 'bo');
       expect(getAllByRole('option').length).toBe(2);
-      fireEvent.click(getAllByRole('option')[1]);
+      act(() => {
+        userEvent.click(getAllByRole('option')[1]);
+      });
       // Ensure that previous and current selection are visible in
       // selected items
       expect(queryAllByText(options[0].label).length).toEqual(2);

--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Combobox, ComboboxProps } from './Combobox';
 
@@ -77,6 +78,26 @@ describe('<Combobox />', () => {
       // onChange
       expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith([options[0], options[4]]);
+    });
+
+    it('user should be able to close the menu with a tab keypress', () => {
+      const onChange = jest.fn();
+      const { getAllByLabelText, queryAllByRole, queryAllByText } = getWrapper({ onChange });
+      const input = getAllByLabelText(label)[0];
+
+      // Search and focus on first option
+      userEvent.type(input, 'Fi');
+      userEvent.type(input, '{arrowdown}');
+      const visibleOptions = queryAllByRole('option');
+      expect(visibleOptions.length).toBe(1);
+      expect(visibleOptions[0].innerHTML).toEqual(options[0].label);
+      expect(visibleOptions[0]).toHaveClass('highlighted'); // Prone to break if className changes
+
+      // A tab keypress should close the menu without selecting an item
+      userEvent.type(input, '{tab}');
+      const visibleOptionsAfterClose = queryAllByRole('option');
+      expect(visibleOptionsAfterClose.length).toBe(0);
+      expect(queryAllByText(options[0].label).length).toEqual(0);
     });
   });
 });

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -183,6 +183,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     isOpen,
     selectedItem,
     selectItem,
+    closeMenu,
     setInputValue,
     getInputProps,
     getComboboxProps,
@@ -309,6 +310,12 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     if (isOpen && (e.key === 'Backspace' || e.key === 'ArrowLeft')) {
       // @ts-ignore
       e.nativeEvent.preventDownshiftDefault = true;
+    }
+
+    // Tab keypress should close the menu without selecting an item.
+    if (e.key === 'Tab' && highlightedIndex > -1 && isOpen) {
+      // @ts-ignore
+      closeMenu();
     }
   };
 


### PR DESCRIPTION
## Description
- Combobox components deselected or selected a highlighted item on tab keypress before closing the menu. This is confusing especially when user has previously selected an item. Now tab keypress closes the menu without selecting or deselecting an item.

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-821
- 
## How Has This Been Tested?
- Locally on developers machine
- Automated unit test

👉 [Storybook demo](https://city-of-helsinki.github.io/hds-demo/combobox-tab/?path=/story/components-dropdowns-combobox--multiselect)