### PR TITLE
Fix date input focus disappear bug

### DIFF
--- a/packages/react/src/components/dateInput/DateInput.stories.tsx
+++ b/packages/react/src/components/dateInput/DateInput.stories.tsx
@@ -4,6 +4,7 @@ import addDays from 'date-fns/addDays';
 import format from 'date-fns/format';
 import isWeekend from 'date-fns/isWeekend';
 import isSameDay from 'date-fns/isSameDay';
+import { addMonths } from 'date-fns';
 
 import { DateInput } from '.';
 import { Button } from '../button';
@@ -36,11 +37,14 @@ export const Default = (args) => {
   return <DateInput {...args} />;
 };
 
-export const WithMinDate = (args) => {
+export const WithMinAndMaxDate = (args) => {
   const minDate = new Date();
   minDate.setDate(4);
-  return <DateInput {...args} minDate={minDate} />;
+  const maxDate = addMonths(new Date(), 4);
+  return <DateInput {...args} minDate={minDate} maxDate={maxDate} />;
 };
+
+WithMinAndMaxDate.parameters = { loki: { skip: true } };
 
 export const WithoutConfirmation = (args) => {
   return <DateInput {...args} />;

--- a/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
@@ -313,7 +313,9 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                   class="hds-datepicker__navigation__buttons"
                 >
                   <button
+                    aria-disabled="false"
                     aria-label="Previous month"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -338,7 +340,9 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                     </svg>
                   </button>
                   <button
+                    aria-disabled="false"
                     aria-label="Next month"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -1795,7 +1799,9 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                   class="hds-datepicker__navigation__buttons"
                 >
                   <button
+                    aria-disabled="false"
                     aria-label="Previous month"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -1820,7 +1826,9 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                     </svg>
                   </button>
                   <button
+                    aria-disabled="false"
                     aria-label="Next month"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -3316,7 +3324,9 @@ exports[`<DateInput /> spec renders the component with different languages 1`] =
                   class="hds-datepicker__navigation__buttons"
                 >
                   <button
+                    aria-disabled="false"
                     aria-label="Previous month"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -3341,7 +3351,9 @@ exports[`<DateInput /> spec renders the component with different languages 1`] =
                     </svg>
                   </button>
                   <button
+                    aria-disabled="false"
                     aria-label="Next month"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -4832,7 +4844,9 @@ exports[`<DateInput /> spec renders the component with different languages 1`] =
                   class="hds-datepicker__navigation__buttons"
                 >
                   <button
+                    aria-disabled="false"
                     aria-label="Edellinen kuukausi"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -4857,7 +4871,9 @@ exports[`<DateInput /> spec renders the component with different languages 1`] =
                     </svg>
                   </button>
                   <button
+                    aria-disabled="false"
                     aria-label="Seuraava kuukausi"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -6348,7 +6364,9 @@ exports[`<DateInput /> spec renders the component with different languages 1`] =
                   class="hds-datepicker__navigation__buttons"
                 >
                   <button
+                    aria-disabled="false"
                     aria-label="Föregående månad"
+                    tabindex="0"
                     type="button"
                   >
                     <svg
@@ -6373,7 +6391,9 @@ exports[`<DateInput /> spec renders the component with different languages 1`] =
                     </svg>
                   </button>
                   <button
+                    aria-disabled="false"
                     aria-label="Nästa månad"
+                    tabindex="0"
                     type="button"
                   >
                     <svg

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
@@ -187,6 +187,11 @@
     justify-content: flex-end;
     transform: translateY(-3px);
 
+    [aria-disabled="true"] {
+      color: rgba(16, 16, 16, 0.3);
+      cursor: not-allowed;
+    }
+
     button {
       cursor: pointer;
       padding: 0.15rem;

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
@@ -188,7 +188,7 @@
     transform: translateY(-3px);
 
     [aria-disabled="true"] {
-      color: rgba(16, 16, 16, 0.3);
+      color: var(--color-black-30);
       cursor: not-allowed;
     }
 

--- a/packages/react/src/components/dateInput/components/monthNavigation/MonthNavigation.tsx
+++ b/packages/react/src/components/dateInput/components/monthNavigation/MonthNavigation.tsx
@@ -134,10 +134,22 @@ export const MonthNavigation = ({ month }: MonthCaptionProps) => {
         </div>
       </div>
       <div className={styles['hds-datepicker__navigation__buttons']}>
-        <button disabled={!prevMonth} type="button" onClick={onPrevClick} aria-label={getPrevMonthLabel()}>
+        <button
+          tabIndex={!prevMonth ? -1 : 0}
+          aria-disabled={!prevMonth}
+          type="button"
+          onClick={onPrevClick}
+          aria-label={getPrevMonthLabel()}
+        >
           <IconAngleLeft aria-hidden />
         </button>
-        <button disabled={!nextMonth} type="button" onClick={onNextClick} aria-label={getNextMonthLabel()}>
+        <button
+          tabIndex={!nextMonth ? -1 : 0}
+          aria-disabled={!nextMonth}
+          type="button"
+          onClick={onNextClick}
+          aria-label={getNextMonthLabel()}
+        >
           <IconAngleRight aria-hidden />
         </button>
       </div>


### PR DESCRIPTION
## Description

Fix date input focus disappearing bug.
Bug could be reproduced by: Set max date to next month, and click next month button.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-862

## How Has This Been Tested?

- Locally on devs machine

👉 [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/date-input-focus-bug-fix/iframe.html?id=components-dateinput--with-min-and-max-date&args=&viewMode=story)

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2777633/144629931-b228ff8f-1714-4f38-9cf1-1decb2765197.png)

