### PR TITLE
[Content] Added a visual documentation page for Koro shapes

### DIFF
--- a/site/docs/visual_elements/koros.mdx
+++ b/site/docs/visual_elements/koros.mdx
@@ -70,7 +70,7 @@ One common use case for Koro shapes is to use them to visually separate elements
 
 <Image src="../../static/visual/koros/koro-usage-visually-separate-elements@2x.png" alt="Koros can be used to visually separate elements from each other, e.g. text areas from images" style="max-width:720px; width:100%;" viewable />
 
-Koro shapes should not be used an an accent element. They are purely meant for visual purposes.
+Koro shapes should not be used as an accent element. They are purely meant for visual purposes.
 
 <Image src="../../static/visual/koros/koro-accent-usage@2x.png" alt="Koro shapes should not be used to accent elements, e.g. to indicate an active state" style="max-width:720px; width:100%;" viewable />
 
@@ -84,7 +84,7 @@ Follow these rules when using wave motifs:
 
 <Image src="../../static/visual/koros/koro-sizes-and-aligment@2x.png" alt="Dos and Don'ts of Koro shape and alignment" style="max-width:720px; width:100%;" viewable />
 
-Be cautious when mixing Koro shapes and sizes. It is a good practise using one shape and size across the whole service or page.
+Be cautious when mixing Koro shapes and sizes. It is a good practice using one shape and size across the whole service or page.
 
 <Image src="../../static/visual/koros/mixing-koro-shapes-and-sizes@2x.png" alt="Be cautious when mixing Koro shapes and sizes." style="max-width:720px; width:100%;" viewable />
 
@@ -94,7 +94,7 @@ HDS includes a few components that have wave motif support built into them:
 - [Footer](/components/footer)
 
 ## Animation
-<p>It is allowed to animate wave motifs. While this is not directly supported in HDS Koro component, you can find more info and downloadable wave motif animation from the <Link href="https://brand.hel.fi/en/downloadable-animations/" external>Helsinki Brand website - Downloadable animations section</Link>.</p>
+<p>It is allowed to animate wave motifs. While this is not directly supported in the HDS Koro component, you can find more info and downloadable wave motif animation from the <Link href="https://brand.hel.fi/en/downloadable-animations/" external>Helsinki Brand website - Downloadable animations section</Link>.</p>
 
 ## Further reading
 Please refer to the Helsinki Brand website to learn more about wave motifs and their usage:

--- a/site/docs/visual_elements/koros.mdx
+++ b/site/docs/visual_elements/koros.mdx
@@ -1,0 +1,103 @@
+---
+name: Koros
+route: /visual-assets/koros
+menu: Visual assets
+---
+
+import LargeParagraph from "../../src/components/LargeParagraph";
+import Image from "../../src/components/Image";
+import Link from "../../src/components/Link";
+import { StatusLabel } from "hds-react";
+
+# Koros
+
+<LargeParagraph>
+  Koros, also known as wave motifs, are graphic elements that are inspired by the City of Helsinki crest. The goal of using a koro shape is to bring visual interest to the identity.
+</LargeParagraph>
+
+See the [Koros component documentation](/components/koros "Koros component documentation") for instructions on using Koros in implementation.
+
+## Visual principles
+
+### Shapes
+Wave motifs are available in six (6) different shapes:
+- Calm (Tyyni)
+- Basic (Perus)
+- Pulse (Pulssi)
+- Beat (Syke)
+- Storm (Tyrsky)
+- Wave (Värinä)
+
+<Image src="../../static/visual/koros/koro-shapes@2x.png" alt="All six (6) available koro shapes" style="max-width:720px; width:100%;" viewable />
+
+### Size
+Wave motifs can be used in any size if at least two wave tips are visible per surface. However, it is recommended to use one of two HDS provided sizes; Default or Dense.
+
+<Image src="../../static/visual/koros/koro-sizes@2x.png" alt="Two recommended Koro sizes; Default and Dense" style="max-width:720px; width:100%;" viewable />
+
+### Angle
+Wave motifs can be used in any 0, 90, and 45 degree angles.
+
+<Image src="../../static/visual/koros/allowed-koro-angles@2x.png" alt="Koros are allowed to be rotated in 45 degree increments" style="max-width:720px; width:100%;" viewable />
+
+### Colour
+Wave motif colour selection follows these guidelines:
+- Only one color per one wave motif shape (no gradients or multiple colours)
+- Any of the City of Helsinki Primary colours can be used as well as Black and White 
+  - Grayscale colours are not recommended
+    - If you need a gray colour, use the brand colour Hopea (Silver) instead
+  - Secondary and Accent colours of the palette must not be used
+
+<Image src="../../static/visual/koros/koro-colour-usage@2x.png" alt="Dos and Don'ts of Koro colour usage" style="max-width:720px; width:100%;" viewable />
+
+Additionally, a Koro shape can also act as a mask for an image.
+
+<Image src="../../static/visual/koros/koro-with-an-image@2x.png" alt="Koro shape used as a mask for an image" style="max-width:720px; width:100%;" viewable />
+
+
+## Usage
+
+### Where to use
+Wave motifs are used to visually divide surfaces from each other.
+
+<Image src="../../static/visual/koros/koro-usage-edge-of-section@2x.png" alt="Using Koros to separate sections from each other" style="max-width:720px; width:100%;" viewable />
+
+However, pay attention to the contrast between section backgrounds. Be cautious when using stark colours that have a large contrast ratio between them.
+
+<Image src="../../static/visual/koros/koro-usage-in-content-sections@2x.png" alt="Pay attention to colour contrasts when using Koros to separate sections" style="max-width:720px; width:100%;" viewable />
+
+One common use case for Koro shapes is to use them to visually separate elements from each other. For example, to separate a text area from an image.
+
+<Image src="../../static/visual/koros/koro-usage-visually-separate-elements@2x.png" alt="Koros can be used to visually separate elements from each other, e.g. text areas from images" style="max-width:720px; width:100%;" viewable />
+
+Koro shapes should not be used an an accent element. They are purely meant for visual purposes.
+
+<Image src="../../static/visual/koros/koro-accent-usage@2x.png" alt="Koro shapes should not be used to accent elements, e.g. to indicate an active state" style="max-width:720px; width:100%;" viewable />
+
+### Which size and shape to use
+Follow these rules when using wave motifs:
+- At least 2 full-wave motif “tips” visible per surface
+- It is recommended to use HDS provided sizes (Default and Dense)
+  - It is recommended to choose one size and use it throughout the whole service
+- Shape can be freely chosen (from the premade 6 shapes) by the service
+  - It is recommended to choose one shape and use it throughout the whole service
+
+<Image src="../../static/visual/koros/koro-sizes-and-aligment@2x.png" alt="Dos and Don'ts of Koro shape and alignment" style="max-width:720px; width:100%;" viewable />
+
+Be cautious when mixing Koro shapes and sizes. It is a good practise using one shape and size across the whole service or page.
+
+<Image src="../../static/visual/koros/mixing-koro-shapes-and-sizes@2x.png" alt="Be cautious when mixing Koro shapes and sizes." style="max-width:720px; width:100%;" viewable />
+
+
+### HDS components that use Koros
+HDS includes a few components that have wave motif support built into them:
+- [Footer](/components/footer)
+
+## Animation
+<p>It is allowed to animate wave motifs. While this is not directly supported in HDS Koro component, you can find more info and downloadable wave motif animation from the <Link href="https://brand.hel.fi/en/downloadable-animations/" external>Helsinki Brand website - Downloadable animations section</Link>.</p>
+
+## Further reading
+Please refer to the Helsinki Brand website to learn more about wave motifs and their usage:
+- <Link href="https://brand.hel.fi/en/wave-motifs/" external>Helsinki Brand - Wave motifs</Link>
+- <Link href="https://brand.hel.fi/en/surface-division/" external>Helsinki Brand - Surface division</Link>
+- <Link href="https://brand.hel.fi/en/downloadable-animations/" external>Helsinki Brand - Downloadable animations</Link>

--- a/site/static/visual/koros/allowed-koro-angles@2x.png
+++ b/site/static/visual/koros/allowed-koro-angles@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b56bf7eb31fbc7dbe8df062515f61d8ed6b1335ef7ecddff0b98d3ecd373b30
+size 85579

--- a/site/static/visual/koros/koro-accent-usage@2x.png
+++ b/site/static/visual/koros/koro-accent-usage@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ffd8ecc0f8a8630099d5d3dd589fd8929f82529a493546b923ed79afb4b58ce
+size 56450

--- a/site/static/visual/koros/koro-colour-usage@2x.png
+++ b/site/static/visual/koros/koro-colour-usage@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b49885bb11c638357ca0cc67b0ac95158cd7966609f471e91fc4fed18b4e6286
+size 262560

--- a/site/static/visual/koros/koro-shapes@2x.png
+++ b/site/static/visual/koros/koro-shapes@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79365d1ba21a5432624cf6827f453e9cd0a0be3f39ede96bee6dddf6e2f8f0bf
+size 201914

--- a/site/static/visual/koros/koro-sizes-and-aligment@2x.png
+++ b/site/static/visual/koros/koro-sizes-and-aligment@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55c05434fa3be73928090b57d4f6af83e84df1a65d95fc9faa91b7b947b7d87f
+size 168059

--- a/site/static/visual/koros/koro-sizes@2x.png
+++ b/site/static/visual/koros/koro-sizes@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52c2342873b5419d396cad6793f88b1d33006717ff192c5aa12e23fb4007cc10
+size 45542

--- a/site/static/visual/koros/koro-usage-edge-of-section@2x.png
+++ b/site/static/visual/koros/koro-usage-edge-of-section@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5c3530261eb9897a3bc8087d3b83a1698fb450d6edc3c2911313d533c0a85b8
+size 230948

--- a/site/static/visual/koros/koro-usage-in-content-sections@2x.png
+++ b/site/static/visual/koros/koro-usage-in-content-sections@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9e12398090a41f38b36866ab19977eb2266397c3f72fcb128bd82a2c497cdc5
+size 226026

--- a/site/static/visual/koros/koro-usage-visually-separate-elements@2x.png
+++ b/site/static/visual/koros/koro-usage-visually-separate-elements@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad048dc0373a88b75768ce5da8ade68a17109a8dea1154f7adef19bee36c7e49
+size 3982226

--- a/site/static/visual/koros/koro-with-an-image@2x.png
+++ b/site/static/visual/koros/koro-with-an-image@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f701c73f83f3241a4a42bc62026812ea4d6a442b4181aebc13ea6dcd204f69e
+size 688739

--- a/site/static/visual/koros/mixing-koro-shapes-and-sizes@2x.png
+++ b/site/static/visual/koros/mixing-koro-shapes-and-sizes@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5c886794ce8aeca51b891329b68f37d7763d0f6b87fc06556c119a1ece80af7
+size 160399


### PR DESCRIPTION
## Description
This PR adds a Visual assets documentation page for Koro shapes. The goal of the documentation is to clarify when and how Koro shapes should be used in the City of Helsinki services.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-944

## How Has This Been Tested?
Tested by running the documentation site locally.

## Screenshots (if appropriate):
![koro-sizes-and-aligment@2x](https://user-images.githubusercontent.com/4214671/148954027-510e871e-e5f0-43bd-b637-3304687d0490.png)
