### PR TITLE
Fix/Add active state to HDS buttons to add focus outline to safari on click

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -50,7 +50,17 @@
   outline: none;
 }
 
+.hds-button:active {
+  background-color: var(--background-color-focus, transparent);
+  color: var(--color-focus);
+  outline: none;
+}
+
 .hds-button:focus:hover {
+  background-color: var(--background-color-hover-focus, transparent);
+}
+
+.hds-button:active:hover {
   background-color: var(--background-color-hover-focus, transparent);
 }
 
@@ -73,7 +83,16 @@
   border-color: var(--border-color-focus, transparent);
 }
 
+.hds-button:not(:disabled):active {
+  border-color: var(--border-color-focus, transparent);
+}
+
 .hds-button:not(:disabled):focus:hover {
+  border-color: var(--border-color-hover-focus, transparent);
+  color: var(--color-hover-focus);
+}
+
+.hds-button:not(:disabled):active:hover {
   border-color: var(--border-color-hover-focus, transparent);
   color: var(--color-hover-focus);
 }
@@ -91,6 +110,11 @@
 }
 
 .hds-button:focus::after {
+  --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
+  border-color: var(--focus-outline-color);
+}
+
+.hds-button:active::after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
   border-color: var(--focus-outline-color);
 }


### PR DESCRIPTION
## Description

Safari does not focus button on press. Therefore the focus outline that is shown in other browser did not appear on Safari. This PR adds the same focus outline for css active state, which is triggered also in Safari when button is pressed.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1126

## How Has This Been Tested?

- Locally on developers machine

:point_right: [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/button-active-styles/iframe.html?id=components-button--primary&args=&viewMode=story)

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2777633/145246864-75add759-b50f-4cbb-9e45-a5b1c5ddf97e.png)

