### PR TITLE
Feature/table background

### DIFF
--- a/packages/core/src/components/table/table.css
+++ b/packages/core/src/components/table/table.css
@@ -7,7 +7,7 @@
 }
 
 .hds-table {
-  background-color: var(--table-background-color);
+  --content-background-color: var(--color-white);
   border-collapse: collapse;
   width: 100%;
   line-height: 1.5;
@@ -20,6 +20,10 @@
   font-weight: 500;
   font-size: var(--fontsize-heading-xxs);
   padding: var(--spacing-xs) var(--spacing-m);
+}
+
+.hds-table__content {
+  background-color: var(--content-background-color);
 }
 
 .hds-table__content tr td {
@@ -44,7 +48,6 @@
 /* DARK VARIANT */
 
 .hds-table--dark {
-  --table-background-color: var(--color-white);
   --background-color: var(--color-bus);
 }
 
@@ -55,7 +58,6 @@
 /* LIGHT VARIANT */
 
 .hds-table--light {
-  --table-background-color: var(--color-white);
   --background-color: var(--color-silver);
 }
 

--- a/packages/core/src/components/table/table.css
+++ b/packages/core/src/components/table/table.css
@@ -22,11 +22,8 @@
   padding: var(--spacing-xs) var(--spacing-m);
 }
 
-.hds-table__content {
-  background-color: var(--content-background-color);
-}
-
 .hds-table__content tr td {
+  background-color: var(--content-background-color);
   font-weight: 400;
   padding: var(--spacing-xs) var(--spacing-m);
   border-bottom: 1px solid var(--color-black-50);

--- a/packages/core/src/components/table/table.css
+++ b/packages/core/src/components/table/table.css
@@ -7,6 +7,7 @@
 }
 
 .hds-table {
+  background-color: var(--table-background-color);
   border-collapse: collapse;
   width: 100%;
   line-height: 1.5;
@@ -43,6 +44,7 @@
 /* DARK VARIANT */
 
 .hds-table--dark {
+  --table-background-color: var(--color-white);
   --background-color: var(--color-bus);
 }
 
@@ -53,6 +55,7 @@
 /* LIGHT VARIANT */
 
 .hds-table--light {
+  --table-background-color: var(--color-white);
   --background-color: var(--color-silver);
 }
 

--- a/packages/core/src/components/table/table.css
+++ b/packages/core/src/components/table/table.css
@@ -35,7 +35,7 @@
 }
 
 .hds-table__header-row {
-  background-color: var(--background-color);
+  background-color: var(--header-background-color);
 }
 
 .hds-table__caption {
@@ -48,7 +48,8 @@
 /* DARK VARIANT */
 
 .hds-table--dark {
-  --background-color: var(--color-bus);
+  /* TODO: --background-color is deprecated. Remove when possible. */
+  --header-background-color: var(--background-color, --color-bus);
 }
 
 .hds-table.hds-table--dark th {
@@ -58,7 +59,8 @@
 /* LIGHT VARIANT */
 
 .hds-table--light {
-  --background-color: var(--color-silver);
+  /* TODO: --background-color is deprecated. Remove when possible. */
+  --header-background-color: var(--background-color, --color-silver);
 }
 
 .hds-table.hds-table--light th {
@@ -104,14 +106,14 @@
 }
 
 .hds-table--with-vertical-lines .hds-table__header-row {
-  border-right: 1px solid var(--background-color);
-  border-left: 1px solid var(--background-color);
+  border-right: 1px solid var(--header-background-color);
+  border-left: 1px solid var(--header-background-color);
 }
 
 /* VERTICAL HEADER VARIANT */
 
 .hds-table__vertical-header-column {
-  background-color: var(--background-color);
+  background-color: var(--header-background-color);
 }
 
 .hds-table--with-vertical-header.hds-table--with-vertical-lines .hds-table__content {

--- a/packages/core/src/components/table/table.stories.js
+++ b/packages/core/src/components/table/table.stories.js
@@ -12,7 +12,7 @@ const tableRow = (firstName, surname, age, profession) =>
     <td>${surname}</td>
     <td class="hds-table--text-align-right">${age}</td>
     <td>${profession}</td>
-  </tr>`
+  </tr>`;
 
 export const Dark = () => `
   <div class="hds-table-container" style="max-width: 640px;" tabindex="0">
@@ -88,7 +88,7 @@ const extendedTableRow = (firstName, surname, age, city, profession, exp) =>
     <td>${city}</td>
     <td>${profession}</td>
     <td class="hds-table--text-align-right">${exp}</td>
-  </tr>`
+  </tr>`;
 
 export const Zebra = () => `
   <div class="hds-table-container" style="max-width: 800px;" tabindex="0">
@@ -211,7 +211,7 @@ export const VerticalLinesLight = () => `
 `;
 
 const unitsContent = () =>
-        `<tr>
+  `<tr>
           <th scope="row">Monday</th>
           <td>324</td>
           <td>562</td>
@@ -245,7 +245,7 @@ const unitsContent = () =>
           <td>142</td>
           <td>362</td>
           <td>455</td>
-        </tr>`
+        </tr>`;
 
 export const VerticalHeader = () => `
   <div class="hds-table-container" style="max-width: 486px" tabindex="0">
@@ -408,10 +408,12 @@ export const CustomBackgroundColorsForLightVariant = () => `
 `;
 
 const wideTableContent = () => {
-  let content = "";
+  let content = '';
 
-  workTrial.default.forEach(work => {
-    content = content + `
+  workTrial.default.forEach((work) => {
+    content =
+      content +
+      `
         <tr>
           <td class="hds-table--text-align-right">${work['Paikka-ID']}</td>
           <td>${work['Paikan tyyppi']}</td>
@@ -422,10 +424,10 @@ const wideTableContent = () => {
           <td class="hds-table--text-align-right">${work['Postinumero']}</td>
           <td class="hds-table--text-align-right">${work['Paikkoja']}</td>
           <td class="hds-table--text-align-right">${work['Haastatteluun halutaan']}</td>
-        </tr>`
-  })
+        </tr>`;
+  });
   return content;
-}
+};
 
 export const WideAndLong = () => `
   <div class="hds-table-container" style="height: 600px;" tabindex="0">

--- a/packages/core/src/components/table/table.stories.js
+++ b/packages/core/src/components/table/table.stories.js
@@ -351,9 +351,10 @@ export const VerticalHeaderAndLines = () => `
   </div>
 `;
 
-export const CustomHeaderBackgroundColorForDarkVariant = () => `
+export const CustomBackgroundColorsForDarkVariant = () => `
   <style type="text/css">
     .custom-background-color-1 {
+      --table-background-color: var(--color-black-5);
       --background-color: var(--color-tram);
     }
   </style>
@@ -378,9 +379,10 @@ export const CustomHeaderBackgroundColorForDarkVariant = () => `
    </div>
 `;
 
-export const CustomHeaderBackgroundColorForLightVariant = () => `
+export const CustomBackgroundColorsForLightVariant = () => `
   <style type="text/css">
     .custom-background-color-2 {
+      --table-background-color: var(--color-black-5);
       --background-color: var(--color-suomenlinna);
     }
   </style>

--- a/packages/core/src/components/table/table.stories.js
+++ b/packages/core/src/components/table/table.stories.js
@@ -354,8 +354,8 @@ export const VerticalHeaderAndLines = () => `
 export const CustomBackgroundColorsForDarkVariant = () => `
   <style type="text/css">
     .custom-background-color-1 {
-      --table-background-color: var(--color-black-5);
       --background-color: var(--color-tram);
+      --content-background-color: var(--color-black-5);
     }
   </style>
   <div class="hds-table-container" style="max-width: 785px;" tabindex="0">
@@ -382,8 +382,8 @@ export const CustomBackgroundColorsForDarkVariant = () => `
 export const CustomBackgroundColorsForLightVariant = () => `
   <style type="text/css">
     .custom-background-color-2 {
-      --table-background-color: var(--color-black-5);
       --background-color: var(--color-suomenlinna);
+      --content-background-color: var(--color-black-5);
     }
   </style>
   <div class="hds-table-container" style="max-width: 785px;" tabindex="0">

--- a/packages/core/src/components/table/table.stories.js
+++ b/packages/core/src/components/table/table.stories.js
@@ -354,7 +354,7 @@ export const VerticalHeaderAndLines = () => `
 export const CustomBackgroundColorsForDarkVariant = () => `
   <style type="text/css">
     .custom-background-color-1 {
-      --background-color: var(--color-tram);
+      --header-background-color: var(--color-tram);
       --content-background-color: var(--color-black-5);
     }
   </style>
@@ -382,7 +382,7 @@ export const CustomBackgroundColorsForDarkVariant = () => `
 export const CustomBackgroundColorsForLightVariant = () => `
   <style type="text/css">
     .custom-background-color-2 {
-      --background-color: var(--color-suomenlinna);
+      --header-background-color: var(--color-suomenlinna);
       --content-background-color: var(--color-black-5);
     }
   </style>

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Background_Colors_For_Dark_Variant.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Background_Colors_For_Dark_Variant.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a86eab8352b9a5fab6caddf3226a62d805c86d3ade1bf2d22bfff14ca047c26
+size 37287

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Background_Colors_For_Light_Variant.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Background_Colors_For_Light_Variant.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e90e85cb352e8011118d9ad9bce8db6271320e542fefdf09938baf03fca1329
+size 37242

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Header_Background_Color_For_Dark_Variant.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Header_Background_Color_For_Dark_Variant.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5ea56c634b05fa99d0fe97feca1f420c3e3b81850edc73ebe139b998adff9e5
-size 37113

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Header_Background_Color_For_Light_Variant.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Table_Custom_Header_Background_Color_For_Light_Variant.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b06a049fe9116b2e81e15e886e29df020805de8f75ee463e506bc5dd0312b5aa
-size 37063

--- a/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Background_Colors_For_Dark_Variant.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Background_Colors_For_Dark_Variant.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cf9bb124039d45bf9d26552145abb18b4f2ebb6320cfbbdadb4f3a4c80d9713
+size 18780

--- a/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Background_Colors_For_Light_Variant.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Background_Colors_For_Light_Variant.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:944840d5a3dc298e4f54af6d983fc8bec7d5d4917f427dba05374b4773f3ed1a
+size 18777

--- a/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Header_Background_Color_For_Dark_Variant.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Header_Background_Color_For_Dark_Variant.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b22b3cd90f8b4dfa31fa6675fbfb92e7001e6666c1a9a1e4e4602adb8b6dd3a2
-size 18876

--- a/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Header_Background_Color_For_Light_Variant.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Table_Custom_Header_Background_Color_For_Light_Variant.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efd78726250f2ab6179859cfa655bbe6d25b58ae3dc40196b2fb0835010fa773
-size 18872

--- a/packages/react/src/components/table/Table.module.scss
+++ b/packages/react/src/components/table/Table.module.scss
@@ -36,6 +36,7 @@
 }
 
 .dark {
+  --table-background-color: var(--color-white);
   --background-color: var(--color-bus);
 
   .sortButton {
@@ -48,6 +49,7 @@
 }
 
 .light {
+  --table-background-color: var(--color-white);
   --background-color: var(--color-silver);
 
   .sortButton {

--- a/packages/react/src/components/table/Table.module.scss
+++ b/packages/react/src/components/table/Table.module.scss
@@ -37,7 +37,7 @@
 }
 
 .dark {
-  --background-color: var(--color-bus);
+  --header-background-color: var(--color-bus);
 
   .sortButton {
     color: var(--color-white);
@@ -49,7 +49,7 @@
 }
 
 .light {
-  --background-color: var(--color-silver);
+  --header-background-color: var(--color-silver);
 
   .sortButton {
     color: var(--color-black-90);

--- a/packages/react/src/components/table/Table.module.scss
+++ b/packages/react/src/components/table/Table.module.scss
@@ -1,6 +1,7 @@
 @value x-small-down, small-down from "../../styles/breakpoints.css";
 
 .table {
+  --content-background-color: var(--color-white);
   composes: hds-table from 'hds-core/lib/components/table/table.css';
 
   &.dark th {
@@ -36,7 +37,6 @@
 }
 
 .dark {
-  --table-background-color: var(--color-white);
   --background-color: var(--color-bus);
 
   .sortButton {
@@ -49,7 +49,6 @@
 }
 
 .light {
-  --table-background-color: var(--color-white);
   --background-color: var(--color-silver);
 
   .sortButton {

--- a/packages/react/src/components/table/Table.stories.tsx
+++ b/packages/react/src/components/table/Table.stories.tsx
@@ -808,7 +808,7 @@ export const CheckboxSelectionWithSorting = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomHeaderBackgroundColorForDarkVariant = (args) => {
+export const CustomBackgroundColorsForDarkVariant = (args) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -837,6 +837,7 @@ export const CustomHeaderBackgroundColorForDarkVariant = (args) => {
   );
 
   const theme = {
+    '--table-background-color': 'var(--color-black-5)',
     '--background-color': 'var(--color-tram)',
   };
 
@@ -857,7 +858,7 @@ export const CustomHeaderBackgroundColorForDarkVariant = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomHeaderBackgroundColorForLightVariant = (args) => {
+export const CustomBackgroundColorsForLightVariant = (args) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -886,6 +887,7 @@ export const CustomHeaderBackgroundColorForLightVariant = (args) => {
   );
 
   const theme = {
+    '--table-background-color': 'var(--color-black-5)',
     '--background-color': 'var(--color-suomenlinna)',
   };
 

--- a/packages/react/src/components/table/Table.stories.tsx
+++ b/packages/react/src/components/table/Table.stories.tsx
@@ -837,7 +837,7 @@ export const CustomBackgroundColorsForDarkVariant = (args) => {
   );
 
   const theme = {
-    '--background-color': 'var(--color-tram)',
+    '--header-background-color': 'var(--color-tram)',
     '--content-background-color': 'var(--color-black-5)',
   };
 
@@ -887,7 +887,7 @@ export const CustomBackgroundColorsForLightVariant = (args) => {
   );
 
   const theme = {
-    '--background-color': 'var(--color-suomenlinna)',
+    '--header-background-color': 'var(--color-suomenlinna)',
     '--content-background-color': 'var(--color-black-5)',
   };
 

--- a/packages/react/src/components/table/Table.stories.tsx
+++ b/packages/react/src/components/table/Table.stories.tsx
@@ -837,8 +837,8 @@ export const CustomBackgroundColorsForDarkVariant = (args) => {
   );
 
   const theme = {
-    '--table-background-color': 'var(--color-black-5)',
     '--background-color': 'var(--color-tram)',
+    '--content-background-color': 'var(--color-black-5)',
   };
 
   return (
@@ -887,8 +887,8 @@ export const CustomBackgroundColorsForLightVariant = (args) => {
   );
 
   const theme = {
-    '--table-background-color': 'var(--color-black-5)',
     '--background-color': 'var(--color-suomenlinna)',
+    '--content-background-color': 'var(--color-black-5)',
   };
 
   return (

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -38,6 +38,11 @@ type Header = {
 
 export interface TableCustomTheme {
   /**
+   * Custom background color for the table.
+   * @default 'var(--color-white)'
+   */
+  '--table-background-color'?: string;
+  /**
    * Custom background color for table headers.
    */
   '--background-color'?: string;

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -38,9 +38,13 @@ type Header = {
 
 export interface TableCustomTheme {
   /**
-   * Custom background color for table headers.
+   * Deprecated. Use --header-background-color instead.
    */
   '--background-color'?: string;
+  /**
+   * Custom background color for table headers.
+   */
+  '--header-background-color'?: string;
   /**
    * Custom background color for the table content.
    * @default 'var(--color-white)'
@@ -275,6 +279,18 @@ export const Table = ({
     console.warn('Cannot use caption prop when checkboxSelection is set to true. Use heading prop instead');
     // eslint-disable-next-line no-param-reassign
     caption = undefined;
+  }
+
+  if (theme && theme['--background-color']) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '--background-color is deprecated, and will be removed in a future release. Please use --header-background-color instead',
+    );
+
+    /* eslint-disable no-param-reassign */
+    theme['--header-background-color'] = theme['--background-color'];
+    delete theme['--background-color'];
+    /* eslint-enable no-param-reassign */
   }
 
   const [sorting, setSorting] = useState<string>(initialSortingColumnKey);

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -38,14 +38,14 @@ type Header = {
 
 export interface TableCustomTheme {
   /**
-   * Custom background color for the table.
-   * @default 'var(--color-white)'
-   */
-  '--table-background-color'?: string;
-  /**
    * Custom background color for table headers.
    */
   '--background-color'?: string;
+  /**
+   * Custom background color for the table content.
+   * @default 'var(--color-white)'
+   */
+  '--content-background-color'?: string;
 }
 
 type SelectedRow = string | number;


### PR DESCRIPTION
## Description
- Add default background color for table (--color-white)
- Make it customizable CSS theme variable: --content-background-color
- Deprecate --background-color and replace it with --header-background-color

## Motivation and Context
- Page background is visible in the table cells 

## How Has This Been Tested?
- locally on dev machine
- in loki tests

## Screenshots (if appropriate):
<img width="1199" alt="Screenshot 2022-02-09 at 16 39 41" src="https://user-images.githubusercontent.com/1610860/153225530-94553171-94e5-4148-88f5-517be0853b2f.png">
<img width="1184" alt="Screenshot 2022-02-09 at 16 39 31" src="https://user-images.githubusercontent.com/1610860/153225539-14a0af2b-baff-455c-90fe-7e51efeb212a.png">
<img width="841" alt="Screenshot 2022-02-09 at 16 38 58" src="https://user-images.githubusercontent.com/1610860/153225545-a85ffdb1-dc0e-4669-ab61-45dd926238b4.png">

👉 [Storybook demo](https://city-of-helsinki.github.io/hds-demo/table-background/?path=/story/components-table--custom-background-colors-for-dark-variant)