### PR TITLE
[Content] Added an example of asking the user's gender to the Form pattern

### DIFF
--- a/site/docs/patterns/forms.mdx
+++ b/site/docs/patterns/forms.mdx
@@ -47,6 +47,16 @@ Forms *should* be designed to be as clear and straightforward as possible, to al
                 <li>The user <em>should not</em> be made to input the same information twice.</li>
             </ul>
         </li>
+        <li><strong>Pre-populate known values</strong> if possible to make filling the form easier.
+            <ul style="margin-top:0;">
+                <li>The user <em>should not</em> be made to input the same information twice.</li>
+            </ul>
+        </li>
+        <li><strong>Use gender-neutral language.</strong>
+            <ul style="margin-top:0;">
+                <li>When asking for gender, refer to the <Link href="#asking-for-gender">example in the gender-neutrality chapter</Link>.</li>
+            </ul>
+        </li>
     </ul>
 </div>
 
@@ -837,3 +847,12 @@ For this reason it is essential to ensure that individual controls receive focus
         </li>
     </ul>
 </div>
+
+--- 
+
+## Gender-neutrality in forms
+
+### Asking for gender
+When asking for the user's gender, `Other` and `Do not want to answer` options must be provided. If these options are ordered, use order `Woman → Man → Other → Do not want to answer` since it is statistically the most probable. Using the [Selection group component](/components/selection-group) with radio buttons is recommended for this purpose.
+
+<Image src="../../static/patterns/form/form-asking-for-gender-example@2x.png" alt="An example of asking the user's gender" style="max-width:432px;" viewable />

--- a/site/static/patterns/form/form-asking-for-gender-example@2x.png
+++ b/site/static/patterns/form/form-asking-for-gender-example@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cd81f607ea748e77319c058a270e7c3947a325219931bd7a13b90d3de5e9d91
+size 26222


### PR DESCRIPTION
## Description
This PR adds an example of asking the user's gender in a form to the Form pattern documentation. 

This is part of a larger gender-neutrality guideline work. More detailed guidelines will be added later.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1083

## How Has This Been Tested?
Tested by running the documentation site locally.

## Screenshots (if appropriate):
![form-asking-for-gender-example@2x](https://user-images.githubusercontent.com/4214671/146376996-d9e880fc-f3ed-466a-aa06-8c115a115646.png)
