### PR TITLE
Feature/new docs playground

### DIFF
--- a/new-site/gatsby-node.js
+++ b/new-site/gatsby-node.js
@@ -1,0 +1,12 @@
+const webpack = require('webpack');
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    plugins: [
+      // We need to provide a polyfill for react-live library to make it work with the latest Gatsby: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed
+      new webpack.ProvidePlugin({
+        process: 'process/browser',
+      }),
+    ],
+  });
+};

--- a/new-site/package.json
+++ b/new-site/package.json
@@ -16,10 +16,12 @@
     "gatsby-plugin-sharp": "^3.13.0",
     "gatsby-source-filesystem": "^3.13.0",
     "gatsby-transformer-sharp": "^3.13.0",
+    "prism-react-renderer": "^1.2.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
+    "react-live": "^2.3.0",
     "sass": "^1.43.2"
   },
   "devDependencies": {

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -128,14 +128,13 @@ const Editor = ({ onChange, initialCode, code, language }) => {
         </div>
       </div>
       <div className="playground-block-buttons">
-        <Button ref={copyButtonRef} variant="secondary" size="small" tabIndex={0} onClick={copy}>
+        <Button ref={copyButtonRef} variant="secondary" size="small" onClick={copy}>
           Copy code
         </Button>
         <Button
           variant="secondary"
           iconLeft={<IconArrowUndo aria-hidden />}
           size="small"
-          tabIndex={0}
           disabled={initialCode === code}
           onClick={reset}
         >

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -119,15 +119,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
               <LiveEditor
                 key={resetCount}
                 onChange={onChange}
-                style={{
-                  background: 'none',
-                  padding: '0 0 var(--spacing-s)',
-                  overflow: 'visible',
-                  whiteSpace: 'nowrap',
-                  width: 'max-content',
-                  minWidth: '100%',
-                  fontSize: '16px'
-                }}
+                className="playground-block-editor-code-input"
                 textareaId={textAreaId}
                 theme={theme}
               />

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
-import * as Hds from 'hds-react';
+import { Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
 import theme from 'prism-react-renderer/themes/github';
 
 import './Playground.scss';
@@ -144,19 +145,19 @@ const Editor = ({ onChange, initialCode, code, languageClass }) => {
         </div>
       </div>
       <div className="playground-block-buttons">
-        <Hds.Button ref={copyButtonRef} variant="secondary" size="small" tabIndex={0} onClick={copy}>
+        <Button ref={copyButtonRef} variant="secondary" size="small" tabIndex={0} onClick={copy}>
           Copy code
-        </Hds.Button>
-        <Hds.Button
+        </Button>
+        <Button
           variant="secondary"
-          iconLeft={<Hds.IconArrowUndo aria-hidden />}
+          iconLeft={<IconArrowUndo aria-hidden />}
           size="small"
           tabIndex={0}
           disabled={initialCode === code}
           onClick={reset}
         >
           Reset example
-        </Hds.Button>
+        </Button>
       </div>
       <LiveError />
     </>
@@ -173,6 +174,7 @@ Editor.propTypes = {
 const EditorWithLive = withLive(Editor);
 
 export const PlaygroundBlock = ({ codeBlocks }) => {
+  const scopeComponents = useMDXScope();
   const codeByLanguage = codeBlocks.reduce((acc, block) => {
     acc[block.languageClass] = block.code;
     return acc;
@@ -185,17 +187,15 @@ export const PlaygroundBlock = ({ codeBlocks }) => {
 
   return (
     <div className="playground-block">
-      <Hds.Tabs>
-        <Hds.TabList className="playground-block-tabs">
+      <Tabs>
+        <TabList className="playground-block-tabs">
           {codeBlocks.map((codeBlock) => (
-            <Hds.Tab key={codeBlock.languageClass}>
-              {codeBlock.languageClass === 'language-jsx' ? 'React' : 'Core'}
-            </Hds.Tab>
+            <Tab key={codeBlock.languageClass}>{codeBlock.languageClass === 'language-jsx' ? 'React' : 'Core'}</Tab>
           ))}
-        </Hds.TabList>
+        </TabList>
         {codeBlocks.map(({ code, languageClass }) => (
-          <Hds.TabPanel key={languageClass}>
-            <LiveProvider code={sanitize(codeByLanguageState[languageClass])} scope={{ ...Hds }}>
+          <TabPanel key={languageClass}>
+            <LiveProvider code={sanitize(codeByLanguageState[languageClass])} scope={scopeComponents}>
               <div className="playground-block-content">
                 <LivePreview className="playground-block-preview" />
                 <EditorWithLive
@@ -206,9 +206,9 @@ export const PlaygroundBlock = ({ codeBlocks }) => {
                 />
               </div>
             </LiveProvider>
-          </Hds.TabPanel>
+          </TabPanel>
         ))}
-      </Hds.Tabs>
+      </Tabs>
     </div>
   );
 };

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -93,7 +93,6 @@ const Editor = ({ onChange, initialCode, code, languageClass }) => {
           className="playground-block-editor-viewport"
           tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
           onKeyDown={onFocusKeyDown}
-          onClick={onFocus}
           ref={viewPortRef}
         >
           <div className="playground-block-editor-code">
@@ -105,13 +104,22 @@ const Editor = ({ onChange, initialCode, code, languageClass }) => {
                 Press Enter to start editing. Press Esc to stop editing.
               </span>
             </div>
-            <LiveEditor
-              key={resetCount}
-              onChange={onChange}
-              style={{ background: 'none', padding: '0', overflow: 'visible', whiteSpace: 'nowrap' }}
-              textareaId={textAreaId}
-              theme={theme}
-            />
+            <div className="playground-block-editor-scrollbox" tabIndex={-1}>
+              <LiveEditor
+                key={resetCount}
+                onChange={onChange}
+                style={{
+                  background: 'none',
+                  padding: '0',
+                  overflow: 'visible',
+                  whiteSpace: 'nowrap',
+                  width: 'max-content',
+                  minWidth: '100%',
+                }}
+                textareaId={textAreaId}
+                theme={theme}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -9,7 +9,7 @@ import './Playground.scss';
 
 const Playground = ({ children }) => {
   if (children) {
-    return <pre>{children}</pre>
+    return <pre>{children}</pre>;
   }
 
   return null;

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -45,7 +45,7 @@ const Editor = ({ onChange, initialCode, code, languageClass }) => {
 
   const onFocusKeyDown = useCallback(
     (event) => {
-      if (event.key === 'Enter' && viewPortRef.current) {
+      if (event.key === 'Enter' && viewPortRef.current && event.target === viewPortRef.current) {
         event.preventDefault();
         const textArea = getTextArea(viewPortRef.current);
         textArea.focus();

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -35,6 +35,16 @@ const clearSelection = () => {
   }
 };
 
+const sanitize = (code) => {
+  const trimmedCode = code.trim();
+  const cleanedCode =
+    trimmedCode.startsWith('{') && trimmedCode.endsWith('}')
+      ? trimmedCode.substr(1, trimmedCode.length - 2).trim()
+      : trimmedCode;
+
+  return cleanedCode;
+};
+
 const Editor = ({ onChange, initialCode, code, languageClass }) => {
   const viewPortRef = useRef();
   const copyButtonRef = useRef();
@@ -162,16 +172,6 @@ Editor.propTypes = {
 
 const EditorWithLive = withLive(Editor);
 
-const sanitize = (code) => {
-  const trimmedCode = code.trim();
-  const cleanedCode =
-    trimmedCode.startsWith('{') && trimmedCode.endsWith('}')
-      ? trimmedCode.substr(1, trimmedCode.length - 2).trim()
-      : trimmedCode;
-
-  return cleanedCode;
-};
-
 export const PlaygroundBlock = ({ codeBlocks }) => {
   const codeByLanguage = codeBlocks.reduce((acc, block) => {
     acc[block.languageClass] = block.code;
@@ -199,7 +199,7 @@ export const PlaygroundBlock = ({ codeBlocks }) => {
               <div className="playground-block-content">
                 <LivePreview className="playground-block-preview" />
                 <EditorWithLive
-                  initialCode={code}
+                  initialCode={sanitize(code)}
                   languageClass={languageClass}
                   onChange={setCodeByLanguage(languageClass)}
                   code={codeByLanguageState[languageClass]}

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { mdx as createMdxReactElement } from '@mdx-js/react';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
 import { Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
@@ -9,14 +8,8 @@ import theme from 'prism-react-renderer/themes/github';
 import './Playground.scss';
 
 const Playground = ({ children }) => {
-  const childrenAsArray = React.Children.toArray(children);
-
   if (children) {
-    // Create a wrapper mxd pre-element around code blocks
-    return createMdxReactElement('pre', {
-      playground: true,
-      children: childrenAsArray,
-    });
+    return <pre>{children}</pre>
   }
 
   return null;

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -162,5 +162,10 @@ export const PlaygroundBlock = ({ codeBlocks }) => {
 };
 
 PlaygroundBlock.propTypes = {
-  codeBlocks: PropTypes.array,
+  codeBlocks: PropTypes.arrayOf(
+    PropTypes.shape({
+      code: PropTypes.string.isRequired,
+      languageClass: PropTypes.string.isRequired,
+    }),
+  ),
 };

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -128,7 +128,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
                 onChange={onChange}
                 style={{
                   background: 'none',
-                  padding: '0',
+                  padding: '0 0 var(--spacing-s)',
                   overflow: 'visible',
                   whiteSpace: 'nowrap',
                   width: 'max-content',

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -38,12 +38,9 @@ const clearSelection = () => {
 
 const sanitize = (code) => {
   const trimmedCode = code.trim();
-  const cleanedCode =
-    trimmedCode.startsWith('{') && trimmedCode.endsWith('}')
-      ? trimmedCode.substr(1, trimmedCode.length - 2).trim()
-      : trimmedCode;
-
-  return cleanedCode;
+  return trimmedCode.startsWith('{') && trimmedCode.endsWith('}')
+    ? trimmedCode.substr(1, trimmedCode.length - 2).trim()
+    : trimmedCode;
 };
 
 const Editor = ({ onChange, initialCode, code, languageClass }) => {

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -1,0 +1,166 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
+import * as Hds from 'hds-react';
+import theme from 'prism-react-renderer/themes/github';
+
+import './Playground.scss';
+
+const Playground = ({ children }) => {
+  const childrenAsArray = React.Children.toArray(children);
+  if (children) {
+    const child = React.Children.only(childrenAsArray[0]);
+
+    // We need to use the first element as a base element to get the right kind of mdx-element for MDXProvider lookup in Layout.
+    return React.cloneElement(child, {
+      playground: true,
+      children: childrenAsArray,
+    });
+  }
+
+  return null;
+};
+
+Playground.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Playground;
+
+const clearSelection = () => {
+  if (window.getSelection) {
+    window.getSelection().removeAllRanges();
+  } else if (document.selection) {
+    document.selection.empty();
+  }
+};
+
+const copy = (textarea) => {
+  textarea.focus();
+  textarea.select();
+
+  try {
+    document.execCommand('copy');
+  } catch (err) {
+    console.warn('Oops, unable to copy');
+  }
+  clearSelection();
+};
+
+const Editor = ({ onChange, hasChanged, languageClass, reset }) => {
+  const editorRef = React.useRef();
+  const textAreaId = `code-block-textarea-${languageClass}`;
+  const helperTextId = `code-block-helper-${languageClass}`;
+  const getTextArea = useCallback((el) => el.querySelector(`#${textAreaId}`), [textAreaId]);
+
+  useEffect(() => {
+    if (editorRef.current) {
+      const textArea = getTextArea(editorRef.current);
+      textArea.setAttribute('aria-describedby', helperTextId);
+    }
+  }, [getTextArea, helperTextId]);
+
+  return (
+    <>
+      <div className="playground-block-editor">
+        <div className="playground-block-editor-viewport">
+          <div ref={editorRef} className="playground-block-editor-code">
+            <div className="playground-block-editor-texts">
+              <label className="playground-block-editor-label" htmlFor={textAreaId}>
+                Editable code example
+              </label>
+              <span className="playground-block-editor-helper" id={helperTextId}>
+                Press Enter to start editing. Press Esc to stop editing.
+              </span>
+            </div>
+            <LiveEditor
+              onChange={onChange}
+              style={{ background: 'none', padding: '0', overflow: 'visible', whiteSpace: 'nowrap' }}
+              textareaId={textAreaId}
+              theme={theme}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="playground-block-buttons">
+        <Hds.Button
+          variant="secondary"
+          size="small"
+          onClick={() => {
+            if (editorRef.current) {
+              const textArea = getTextArea(editorRef.current);
+              copy(textArea);
+            }
+          }}
+        >
+          Copy code
+        </Hds.Button>
+        <Hds.Button
+          variant="secondary"
+          iconLeft={<Hds.IconArrowUndo aria-hidden />}
+          size="small"
+          disabled={!hasChanged}
+          onClick={() => {
+            reset();
+          }}
+        >
+          Reset example
+        </Hds.Button>
+      </div>
+      <LiveError />
+    </>
+  );
+};
+
+Editor.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  reset: PropTypes.func.isRequired,
+  hasChanged: PropTypes.bool.isRequired,
+  languageClass: PropTypes.string.isRequired,
+};
+
+const EditorWithLive = withLive(Editor);
+
+const CodeBlock = ({ codeBlock }) => {
+  const initialCode = codeBlock.code;
+  const [code, setCode] = useState(initialCode);
+
+  return (
+    <LiveProvider code={code} scope={{ ...Hds }}>
+      <div className="playground-block-content">
+        <LivePreview className="playground-block-preview" />
+        <EditorWithLive
+          onChange={setCode}
+          reset={() => setCode(initialCode)}
+          hasChanged={code !== initialCode}
+          languageClass={codeBlock.languageClass}
+        />
+      </div>
+    </LiveProvider>
+  );
+};
+
+export const PlaygroundBlock = ({ codeBlocks }) => {
+  return (
+    <div className="playground-block">
+      <Hds.Tabs>
+        <Hds.TabList className="playground-block-tabs">
+          {codeBlocks.map((codeBlock) => (
+            <Hds.Tab key={codeBlock.languageClass}>
+              {codeBlock.languageClass === 'language-jsx' ? 'React' : 'Core'}
+            </Hds.Tab>
+          ))}
+        </Hds.TabList>
+        {codeBlocks.map((codeBlock) => (
+          <Hds.TabPanel key={codeBlock.languageClass}>
+            <CodeBlock codeBlock={codeBlock} />
+          </Hds.TabPanel>
+        ))}
+      </Hds.Tabs>
+    </div>
+  );
+};
+
+PlaygroundBlock.propTypes = {
+  codeBlocks: PropTypes.array,
+};

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -162,26 +162,17 @@ Editor.propTypes = {
 
 const EditorWithLive = withLive(Editor);
 
-const CodeBlock = ({ codeBlock }) => {
-  const initialCode = codeBlock.code;
-  const [code, setCode] = useState(initialCode);
-
-  return (
-    <LiveProvider code={code} scope={{ ...Hds }}>
-      <div className="playground-block-content">
-        <LivePreview className="playground-block-preview" />
-        <EditorWithLive
-          onChange={setCode}
-          initialCode={initialCode}
-          code={code}
-          languageClass={codeBlock.languageClass}
-        />
-      </div>
-    </LiveProvider>
-  );
-};
-
 export const PlaygroundBlock = ({ codeBlocks }) => {
+  const codeByLanguage = codeBlocks.reduce((acc, block) => {
+    acc[block.languageClass] = block.code;
+    return acc;
+  }, {});
+
+  const [codeByLanguageState, setCodeByLanguageState] = useState(codeByLanguage);
+  const setCodeByLanguage = (languageClass) => (code) => {
+    setCodeByLanguageState({ ...codeByLanguageState, [languageClass]: code });
+  };
+
   return (
     <div className="playground-block">
       <Hds.Tabs>
@@ -192,9 +183,19 @@ export const PlaygroundBlock = ({ codeBlocks }) => {
             </Hds.Tab>
           ))}
         </Hds.TabList>
-        {codeBlocks.map((codeBlock) => (
-          <Hds.TabPanel key={codeBlock.languageClass}>
-            <CodeBlock codeBlock={codeBlock} />
+        {codeBlocks.map(({ code, languageClass }) => (
+          <Hds.TabPanel key={languageClass}>
+            <LiveProvider code={codeByLanguageState[languageClass]} scope={{ ...Hds }}>
+              <div className="playground-block-content">
+                <LivePreview className="playground-block-preview" />
+                <EditorWithLive
+                  initialCode={code}
+                  languageClass={languageClass}
+                  onChange={setCodeByLanguage(languageClass)}
+                  code={codeByLanguageState[languageClass]}
+                />
+              </div>
+            </LiveProvider>
           </Hds.TabPanel>
         ))}
       </Hds.Tabs>

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -55,13 +55,6 @@ const Editor = ({ onChange, initialCode, code, language }) => {
     [getTextArea],
   );
 
-  const onTextAreaBlur = useCallback((e) => {
-    // Set viewport focus on textarea Esc keypress (no related target)
-    if (viewPortRef.current && !e.relatedTarget) {
-      viewPortRef.current.focus();
-    }
-  }, []);
-
   const copy = () => {
     if (viewPortRef.current && copyButtonRef.current) {
       const textArea = getTextArea(viewPortRef.current);
@@ -93,9 +86,14 @@ const Editor = ({ onChange, initialCode, code, language }) => {
       const textArea = getTextArea(viewPortRef.current);
       textArea.setAttribute('aria-describedby', helperTextId);
       textArea.setAttribute('tabIndex', '-1');
-      textArea.addEventListener('blur', onTextAreaBlur);
+      textArea.addEventListener('blur', (e) => {
+        // Set viewport focus on textarea Esc keypress (no related target)
+        if (viewPortRef.current && !e.relatedTarget) {
+          viewPortRef.current.focus();
+        }
+      });
     }
-  }, [getTextArea, helperTextId, onTextAreaBlur]);
+  }, [getTextArea, helperTextId]);
 
   return (
     <>

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -133,6 +133,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
                   whiteSpace: 'nowrap',
                   width: 'max-content',
                   minWidth: '100%',
+                  fontSize: '16px'
                 }}
                 textareaId={textAreaId}
                 theme={theme}

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { mdx as createMdxReactElement } from '@mdx-js/react';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
 import { Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
@@ -9,11 +10,10 @@ import './Playground.scss';
 
 const Playground = ({ children }) => {
   const childrenAsArray = React.Children.toArray(children);
-  if (children) {
-    const child = React.Children.only(childrenAsArray[0]);
 
-    // We need to use the first element as a base element to get the right kind of mdx-element for MDXProvider lookup in Layout.
-    return React.cloneElement(child, {
+  if (children) {
+    // Create a wrapper mxd pre-element around code blocks
+    return createMdxReactElement('pre', {
       playground: true,
       children: childrenAsArray,
     });

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -162,6 +162,16 @@ Editor.propTypes = {
 
 const EditorWithLive = withLive(Editor);
 
+const sanitize = (code) => {
+  const trimmedCode = code.trim();
+  const cleanedCode =
+    trimmedCode.startsWith('{') && trimmedCode.endsWith('}')
+      ? trimmedCode.substr(1, trimmedCode.length - 2).trim()
+      : trimmedCode;
+
+  return cleanedCode;
+};
+
 export const PlaygroundBlock = ({ codeBlocks }) => {
   const codeByLanguage = codeBlocks.reduce((acc, block) => {
     acc[block.languageClass] = block.code;
@@ -185,7 +195,7 @@ export const PlaygroundBlock = ({ codeBlocks }) => {
         </Hds.TabList>
         {codeBlocks.map(({ code, languageClass }) => (
           <Hds.TabPanel key={languageClass}>
-            <LiveProvider code={codeByLanguageState[languageClass]} scope={{ ...Hds }}>
+            <LiveProvider code={sanitize(codeByLanguageState[languageClass])} scope={{ ...Hds }}>
               <div className="playground-block-content">
                 <LivePreview className="playground-block-preview" />
                 <EditorWithLive

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -3,6 +3,7 @@
 @import '~hds-design-tokens/lib/all.scss';
 
 .playground-block {
+  --focus-border-width: 2px;
   margin: var(--spacing-l) 0;
 }
 
@@ -21,8 +22,6 @@
 }
 
 .playground-block-editor {
-  --focus-border-width: 2px;
-
   background-color: var(--color-black-5);
   border: 2px solid var(--color-black-50);
   border-top: 0 none;
@@ -44,15 +43,22 @@
 .playground-block-editor-viewport {
   position: relative;
 
-  textarea,
-  pre {
-    padding-left: calc(var(--spacing-s) - var(--focus-border-width)) !important;
+  &:after {
+    border: var(--focus-border-width) solid transparent;
+    box-sizing: border-box;
+    content: '';
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    width: 100%;
+    top: 0;
   }
 
-  textarea {
-    &:focus {
-      outline: 0 none;
-      border: 3px solid var(--color-coat-of-arms) !important;
+  &:focus {
+    outline: 0 none;
+
+    &:after {
+      border-color: var(--color-coat-of-arms);
     }
   }
 }

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -25,17 +25,28 @@
   background-color: var(--color-black-5);
   border: 2px solid var(--color-black-50);
   border-top: 0 none;
+}
+
+.playground-block-editor-code-input {
+  background: none !important;
+  font-size: 16px !important;
+  min-width: 100% !important;
+  overflow: visible !important;
+  white-space: nowrap !important;
+  width: max-content !important;
 
   textarea,
   pre {
-    padding-left: calc(var(--spacing-s) - var(--focus-border-width)) !important;
-    padding-right: var(--spacing-s);
+    border: 3px solid transparent !important;
+    line-height: 24px !important;
+    padding: 0 var(--spacing-s) var(--spacing-s) !important;
+    vertical-align: middle !important;
   }
 
   textarea {
     &:focus {
       outline: 0 none;
-      border: 3px solid var(--color-coat-of-arms) !important;
+      border-color: var(--color-coat-of-arms) !important;
     }
   }
 }

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -30,6 +30,7 @@
   textarea,
   pre {
     padding-left: calc(var(--spacing-s) - var(--focus-border-width)) !important;
+    padding-right: var(--spacing-s);
   }
 
   textarea {
@@ -41,16 +42,7 @@
 }
 
 .playground-block-editor-viewport {
-  overflow-x: auto;
-  width: 100%;
-}
-
-.playground-block-editor-code {
-  --focus-border-width: 2px;
-
-  overflow-x: auto;
   position: relative;
-  width: max(100%, 660px);
 
   textarea,
   pre {
@@ -63,6 +55,10 @@
       border: 3px solid var(--color-coat-of-arms) !important;
     }
   }
+}
+
+.playground-block-editor-scrollbox {
+  overflow-x: auto;
 }
 
 .playground-block-editor-texts {

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -65,7 +65,6 @@
 
 .playground-block-editor-scrollbox {
   overflow-x: auto;
-  padding-bottom: var(--spacing-s);
 }
 
 .playground-block-editor-texts {

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -46,8 +46,23 @@
 }
 
 .playground-block-editor-code {
+  --focus-border-width: 2px;
+
   overflow-x: auto;
+  position: relative;
   width: max(100%, 660px);
+
+  textarea,
+  pre {
+    padding-left: calc(var(--spacing-s) - var(--focus-border-width)) !important;
+  }
+
+  textarea {
+    &:focus {
+      outline: 0 none;
+      border: 3px solid var(--color-coat-of-arms) !important;
+    }
+  }
 }
 
 .playground-block-editor-texts {

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -65,6 +65,7 @@
 
 .playground-block-editor-scrollbox {
   overflow-x: auto;
+  padding-bottom: var(--spacing-s);
 }
 
 .playground-block-editor-texts {

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -1,0 +1,89 @@
+@charset "utf-8";
+
+@import '~hds-design-tokens/lib/all.scss';
+
+.playground-block {
+  margin: var(--spacing-l) 0;
+}
+
+.playground-block-tabs {
+  --tablist-border-color: transparent;
+  background: var(--color-black-5);
+}
+
+.playground-block-content {
+  margin: -1px 0 var(--spacing-2-xl);
+}
+
+.playground-block-preview {
+  border: 2px solid var(--color-black-50);
+  padding: var(--spacing-l);
+}
+
+.playground-block-editor {
+  --focus-border-width: 2px;
+
+  background-color: var(--color-black-5);
+  border: 2px solid var(--color-black-50);
+  border-top: 0 none;
+
+  textarea,
+  pre {
+    padding-left: calc(var(--spacing-s) - var(--focus-border-width)) !important;
+  }
+
+  textarea {
+    &:focus {
+      outline: 0 none;
+      border: 3px solid var(--color-coat-of-arms) !important;
+    }
+  }
+}
+
+.playground-block-editor-viewport {
+  overflow-x: auto;
+  width: 100%;
+}
+
+.playground-block-editor-code {
+  overflow-x: auto;
+  width: max(100%, 660px);
+}
+
+.playground-block-editor-texts {
+  padding: var(--spacing-s);
+}
+
+.playground-block-editor-label {
+  display: block;
+  font: var(--font-default);
+  font-weight: bold;
+}
+
+.playground-block-editor-helper {
+  display: block;
+  font-size: var(--fontsize-body-s);
+}
+
+.playground-block-buttons {
+  > * {
+    margin-top: var(--spacing-s);
+    width: 100%;
+  }
+}
+
+@media screen and (min-width: $breakpoint-m) {
+  .playground-block-buttons {
+    display: flex;
+    margin-top: var(--spacing-s);
+
+    > * {
+      margin-top: 0;
+      width: auto;
+    }
+
+    > * + * {
+      margin-left: var(--spacing-s);
+    }
+  }
+}

--- a/new-site/src/components/SyntaxHighlighter.js
+++ b/new-site/src/components/SyntaxHighlighter.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Highlight, { defaultProps } from 'prism-react-renderer';
+import theme from 'prism-react-renderer/themes/github';
+
+import './SyntaxHighlighter.scss';
+
+const SyntaxHighlighter = (props) => {
+  const className = props.children.props.className;
+  const matches = className.match(/language-(?<lang>.*)/);
+  return (
+    <Highlight
+      {...defaultProps}
+      code={props.children.props.children.trim()}
+      theme={theme}
+      language={matches && matches.groups && matches.groups.lang ? matches.groups.lang : ''}
+    >
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={`${className} syntax-highlighter`} style={style}>
+          {tokens.map((line, i) => (
+            <div {...getLineProps({ line, key: i })}>
+              {line.map((token, key) => (
+                <span {...getTokenProps({ token, key })} />
+              ))}
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
+};
+
+export default SyntaxHighlighter;

--- a/new-site/src/components/SyntaxHighlighter.scss
+++ b/new-site/src/components/SyntaxHighlighter.scss
@@ -1,0 +1,3 @@
+.syntax-highlighter {
+  padding: var(--spacing-s);
+}

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -12,6 +12,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { Container, Footer, Navigation, SideNavigation } from 'hds-react';
 import Seo from './seo';
 import { PlaygroundBlock } from './Playground';
+import SyntaxHighlighter from './SyntaxHighlighter';
 import './layout.scss';
 
 const PreComponent = (props) => {
@@ -26,9 +27,8 @@ const PreComponent = (props) => {
     );
   }
 
-  return null;
-};
-
+  return <SyntaxHighlighter {...props} />;
+}
 PreComponent.propTypes = {
   children: PropTypes.node.isRequired,
 };

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -17,18 +17,11 @@ import './layout.scss';
 
 const PreComponent = (props) => {
   if (props.playground) {
-    return (
-      <PlaygroundBlock
-        codeBlocks={props.children.map((child) => ({
-          languageClass: child.props.children.props.className,
-          code: child.props.children.props.children,
-        }))}
-      />
-    );
+    return <PlaygroundBlock {...props} />;
   }
 
   return <SyntaxHighlighter {...props} />;
-}
+};
 PreComponent.propTypes = {
   children: PropTypes.node.isRequired,
 };

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -10,9 +10,32 @@ import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, withPrefix, Link as GatsbyLink, navigate } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import { Container, Footer, Navigation, SideNavigation } from 'hds-react';
-
 import Seo from './seo';
+import { PlaygroundBlock } from './Playground';
 import './layout.scss';
+
+const PreComponent = (props) => {
+  if (props.playground) {
+    return (
+      <PlaygroundBlock
+        codeBlocks={props.children.map((child) => ({
+          languageClass: child.props.children.props.className,
+          code: child.props.children.props.children,
+        }))}
+      />
+    );
+  }
+
+  return null;
+};
+
+PreComponent.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const components = {
+  pre: PreComponent,
+};
 
 const resolveCurrentMenuItem = (menuItems, slugWithPrefix) => {
   const rootPath = withPrefix('/');
@@ -180,7 +203,7 @@ const Layout = ({ children, pageContext }) => {
             </aside>
           )}
           <main id={contentId} className="mainContent">
-            <MDXProvider>{children}</MDXProvider>
+            <MDXProvider components={components}>{children}</MDXProvider>
           </main>
         </Container>
         <Footer id="page-footer" className="pageFooter" title={footerTitle} footerAriaLabel={footerAriaLabel}>

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -15,19 +15,9 @@ import { PlaygroundBlock } from './Playground';
 import SyntaxHighlighter from './SyntaxHighlighter';
 import './layout.scss';
 
-const PreComponent = (props) => {
-  if (props.playground) {
-    return <PlaygroundBlock {...props} />;
-  }
-
-  return <SyntaxHighlighter {...props} />;
-};
-PreComponent.propTypes = {
-  children: PropTypes.node.isRequired,
-};
-
 const components = {
-  pre: PreComponent,
+  Playground: PlaygroundBlock,
+  pre: SyntaxHighlighter
 };
 
 const resolveCurrentMenuItem = (menuItems, slugWithPrefix) => {

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -93,6 +93,11 @@ body {
   min-width: 230px;
 }
 
+.mainContent {
+  overflow: hidden;
+  width: 100%;
+}
+
 @media screen and (min-width: $breakpoint-m) {
   .pageContent {
     display: flex;

--- a/new-site/src/docs/elements/components/button.mdx
+++ b/new-site/src/docs/elements/components/button.mdx
@@ -1,8 +1,0 @@
----
-slug: "/elements/components/button"
-title: "Button"
----
-
-# Button
-
-Button

--- a/new-site/src/docs/elements/components/buttons.mdx
+++ b/new-site/src/docs/elements/components/buttons.mdx
@@ -1,0 +1,38 @@
+---
+slug: '/elements/components/buttons'
+title: 'Buttons'
+---
+
+import { Button, StatusLabel } from 'hds-react';
+import Playground from '../../../components/Playground';
+
+import 'hds-core/lib/components/button/button.css';
+
+# Buttons
+
+## Usage & variations
+
+### Primary button
+
+A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
+
+<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
+  Accessible
+</StatusLabel>
+
+Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
+
+<Playground>
+
+```jsx
+<Button>Primary</Button>
+```
+
+```html
+<button type="button" class="hds-button hds-button--primary">
+  <span class="hds-button__label">Primary</span>
+</button>
+```
+
+</Playground>

--- a/new-site/src/docs/elements/components/buttons.mdx
+++ b/new-site/src/docs/elements/components/buttons.mdx
@@ -23,6 +23,7 @@ A Primary button is reserved for the most important action on the screen. Primar
 
 Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
 
+### Code examples
 <Playground>
 
 ```jsx

--- a/new-site/src/docs/elements/components/buttons.mdx
+++ b/new-site/src/docs/elements/components/buttons.mdx
@@ -24,10 +24,15 @@ A Primary button is reserved for the most important action on the screen. Primar
 Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
 
 ### Code examples
+
 <Playground>
 
 ```jsx
-<Button>Primary</Button>
+{
+  () => {
+    return <Button>Primary</Button>;
+  }
+}
 ```
 
 ```html

--- a/new-site/src/docs/elements/components/buttons.mdx
+++ b/new-site/src/docs/elements/components/buttons.mdx
@@ -28,11 +28,7 @@ Buttons are meant to make actions easily visible and understandable to the user.
 <Playground>
 
 ```jsx
-{
-  () => {
-    return <Button>Primary</Button>;
-  }
-}
+<Button>Primary</Button>
 ```
 
 ```html

--- a/new-site/yarn.lock
+++ b/new-site/yarn.lock
@@ -1996,6 +1996,13 @@
   resolved "https://registry.yarnpkg.com/@turist/time/-/time-0.0.2.tgz#32fe0ce708ea0f4512776bd313409f1459976dda"
   integrity sha512-qLOvfmlG2vCVw5fo/oz8WAZYlpe5a5OurgTj3diIxJCdjRHpapC+vQCz3er9LV79Vcat+DifBjeAhOAdmndtDQ==
 
+"@types/buble@^0.20.0":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@types/buble/-/buble-0.20.1.tgz#cba009801fd417b0d2eb8fa6824b537842e05803"
+  integrity sha512-itmN3lGSTvXg9IImY5j290H+n0B3PpZST6AgEfJJDXfaMx2cdJJZro3/Ay+bZZdIAa25Z5rnoo9rHiPCbANZoQ==
+  dependencies:
+    magic-string "^0.25.0"
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
@@ -3211,6 +3218,18 @@ browserslist@^4.0.0, browserslist@^4.12.2, browserslist@^4.14.5, browserslist@^4
     nanocolors "^0.1.5"
     node-releases "^1.1.76"
 
+buble@0.19.6:
+  version "0.19.6"
+  resolved "https://registry.yarnpkg.com/buble/-/buble-0.19.6.tgz#915909b6bd5b11ee03b1c885ec914a8b974d34d3"
+  integrity sha512-9kViM6nJA1Q548Jrd06x0geh+BG2ru2+RMDkIHHgJY/8AcyCs34lTHwra9BX7YdPrZXd5aarkpr/SY8bmPgPdg==
+  dependencies:
+    chalk "^2.4.1"
+    magic-string "^0.25.1"
+    minimist "^1.2.0"
+    os-homedir "^1.0.1"
+    regexpu-core "^4.2.0"
+    vlq "^1.0.0"
+
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
@@ -3706,6 +3725,16 @@ component-emitter@^1.2.1, component-emitter@~1.3.0:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
+component-props@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/component-props/-/component-props-1.1.1.tgz#f9b7df9b9927b6e6d97c9bd272aa867670f34944"
+  integrity sha1-+bffm5kntubZfJvScqqGdnDzSUQ=
+
+component-xor@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/component-xor/-/component-xor-0.0.4.tgz#c55d83ccc1b94cd5089a4e93fa7891c7263e59aa"
+  integrity sha1-xV2DzMG5TNUImk6T+niRxyY+Wao=
+
 compose-function@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
@@ -3885,6 +3914,11 @@ core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
+core-js@^3.14.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.0.tgz#9e40098a9bc326c7e81b486abbd5e12b9d275176"
+  integrity sha512-L1TpFRWXZ76vH1yLM+z6KssLZrP8Z6GxxW4auoCj+XiViOzNPJCAuTIkn03BGdFe6Z5clX5t64wRIRypsZQrUg==
 
 core-js@^3.17.2:
   version "3.18.1"
@@ -4470,6 +4504,14 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dom-iterator/-/dom-iterator-1.0.0.tgz#9c09899846ec41c2d257adc4d6015e4759ef05ad"
+  integrity sha512-7dsMOQI07EMU98gQM8NSB3GsAiIeBYIPKpnxR3c9xOvdvBjChAcOM0iJ222I3p5xyiZO9e5oggkNaCusuTdYig==
+  dependencies:
+    component-props "1.1.1"
+    component-xor "0.0.4"
 
 dom-serializer@0:
   version "0.2.2"
@@ -7960,6 +8002,13 @@ lru-queue@^0.1.0:
   dependencies:
     es5-ext "~0.10.2"
 
+magic-string@^0.25.0, magic-string@^0.25.1:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -8853,6 +8902,11 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -9625,6 +9679,11 @@ pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+prism-react-renderer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
+  integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==
+
 probe-image-size@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-6.0.0.tgz#4a85b19d5af4e29a8de7d53a9aa036f6fd02f5f4"
@@ -9904,6 +9963,20 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-live@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-live/-/react-live-2.3.0.tgz#09fbac361903970e7cf51cee60729eeb164a5d87"
+  integrity sha512-b+Nc7x/bLu2sPX/If1uncrmUvYtXTqxY8QpzBw/X76SA3QJ1ggU0Ld6X5phLXZ469+XWO5lOU7OpAt0JoTyZPQ==
+  dependencies:
+    "@types/buble" "^0.20.0"
+    buble "0.19.6"
+    core-js "^3.14.0"
+    dom-iterator "^1.0.0"
+    prism-react-renderer "^1.2.1"
+    prop-types "^15.7.2"
+    react-simple-code-editor "^0.11.0"
+    unescape "^1.0.1"
+
 react-merge-refs@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
@@ -9926,6 +9999,11 @@ react-side-effect@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
   integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
+
+react-simple-code-editor@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.11.0.tgz#bb57c7c29b570f2ab229872599eac184f5bc673c"
+  integrity sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw==
 
 react-spring@9.0.0-rc.3:
   version "9.0.0-rc.3"
@@ -10107,7 +10185,7 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
-regexpu-core@^4.7.1:
+regexpu-core@^4.2.0, regexpu-core@^4.7.1:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.8.0.tgz#e5605ba361b67b1718478501327502f4479a98f0"
   integrity sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==
@@ -10939,6 +11017,11 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
 space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
@@ -11762,6 +11845,13 @@ underscore.string@^3.3.5:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+unescape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unescape/-/unescape-1.0.1.tgz#956e430f61cad8a4d57d82c518f5e6cc5d0dda96"
+  integrity sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==
+  dependencies:
+    extend-shallow "^2.0.1"
+
 unherit@^1.0.4:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
@@ -12226,6 +12316,11 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vlq@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
+  integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
 warning@^4.0.2:
   version "4.0.3"


### PR DESCRIPTION
## Description
- Add custom playground component which is more accessible and easier to use for new documentation
- Show Syntaxblock for other code blocks (non-playground blocks)

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1021

## Motivation and Context
- HDS is using Docz's playground component to provide a live example of components. This PR uses the same component react-live underneath. But it is more customized for HDS needs, accessibility, more apparent code block, etc.

## How Has This Been Tested?
- Locally on dev's machine

## Screenshots (if appropriate):
<img width="316" alt="Screenshot 2021-11-02 at 13 03 59" src="https://user-images.githubusercontent.com/1610860/139860182-7be9f597-8ef7-4dd6-8c75-37359887f9c8.png">
<img width="700" alt="Screenshot 2021-11-02 at 13 03 39" src="https://user-images.githubusercontent.com/1610860/139860192-9093a8f1-9461-4326-a7bc-47c775ca055c.png">

👉 [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/docsite-playground/elements/components/buttons/)