### PR TITLE
Feature/tabs new docs

### DIFF
--- a/new-site/src/components/LeadParagraph.js
+++ b/new-site/src/components/LeadParagraph.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LeadParagraph = ({
+  color = 'var(--color-black-90)',
+  size = 'var(--fontsize-body-xl)',
+  style = {},
+  children,
+}) => (
+  <p
+    style={{
+      fontSize: size,
+      color,
+      maxWidth: 600,
+      ...style,
+    }}
+  >
+    {children}
+  </p>
+);
+
+LeadParagraph.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.string,
+};
+
+export default LeadParagraph;

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -129,12 +129,8 @@ body {
   margin-top: auto;
 }
 
-.pageTabs {
-  margin: var(--spacing-m) 0;
-}
-
 .pageTabsList {
-  margin: 0 calc(-1 * var(--spacing-m)) var(--spacing-m);
+  margin: var(--spacing-2-xl) calc(-1 * var(--spacing-m)) var(--spacing-l);
   padding: 0 var(--spacing-m);
   position: relative;
 

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -78,6 +78,10 @@ body {
   word-wrap: break-word;
 }
 
+.mainContent div[role="heading"] {
+  font-size: var(--fontsize-heading-xs);
+}
+
 .page {
   display: flex;
   flex-direction: column;

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -2,6 +2,10 @@
 
 @import '~hds-design-tokens/lib/all.scss';
 
+:root {
+  --page-border-color: var(--color-black-20);
+}
+
 @font-face {
   font-family: HelsinkiGrotesk;
   src: url(https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff) format("woff");
@@ -115,7 +119,7 @@ body {
   }
 
   .sideContent + .mainContent {
-    border-left: 1px solid var(--color-black-20);
+    border-left: 1px solid var(--page-border-color);
     padding: 0 var(--spacing-m) var(--spacing-m);
   }
 }
@@ -123,4 +127,25 @@ body {
 .pageFooter {
   /* ensure footer stays on bottom of the page */
   margin-top: auto;
+}
+
+.pageTabs {
+  margin: var(--spacing-m) 0;
+}
+
+.pageTabsList {
+  margin: 0 calc(-1 * var(--spacing-m)) var(--spacing-m);
+  padding: 0 var(--spacing-m);
+  position: relative;
+
+  &:before {
+    bottom: 1px;
+    border-bottom: 1px solid var(--page-border-color);
+    content: "";
+    height: 1px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    width: 100%;
+  }
 }

--- a/new-site/src/docs/elements/components/buttons/accessibility.mdx
+++ b/new-site/src/docs/elements/components/buttons/accessibility.mdx
@@ -1,0 +1,25 @@
+---
+slug: '/elements/components/buttons/accessibility'
+title: 'Buttons accessibility'
+---
+
+import { Link } from 'hds-react';
+
+## Buttons Accessibility
+
+### Principles
+
+- **Buttons are used to trigger an action.** Be cautious when using buttons for navigating. In most cases, you should prefer links for this purpose.
+- Button label should always describe the action that the buttons is going to trigger. A good practice is to start the label with a verb and use two-word labels at maximum.
+- Use provided button types to control the visual priority of the view. Priority of the button types is the following: _Primary -> Secondary -> Supplementary_.
+- In mobile screen sizes, use full-width buttons. In other sizes use buttons that scale according to their content.
+- Try to keep the amount of buttons in one view low. If there is a need for several actions in one view, consider using the smaller button variant.
+
+### Accessibility
+
+- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to <Link size="M" href="/design-tokens/colour">colour guidelines</Link> to ensure accessibility.
+- In most cases, prefer using normal size buttons over small buttons. Default sized buttons are easier for users to notice and press.
+- Pay attention to the button role. If you use the button as a link instead of an action (i.e. the button press causes a page load), you must specify a `role="link"` attribute to the button.
+- HDS Buttons (even the Small variant) comply with <Link size="M" href="https://www.w3.org/TR/WCAG21/#target-size" external>WCAG 2.5.5 Target Size (AAA) guideline</Link>. Customizing button sizes is not recommended.
+
+export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/accessibility.mdx
+++ b/new-site/src/docs/elements/components/buttons/accessibility.mdx
@@ -5,17 +5,7 @@ title: 'Buttons accessibility'
 
 import { Link } from 'hds-react';
 
-## Buttons Accessibility
-
-### Principles
-
-- **Buttons are used to trigger an action.** Be cautious when using buttons for navigating. In most cases, you should prefer links for this purpose.
-- Button label should always describe the action that the buttons is going to trigger. A good practice is to start the label with a verb and use two-word labels at maximum.
-- Use provided button types to control the visual priority of the view. Priority of the button types is the following: _Primary -> Secondary -> Supplementary_.
-- In mobile screen sizes, use full-width buttons. In other sizes use buttons that scale according to their content.
-- Try to keep the amount of buttons in one view low. If there is a need for several actions in one view, consider using the smaller button variant.
-
-### Accessibility
+## Accessibility
 
 - **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to <Link size="M" href="/design-tokens/colour">colour guidelines</Link> to ensure accessibility.
 - In most cases, prefer using normal size buttons over small buttons. Default sized buttons are easier for users to notice and press.

--- a/new-site/src/docs/elements/components/buttons/accessibility.mdx
+++ b/new-site/src/docs/elements/components/buttons/accessibility.mdx
@@ -1,15 +1,20 @@
 ---
 slug: '/elements/components/buttons/accessibility'
-title: 'Buttons accessibility'
+title: 'Button - Accessibility'
 ---
 
 import { Link } from 'hds-react';
 
 ## Accessibility
 
+### Pay attention to
 - **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to <Link size="M" href="/design-tokens/colour">colour guidelines</Link> to ensure accessibility.
 - In most cases, prefer using normal size buttons over small buttons. Default sized buttons are easier for users to notice and press.
 - Pay attention to the button role. If you use the button as a link instead of an action (i.e. the button press causes a page load), you must specify a `role="link"` attribute to the button.
 - HDS Buttons (even the Small variant) comply with <Link size="M" href="https://www.w3.org/TR/WCAG21/#target-size" external>WCAG 2.5.5 Target Size (AAA) guideline</Link>. Customizing button sizes is not recommended.
+
+### Related accessibility requirements
+- <Link size="M" href="https://www.w3.org/TR/WCAG21/#focus-visible" external>WCAG 2.4.7 - Focus visible</Link>
+- <Link size="M" href="https://www.w3.org/TR/WCAG21/#on-input" external>WCAG 3.2.2 - On input</Link>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/code.mdx
+++ b/new-site/src/docs/elements/components/buttons/code.mdx
@@ -6,24 +6,21 @@ title: 'Buttons Code'
 import { Button } from 'hds-react';
 import Playground from '../../../../components/Playground';
 
-## Button code examples
+## Code examples
 
 <Playground>
 
-  ```jsx
-  <Button>Primary</Button>
-  ```
 
-  ```html
-  <button type="button" class="hds-button hds-button--primary">
-    <span class="hds-button__label">Primary</span>
-  </button>
-  ```
+```jsx
+<Button>Primary</Button>
+```
+
+```html
+<button type="button" class="hds-button hds-button--primary">
+  <span class="hds-button__label">Primary</span>
+</button>
+```
 
 </Playground>
 
-export default ({ children }) => (
-  <>
-    {children}
-  </>
-)
+export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/code.mdx
+++ b/new-site/src/docs/elements/components/buttons/code.mdx
@@ -1,0 +1,29 @@
+---
+slug: '/elements/components/buttons/code'
+title: 'Buttons Code'
+---
+
+import { Button } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
+### Button code examples
+
+<Playground>
+
+  ```jsx
+  <Button>Primary</Button>
+  ```
+
+  ```html
+  <button type="button" class="hds-button hds-button--primary">
+    <span class="hds-button__label">Primary</span>
+  </button>
+  ```
+
+</Playground>
+
+export default ({ children }) => (
+  <>
+    {children}
+  </>
+)

--- a/new-site/src/docs/elements/components/buttons/code.mdx
+++ b/new-site/src/docs/elements/components/buttons/code.mdx
@@ -6,7 +6,7 @@ title: 'Buttons Code'
 import { Button } from 'hds-react';
 import Playground from '../../../../components/Playground';
 
-### Button code examples
+## Button code examples
 
 <Playground>
 

--- a/new-site/src/docs/elements/components/buttons/code.mdx
+++ b/new-site/src/docs/elements/components/buttons/code.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/buttons/code'
 title: 'Button - Code'
 ---
 
-import { Button, Table } from 'hds-react';
-import { IconTrash } from 'hds-react';
+import { Button, Link, Notification, Table } from 'hds-react';
+import { IconTrash, IconAngleRight, IconShare } from 'hds-react';
 import PropertyTable from './components/properties';
 import PackageTable from './components/packages';
 import Playground from '../../../../components/Playground';
@@ -66,8 +66,154 @@ import Playground from '../../../../components/Playground';
 
 </Playground>
 
-### Component properties
+#### Icon button
+<Playground>
+
+
+```jsx
+<div>
+  <Button iconLeft={<IconShare />}>Button</Button>
+  <Button iconRight={<IconAngleRight />}>Button</Button>
+  <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>Button</Button>
+</div>
+```
+
+```html
+<div>
+  <button type="button" class="hds-button hds-button--primary">
+    <span aria-hidden="true" class="hds-icon hds-icon--share"></span>
+    <span class="hds-button__label">Button</span>
+  </button>
+
+  <button type="button" class="hds-button hds-button--primary">
+    <span class="hds-button__label">Button</span>
+    <span aria-hidden="true" class="hds-icon hds-icon--angle-right"></span>
+  </button>
+
+  <button type="button" class="hds-button hds-button--primary">
+    <span aria-hidden="true" class="hds-icon hds-icon--share"></span>
+    <span class="hds-button__label">Button</span>
+    <span aria-hidden="true" class="hds-icon hds-icon--angle-right"></span>
+  </button>
+</div>
+```
+
+
+</Playground>
+
+#### Small button
+<Playground>
+
+
+```jsx
+<div>
+  <Button size="small">Primary</Button>
+  <Button variant="secondary" size="small">Secondary</Button>
+  <Button variant="supplementary" size="small">Supplementary</Button>
+</div>
+```
+
+```html
+<div>
+  <button type="button" class="hds-button hds-button--primary hds-button--small">
+    <span class="hds-button__label">Button</span>
+  </button>
+
+  <button type="button" class="hds-button hds-button--secondary hds-button--small">
+    <span class="hds-button__label">Button</span>
+  </button>
+
+  <button type="button" class="hds-button hds-button--supplementary hds-button--small">
+    <span class="hds-button__label">Button</span>
+  </button>
+</div>
+```
+
+</Playground>
+
+#### Utility button
+<Playground>
+
+
+```jsx
+<div>
+  <Button variant="success">Success</Button>
+  <Button variant="danger">Danger</Button>
+</div>
+```
+
+```html
+<div>
+  <button type="button" class="hds-button hds-button--success">
+    <span class="hds-button__label">Success</span>
+  </button>
+
+  <button type="button" class="hds-button hds-button--danger">
+    <span class="hds-button__label">Danger</span>
+  </button>
+</div>
+```
+
+</Playground>
+
+#### Loading button
+<Playground>
+
+
+```jsx
+{() => {
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [showNotification, setShowNotification] = React.useState(false);
+  React.useEffect(() => {
+    let timeout;
+    if (isLoading) {
+      timeout = setTimeout(() => {
+        setShowNotification(true);
+        setIsLoading(false);
+      }, 2000);
+    }
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [isLoading]);
+  return (
+    <>
+      <Button
+        isLoading={isLoading}
+        loadingText="Saving form changes"
+        onClick={() => {
+          setShowNotification(false);
+          setIsLoading(true);
+        }}>
+        Save form
+      </Button>
+      {showNotification
+      && <Notification
+            key={new Date().toString()}
+            position="top-right"
+            displayAutoCloseProgress={false}
+            autoClose
+            dismissible
+            label="Form saved!"
+            type="success"
+            onClose={() => {
+              setShowNotification(false)
+            }}>
+            Saving your form was successful.
+        </Notification>}
+    </>
+  )
+}}
+```
+
+```html
+
+```
+
+</Playground>
 
 <PropertyTable />
+
+Note! You can find the full list of properties in the <Link size="M" href="https://hds.hel.fi/storybook/react/?path=/docs/components-button--primary" external>React Storybook.</Link>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/code.mdx
+++ b/new-site/src/docs/elements/components/buttons/code.mdx
@@ -1,13 +1,23 @@
 ---
 slug: '/elements/components/buttons/code'
-title: 'Buttons Code'
+title: 'Button - Code'
 ---
 
-import { Button } from 'hds-react';
+import { Button, Table } from 'hds-react';
+import { IconTrash } from 'hds-react';
+import PropertyTable from './components/properties';
+import PackageTable from './components/packages';
 import Playground from '../../../../components/Playground';
 
-## Code examples
+## Code
 
+### Packages
+<PackageTable />
+
+
+### Code examples 
+
+#### Primary
 <Playground>
 
 
@@ -22,5 +32,42 @@ import Playground from '../../../../components/Playground';
 ```
 
 </Playground>
+
+#### Secondary
+<Playground>
+
+
+```jsx
+<Button variant="secondary">Secondary</Button>
+```
+
+```html
+<button type="button" class="hds-button hds-button--secondary">
+  <span class="hds-button__label">Secondary</span>
+</button>
+```
+
+</Playground>
+
+#### Supplementary
+<Playground>
+
+
+```jsx
+<Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+```
+
+```html
+<button type="button" class="hds-button hds-button--supplementary">
+  <span aria-hidden="true" class="hds-icon hds-icon--trash"></span>
+  <span class="hds-button__label">Supplementary</span>
+</button>
+```
+
+</Playground>
+
+### Component properties
+
+<PropertyTable />
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/components/packages.tsx
+++ b/new-site/src/docs/elements/components/buttons/components/packages.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+import { Link, Table } from 'hds-react';
+import { IconCheckCircleFill } from 'hds-react';
+
+const cols = [
+  { key: 'package', headerName: 'Package' },
+  { key: 'included', headerName: 'Included' },
+  { key: 'linkToStorybook', headerName: 'Storybook link' },
+  { key: 'linkToSource', headerName: 'Source link' },
+];
+
+const rows = [
+  { package: <b>HDS React</b>, included: <div><IconCheckCircleFill /> <span>Yes</span></div>, linkToStorybook: <Link size="M" external href="https://hds.hel.fi/storybook/react/?path=/story/components-button--primary">View in Storybook</Link>, linkToSource: <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/components/button">View source</Link> },
+  { package: <b>HDS Core</b>, included: <div><IconCheckCircleFill /> <span>Yes</span></div>, linkToStorybook: <Link size="M" external href="https://hds.hel.fi/storybook/core/?path=/story/components-button--primary">View in Storybook</Link>, linkToSource: <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/button">View source</Link> },
+];
+
+export default function PackageTable() {
+  return (
+    <Table cols={cols} rows={rows} indexKey="id" renderIndexCol={false} />
+  );
+}

--- a/new-site/src/docs/elements/components/buttons/components/properties.tsx
+++ b/new-site/src/docs/elements/components/buttons/components/properties.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+
+import { Table } from 'hds-react';
+
+const cols = [
+  { key: 'property', headerName: 'Property' },
+  { key: 'description', headerName: 'Description' },
+  { key: 'values', headerName: 'Values' },
+  { key: 'defaultValue', headerName: 'Default value' },
+];
+
+const rows = [
+  { property: <code>variant</code>, description: 'Variant of the button', values: "primary, secondary, supplementary, success, danger", defaultValue: 'primary' },
+  { property: <code>size</code>, description: 'Size of the button', values: 'default, small', defaultValue: 'default' },
+  { property: <code>iconLeft</code>, description: 'Icon placed on the left side of the button label', values: '-', defaultValue: '-' },
+  { property: <code>iconLeft</code>, description: 'Icon placed on the right side of the button label', values: '-', defaultValue: '-' },
+  { property: <code>fullWidth</code>, description: 'If set to true, the button will take full width of its container', values: 'true, false', defaultValue: 'false' },
+  { property: <code>isLoading</code>, description: 'If set to true, a loading spinner is displayed inside the button', values: 'true, false', defaultValue: 'false' },
+  { property: <code>loadingText</code>, description: 'Visible loading text to be shown next to the loading spinner', values: '-', defaultValue: '-' },
+];
+
+const caption = (
+  <span>
+    <b>Table 1</b>: Button component properties
+  </span>
+)
+
+export default function PropertyTable() {
+  return (
+    <Table cols={cols} rows={rows} caption={caption} indexKey="id" renderIndexCol={false} />
+  );
+}

--- a/new-site/src/docs/elements/components/buttons/components/properties.tsx
+++ b/new-site/src/docs/elements/components/buttons/components/properties.tsx
@@ -19,14 +19,8 @@ const rows = [
   { property: <code>loadingText</code>, description: 'Visible loading text to be shown next to the loading spinner', values: '-', defaultValue: '-' },
 ];
 
-const caption = (
-  <span>
-    <b>Table 1</b>: Button component properties
-  </span>
-)
-
 export default function PropertyTable() {
   return (
-    <Table cols={cols} rows={rows} caption={caption} indexKey="id" renderIndexCol={false} />
+    <Table cols={cols} rows={rows} heading="Component properties" indexKey="id" renderIndexCol={false} />
   );
 }

--- a/new-site/src/docs/elements/components/buttons/customisation.mdx
+++ b/new-site/src/docs/elements/components/buttons/customisation.mdx
@@ -1,0 +1,37 @@
+---
+slug: '/elements/components/buttons/customisation'
+title: 'Button - Customisation'
+---
+
+import { Button, Link } from 'hds-react';
+import { IconArrowRight } from 'hds-react';
+
+## Customisation
+
+### What can you customise?
+Use brand and grayscale colours to customise:
+- Background colour
+- Border colour
+- Label text colour
+- Icon colour
+
+### Customisation properties
+
+### Customisation example
+<Playground>
+
+
+```jsx
+<Button theme="coat" iconRight=<IconArrowRight />>Customised button</Button>
+```
+
+```html
+<button type="button" class="hds-button hds-button--primary hds-button--theme-coat">
+  <span class="hds-button__label">Customised button</span>
+  <span aria-hidden="true" class="hds-icon hds-icon--arrow-right"></span>
+</button>
+```
+
+</Playground>
+
+export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -7,6 +7,8 @@ import { Button, StatusLabel, Tabs } from 'hds-react';
 
 import 'hds-core/lib/components/button/button.css';
 
+import LeadParagraph from '../../../../components/LeadParagraph';
+
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';
 import Customisation from './customisation.mdx';
@@ -19,7 +21,9 @@ import Usage from './usage.mdx';
   Accessible
 </StatusLabel>
 
+<LeadParagraph>
 Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
+</LeadParagraph>
 
 <Tabs>
   <Tabs.TabList className="pageTabsList">

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: '/elements/components/buttons'
-title: 'Buttons'
+title: 'Button'
 ---
 
 import { Button, StatusLabel, Tabs } from 'hds-react';
@@ -9,22 +9,24 @@ import 'hds-core/lib/components/button/button.css';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';
+import Customisation from './customisation.mdx';
 import Usage from './usage.mdx';
 
 # Button
-
-Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
 
 <StatusLabel type="info">Stable</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>
 
+Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
+
 <Tabs>
   <Tabs.TabList className="pageTabsList">
     <Tabs.Tab>Usage</Tabs.Tab>
     <Tabs.Tab>Code</Tabs.Tab>
     <Tabs.Tab>Accessibility</Tabs.Tab>
+    <Tabs.Tab>Customisation</Tabs.Tab>
   </Tabs.TabList>
   <Tabs.TabPanel>
     <Usage />
@@ -34,5 +36,8 @@ Buttons are meant to make actions easily visible and understandable to the user.
   </Tabs.TabPanel>
   <Tabs.TabPanel>
     <Accessibility />
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>
+    <Customisation />
   </Tabs.TabPanel>
 </Tabs>

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -3,10 +3,12 @@ slug: '/elements/components/buttons'
 title: 'Buttons'
 ---
 
-import { Button, StatusLabel } from 'hds-react';
-import Playground from '../../../components/Playground';
+import { Button, StatusLabel, Tabs } from 'hds-react';
 
 import 'hds-core/lib/components/button/button.css';
+
+import Accessibility from './accessibility.mdx'
+import Code from './code.mdx'
 
 # Buttons
 
@@ -23,18 +25,15 @@ A Primary button is reserved for the most important action on the screen. Primar
 
 Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
 
-### Code examples
-
-<Playground>
-
-```jsx
-<Button>Primary</Button>
-```
-
-```html
-<button type="button" class="hds-button hds-button--primary">
-  <span class="hds-button__label">Primary</span>
-</button>
-```
-
-</Playground>
+<Tabs className="pageTabs">
+  <Tabs.TabList className="pageTabsList" style={{ marginBottom: 'var(--spacing-m)' }}>
+    <Tabs.Tab className="pageTab">Code</Tabs.Tab>
+    <Tabs.Tab className="pageTab">Accessibility</Tabs.Tab>
+  </Tabs.TabList>
+  <Tabs.TabPanel>
+    <Code />
+  </Tabs.TabPanel>
+  <Tabs.TabPanel>
+    <Accessibility />
+  </Tabs.TabPanel>
+</Tabs>

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -7,29 +7,28 @@ import { Button, StatusLabel, Tabs } from 'hds-react';
 
 import 'hds-core/lib/components/button/button.css';
 
-import Accessibility from './accessibility.mdx'
-import Code from './code.mdx'
+import Accessibility from './accessibility.mdx';
+import Code from './code.mdx';
+import Usage from './usage.mdx';
 
-# Buttons
+# Button
 
-## Usage & variations
-
-### Primary button
-
-A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
+Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
 
 <StatusLabel type="info">Stable</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>
 
-Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button variations which each suit for different needs.
-
-<Tabs className="pageTabs">
-  <Tabs.TabList className="pageTabsList" style={{ marginBottom: 'var(--spacing-m)' }}>
-    <Tabs.Tab className="pageTab">Code</Tabs.Tab>
-    <Tabs.Tab className="pageTab">Accessibility</Tabs.Tab>
+<Tabs>
+  <Tabs.TabList className="pageTabsList">
+    <Tabs.Tab>Usage</Tabs.Tab>
+    <Tabs.Tab>Code</Tabs.Tab>
+    <Tabs.Tab>Accessibility</Tabs.Tab>
   </Tabs.TabList>
+  <Tabs.TabPanel>
+    <Usage />
+  </Tabs.TabPanel>
   <Tabs.TabPanel>
     <Code />
   </Tabs.TabPanel>

--- a/new-site/src/docs/elements/components/buttons/usage.mdx
+++ b/new-site/src/docs/elements/components/buttons/usage.mdx
@@ -1,30 +1,114 @@
 ---
 slug: '/elements/components/buttons/code'
-title: 'Buttons Code'
+title: 'Button - Usage'
 ---
 
-import { Button } from 'hds-react';
+import { Button, Accordion } from 'hds-react';
+import { IconAngleRight, IconShare, IconTrash } from 'hds-react';
 import Playground from '../../../../components/Playground';
 
-## Example
+## Usage
 
+### Example
 <Button>Button</Button>
 
-<br/>
-<br/>
+### Principles
+- <b>Buttons are used to trigger an action.</b> Be cautious when using buttons for navigating. In most cases, you should prefer links for this purpose. 
+- Button label should always describe the action that the buttons is going to trigger. A good practice is to start the label with a verb and use two-word labels at maximum.
+- Use provided button types to control the visual priority of the view. Priority of the button types is the following: Primary -> Secondary -> Supplementary.
+- In mobile screen sizes, use full-width buttons. In other sizes use buttons that scale according to their content.
+- Try to keep the amount of buttons in one view low. If there is a need for several actions in one view, consider using the smaller button variant.
 
-## Variations
+### Variations
 
-### Primary button
+<Accordion 
+  heading="Primary button" 
+  headingLevel="4"
+  initiallyOpen
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
+  <br />
+  <Button>Primary</Button>
+</Accordion>
 
-A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
+<Accordion 
+  heading="Secondary button" 
+  headingLevel="4" 
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  Secondary buttons are used for actions which are not mandatory or essential for the user. Often screens will include multiple secondary buttons alongside one primary button.
+  <br />
+  <Button variant="secondary">Primary</Button>
+</Accordion>
 
-<Button>Primary</Button>
+<Accordion 
+  heading="Supplementary button" 
+  headingLevel="4" 
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  Supplementary buttons can be used in similar cases as secondary buttons. However, supplementary buttons are meant for actions which are intentionally wanted to be less visible to the user. These kind of actions include i.e. cancel and dismiss functionalities.
 
-### Secondary button
+  Note! Since supplementary buttons do not have borders, an accompanying icon is required to clearly distinguish them from links and passive text elements.
+  <Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+</Accordion>
 
-Secondary buttons are used for actions which are not mandatory or essential for the user. Often screens will include multiple secondary buttons alongside one primary button.
+<Accordion 
+  heading="Icon button" 
+  headingLevel="4" 
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  Icons can be added to buttons to make the action easier to understand. Sometimes it can also be beneficial to add icons to make important actions more distinguishable. It is not recommended to use buttons with icons without text label because users interpret icons in different ways. More information on icon usage in the icon guidelines.
+  <Button iconLeft={<IconShare />}>Button</Button>
+  <Button iconRight={<IconAngleRight />}>Button</Button>
+  <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>Button</Button>
+</Accordion>
 
-<Button variant="secondary">Primary</Button>
+<Accordion 
+  heading="Small button" 
+  headingLevel="4" 
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  It is recommended to use the standard button size in most cases. If there is a big number of actions in the same view, small buttons can be used instead of the normal sized buttons. Small buttons can be especially useful in mobile screen sizes to ensure uncluttered view with multiple available actions.
+  <Button size="small">Primary</Button>
+  <Button variant="secondary" size="small">Secondary</Button>
+  <Button variant="supplementary" size="small">Supplementary</Button>
+</Accordion>
+
+<Accordion 
+  heading="Utility button" 
+  headingLevel="4" 
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  If required, to achieve clearer user interface, you may also use additional utility colours. Different visual styles of these buttons can be used to better inform users of destructive or dangerous actions. To comply with WCAG requirement 1.4.1 Use of Color, these colours are more accessible when paired with an icon.
+  <Button variant="success">Success</Button>
+  <Button variant="danger">Danger</Button>
+</Accordion>
+
+<Accordion 
+  heading="Loading button" 
+  headingLevel="4" 
+  theme={{
+    '--header-font-size': 'var(--fontsize-heading-xs)',
+    '--padding-vertical': 'var(--spacing-s)',
+  }}>
+  If an action triggered by the button press is not immediate, a loading button state should be shown to the user to indicate the loading period.
+
+  When the loading action is triggered at the button press, the button will change its state to loading. After the loading is complete, either the next page loads or if the page stays the same, you should use other methods (such as notifications) to indicate the loading result.
+
+  Note! It is not recommended to use Supplementary buttons for loading actions since it can be difficult for the user to differentiate from the loading state button.
+</Accordion>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/usage.mdx
+++ b/new-site/src/docs/elements/components/buttons/usage.mdx
@@ -1,0 +1,30 @@
+---
+slug: '/elements/components/buttons/code'
+title: 'Buttons Code'
+---
+
+import { Button } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
+## Example
+
+<Button>Button</Button>
+
+<br/>
+<br/>
+
+## Variations
+
+### Primary button
+
+A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
+
+<Button>Primary</Button>
+
+### Secondary button
+
+Secondary buttons are used for actions which are not mandatory or essential for the user. Often screens will include multiple secondary buttons alongside one primary button.
+
+<Button variant="secondary">Primary</Button>
+
+export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/link.mdx
+++ b/new-site/src/docs/elements/components/link.mdx
@@ -1,8 +1,0 @@
----
-slug: "/elements/components/link"
-title: "Link"
----
-
-# Link Overview
-
-Link content


### PR DESCRIPTION
## Description
- Split buttons.mdx into smaller page sections
- Use tabs to combine page sections on index page 

Depends on: #627 

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-915

## Motivation and Context
- By using Tabs the page size stays smaller and does not feel that overwhelming for the user.

## How Has This Been Tested?
- Locally on dev machine

## Screenshots (if appropriate):
<img width="1613" alt="Screenshot 2022-01-18 at 17 44 11" src="https://user-images.githubusercontent.com/1610860/149970890-46345a1e-9fe7-4bcd-8195-4161836c9e32.png">


[👉 Storybook Demo](https://city-of-helsinki.github.io/hds-demo/docsite-playground/elements/components/buttons/)