### PR TITLE
Fix/select null resetting

### DIFF
--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -96,7 +96,7 @@ export const Controlled = (args) => {
         style={{ marginTop: 'var(--spacing-s)' }}
       />
 
-      <Button onClick={() => setSelectedItems(null)} style={{ marginTop: 'var(--spacing-l)' }}>
+      <Button onClick={() => setSelectedItems([])} style={{ marginTop: 'var(--spacing-l)' }}>
         Reset
       </Button>
       <Button

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -96,7 +96,7 @@ export const Controlled = (args) => {
         style={{ marginTop: 'var(--spacing-s)' }}
       />
 
-      <Button onClick={() => setSelectedItems([])} style={{ marginTop: 'var(--spacing-l)' }}>
+      <Button onClick={() => setSelectedItems(null)} style={{ marginTop: 'var(--spacing-l)' }}>
         Reset
       </Button>
       <Button

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -204,7 +204,7 @@ export type MultiSelectProps<OptionType> = CommonSelectProps<OptionType> & {
   /**
    * Value(s) that should be selected when the dropdown is initialized
    */
-  defaultValue?: OptionType[];
+  defaultValue?: OptionType[] | null;
   /**
    * Function used to generate an ARIA a11y message when an item is removed. See [here](https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection#geta11yremovalmessage) for more information.
    */
@@ -228,7 +228,7 @@ export type MultiSelectProps<OptionType> = CommonSelectProps<OptionType> & {
   /**
    * The selected value(s)
    */
-  value?: OptionType[];
+  value?: OptionType[] | null;
 };
 
 export type SelectProps<OptionType> = SingleSelectProps<OptionType> | MultiSelectProps<OptionType>;

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -177,7 +177,7 @@ export type SingleSelectProps<OptionType> = CommonSelectProps<OptionType> & {
   /**
    * Value that should be selected when the dropdown is initialized
    */
-  defaultValue?: OptionType;
+  defaultValue?: OptionType | null;
   /**
    * Icon to be shown in the dropdown
    */
@@ -189,7 +189,7 @@ export type SingleSelectProps<OptionType> = CommonSelectProps<OptionType> & {
   /**
    * The selected value
    */
-  value?: OptionType;
+  value?: OptionType | null;
 };
 
 export type MultiSelectProps<OptionType> = CommonSelectProps<OptionType> & {


### PR DESCRIPTION
## Description
- Accept null as single Select defaultValue and value

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1034

## Motivation and Context
- Resetting Select value with null (as it should be with controlled components) causes a Typescript error

## How Has This Been Tested?
- Locally on dev's machine