### PR TITLE
Feature/search input on change

### DIFF
--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -65,13 +65,10 @@ const asynchronousSearchOperation = (inputValue: string, timeout = 0) => {
 const longLastingAsynchronousSearchOperation = (inputValue: string) => asynchronousSearchOperation(inputValue, 5000);
 
 export const Default = (args) => {
-  const onChange = (value: string) => {
-    console.log('input value changed:', value);
-  };
   const onSubmit = (value: string) => {
     console.log('Search for:', value);
   };
-  return <SearchInput {...args} onSubmit={onSubmit} onChange={onChange} />;
+  return <SearchInput {...args} onSubmit={onSubmit} />;
 };
 Default.args = {
   label: 'Search',
@@ -82,6 +79,7 @@ export const WithCustomSearchButton = (args) => {
   const currentValue = useRef<string>('');
 
   const onChange = (value: string) => {
+    console.log('Input value changed:', value);
     currentValue.current = value;
   };
 
@@ -134,10 +132,6 @@ export const WithSuggestions = (args) => {
     return suggestions;
   };
 
-  const onChange = (value: string) => {
-    console.log('input value changed:', value);
-  };
-
   const onSubmit = (value: string) => {
     console.log('Submitted value:', value);
   };
@@ -148,7 +142,6 @@ export const WithSuggestions = (args) => {
       suggestionLabelField="value"
       getSuggestions={getSuggestions}
       onSubmit={onSubmit}
-      onChange={onChange}
     />
   );
 };
@@ -168,10 +161,6 @@ export const WithSuggestionsAndHighlighting = (args) => {
     return suggestions;
   };
 
-  const onChange = (value: string) => {
-    console.log('input value changed:', value);
-  };
-
   const onSubmit = (value: string) => {
     console.log('Submitted value:', value);
   };
@@ -182,7 +171,6 @@ export const WithSuggestionsAndHighlighting = (args) => {
       suggestionLabelField="value"
       getSuggestions={getSuggestions}
       onSubmit={onSubmit}
-      onChange={onChange}
     />
   );
 };

--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { SearchInput } from './SearchInput';
 import { Button } from '../button';
@@ -65,10 +65,13 @@ const asynchronousSearchOperation = (inputValue: string, timeout = 0) => {
 const longLastingAsynchronousSearchOperation = (inputValue: string) => asynchronousSearchOperation(inputValue, 5000);
 
 export const Default = (args) => {
+  const onChange = (value: string) => {
+    console.log('input value changed:', value);
+  };
   const onSubmit = (value: string) => {
     console.log('Search for:', value);
   };
-  return <SearchInput {...args} onSubmit={onSubmit} />;
+  return <SearchInput {...args} onSubmit={onSubmit} onChange={onChange} />;
 };
 Default.args = {
   label: 'Search',
@@ -76,13 +79,20 @@ Default.args = {
 };
 
 export const WithCustomSearchButton = (args) => {
-  const onSubmit = (value: string) => {
-    console.log('Search for:', value);
+  const currentValue = useRef<string>('');
+
+  const onChange = (value: string) => {
+    currentValue.current = value;
+  };
+
+  const onSubmit = (string) => {
+    console.log('Search for:', string);
   };
 
   const doSearch = () => {
-    console.log('Search');
+    if (currentValue.current) console.log('Search:', currentValue.current);
   };
+
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap' }}>
       <style>
@@ -106,7 +116,7 @@ export const WithCustomSearchButton = (args) => {
         }
       `}
       </style>
-      <SearchInput className="search-input" {...args} hideSearchButton onSubmit={onSubmit} />
+      <SearchInput className="search-input" {...args} hideSearchButton onSubmit={onSubmit} onChange={onChange} />
       <Button className="search-button" onClick={doSearch}>
         Search
       </Button>
@@ -124,6 +134,10 @@ export const WithSuggestions = (args) => {
     return suggestions;
   };
 
+  const onChange = (value: string) => {
+    console.log('input value changed:', value);
+  };
+
   const onSubmit = (value: string) => {
     console.log('Submitted value:', value);
   };
@@ -134,6 +148,7 @@ export const WithSuggestions = (args) => {
       suggestionLabelField="value"
       getSuggestions={getSuggestions}
       onSubmit={onSubmit}
+      onChange={onChange}
     />
   );
 };
@@ -153,6 +168,10 @@ export const WithSuggestionsAndHighlighting = (args) => {
     return suggestions;
   };
 
+  const onChange = (value: string) => {
+    console.log('input value changed:', value);
+  };
+
   const onSubmit = (value: string) => {
     console.log('Submitted value:', value);
   };
@@ -163,6 +182,7 @@ export const WithSuggestionsAndHighlighting = (args) => {
       suggestionLabelField="value"
       getSuggestions={getSuggestions}
       onSubmit={onSubmit}
+      onChange={onChange}
     />
   );
 };
@@ -183,6 +203,10 @@ export const WithSuggestionsSpinner = (args) => {
     return suggestions;
   };
 
+  const onChange = (value: string) => {
+    console.log('input value changed:', value);
+  };
+
   const onSubmit = (value: string) => {
     console.log('Submitted value:', value);
   };
@@ -193,6 +217,7 @@ export const WithSuggestionsSpinner = (args) => {
       suggestionLabelField="value"
       getSuggestions={getSuggestions}
       onSubmit={onSubmit}
+      onChange={onChange}
     />
   );
 };

--- a/packages/react/src/components/searchInput/SearchInput.test.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.test.tsx
@@ -1,11 +1,53 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { SearchInput } from './SearchInput';
+
+type SuggestionItemType = {
+  value: string;
+};
+
+const suggestions: SuggestionItemType[] = ['Apple', 'Apricot', 'Avocado', 'Banana'].map((str) => ({ value: str }));
+
+const getSuggestions = (inputValue: string): Promise<SuggestionItemType[]> => {
+  return new Promise<Array<{ value: string }>>((resolve) => {
+    resolve(
+      suggestions.filter((suggestion) => {
+        return suggestion.value.toLowerCase().indexOf(inputValue.toLowerCase()) > -1;
+      }),
+    );
+  });
+};
 
 describe('<SearchInput /> spec', () => {
   it('renders the component', () => {
     const { asFragment } = render(<SearchInput label="Search" onSubmit={() => null} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('calls onChange when input value changes', async () => {
+    const onChange = jest.fn();
+    // eslint-disable-next-line no-console
+    const onSubmit = () => console.log('submit');
+    const { getAllByLabelText } = render(
+      <SearchInput<SuggestionItemType>
+        label="search"
+        suggestionLabelField="value"
+        getSuggestions={getSuggestions}
+        onChange={onChange}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const input = getAllByLabelText('search')[0];
+    userEvent.type(input, 't');
+    expect(onChange.mock.calls[0][0]).toBe('t');
+    userEvent.type(input, 'e');
+    expect(onChange.mock.calls[1][0]).toBe('te');
+    userEvent.type(input, 's');
+    expect(onChange.mock.calls[2][0]).toBe('tes');
+    userEvent.type(input, 't');
+    expect(onChange.mock.calls[3][0]).toBe('test');
   });
 });

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useState, useRef } from 'react';
+import React, { KeyboardEvent, useState, useRef, useEffect } from 'react';
 import { useCombobox } from 'downshift';
 
 // import core base styles
@@ -56,6 +56,10 @@ export type SearchInputProps<SuggestionItem> = {
    */
   onSubmit: (value: string) => void;
   /**
+   * Callback function fired after input value has changed.
+   */
+  onChange?: (value: string) => void;
+  /**
    * The aria-label for the search button.
    * @default Search
    */
@@ -96,7 +100,9 @@ export const SearchInput = <SuggestionItem,>({
   style,
   suggestionLabelField,
   visibleSuggestions = 8,
+  onChange,
 }: SearchInputProps<SuggestionItem>) => {
+  const didMount = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>('');
@@ -137,6 +143,17 @@ export const SearchInput = <SuggestionItem,>({
     reset();
     inputRef.current.focus();
   };
+
+  /**
+   * Set the input value if value prop changes
+   */
+  useEffect(() => {
+    if (didMount.current && onChange) {
+      onChange(inputValue);
+    } else {
+      didMount.current = true;
+    }
+  }, [onChange, inputValue]);
 
   return (
     <div className={classNames(styles.root, isOpen && styles.open, className)} style={style}>

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -145,7 +145,7 @@ export const SearchInput = <SuggestionItem,>({
   };
 
   /**
-   * Set the input value if value prop changes
+   * Call optional onChange if input value changes
    */
   useEffect(() => {
     if (didMount.current) {

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -148,8 +148,10 @@ export const SearchInput = <SuggestionItem,>({
    * Set the input value if value prop changes
    */
   useEffect(() => {
-    if (didMount.current && onChange) {
-      onChange(inputValue);
+    if (didMount.current) {
+      if (onChange) {
+        onChange(inputValue);
+      }
     } else {
       didMount.current = true;
     }


### PR DESCRIPTION
## Description
- Add support for onChange callback
- Depends on https://github.com/City-of-Helsinki/helsinki-design-system/pull/603

## Related Issues
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-754

## Motivation and Context
- This is part of the larger concept of adding custom search button functionality. In some cases, using a custom search button might be more obvious for the user. This also makes it possible to trigger a search on input change.
- Even though originally the issue mentions onReset callback, the onChange callback can be used to detect if the input value is empty. 


## How Has This Been Tested?
- locally in dev machine
- in unit test

👉 [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/search-input-on-change/?path=/story/components-searchinput--default)
