### PR TITLE
Fix/Duplicate checkbox id bug

### DIFF
--- a/packages/react/src/components/table/Table.stories.tsx
+++ b/packages/react/src/components/table/Table.stories.tsx
@@ -547,6 +547,7 @@ export const CheckboxSelection = (args) => {
         selectedRows={selectedRows}
         setSelectedRows={setSelectedRows}
         heading="Employees"
+        id="checkbox-selection"
         indexKey="id"
         renderIndexCol={false}
         cols={cols}
@@ -593,6 +594,7 @@ export const CheckboxSelectionDense = (args) => {
         selectedRows={selectedRows}
         setSelectedRows={setSelectedRows}
         heading="Employees"
+        id="checkbox-selection-dense"
         cols={cols}
         rows={rows}
         indexKey="id"
@@ -635,6 +637,7 @@ export const InitiallySelectedRows = (args) => {
     <div style={{ maxWidth: '640px' }}>
       <Table
         heading="Employees"
+        id="initially-selected"
         checkboxSelection
         selectedRows={selectedRows}
         setSelectedRows={setSelectedRows}
@@ -739,6 +742,7 @@ export const WithCustomActions = (args) => {
         cols={cols}
         rows={tableRows}
         heading="Employees"
+        id="custom-actions"
         indexKey={indexKey}
         renderIndexCol={false}
         variant="dark"
@@ -796,6 +800,7 @@ export const CheckboxSelectionWithSorting = (args) => {
         indexKey="id"
         renderIndexCol={false}
         heading="Employees"
+        id="selection-with-sorting"
       />
     </div>
   );

--- a/packages/react/src/components/table/Table.test.tsx
+++ b/packages/react/src/components/table/Table.test.tsx
@@ -97,7 +97,7 @@ describe('<Table /> spec', () => {
     );
     const ageOfFirstRow = container.querySelector('[data-testid="age-0"] > div');
     expect(ageOfFirstRow).toHaveTextContent('39');
-    userEvent.click(container.querySelector('[data-testid="table-sorting-header-age"]'));
+    userEvent.click(container.querySelector('[data-testid="hds-table-sorting-header-age"]'));
     const ageOfSortedTableFirstRow = container.querySelector('[data-testid="age-0"] > div');
     expect(ageOfSortedTableFirstRow).toHaveTextContent('8');
   });
@@ -122,13 +122,13 @@ describe('<Table /> spec', () => {
 
     const { container } = render(<TableWithSelection />);
 
-    expect(container.querySelector('[id="hds-table-checkbox-1000"]')).not.toBeChecked();
+    expect(container.querySelector('[id="hds-table-id-checkbox-1000"]')).not.toBeChecked();
 
-    userEvent.click(container.querySelector('[id="hds-table-checkbox-1000"]'));
-    expect(container.querySelector('[id="hds-table-checkbox-1000"]')).toBeChecked();
+    userEvent.click(container.querySelector('[id="hds-table-id-checkbox-1000"]'));
+    expect(container.querySelector('[id="hds-table-id-checkbox-1000"]')).toBeChecked();
 
-    userEvent.click(container.querySelector('[id="hds-table-checkbox-1000"]'));
-    expect(container.querySelector('[id="hds-table-checkbox-1000"]')).not.toBeChecked();
+    userEvent.click(container.querySelector('[id="hds-table-id-checkbox-1000"]'));
+    expect(container.querySelector('[id="hds-table-id-checkbox-1000"]')).not.toBeChecked();
   });
 
   it('Should successfully select all and deselect all rows', () => {
@@ -152,17 +152,17 @@ describe('<Table /> spec', () => {
     const { container } = render(<TableWithSelection />);
 
     rows.forEach((row) => {
-      expect(container.querySelector(`[id="hds-table-checkbox-${row.id}"]`)).not.toBeChecked();
+      expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).not.toBeChecked();
     });
 
     userEvent.click(container.querySelector('[data-testid="hds-table-select-all-button"]'));
     rows.forEach((row) => {
-      expect(container.querySelector(`[id="hds-table-checkbox-${row.id}"]`)).toBeChecked();
+      expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).toBeChecked();
     });
 
     userEvent.click(container.querySelector('[data-testid="hds-table-deselect-all-button"]'));
     rows.forEach((row) => {
-      expect(container.querySelector(`[id="hds-table-checkbox-${row.id}"]`)).not.toBeChecked();
+      expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).not.toBeChecked();
     });
   });
 });

--- a/packages/react/src/components/table/Table.test.tsx
+++ b/packages/react/src/components/table/Table.test.tsx
@@ -155,12 +155,12 @@ describe('<Table /> spec', () => {
       expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).not.toBeChecked();
     });
 
-    userEvent.click(container.querySelector('[data-testid="hds-table-select-all-button"]'));
+    userEvent.click(container.querySelector('[data-testid="hds-table-select-all-button-hds-table-data-testid"]'));
     rows.forEach((row) => {
       expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).toBeChecked();
     });
 
-    userEvent.click(container.querySelector('[data-testid="hds-table-deselect-all-button"]'));
+    userEvent.click(container.querySelector('[data-testid="hds-table-deselect-all-button-hds-table-data-testid"]'));
     rows.forEach((row) => {
       expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).not.toBeChecked();
     });

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -107,9 +107,14 @@ export type TableProps = React.ComponentPropsWithoutRef<'table'> & {
   headingAriaLevel?: number;
   /**
    * Table heading id. Used to name table to assistive technologies. Only applicable when heading prop is used.
-   * @default 'hds-table'
+   * @default 'hds-table-heading-id'
    */
   headingId?: string;
+  /**
+   * Id that is passed to the native html table element.
+   * @default 'hds-table-id'
+   */
+  id?: string;
   /**
    * Column key used as a unique identifier for a row
    */
@@ -232,7 +237,8 @@ export const Table = ({
   dense = false,
   heading,
   headingAriaLevel = 2,
-  headingId = 'hds-table',
+  headingId = 'hds-table-heading-id',
+  id = 'hds-table-id',
   indexKey,
   initialSortingColumnKey,
   initialSortingOrder,
@@ -357,6 +363,7 @@ export const Table = ({
         variant={variant}
         dataTestId={dataTestId}
         dense={dense}
+        id={id}
         zebra={zebra}
         verticalLines={verticalLines}
         customThemeClass={customThemeClass}
@@ -401,7 +408,7 @@ export const Table = ({
                 <td className={styles.checkboxData}>
                   <Checkbox
                     checked={selectedRows.includes(row[indexKey])}
-                    id={`hds-table-checkbox-${row[indexKey]}`}
+                    id={`${id}-checkbox-${row[indexKey]}`}
                     aria-label={`${ariaLabelCheckboxSelection} ${row[firstRenderedColumnKey]}`}
                     onChange={(e) => {
                       if (e.target.checked) {

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -90,6 +90,7 @@ export type TableProps = React.ComponentPropsWithoutRef<'table'> & {
   customActionButtons?: React.ReactNode[];
   /**
    * Test id attribute that is passed to the html table element.
+   * @default 'hds-table-data-testid'
    */
   dataTestId?: string;
   /**
@@ -233,7 +234,7 @@ export const Table = ({
   clearSelectionsText = 'Tyhjennä valinnat',
   cols,
   customActionButtons,
-  dataTestId,
+  dataTestId = 'hds-table-data-testid',
   dense = false,
   heading,
   headingAriaLevel = 2,
@@ -329,9 +330,7 @@ export const Table = ({
                     size="small"
                     disabled={selectedRows.length === rows.length}
                     className={styles.actionButton}
-                    data-testid={
-                      dataTestId ? `hds-table-select-all-button-${dataTestId}` : 'hds-table-select-all-button'
-                    }
+                    data-testid={`hds-table-select-all-button-${dataTestId}`}
                   >
                     {selectAllRowsText}
                   </Button>
@@ -343,9 +342,7 @@ export const Table = ({
                     size="small"
                     disabled={selectedRows.length === 0}
                     className={styles.actionButton}
-                    data-testid={
-                      dataTestId ? `hds-table-deselect-all-button-${dataTestId}` : 'hds-table-deselect-all-button'
-                    }
+                    data-testid={`hds-table-deselect-all-button-${dataTestId}`}
                   >
                     {clearSelectionsText}
                   </Button>

--- a/packages/react/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<Table /> spec renders the component 1`] = `
   >
     <table
       class="table dark"
+      id="hds-table-id"
     >
       <caption
         class="caption"

--- a/packages/react/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<Table /> spec renders the component 1`] = `
   >
     <table
       class="table dark"
+      data-testid="hds-table-data-testid"
       id="hds-table-id"
     >
       <caption

--- a/packages/react/src/components/table/components/SortingHeaderCell/SortingHeaderCell.tsx
+++ b/packages/react/src/components/table/components/SortingHeaderCell/SortingHeaderCell.tsx
@@ -69,7 +69,7 @@ export const SortingHeaderCell = ({
     <th className={styles.sortingHeader} scope="col" {...rest}>
       <div className={styles.sortColumnCell}>
         <button
-          data-testid={`table-sorting-header-${colKey}`}
+          data-testid={`hds-table-sorting-header-${colKey}`}
           className={styles.sortButton}
           type="button"
           onClick={(event) => {

--- a/packages/react/src/components/table/components/TableContainer/TableContainer.tsx
+++ b/packages/react/src/components/table/components/TableContainer/TableContainer.tsx
@@ -9,6 +9,7 @@ export type TableContainerProps = React.ComponentPropsWithoutRef<'table'> & {
   children: React.ReactNode;
   dataTestId?: string;
   variant?: 'dark' | 'light';
+  id: string;
   dense?: boolean;
   zebra?: boolean;
   verticalLines?: boolean;
@@ -20,6 +21,7 @@ export const TableContainer = ({
   children,
   dataTestId,
   variant = 'dark',
+  id,
   dense = false,
   zebra = false,
   verticalLines = false,
@@ -41,6 +43,7 @@ export const TableContainer = ({
         )}
         aria-labelledby={headingId}
         data-testid={dataTestId}
+        id={id}
         {...rest}
       >
         {children}

--- a/site/docs/components/table.mdx
+++ b/site/docs/components/table.mdx
@@ -1418,6 +1418,7 @@ HDS Table rows can be set to be selectable. This makes the first column to be a 
         selectedRows={selectedRows}
         setSelectedRows={setSelectedRows}
         heading="Employees"
+        id="checkbox-selection"
         indexKey="id"
         renderIndexCol={false}
         cols={cols}
@@ -1466,6 +1467,7 @@ return (
       selectedRows={selectedRows}
       setSelectedRows={setSelectedRows}
       heading="Employees"
+      id="checkbox-selection"
       indexKey="id"
       renderIndexCol={false}
       cols={cols}
@@ -1560,6 +1562,7 @@ If the action you need is not directly supported by the HDS Table, you can also 
         cols={cols}
         rows={tableRows}
         heading="Employees"
+        id="custom-actions"
         indexKey={indexKey}
         renderIndexCol={false}
         variant="dark"
@@ -1661,6 +1664,7 @@ return (
       cols={cols}
       rows={tableRows}
       heading="Employees"
+      id="custom-actions"
       indexKey={indexKey}
       renderIndexCol={false}
       variant="dark"


### PR DESCRIPTION
## Description

Fixes the bug with duplicate ids with table checkboxes. Also small improvements to table id's default names

## How to reproduce the bug

Have multiple HDS React tables on the same page, which are created from the same data rows. When this condition is met, there will be identical ids for the table checkboxes. Having duplicate ids is a violation of html in some cases, and generally not recommended at all.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1123

## How Has This Been Tested?

- Locally on developers machine
