### PR TITLE
[Fix] add support to remove selectedItem with an enter and space keypress

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -67,6 +67,22 @@ describe('<Combobox />', () => {
   });
 
   describe('in multi select mode', () => {
+    it('user should be able to remove selected item with enter keypress', async () => {
+      const onChange = jest.fn();
+      const firstSelectedOptionName = `Selected item ${options[0].label}`;
+      const { getAllByLabelText, getAllByRole, queryAllByRole } = getWrapper({ onChange, multiselect: true });
+      const input = getAllByLabelText(label)[0];
+      userEvent.type(input, 'Fi');
+      const visibleOptions = getAllByRole('option');
+      userEvent.click(visibleOptions[0]);
+
+      await waitFor(() => {
+        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(1);
+        userEvent.type(queryAllByRole('link', { name: firstSelectedOptionName })[0], '{enter}');
+        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(0);
+      });
+    });
+
     it('user should be able to search and choose multiple options', async () => {
       const onChange = jest.fn();
       const { getAllByLabelText, getAllByRole, queryAllByText } = getWrapper({

--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -83,6 +83,22 @@ describe('<Combobox />', () => {
       });
     });
 
+    it('user should be able to remove selected item with space keypress', async () => {
+      const onChange = jest.fn();
+      const firstSelectedOptionName = `Selected item ${options[0].label}`;
+      const { getAllByLabelText, getAllByRole, queryAllByRole } = getWrapper({ onChange, multiselect: true });
+      const input = getAllByLabelText(label)[0];
+      userEvent.type(input, 'Fi');
+      const visibleOptions = getAllByRole('option');
+      userEvent.click(visibleOptions[0]);
+
+      await waitFor(() => {
+        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(1);
+        userEvent.type(queryAllByRole('link', { name: firstSelectedOptionName })[0], '{space}');
+        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(0);
+      });
+    });
+
     it('user should be able to search and choose multiple options', async () => {
       const onChange = jest.fn();
       const { getAllByLabelText, getAllByRole, queryAllByText } = getWrapper({

--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -77,9 +77,9 @@ describe('<Combobox />', () => {
       userEvent.click(visibleOptions[0]);
 
       await waitFor(() => {
-        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(1);
-        userEvent.type(queryAllByRole('link', { name: firstSelectedOptionName })[0], '{enter}');
-        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(0);
+        expect(queryAllByRole('button', { name: firstSelectedOptionName }).length).toBe(1);
+        userEvent.type(queryAllByRole('button', { name: firstSelectedOptionName })[0], '{enter}');
+        expect(queryAllByRole('button', { name: firstSelectedOptionName }).length).toBe(0);
       });
     });
 
@@ -93,9 +93,9 @@ describe('<Combobox />', () => {
       userEvent.click(visibleOptions[0]);
 
       await waitFor(() => {
-        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(1);
-        userEvent.type(queryAllByRole('link', { name: firstSelectedOptionName })[0], '{space}');
-        expect(queryAllByRole('link', { name: firstSelectedOptionName }).length).toBe(0);
+        expect(queryAllByRole('button', { name: firstSelectedOptionName }).length).toBe(1);
+        userEvent.type(queryAllByRole('button', { name: firstSelectedOptionName })[0], '{space}');
+        expect(queryAllByRole('button', { name: firstSelectedOptionName }).length).toBe(0);
       });
     });
 

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -239,7 +239,8 @@ export const SelectedItems = <OptionType,>({
                 onKeyDown: (event) => {
                   // some browsers navigate back when Backspace is pressed
                   if (event.key === 'Backspace') event.preventDefault();
-                  else if (event.key === 'Enter') {
+                  // Add support to remove an item with an enter or a space keypress
+                  else if (event.key === 'Enter' || event.key === ' ') {
                     event.preventDefault();
                     onRemove(_selectedItem);
                   }

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -223,6 +223,7 @@ export const SelectedItems = <OptionType,>({
               className={styles.tag}
               id={tagId}
               labelProps={{ 'aria-labelledby': `${dropdownId}-label ${tagId}-label` }}
+              role="button"
               deleteButtonAriaLabel={replaceTokenWithValue(removeButtonAriaLabel, selectedItemLabel)}
               // remove delete button from focus order
               deleteButtonProps={{

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -239,6 +239,10 @@ export const SelectedItems = <OptionType,>({
                 onKeyDown: (event) => {
                   // some browsers navigate back when Backspace is pressed
                   if (event.key === 'Backspace') event.preventDefault();
+                  else if (event.key === 'Enter') {
+                    event.preventDefault();
+                    onRemove(_selectedItem);
+                  }
                 },
                 onFocus: () => setActiveIndex(index),
               })}


### PR DESCRIPTION
## Description
- Add support for removing a selected item with an enter and space keypress from multiselect and combobox
- Use role=button in Combobox and Select tags

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1107

## Motivation and Context
- This feature was reported as a bug. The behaviour might have changed in some library update. I did not find this change from the [Downshift major release](https://github.com/downshift-js/downshift/releases/tag/v6.0.0).

## How Has This Been Tested?
- locally on dev machine
- in unit test

👉 [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/combobox-enter-remove/?path=/story/components-dropdowns-combobox--multiselect)