### PR TITLE
[Fix] Add border-radius to TextInput and TextArea to prevent rounded corners on iOS

### DIFF
--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -79,6 +79,8 @@
   -webkit-appearance: none;
   background-color: var(--input-background-default);
   border: var(--border-width) solid var(--input-border-color-default);
+  /* removes the border radius on iOS */
+  border-radius: 0;
   box-sizing: border-box;
   color: var(--input-color-default);
   font-size: 1.125em;


### PR DESCRIPTION
## Description
This PR adds `border-radius: 0` to TextInput and TextArea components. This change prevents rounded corners on iOS Safari and Chrome browsers.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1158

## How Has This Been Tested?
Tested by running the Storybook locally. Tested with an iOS simulator.

## Screenshots

**Old**
<img width="375" alt="border-old" src="https://user-images.githubusercontent.com/4214671/149916178-01e1dc89-29fa-4e45-8d8e-e65a7e0ca1fb.png">

**New**
<img width="380" alt="border-new" src="https://user-images.githubusercontent.com/4214671/149916194-7fc7a846-e6e1-4dbf-8e42-068725f95fb3.png">
