### PR TITLE
[Content] Added WP and Drupal notes to the Getting Started documentation

### DIFF
--- a/site/docs/get_started/for_developers.mdx
+++ b/site/docs/get_started/for_developers.mdx
@@ -15,23 +15,24 @@ import Link from "../../src/components/Link";
 
 <LargeParagraph>Helsinki Design System provides a collection of ready-made components for building accessible websites and applications that are in line with the Helsinki City Design Language.</LargeParagraph>
 
+The approved implementation techniques in the City of Helsinki are **React, WordPress and Drupal**. Currently, HDS offers implementation in HTML and React only. If your project is using WordPress or Drupal, please [refer below for more information](#wordpress-and-drupal).
+
 ## Getting started
 
-
-1. Have a look at <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external>Helsinki Design System in GitHub</Link>. You'll probably want to read the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/README.md" external>repo README</Link> first and to take a peek at the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react" external>hds-react</Link> and <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core" external>hds-core</Link>.
-2. Explore the [Components documentation](/components "Components") and <Link href="https://city-of-helsinki.github.io/helsinki-design-system/storybook/core/">HDS storybook</Link>, to see what’s there and how to implement them.
+1. Have a look at <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external>Helsinki Design System in GitHub</Link>. It is recommended to read the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/README.md" external>repository README</Link> first and then take a peek at the <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react" external>hds-react</Link> and <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core" external>hds-core</Link> packages.
+2. Explore the [Components documentation](/components "Components") and <Link href="https://city-of-helsinki.github.io/helsinki-design-system/storybook/core/">HDS storybook</Link> to see what is available and how to use them.
 3. If you want to contribute, see the [Contributing](/contributing/before-contributing "Contributing") page for more information. Please follow the <Link href="https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow" external>Git Feature Branch Workflow</Link>.
 4. Take a look at <Link href="https://dev.hel.fi/" external>Develop with Helsinki site</Link> for practical details for developing open source code for the City of Helsinki.
 
 ## Core styles
-The core package provides Helsinki City brand colours, typography and base styles as css-styles and variables.
+The Core package provides Helsinki brand colours, typography and base styles as CSS styles, and variables. Basic components are also available in HDS Core.
 
 <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core" external>hds-core in GitHub</Link>
 
 [![https://nodei.co/npm/hds-core.png?downloads=true&downloadRank=true&stars=true](https://nodei.co/npm/hds-core.png?downloads=true&downloadRank=true&stars=true)](https://www.npmjs.com/package/hds-core)
 
 ## React components
-Helsinki Design System React library provides a collection of React component for building websites and applications. Using the components will help developers to rapidly create user interfaces that are in line with the Helsinki City Design Language as well as accessible and consistent in behaviour across applications.
+Helsinki Design System React library provides a collection of React components for building websites and applications. Using these components will help developers to rapidly create user interfaces that are in line with the Helsinki City Design Language as well as accessible and consistent in behaviour across applications.
 
 <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react" external>hds-react in GitHub</Link>
 
@@ -53,3 +54,8 @@ import { TextInput } from "hds-react";
 // or
 import { TextInput } from "hds-react/components/TextInput";
 ```
+
+## WordPress and Drupal
+While HDS does not currently offer WordPress or Drupal implementations, HDS cooperates with multiple WordPress and Drupal projects in the City of Helsinki. Many of these projects have already implemented HDS components which can be reused in other projects.
+
+If your project is using either WordPress or Drupal, please contact [ketu@hel.fi](mailto:ketu@hel.fi) to learn about available implementations that follow HDS.


### PR DESCRIPTION
## Description
Added WP and Drupal notes to the developers' Getting Started documentation. The page now describes which implementations are part of HDS and which are not. Also, it states where to contact if the project is using WP or Drupal.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1008

## How Has This Been Tested?
Tested by running the documentation site locally.
