### PR TITLE
Restrict node version because of node-sass

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,6 +4,9 @@
   "description": "React components for the Helsinki Design System",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",
   "license": "MIT",
+  "engines": {
+    "node": ">=12 <15"
+  },
   "main": "./cjs/index.js",
   "module": "./index.js",
   "esnext": "./index.js",


### PR DESCRIPTION
## Description
- Add supported node range (v12 - v14) into package.json

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1058

## Motivation and Context
- HDS uses version 4.14 of node-sass, and it only works in node versions from v12 to v14 
- [Node-sass's Node version support policy](https://www.npmjs.com/package/node-sass)
