### PR TITLE
backToTopButton move focus to first visible focusable element

### DIFF
--- a/packages/react/src/components/footer/footerUtilities/FooterUtilities.test.tsx
+++ b/packages/react/src/components/footer/footerUtilities/FooterUtilities.test.tsx
@@ -4,7 +4,6 @@ import { axe } from 'jest-axe';
 
 import { FooterUtilities } from './FooterUtilities';
 import { FooterWrapper } from '../../../utils/test-utils';
-import getKeyboardFocusableElements from '../../../utils/getKeyboardFocusableElements';
 
 describe('<Footer.Utilities /> spec', () => {
   it('renders the component', () => {
@@ -30,9 +29,17 @@ describe('<Footer.Utilities /> spec', () => {
       value: 1,
     });
 
-    const { container } = render(<FooterUtilities backToTopLabel="Test label" />, { wrapper: FooterWrapper });
-
-    const firstFocusable = getKeyboardFocusableElements(container)[0];
+    const { container } = render(
+      <>
+        <p>Test paragraph</p>
+        <a id="top-link" href="/#">
+          Top link
+        </a>
+        <FooterWrapper>
+          <FooterUtilities backToTopLabel="Test label" />
+        </FooterWrapper>
+      </>,
+    );
 
     fireEvent.scroll(window, { target: { scrollY: 100 } });
 
@@ -41,6 +48,7 @@ describe('<Footer.Utilities /> spec', () => {
     fireEvent.click(backToTopButton);
 
     expect(spyScrollTo).toHaveBeenCalledWith({ top: 0 });
-    expect(firstFocusable).toHaveFocus();
+
+    expect(container.querySelector('#top-link')).toHaveFocus();
   });
 });

--- a/packages/react/src/utils/getKeyboardFocusableElements.ts
+++ b/packages/react/src/utils/getKeyboardFocusableElements.ts
@@ -9,4 +9,4 @@ export default (element = document): HTMLElement[] =>
       'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])',
     ),
     // filter out disabled elements
-  ].filter((el) => !el.hasAttribute('disabled'));
+  ].filter((el) => !el.hasAttribute('disabled') && el.offsetWidth > 0 && el.offsetHeight > 0);


### PR DESCRIPTION
## Description
Scroll to top button in footer scrolls the user to the top of the page and tries shift focus on first focusable element. However, the first element might be hidden in DOM, making it unfocusable.
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

[Bug ticket](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1161)

## Motivation and Context
Will help users relying on screen readers by shifting focus correctly
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in local HDS development environment and also in local ASTI environment
