### PR TITLE
Fix/Cascade linkbox styles to correct div

### DIFF
--- a/packages/react/src/components/linkbox/Linkbox.tsx
+++ b/packages/react/src/components/linkbox/Linkbox.tsx
@@ -108,7 +108,7 @@ export const Linkbox = ({
       onClick={() => {
         linkRef.current.click();
       }}
-      className={classNames(styles.linkbox, withBorder && styles.withBorder)}
+      className={classNames(styles.linkbox, withBorder && styles.withBorder, className)}
       aria-label={composeAriaLabel(linkboxAriaLabel)}
     >
       {imgProps && <img {...imgProps} className={styles.image} alt="" />}
@@ -144,7 +144,7 @@ export const Linkbox = ({
         {children}
       </div>
       <a
-        className={classNames(styles.link, className)}
+        className={styles.link}
         aria-label={composeAriaLabel(linkAriaLabel)}
         ref={linkRef}
         tabIndex={-1}


### PR DESCRIPTION
## Description

Cascade linkbox className to correct div. This helps to customize the component more if needed

## Resolves

https://github.com/City-of-Helsinki/helsinki-design-system/issues/533