### PR TITLE
Feature/Add icon support for multiselect variants of Select and Combobox components

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.module.scss
+++ b/packages/react/src/components/dropdown/combobox/Combobox.module.scss
@@ -15,6 +15,10 @@
   display: flex;
 }
 
+.wrapper.wrapperWithMultiSelectAndIcon {
+  align-items: flex-start;
+}
+
 /**
  * TOGGLE BUTTON
  */
@@ -144,6 +148,24 @@
     &.adjustSpacing {
       margin-top: calc(var(--spacing-2-xs) * -1);
       padding: 0 var(--spacing-s);
+    }
+  }
+
+  .inputWithIcon.inputWithIcon {
+    padding-left: 0;
+  }
+
+  .multiselectIconAndInputWrapper {
+    flex-direction: row;
+    display: flex;
+    align-items: center;
+
+    &:not(:focus-within).hidden {
+      @extend %hiddenFromScreen;
+    }
+
+    .icon.adjustSpacingForIcon {
+      margin-top: calc(var(--spacing-2-xs) * -1);
     }
   }
 }

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -153,6 +153,15 @@ DisabledOptions.storyName = 'With disabled options';
 export const Icon = (args) => <Combobox {...args} icon={<IconFaceSmile />} />;
 Icon.storyName = 'With icon';
 
+export const MultiselectWithIcon = (args) => <Combobox {...args} icon={<IconFaceSmile />} />;
+MultiselectWithIcon.storyName = 'Multi-select with icon';
+MultiselectWithIcon.args = {
+  multiselect: true,
+  options: getRegionOptions(),
+};
+
+MultiselectWithIcon.parameters = { loki: { skip: true } };
+
 export const Tooltip = (args) => <Combobox {...args} />;
 Tooltip.storyName = 'With tooltip';
 Tooltip.args = {

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -5,7 +5,7 @@ import uniqueId from 'lodash.uniqueid';
 
 import { Button } from '../../button';
 import { Combobox } from './Combobox';
-import { IconFaceSmile } from '../../../icons';
+import { IconFaceSmile, IconLocation } from '../../../icons';
 
 type Option = { label: string };
 
@@ -153,7 +153,7 @@ DisabledOptions.storyName = 'With disabled options';
 export const Icon = (args) => <Combobox {...args} icon={<IconFaceSmile />} />;
 Icon.storyName = 'With icon';
 
-export const MultiselectWithIcon = (args) => <Combobox {...args} icon={<IconFaceSmile />} />;
+export const MultiselectWithIcon = (args) => <Combobox {...args} icon={<IconLocation />} />;
 MultiselectWithIcon.storyName = 'Multi-select with icon';
 MultiselectWithIcon.args = {
   multiselect: true,

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -335,7 +335,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   const inputAriaLabel =
     `${getLabelProps().id}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getInputProps().id}`;
 
-  const renderInput = () => (
+  const ComboboxInput = () => (
     <input
       {...getInputProps({
         ...(invalid && { 'aria-invalid': true }),
@@ -482,10 +482,10 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             >
               {props.icon}
             </span>
-            {renderInput()}
+            <ComboboxInput />
           </div>
         ) : (
-          renderInput()
+          <ComboboxInput />
         )}
         {/* TOGGLE BUTTON */}
         <button

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -335,7 +335,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   const inputAriaLabel =
     `${getLabelProps().id}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getInputProps().id}`;
 
-  const ComboboxInput = () => (
+  const renderInput = () => (
     <input
       {...getInputProps({
         ...(invalid && { 'aria-invalid': true }),
@@ -482,10 +482,10 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             >
               {props.icon}
             </span>
-            <ComboboxInput />
+            {renderInput()}
           </div>
         ) : (
-          <ComboboxInput />
+          renderInput()
         )}
         {/* TOGGLE BUTTON */}
         <button

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -335,6 +335,53 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   const inputAriaLabel =
     `${getLabelProps().id}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getInputProps().id}`;
 
+  const renderInput = () => (
+    <input
+      {...getInputProps({
+        ...(invalid && { 'aria-invalid': true }),
+        ...(props.multiselect && {
+          ...getDropdownProps({
+            // Change Downshift's default behavior with space.
+            // Instead of typing a space character into the
+            // search input, it now selects an item without
+            // closing the dropdown menu.
+
+            // Our custom keyDown handler also blocks other
+            // dropdown key events when the menu is open. This
+            // would normally be done with the
+            // 'preventKeyAction' setting, but it would also
+            // block our custom handler from executing, which
+            // would break the special behavior we have
+            // implemented for space. We want to block other key
+            // actions in order to ensure that dropdown and
+            // input props don't conflict.
+            onKeyDown: handleMultiSelectInputKeyDown,
+            ref: inputRef,
+          }),
+        }),
+        type: 'text',
+        disabled,
+        required,
+        role: getComboboxProps().role,
+        'aria-expanded': getComboboxProps()['aria-expanded'],
+        'aria-haspopup': getComboboxProps()['aria-haspopup'],
+        'aria-owns': getComboboxProps()['aria-owns'],
+        'aria-labelledby': inputAriaLabel,
+        'aria-describedby': customAriaDescribedBy,
+      })}
+      placeholder={placeholder}
+      className={classNames(
+        styles.input,
+        !isInputVisible && styles.hidden,
+        !showToggleButton && styles.noToggle,
+        hasFocus && selectedItems.length > 0 && styles.adjustSpacing,
+        props.icon && props.multiselect && styles.inputWithIcon,
+      )}
+      autoCorrect="off"
+      autoComplete="off"
+    />
+  );
+
   return (
     <div
       className={classNames(
@@ -394,7 +441,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
         onFocus={ignoreFocusHandlerWhenClickingItem(handleWrapperFocus)}
         onBlur={ignoreFocusHandlerWhenClickingItem(handleWrapperBlur)}
         onClick={handleWrapperClick}
-        className={classNames(styles.wrapper)}
+        className={classNames(styles.wrapper, props.multiselect && props.icon && styles.wrapperWithMultiSelectAndIcon)}
         ref={getComboboxProps().ref}
       >
         {/* SELECTED ITEMS */}
@@ -421,56 +468,25 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             toggleButtonHidden={!showToggleButton}
           />
         )}
-        {/* icons are only supported by the single select combobox */}
         {props.multiselect === false && props.icon && (
           <span className={styles.icon} aria-hidden>
             {props.icon}
           </span>
         )}
         {/* FILTER INPUT */}
-        <input
-          {...getInputProps({
-            ...(invalid && { 'aria-invalid': true }),
-            ...(props.multiselect && {
-              ...getDropdownProps({
-                // Change Downshift's default behavior with space.
-                // Instead of typing a space character into the
-                // search input, it now selects an item without
-                // closing the dropdown menu.
-
-                // Our custom keyDown handler also blocks other
-                // dropdown key events when the menu is open. This
-                // would normally be done with the
-                // 'preventKeyAction' setting, but it would also
-                // block our custom handler from executing, which
-                // would break the special behavior we have
-                // implemented for space. We want to block other key
-                // actions in order to ensure that dropdown and
-                // input props don't conflict.
-                onKeyDown: handleMultiSelectInputKeyDown,
-                ref: inputRef,
-              }),
-            }),
-            type: 'text',
-            disabled,
-            required,
-            role: getComboboxProps().role,
-            'aria-expanded': getComboboxProps()['aria-expanded'],
-            'aria-haspopup': getComboboxProps()['aria-haspopup'],
-            'aria-owns': getComboboxProps()['aria-owns'],
-            'aria-labelledby': inputAriaLabel,
-            'aria-describedby': customAriaDescribedBy,
-          })}
-          placeholder={placeholder}
-          className={classNames(
-            styles.input,
-            !isInputVisible && styles.hidden,
-            !showToggleButton && styles.noToggle,
-            hasFocus && selectedItems.length > 0 && styles.adjustSpacing,
-          )}
-          autoCorrect="off"
-          autoComplete="off"
-        />
+        {props.multiselect && props.icon ? (
+          <div className={classNames(styles.multiselectIconAndInputWrapper, !isInputVisible && styles.hidden)}>
+            <span
+              className={classNames(styles.icon, hasFocus && selectedItems.length > 0 && styles.adjustSpacingForIcon)}
+              aria-hidden
+            >
+              {props.icon}
+            </span>
+            {renderInput()}
+          </div>
+        ) : (
+          renderInput()
+        )}
         {/* TOGGLE BUTTON */}
         <button
           type="button"

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -140,6 +140,13 @@ DisabledOptions.storyName = 'With disabled options';
 export const Icon = (args) => <Select {...args} icon={<IconFaceSmile />} />;
 Icon.storyName = 'With icon';
 
+export const MultiselectWithIcon = (args) => <Select {...args} icon={<IconFaceSmile />} />;
+MultiselectWithIcon.storyName = 'Multi-select with icon';
+MultiselectWithIcon.args = {
+  multiselect: true,
+};
+MultiselectWithIcon.parameters = { loki: { skip: true } };
+
 export const Tooltip = (args) => <Select {...args} />;
 Tooltip.storyName = 'With tooltip';
 Tooltip.args = {

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -5,7 +5,7 @@ import uniqueId from 'lodash.uniqueid';
 
 import { Button } from '../../button';
 import { Select } from './Select';
-import { IconFaceSmile } from '../../../icons';
+import { IconFaceSmile, IconLocation } from '../../../icons';
 
 type Option = { label: string };
 
@@ -140,7 +140,7 @@ DisabledOptions.storyName = 'With disabled options';
 export const Icon = (args) => <Select {...args} icon={<IconFaceSmile />} />;
 Icon.storyName = 'With icon';
 
-export const MultiselectWithIcon = (args) => <Select {...args} icon={<IconFaceSmile />} />;
+export const MultiselectWithIcon = (args) => <Select {...args} icon={<IconLocation />} />;
 MultiselectWithIcon.storyName = 'Multi-select with icon';
 MultiselectWithIcon.args = {
   multiselect: true,

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -98,6 +98,10 @@ export type CommonSelectProps<OptionType> = {
    */
   error?: React.ReactNode;
   /**
+   * Icon to be shown in the dropdown
+   */
+  icon?: React.ReactNode;
+  /**
    * Used to generate the first part of the id on the elements
    */
   id?: string;
@@ -178,10 +182,6 @@ export type SingleSelectProps<OptionType> = CommonSelectProps<OptionType> & {
    * Value that should be selected when the dropdown is initialized
    */
   defaultValue?: OptionType | null;
-  /**
-   * Icon to be shown in the dropdown
-   */
-  icon?: React.ReactNode;
   /**
    * Callback function fired when the state is changed
    */
@@ -458,6 +458,9 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   // show placeholder if no value is selected
   const showPlaceholder = (props.multiselect && selectedItems.length === 0) || (!props.multiselect && !selectedItem);
 
+  const showIcon =
+    (props.icon && props.multiselect === false) || (props.icon && props.multiselect && selectedItems.length === 0);
+
   return (
     <div
       className={classNames(
@@ -515,8 +518,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
             className: classNames(styles.button, showPlaceholder && styles.placeholder),
           })}
         >
-          {/* icons are only supported by single selects */}
-          {props.multiselect === false && props.icon && (
+          {showIcon && (
             <span className={styles.icon} aria-hidden>
               {props.icon}
             </span>

--- a/site/docs/components/dropdown.mdx
+++ b/site/docs/components/dropdown.mdx
@@ -137,7 +137,7 @@ Select dropdown serves in most use cases when the user needs to select one of 4 
 
 Select multi-selection variant allows the user to select one or more options simultaneously. Note! Select dropdown does not feature filtering options by typing. When this feature is needed or there are a large number of options available, consider using consider using [Combobox](#combobox-multi-selection).
 
-An icon depicting the specific functionality of the multiselect variant in question should be added before the text input.  
+Multi-select also supports icon if needed.
 
 <Playground>
 <Select
@@ -279,7 +279,7 @@ Combobox dropdown serves in most use cases when the user needs to select one fro
 
 Combobox multi-select variant allows the user to select one or more options simultaneously. Combobox variant features filtering options by typing.
 
-An icon depicting the specific functionality of the multiselect in question should be added before the text input or filter tags.  
+Multi-select also supports icon if needed.
 
 <Playground>
 <Combobox

--- a/site/docs/components/dropdown.mdx
+++ b/site/docs/components/dropdown.mdx
@@ -39,6 +39,12 @@ import Link from "../../src/components/Link";
   - there are 8 or more options
   - the user needs to be able to filter options by typing
 
+### Icon or no icon?
+- **Use an icon when**
+  - there is a clear added value to using an icon
+  - when the icon is not just for illustrative purposes
+  - when you can add an icon to all select and combobox elements in the formgroup to maintain consistency
+  
 ## Accessibility
 
 - Dropdowns should be only used as form controls or as value pickers. Do not use dropdowns for menus or navigation since they cannot contain links or buttons.
@@ -130,6 +136,8 @@ Select dropdown serves in most use cases when the user needs to select one of 4 
 ### Select (multi-selection)
 
 Select multi-selection variant allows the user to select one or more options simultaneously. Note! Select dropdown does not feature filtering options by typing. When this feature is needed or there are a large number of options available, consider using consider using [Combobox](#combobox-multi-selection).
+
+An icon depicting the specific functionality of the multiselect variant in question should be added before the text input.  
 
 <Playground>
 <Select
@@ -270,6 +278,8 @@ Combobox dropdown serves in most use cases when the user needs to select one fro
 ### Combobox (multi-selection)
 
 Combobox multi-select variant allows the user to select one or more options simultaneously. Combobox variant features filtering options by typing.
+
+An icon depicting the specific functionality of the multiselect in question should be added before the text input or filter tags.  
 
 <Playground>
 <Combobox


### PR DESCRIPTION
## Description

Add icon support for multiselect variants of Select and Combobox components

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-991

## How Has This Been Tested?

- Locally on developers machine

:point_right: [Storybook demo Combobox](https://city-of-helsinki.github.io/hds-demo/icon-with-multiselect-for-select-and-combobox/?path=/story/components-dropdowns-combobox--multiselect-with-icon)
:point_right: [Storybook demo Select](https://city-of-helsinki.github.io/hds-demo/icon-with-multiselect-for-select-and-combobox/?path=/story/components-dropdowns-select--multiselect-with-icon)

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2777633/144254171-fdbfb564-037b-4027-b665-678d3f3cef21.png)
![image](https://user-images.githubusercontent.com/2777633/144254264-c601606d-c1d5-4d0d-9ca5-db8cc6dddf0f.png)



