### PR TITLE
Add support to use Tabs component with namespace convention

### DIFF
--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
 import { Tabs } from './Tabs';
-import { TabList } from './TabList';
-import { Tab } from './Tab';
-import { TabPanel } from './TabPanel';
 
 export default {
   component: Tabs,
@@ -23,55 +20,59 @@ export default {
 
 export const Default = () => (
   <Tabs>
-    <TabList className="example-tablist">
-      <Tab>Daycare</Tab>
-      <Tab>Pre-school</Tab>
-      <Tab>Basic education</Tab>
-      <Tab>Upper secondary</Tab>
-      <Tab>University</Tab>
-    </TabList>
-    <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-    <TabPanel>
+    <Tabs.TabList className="example-tablist">
+      <Tabs.Tab>Daycare</Tabs.Tab>
+      <Tabs.Tab>Pre-school</Tabs.Tab>
+      <Tabs.Tab>Basic education</Tabs.Tab>
+      <Tabs.Tab>Upper secondary</Tabs.Tab>
+      <Tabs.Tab>University</Tabs.Tab>
+    </Tabs.TabList>
+    <Tabs.TabPanel>
+      Daytime care for people who cannot be fully independent, such as children or elderly people.
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A pre-school is an educational establishment offering early childhood education to children before they begin
       compulsory education at primary school.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
       responsible membership of society.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       Upper secondary school studies last three to four years, preparing the students for the matriculation examination.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A high-level educational institution in which students study for degrees and academic research is done.
-    </TabPanel>
+    </Tabs.TabPanel>
   </Tabs>
 );
 
 export const Small = () => (
   <Tabs small>
-    <TabList className="example-tablist">
-      <Tab>Daycare</Tab>
-      <Tab>Pre-school</Tab>
-      <Tab>Basic education</Tab>
-      <Tab>Upper secondary</Tab>
-      <Tab>University</Tab>
-    </TabList>
-    <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-    <TabPanel>
+    <Tabs.TabList className="example-tablist">
+      <Tabs.Tab>Daycare</Tabs.Tab>
+      <Tabs.Tab>Pre-school</Tabs.Tab>
+      <Tabs.Tab>Basic education</Tabs.Tab>
+      <Tabs.Tab>Upper secondary</Tabs.Tab>
+      <Tabs.Tab>University</Tabs.Tab>
+    </Tabs.TabList>
+    <Tabs.TabPanel>
+      Daytime care for people who cannot be fully independent, such as children or elderly people.
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A pre-school is an educational establishment offering early childhood education to children before they begin
       compulsory education at primary school.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
       responsible membership of society.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       Upper secondary school studies last three to four years, preparing the students for the matriculation examination.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A high-level educational institution in which students study for degrees and academic research is done.
-    </TabPanel>
+    </Tabs.TabPanel>
   </Tabs>
 );
 
@@ -83,29 +84,31 @@ export const WithCustomTheme = () => {
 
   return (
     <Tabs theme={theme}>
-      <TabList className="example-tablist">
-        <Tab>Daycare</Tab>
-        <Tab>Pre-school</Tab>
-        <Tab>Basic education</Tab>
-        <Tab>Upper secondary</Tab>
-        <Tab>University</Tab>
-      </TabList>
-      <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-      <TabPanel>
+      <Tabs.TabList className="example-tablist">
+        <Tabs.Tab>Daycare</Tabs.Tab>
+        <Tabs.Tab>Pre-school</Tabs.Tab>
+        <Tabs.Tab>Basic education</Tabs.Tab>
+        <Tabs.Tab>Upper secondary</Tabs.Tab>
+        <Tabs.Tab>University</Tabs.Tab>
+      </Tabs.TabList>
+      <Tabs.TabPanel>
+        Daytime care for people who cannot be fully independent, such as children or elderly people.
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
         A pre-school is an educational establishment offering early childhood education to children before they begin
         compulsory education at primary school.
-      </TabPanel>
-      <TabPanel>
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
         The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
         responsible membership of society.
-      </TabPanel>
-      <TabPanel>
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
         Upper secondary school studies last three to four years, preparing the students for the matriculation
         examination.
-      </TabPanel>
-      <TabPanel>
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
         A high-level educational institution in which students study for degrees and academic research is done.
-      </TabPanel>
+      </Tabs.TabPanel>
     </Tabs>
   );
 };

--- a/packages/react/src/components/tabs/Tabs.tsx
+++ b/packages/react/src/components/tabs/Tabs.tsx
@@ -75,6 +75,8 @@ export const Tabs = ({ children, small = false, theme }: TabsProps) => {
   );
 };
 
+// Using the Tabs component and its child components in the same namespace ensures that the group is considered as a single component.
+// Tabs components do some child tab component processing and this might break in some preprocessed environments if the components were separate components, for example in mdx environment.
 Tabs.TabList = TabList;
 Tabs.TabPanel = TabPanel;
 Tabs.Tab = Tab;

--- a/packages/react/src/components/tabs/Tabs.tsx
+++ b/packages/react/src/components/tabs/Tabs.tsx
@@ -7,6 +7,9 @@ import classNames from '../../utils/classNames';
 import { TabsContext } from './TabsContext';
 import { FCWithName } from '../../common/types';
 import { useTheme } from '../../hooks/useTheme';
+import { TabList } from './TabList';
+import { TabPanel } from './TabPanel';
+import { Tab } from './Tab';
 
 export interface TabsCustomTheme {
   '--tablist-border-color'?: string;
@@ -71,3 +74,7 @@ export const Tabs = ({ children, small = false, theme }: TabsProps) => {
     </TabsContext.Provider>
   );
 };
+
+Tabs.TabList = TabList;
+Tabs.TabPanel = TabPanel;
+Tabs.Tab = Tab;

--- a/site/docs/components/tabs.mdx
+++ b/site/docs/components/tabs.mdx
@@ -4,27 +4,27 @@ menu: Components
 route: /components/tabs
 ---
 
-import { Playground } from "docz";
-import { Tabs, TabList, Tab, TabPanel, StatusLabel } from "hds-react";
+import { Playground } from 'docz';
+import { Tabs, StatusLabel } from 'hds-react';
 
-import ColorBox from "../../src/components/ColorBox";
-import LargeParagraph from "../../src/components/LargeParagraph";
-import Link from "../../src/components/Link";
-import Text from "../../src/components/Text";
+import LargeParagraph from '../../src/components/LargeParagraph';
 
 # Tabs
 
 <StatusLabel type="info">Stable</StatusLabel>
-<StatusLabel type="success" style={{marginLeft: 'var(--spacing-xs)'}}>Accessible</StatusLabel>
+<StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
+  Accessible
+</StatusLabel>
 
 <LargeParagraph>
-    Tabs are used to help the user browse and navigate between information contents that have a relation.
+  Tabs are used to help the user browse and navigate between information contents that have a relation.
 </LargeParagraph>
 
 ## Principles
+
 - **Contents of the tabs in a single tab list should have a relation to each other. Do not use tabs for only navigation purposes but actually group views within a context.**
 - **Pay close attention to tab labels.** They should clearly indicate the contents of the tab so the user can reliably guess what they will find inside the tab.
-    - Keep tab labels short and concise - maximum of 1-2 words long. Do not use ALL CAPS in tab labels.
+  - Keep tab labels short and concise - maximum of 1-2 words long. Do not use ALL CAPS in tab labels.
 - It is recommended that the maximum amount of tabs in a single tab list is six (6).
 - **When using tabs, keep in mind that the user should not be required to compare information between tabs.** Constantly switching between tabs can be a very cumbersome experience, so make sure that all information that the user needs is available in a single view.
 - **Do not use HDS Tabs to create step-by-step forms.** You must not expect that the user activates all tabs in a specific order.
@@ -32,7 +32,7 @@ import Text from "../../src/components/Text";
 
 ## Accessibility
 
-- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
+- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to [colour guidelines](/design-tokens/colour 'Colour') to ensure accessibility.
 - The TabPanel must appear right below the TabList in the DOM tree. This means that the next focusable element after the TabList will be the tab's content.
 - While HDS Tabs are accessible, you must ensure that the content displayed in the TabPanel is also accessible.
 - HDS Tabs use manual activation. This means that when using tabs with a keyboard, each tab must be separately activated with Enter/Space, and they do not activate automatically. If you are creating custom tabs for your project, follow the same control scheme.
@@ -40,198 +40,221 @@ import Text from "../../src/components/Text";
 ## Usage & variations
 
 ### Default
+
 Default tab variant is suitable for most use cases. It features tabs that are at equal width based on the widest tab label.
 
 <Playground>
-<Tabs>
-    <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-        <Tab>Daycare</Tab>
-        <Tab>Pre-school</Tab>
-        <Tab>Basic education</Tab>
-        <Tab>Upper secondary</Tab>
-        <Tab>University</Tab>
-    </TabList>
-    <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-    <TabPanel>
+  <Tabs>
+    <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+      <Tabs.Tab>Daycare</Tabs.Tab>
+      <Tabs.Tab>Pre-school</Tabs.Tab>
+      <Tabs.Tab>Basic education</Tabs.Tab>
+      <Tabs.Tab>Upper secondary</Tabs.Tab>
+      <Tabs.Tab>University</Tabs.Tab>
+    </Tabs.TabList>
+    <Tabs.TabPanel>
+      Daytime care for people who cannot be fully independent, such as children or elderly people.
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A pre-school is an educational establishment offering early childhood education to children before they begin
       compulsory education at primary school.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
       responsible membership of society.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       Upper secondary school studies last three to four years, preparing the students for the matriculation examination.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A high-level educational institution in which students study for degrees and academic research is done.
-    </TabPanel>
-</Tabs>
+    </Tabs.TabPanel>
+  </Tabs>
 </Playground>
 
 #### React code example:
+
 ```tsx
 <Tabs>
-    <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-        <Tab>Daycare</Tab>
-        <Tab>Pre-school</Tab>
-        <Tab>Basic education</Tab>
-        <Tab>Upper secondary</Tab>
-        <Tab>University</Tab>
-    </TabList>
-    <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-    <TabPanel>...</TabPanel>
-    <TabPanel>...</TabPanel>
-    <TabPanel>...</TabPanel>
-    <TabPanel>...</TabPanel>
+  <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+    <Tabs.Tab>Daycare</Tabs.Tab>
+    <Tabs.Tab>Pre-school</Tabs.Tab>
+    <Tabs.Tab>Basic education</Tabs.Tab>
+    <Tabs.Tab>Upper secondary</Tabs.Tab>
+    <Tabs.Tab>University</Tabs.Tab>
+  </Tabs.TabList>
+  <Tabs.TabPanel>
+    Daytime care for people who cannot be fully independent, such as children or elderly people.
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
 </Tabs>
 ```
 
 ### Small
+
 Small tabs variant can be used on smaller screens or when you are tight on space. Small tabs use space much more efficiently by reducing a single tab width and font size.
 
 <Playground>
-<Tabs small>
-    <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-        <Tab>Daycare</Tab>
-        <Tab>Pre-school</Tab>
-        <Tab>Basic education</Tab>
-        <Tab>Upper secondary</Tab>
-        <Tab>University</Tab>
-    </TabList>
-    <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-    <TabPanel>
+  <Tabs small>
+    <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+      <Tabs.Tab>Daycare</Tabs.Tab>
+      <Tabs.Tab>Pre-school</Tabs.Tab>
+      <Tabs.Tab>Basic education</Tabs.Tab>
+      <Tabs.Tab>Upper secondary</Tabs.Tab>
+      <Tabs.Tab>University</Tabs.Tab>
+    </Tabs.TabList>
+    <Tabs.TabPanel>
+      Daytime care for people who cannot be fully independent, such as children or elderly people.
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A pre-school is an educational establishment offering early childhood education to children before they begin
       compulsory education at primary school.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
       responsible membership of society.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       Upper secondary school studies last three to four years, preparing the students for the matriculation examination.
-    </TabPanel>
-    <TabPanel>
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>
       A high-level educational institution in which students study for degrees and academic research is done.
-    </TabPanel>
-</Tabs>
+    </Tabs.TabPanel>
+  </Tabs>
 </Playground>
 
 #### React code example:
+
 ```tsx
 <Tabs small>
-    <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-        <Tab>Daycare</Tab>
-        <Tab>Pre-school</Tab>
-        <Tab>Basic education</Tab>
-        <Tab>Upper secondary</Tab>
-        <Tab>University</Tab>
-    </TabList>
-    <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-    <TabPanel>...</TabPanel>
-    <TabPanel>...</TabPanel>
-    <TabPanel>...</TabPanel>
-    <TabPanel>...</TabPanel>
+  <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+    <Tabs.Tab>Daycare</Tabs.Tab>
+    <Tabs.Tab>Pre-school</Tabs.Tab>
+    <Tabs.Tab>Basic education</Tabs.Tab>
+    <Tabs.Tab>Upper secondary</Tabs.Tab>
+    <Tabs.Tab>University</Tabs.Tab>
+  </Tabs.TabList>
+  <Tabs.TabPanel>
+    Daytime care for people who cannot be fully independent, such as children or elderly people.
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
+  <Tabs.TabPanel>...</Tabs.TabPanel>
 </Tabs>
 ```
 
 ### Overflow tabs
+
 HDS Tabs have an automatic overflow functionality when the TabList does not fit into its container. In this case, an overflow indicator icon is shown at the edge of the TabList if there are tabs outside of the visible area. TabList scrolls automatically when the user selects tabs, presses the overflow icon or uses keyboard controls to move between tabs.
 
 Note! It is generally recommended that before relying on the overflow you attempt other solutions first. For example, you can try using the small tabs variant or reducing the number of tabs in the tablist.
 
 <Playground>
-<div style={{maxWidth: '400px'}}>
+  <div style={{ maxWidth: '400px' }}>
     <Tabs>
-        <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-            <Tab>Daycare</Tab>
-            <Tab>Pre-school</Tab>
-            <Tab>Basic education</Tab>
-            <Tab>Upper secondary</Tab>
-            <Tab>University</Tab>
-        </TabList>
-        <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-        <TabPanel>
-            A pre-school is an educational establishment offering early childhood education to children before they begin
-            compulsory education at primary school.
-        </TabPanel>
-        <TabPanel>
-            The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
-            responsible membership of society.
-        </TabPanel>
-        <TabPanel>
-            Upper secondary school studies last three to four years, preparing the students for the matriculation examination.
-        </TabPanel>
-        <TabPanel>
-            A high-level educational institution in which students study for degrees and academic research is done.
-        </TabPanel>
+      <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+        <Tabs.Tab>Daycare</Tabs.Tab>
+        <Tabs.Tab>Pre-school</Tabs.Tab>
+        <Tabs.Tab>Basic education</Tabs.Tab>
+        <Tabs.Tab>Upper secondary</Tabs.Tab>
+        <Tabs.Tab>University</Tabs.Tab>
+      </Tabs.TabList>
+      <Tabs.TabPanel>
+        Daytime care for people who cannot be fully independent, such as children or elderly people.
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
+        A pre-school is an educational establishment offering early childhood education to children before they begin
+        compulsory education at primary school.
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
+        The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
+        responsible membership of society.
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
+        Upper secondary school studies last three to four years, preparing the students for the matriculation
+        examination.
+      </Tabs.TabPanel>
+      <Tabs.TabPanel>
+        A high-level educational institution in which students study for degrees and academic research is done.
+      </Tabs.TabPanel>
     </Tabs>
-</div>
+  </div>
 </Playground>
 
 #### React code example:
+
 ```tsx
 // TabList does not fit into this container
-<div style={{maxWidth: '400px'}}>
-    <Tabs>
-        <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-            <Tab>Daycare</Tab>
-            <Tab>Pre-school</Tab>
-            <Tab>Basic education</Tab>
-            <Tab>Upper secondary</Tab>
-            <Tab>University</Tab>
-        </TabList>
-        <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-        <TabPanel>...</TabPanel>
-        <TabPanel>...</TabPanel>
-        <TabPanel>...</TabPanel>
-        <TabPanel>...</TabPanel>
-    </Tabs>
+<div style={{ maxWidth: '400px' }}>
+  <Tabs>
+    <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+      <Tabs.Tab>Daycare</Tabs.Tab>
+      <Tabs.Tab>Pre-school</Tabs.Tab>
+      <Tabs.Tab>Basic education</Tabs.Tab>
+      <Tabs.Tab>Upper secondary</Tabs.Tab>
+      <Tabs.Tab>University</Tabs.Tab>
+    </Tabs.TabList>
+    <Tabs.TabPanel>
+      Daytime care for people who cannot be fully independent, such as children or elderly people.
+    </Tabs.TabPanel>
+    <Tabs.TabPanel>...</Tabs.TabPanel>
+    <Tabs.TabPanel>...</Tabs.TabPanel>
+    <Tabs.TabPanel>...</Tabs.TabPanel>
+    <Tabs.TabPanel>...</Tabs.TabPanel>
+  </Tabs>
 </div>
 ```
 
 ### With custom colours
-Tab colours are allowed be to customised with brand and grayscale colours. 
+
+Tab colours are allowed be to customised with brand and grayscale colours.
 
 Pay attention to colour contrast. The active tab accent line has to have at least a contrast of `3:1` and the tab text `4.5:1`. Not all brand colours can be used as text colour and in this case, use `color-black-90` as the text colour and your chosen brand as the accent line colour.
 
 <Playground>
-{() => {
-  const theme = {
-    '--tab-color': 'var(--color-black-90)',
-    '--tab-active-border-color': 'var(--color-metro)',
-  };
-  return (
-    <Tabs theme={theme}>
-      <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-        <Tab>Daycare</Tab>
-        <Tab>Pre-school</Tab>
-        <Tab>Basic education</Tab>
-        <Tab>Upper secondary</Tab>
-        <Tab>University</Tab>
-      </TabList>
-      <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-      <TabPanel>
-        A pre-school is an educational establishment offering early childhood education to children before they begin
-        compulsory education at primary school.
-      </TabPanel>
-      <TabPanel>
-        The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
-        responsible membership of society.
-      </TabPanel>
-      <TabPanel>
-        Upper secondary school studies last three to four years, preparing the students for the matriculation
-        examination.
-      </TabPanel>
-      <TabPanel>
-        A high-level educational institution in which students study for degrees and academic research is done.
-      </TabPanel>
-    </Tabs>
-  );
-}}
+  {() => {
+    const theme = {
+      '--tab-color': 'var(--color-black-90)',
+      '--tab-active-border-color': 'var(--color-metro)',
+    };
+    return (
+      <Tabs theme={theme}>
+        <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+          <Tabs.Tab>Daycare</Tabs.Tab>
+          <Tabs.Tab>Pre-school</Tabs.Tab>
+          <Tabs.Tab>Basic education</Tabs.Tab>
+          <Tabs.Tab>Upper secondary</Tabs.Tab>
+          <Tabs.Tab>University</Tabs.Tab>
+        </Tabs.TabList>
+        <Tabs.TabPanel>
+          Daytime care for people who cannot be fully independent, such as children or elderly people.
+        </Tabs.TabPanel>
+        <Tabs.TabPanel>
+          A pre-school is an educational establishment offering early childhood education to children before they begin
+          compulsory education at primary school.
+        </Tabs.TabPanel>
+        <Tabs.TabPanel>
+          The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
+          responsible membership of society.
+        </Tabs.TabPanel>
+        <Tabs.TabPanel>
+          Upper secondary school studies last three to four years, preparing the students for the matriculation
+          examination.
+        </Tabs.TabPanel>
+        <Tabs.TabPanel>
+          A high-level educational institution in which students study for degrees and academic research is done.
+        </Tabs.TabPanel>
+      </Tabs>
+    );
+  }}
 </Playground>
 
 #### React code example:
+
 ```tsx
 const theme = {
   '--tab-color': 'var(--color-black-90)',
@@ -239,30 +262,31 @@ const theme = {
 };
 
 <Tabs theme={theme}>
-  <TabList style={{marginBottom: 'var(--spacing-m)'}}>
-    <Tab>Daycare</Tab>
-    <Tab>Pre-school</Tab>
-    <Tab>Basic education</Tab>
-    <Tab>Upper secondary</Tab>
-    <Tab>University</Tab>
-  </TabList>
-  <TabPanel>Daytime care for people who cannot be fully independent, such as children or elderly people.</TabPanel>
-  <TabPanel>
+  <Tabs.TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+    <Tabs.Tab>Daycare</Tabs.Tab>
+    <Tabs.Tab>Pre-school</Tabs.Tab>
+    <Tabs.Tab>Basic education</Tabs.Tab>
+    <Tabs.Tab>Upper secondary</Tabs.Tab>
+    <Tabs.Tab>University</Tabs.Tab>
+  </Tabs.TabList>
+  <Tabs.TabPanel>
+    Daytime care for people who cannot be fully independent, such as children or elderly people.
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>
     A pre-school is an educational establishment offering early childhood education to children before they begin
     compulsory education at primary school.
-  </TabPanel>
-  <TabPanel>
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>
     The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically
     responsible membership of society.
-  </TabPanel>
-  <TabPanel>
-    Upper secondary school studies last three to four years, preparing the students for the matriculation
-    examination.
-  </TabPanel>
-  <TabPanel>
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>
+    Upper secondary school studies last three to four years, preparing the students for the matriculation examination.
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>
     A high-level educational institution in which students study for degrees and academic research is done.
-  </TabPanel>
-</Tabs>
+  </Tabs.TabPanel>
+</Tabs>;
 ```
 
 ## Demos & API

--- a/site/docs/components/tabs.mdx
+++ b/site/docs/components/tabs.mdx
@@ -12,9 +12,7 @@ import LargeParagraph from '../../src/components/LargeParagraph';
 # Tabs
 
 <StatusLabel type="info">Stable</StatusLabel>
-<StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
-  Accessible
-</StatusLabel>
+<StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
 
 <LargeParagraph>
   Tabs are used to help the user browse and navigate between information contents that have a relation.
@@ -32,7 +30,7 @@ import LargeParagraph from '../../src/components/LargeParagraph';
 
 ## Accessibility
 
-- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to [colour guidelines](/design-tokens/colour 'Colour') to ensure accessibility.
+- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to [colour guidelines](/design-tokens/colour "Colour") to ensure accessibility.
 - The TabPanel must appear right below the TabList in the DOM tree. This means that the next focusable element after the TabList will be the tab's content.
 - While HDS Tabs are accessible, you must ensure that the content displayed in the TabPanel is also accessible.
 - HDS Tabs use manual activation. This means that when using tabs with a keyboard, each tab must be separately activated with Enter/Space, and they do not activate automatically. If you are creating custom tabs for your project, follow the same control scheme.


### PR DESCRIPTION
## Description
- Add support for component namespace into Tabs component

## Motivation and Context
- Problem: Tabs components do not render on MDX pages
- At the moment, Tabs-component's subsequent components are independent. But they can not be used without any of the parent components separately. The parent components modify the properties of child components (add indexes, etc.) to render them correctly. So the Tabs component group should be considered as a single component.

- MDX engine processes independent components into MDX components separately. This prevents parent components from finding the child components as the parents are using componentName to find the correct component. The componentName is lost in the MDX process. Now when the whole group is using the same namespace, the MDX considers the group as a single component and leaves child components intact. 

## How Has This Been Tested?
- Locally on dev machine