### PR TITLE
Submit selected suggestionItem on click

### DIFF
--- a/packages/react/src/components/searchInput/SearchInput.test.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { SearchInput } from './SearchInput';
@@ -49,5 +49,25 @@ describe('<SearchInput /> spec', () => {
     expect(onChange.mock.calls[2][0]).toBe('tes');
     userEvent.type(input, 't');
     expect(onChange.mock.calls[3][0]).toBe('test');
+  });
+
+  it('submits the selected item on mouse click', async () => {
+    const onSubmit = jest.fn();
+    const { getAllByLabelText, getAllByRole } = render(
+      <SearchInput<SuggestionItemType>
+        label="search"
+        suggestionLabelField="value"
+        getSuggestions={getSuggestions}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const input = getAllByLabelText('search')[0];
+    userEvent.type(input, 'a');
+    await waitFor(() => {
+      const options = getAllByRole('option');
+      userEvent.click(options[0]);
+    });
+    expect(onSubmit.mock.calls[0][0]).toBe('Apple');
   });
 });

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useState, useRef, useEffect } from 'react';
+import React, { KeyboardEvent, useState, useRef, useEffect, useCallback } from 'react';
 import { useCombobox } from 'downshift';
 
 // import core base styles
@@ -104,9 +104,9 @@ export const SearchInput = <SuggestionItem,>({
 }: SearchInputProps<SuggestionItem>) => {
   const didMount = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isItemClicked = useRef<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>('');
-  const [isItemClicked, setIsItemClicked] = useState<boolean>(false);
   const { suggestions, isLoading } = useSuggestions<SuggestionItem>(inputValue, getSuggestions, isSubmitted);
   const showLoadingSpinner = useShowLoadingSpinner(isLoading, 1500 - SUGGESTIONS_DEBOUNCE_VALUE);
 
@@ -127,16 +127,16 @@ export const SearchInput = <SuggestionItem,>({
     onStateChange(props) {
       const { ItemClick } = useCombobox.stateChangeTypes;
       if (props.type === ItemClick) {
-        setIsItemClicked(true);
+        isItemClicked.current = true;
       }
     },
     itemToString: (item) => (item ? `${item[suggestionLabelField]}` : ''),
   });
 
-  const submit = () => {
+  const submit = useCallback(() => {
     setIsSubmitted(true);
     onSubmit(inputValue);
-  };
+  }, [setIsSubmitted, onSubmit, inputValue]);
 
   const onInputKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
     const key = event.key || event.keyCode;
@@ -148,11 +148,11 @@ export const SearchInput = <SuggestionItem,>({
   };
 
   useEffect(() => {
-    if (isItemClicked) {
+    if (isItemClicked.current) {
+      isItemClicked.current = false;
       submit();
-      setIsItemClicked(false);
     }
-  }, [isItemClicked, submit, setIsItemClicked]);
+  }, [isItemClicked, submit]);
 
   const clear = () => {
     reset();

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -106,8 +106,10 @@ export const SearchInput = <SuggestionItem,>({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>('');
+  const [isItemClicked, setIsItemClicked] = useState<boolean>(false);
   const { suggestions, isLoading } = useSuggestions<SuggestionItem>(inputValue, getSuggestions, isSubmitted);
   const showLoadingSpinner = useShowLoadingSpinner(isLoading, 1500 - SUGGESTIONS_DEBOUNCE_VALUE);
+
   const {
     isOpen,
     getLabelProps,
@@ -121,6 +123,12 @@ export const SearchInput = <SuggestionItem,>({
     items: suggestions,
     onInputValueChange: (e) => {
       setInputValue(e.inputValue);
+    },
+    onStateChange(props) {
+      const { ItemClick } = useCombobox.stateChangeTypes;
+      if (props.type === ItemClick) {
+        setIsItemClicked(true);
+      }
     },
     itemToString: (item) => (item ? `${item[suggestionLabelField]}` : ''),
   });
@@ -138,6 +146,13 @@ export const SearchInput = <SuggestionItem,>({
       setIsSubmitted(false);
     }
   };
+
+  useEffect(() => {
+    if (isItemClicked) {
+      submit();
+      setIsItemClicked(false);
+    }
+  }, [isItemClicked, submit, setIsItemClicked]);
 
   const clear = () => {
     reset();


### PR DESCRIPTION
## Description
- Submit selected item on mouse click

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-986

## Motivation and Context
- Search did not trigger submit when suggestionItem was selected with a mouse click. It triggered the submit only with an enter keypress

## How Has This Been Tested?
- Locally on dev machine
- in unit test

👉 [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/search-input-fix/?path=/story/components-searchinput--with-suggestions)

## How it can be tested: 
Go to [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/search-input-fix/?path=/story/components-searchinput--with-suggestions). Open the browser console and type "a" to Search input and select "Apple". It should write "Submitted value: Apple" in the console. 
It does not write anything in the [production](https://hds.hel.fi/storybook/react/?path=/story/components-searchinput--with-suggestions) when an item is selected with a click.