### PR TITLE
[hotfix] Remove confusing inline transform rotate from example

### DIFF
--- a/site/docs/components/koros.mdx
+++ b/site/docs/components/koros.mdx
@@ -170,7 +170,6 @@ return (
         left: 'calc(-1 * var(--koros-height))',
         position: 'absolute',
         top: 'var(--koros-height)',
-        transform: 'rotate(135deg)',
         transformOrigin: 'center',
         width: 'calc(2 * var(--hero-height))',
       }}


### PR DESCRIPTION
## Description
- Remove confusing inline rotate style from docs example

## Motivation and Context
- Koros should be rotated only with the rotate property

## How Has This Been Tested?
- locally on dev machine

