### PR TITLE
Maintenance/remove knobs

### DIFF
--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -11,7 +11,6 @@ module.exports = {
     '@storybook/addon-controls',
     '@storybook/addon-viewport',
     '@storybook/addon-backgrounds',
-    '@storybook/addon-knobs',
     '@storybook/addon-a11y',
     '@storybook/addon-actions',
     '@storybook/addon-storysource',

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -39,4 +39,5 @@ export const parameters = {
       { name: 'Black', value: '#111' },
     ],
   },
+  controls: { expanded: true },
 };

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { boolean, radios, text, withKnobs } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { IconShare, IconAngleRight, IconFaceSmile, IconTrash } from '../../icons';
@@ -11,7 +10,6 @@ const onClick = action('button-click');
 export default {
   component: Button,
   title: 'Components/Button',
-  decorators: [withKnobs],
   parameters: {
     controls: { hideNoControlsWarning: true },
     docs: {
@@ -114,36 +112,19 @@ LoadingOnClick.args = {
   variant: 'primary',
 };
 
-export const Playground = () => {
-  const label = text('Label', 'Button');
-  const variant = radios(
-    'Variant',
-    {
-      primary: 'primary',
-      secondary: 'secondary',
-      supplementary: 'supplementary',
-      success: 'success',
-      danger: 'danger',
-    },
-    'primary',
-  );
-  const theme = radios(
-    'Theme',
-    {
-      default: 'default',
-      coat: 'coat',
-      black: 'black',
-    },
-    'default',
-  );
-  const size = radios('Size', { default: 'default', small: 'small' }, 'default');
-  const disabled = boolean('Disabled', false);
-  const fullWidth = boolean('Full width', false);
-  const iconLeft = boolean('Icon left', false);
-  const iconRight = boolean('Icon right', false);
-  const isLoading = boolean('Is loading', false);
-  const loadingText = text('Loading text', 'Saving your changes');
-
+export const Playground = ({
+  label,
+  variant,
+  theme,
+  size,
+  disabled,
+  fullWidth,
+  iconLeft,
+  iconRight,
+  isLoading,
+  loadingText,
+  ...args
+}) => {
   return (
     <Button
       variant={variant}
@@ -155,6 +136,7 @@ export const Playground = () => {
       iconRight={iconRight ? <IconFaceSmile /> : null}
       isLoading={isLoading}
       loadingText={loadingText}
+      {...args}
     >
       {label}
     </Button>
@@ -168,5 +150,33 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  label: 'Button',
+  variant: 'primary',
+  theme: 'default',
+  size: 'default',
+  disabled: false,
+  fullWidth: false,
+  iconLeft: false,
+  iconRight: false,
+  isLoading: false,
+  loadingText: 'Saving your changes',
+};
+
+Playground.argTypes = {
+  variant: {
+    options: ['primary', 'secondary', 'supplementary', 'success', 'danger'],
+    control: { type: 'radio' },
+  },
+  theme: {
+    options: ['default', 'coat', 'black'],
+    control: { type: 'radio' },
+  },
+  size: {
+    options: ['default', 'small'],
+    control: { type: 'radio' },
   },
 };

--- a/packages/react/src/components/card/Card.stories.tsx
+++ b/packages/react/src/components/card/Card.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { withKnobs } from '@storybook/addon-knobs';
 
 import { Card } from './Card';
 import { Button } from '../button';
@@ -7,7 +6,6 @@ import { Button } from '../button';
 export default {
   component: Card,
   title: 'Components/Card',
-  decorators: [withKnobs],
   parameters: {
     controls: { expanded: true },
   },

--- a/packages/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { color, number } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { Checkbox } from './Checkbox';
@@ -58,125 +57,40 @@ export const Custom = () => {
 };
 Custom.storyName = 'With custom styles';
 
-export const Playground = () => {
+export const Playground = (args) => {
   const [checkedItems, setCheckedItems] = useState({});
   const options = ['Option 1', 'Option 2', 'Option 3'];
-  const groupSize = 'Size';
-  const groupColor = 'Color';
 
   const handleChange = (e) => {
     const item = e.target.name;
     const isChecked = e.target.checked;
     setCheckedItems({ ...checkedItems, [item]: isChecked });
   };
-  const size = number(
-    'Size',
-    24,
-    {
-      range: true,
-      min: 10,
-      max: 100,
-      step: 1,
-    },
-    groupSize,
-  );
-  const iconScale = number(
-    'Icon scale',
-    1,
-    {
-      range: true,
-      min: 0.1,
-      max: 1,
-      step: 0.05,
-    },
-    groupSize,
-  );
-  const borderWidth = number(
-    'Border width',
-    2,
-    {
-      range: true,
-      min: 1,
-      max: 10,
-      step: 1,
-    },
-    groupSize,
-  );
-  const outlineWidth = number(
-    'Outline width',
-    3,
-    {
-      range: true,
-      min: 1,
-      max: 10,
-      step: 1,
-    },
-    groupSize,
-  );
-  const fontSize = number(
-    'Font-size',
-    16,
-    {
-      range: true,
-      min: 12,
-      max: 32,
-      step: 1,
-    },
-    groupSize,
-  );
-  const labelPadding = number(
-    'Label padding',
-    8,
-    {
-      range: true,
-      min: 4,
-      max: 32,
-      step: 2,
-    },
-    groupSize,
-  );
-  const backgroundUnselected = color('Background - unselected', 'rgba(0, 0, 0, 0)', groupColor);
-  const backgroundSelected = color('Background - selected', '#0000bf', groupColor);
-  const backgroundHover = color('Background - hover', '#000098', groupColor);
-  const backgroundDisabled = color('Background - disabled', '#e5e5e5', groupColor);
-  const borderSelected = color('Border - selected', '#0000bf', groupColor);
-  const borderSelectedHover = color('Border - selected - hover', '#000098', groupColor);
-  const borderSelectedFocus = color('Border - selected - focus', '#0000bf', groupColor);
-  const borderUnselected = color('Border - unselected', '#808080', groupColor);
-  const borderUnselectedHover = color('Border - unselected - hover', '#1a1a1a', groupColor);
-  const borderUnselectedFocus = color('Border - unselected - focus', '#000000', groupColor);
-  const borderDisabled = color('Border - disabled', '#e5e5e5', groupColor);
-  const focusOutline = color('Focus outline', '#0072c6', groupColor);
-  const iconUnselected = color('Icon - unselected', 'rgba(0, 0, 0, 0)', groupColor);
-  const iconSelected = color('Icon - selected', '#ffffff', groupColor);
-  const iconDisabled = color('Icon - disabled', '#ffffff', groupColor);
-  const labelDefault = color('Label', '#1a1a1a', groupColor);
-  const labelDisabled = color('Label - disabled', '#999898', groupColor);
 
   const styles = {
-    '--size': `${size}px`,
-    '--icon-scale': iconScale,
-    '--border-width': `${borderWidth}px`,
-    '--outline-width': `${outlineWidth}px`,
-    '--label-font-size': `${fontSize}px`,
-    '--label-padding': `${labelPadding}px`,
-    '--background-unselected': backgroundUnselected,
-    '--background-selected': backgroundSelected,
-    '--background-hover': backgroundHover,
-    '--background-disabled': backgroundDisabled,
-    '--border-color-selected': borderSelected,
-    '--border-color-selected-hover': borderSelectedHover,
-    '--border-color-selected-focus': borderSelectedFocus,
-    '--border-color-unselected': borderUnselected,
-    '--border-color-unselected-hover': borderUnselectedHover,
-    '--border-color-unselected-focus': borderUnselectedFocus,
-    '--border-color-disabled': borderDisabled,
-    '--focus-outline-color': focusOutline,
-    '--icon-color-unselected': iconUnselected,
-    '--icon-color-selected': iconSelected,
-    '--icon-color-disabled': iconDisabled,
-    '--label-color': labelDefault,
-    '--label-color-disabled': labelDisabled,
+    '--size': `${args.size}px`,
+    '--icon-scale': args.iconScale,
+    '--border-width': `${args.borderWidth}px`,
+    '--outline-width': `${args.outlineWidth}px`,
+    '--label-font-size': `${args.labelFontSize}px`,
+    '--label-padding': `${args.labelPadding}px`,
+    '--background-unselected': args.backgroundUnselected,
+    '--background-selected': args.backgroundSelected,
+    '--background-hover': args.backgroundHover,
+    '--background-disabled': args.backgroundDisabled,
+    '--border-color-selected': args.borderColorSelected,
+    '--border-color-selected-hover': args.borderColorSelectedHover,
+    '--border-color-selected-focus': args.borderColorSelectedFocus,
+    '--border-color-unselected': args.borderColorUnselected,
+    '--border-color-unselected-hover': args.borderColorUnselectedHover,
+    '--border-color-unselected-focus': args.borderColorUnselectedFocus,
+    '--border-color-disabled': args.borderColorDisabled,
+    '--focus-outline-color': args.focusOutlineColor,
+    '--icon-color-unselected': args.iconColorUnselected,
+    '--icon-color-selected': args.iconColorSelected,
+    '--icon-color-disabled': args.iconColorDisabled,
+    '--label-color': args.labelColorDefault,
+    '--label-color-disabled': args.labelColorDisabled,
   } as React.CSSProperties;
 
   return (
@@ -206,4 +120,98 @@ Playground.parameters = {
   docs: {
     disable: true,
   },
+};
+
+Playground.args = {
+  size: 24,
+  iconScale: 1,
+  borderWidth: 2,
+  outlineWidth: 3,
+  labelFontSize: 16,
+  labelPadding: 8,
+  backgroundUnselected: 'rgba(0, 0, 0, 0)',
+  backgroundSelected: '#0000bf',
+  backgroundHover: '#000098',
+  backgroundDisabled: '#e5e5e5',
+  borderColorSelected: '#0000bf',
+  borderColorSelectedHover: '#000098',
+  borderColorSelectedFocus: '#0000bf',
+  borderColorUnselected: '#808080',
+  borderColorUnselectedHover: '#1a1a1a',
+  borderColorUnselectedFocus: '#000000',
+  borderColorDisabled: '#e5e5e5',
+  focusOutlineColor: '#0072c6',
+  iconColorUnselected: 'rgba(0, 0, 0, 0)',
+  iconColorSelected: '#ffffff',
+  iconColorDisabled: '#ffffff',
+  labelColorDefault: '#1a1a1a',
+  labelColorDisabled: '#999898',
+};
+
+Playground.argTypes = {
+  size: {
+    control: {
+      type: 'range',
+      min: 10,
+      max: 100,
+      step: 1,
+    },
+  },
+  iconScale: {
+    control: {
+      type: 'range',
+      min: 0.1,
+      max: 1,
+      step: 0.05,
+    },
+  },
+  borderWidth: {
+    control: {
+      type: 'range',
+      min: 1,
+      max: 10,
+      step: 1,
+    },
+  },
+  outlineWidth: {
+    control: {
+      type: 'range',
+      min: 1,
+      max: 10,
+      step: 1,
+    },
+  },
+  labelFontSize: {
+    control: {
+      type: 'range',
+      min: 12,
+      max: 32,
+      step: 1,
+    },
+  },
+  labelPadding: {
+    control: {
+      type: 'range',
+      min: 4,
+      max: 32,
+      step: 2,
+    },
+  },
+  backgroundUnselected: { control: { type: 'color' } },
+  backgroundSelected: { control: { type: 'color' } },
+  backgroundHover: { control: { type: 'color' } },
+  backgroundDisabled: { control: { type: 'color' } },
+  borderColorSelected: { control: { type: 'color' } },
+  borderColorSelectedHover: { control: { type: 'color' } },
+  borderColorSelectedFocus: { control: { type: 'color' } },
+  borderColorUnselected: { control: { type: 'color' } },
+  borderColorUnselectedHover: { control: { type: 'color' } },
+  borderColorUnselectedFocus: { control: { type: 'color' } },
+  borderColorDisabled: { control: { type: 'color' } },
+  focusOutlineColor: { control: { type: 'color' } },
+  iconColorUnselected: { control: { type: 'color' } },
+  iconColorSelected: { control: { type: 'color' } },
+  iconColorDisabled: { control: { type: 'color' } },
+  labelColorDefault: { control: { type: 'color' } },
+  labelColorDisabled: { control: { type: 'color' } },
 };

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import uniqueId from 'lodash.uniqueid';
 
@@ -43,7 +42,7 @@ function getRegionOptions() {
 export default {
   component: Combobox,
   title: 'Components/Dropdowns/Combobox',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '420px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '420px' }}>{storyFn()}</div>],
   parameters: {
     controls: { expanded: true },
   },

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import uniqueId from 'lodash.uniqueid';
 
@@ -32,7 +31,7 @@ const options = getOptions();
 export default {
   component: Select,
   title: 'Components/Dropdowns/Select',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '420px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '420px' }}>{storyFn()}</div>],
   parameters: {
     controls: { expanded: true },
   },

--- a/packages/react/src/components/fieldset/Fieldset.stories.tsx
+++ b/packages/react/src/components/fieldset/Fieldset.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { withKnobs } from '@storybook/addon-knobs';
 
 import { Fieldset } from './Fieldset';
 import { TextInput } from '../textInput/TextInput';
@@ -9,7 +8,7 @@ import { SelectionGroup } from '../selectionGroup/SelectionGroup';
 export default {
   component: Fieldset,
   title: 'Components/Fieldset',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '600px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '600px' }}>{storyFn()}</div>],
   parameters: {
     controls: { expanded: true },
   },

--- a/packages/react/src/components/fileInput/FileInput.stories.tsx
+++ b/packages/react/src/components/fileInput/FileInput.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { boolean, number, radios, text } from '@storybook/addon-knobs';
 
 import { FileInput } from './FileInput';
 
@@ -199,55 +198,30 @@ Required.args = {
   accept: 'image/*',
 };
 
-export const Playground = () => {
+export const Playground = (args) => {
   const onChange = (files) => {
     // eslint-disable-next-line no-console
     console.log('onChange callback files:', files);
   };
 
-  const id = text('id', 'file-input');
-  const label = text('Label', 'Choose files');
-  const buttonLabel = text('ButtonLabel', '');
-  const language = radios(
-    'language',
-    {
-      fi: 'fi',
-      en: 'en',
-      sv: 'sv',
-    },
-    'en',
-  );
-
-  const multiple = boolean('Multiple', false);
-  const maxSize = number('MaxSize', 300 * 1024);
-  const accept = text('Accept', '.png,.jpg,.pdf,.json');
-  const disabled = boolean('Disabled', false);
-  const required = boolean('Required', false);
-  const helperText = text('HelperText', '');
-  const errorText = text('ErrorText', '');
-  const infoText = text('InfoText', '');
-  const dragAndDrop = boolean('DragAndDrop', false);
-  const dragAndDropLabel = text('DragAndDropLabel', '');
-  const dragAndDropInputLabel = text('DragAndDropInputLabel', '');
-
   return (
     <FileInput
-      id={id}
-      label={label}
-      buttonLabel={buttonLabel}
-      maxSize={maxSize}
-      language={language}
+      id={args.id}
+      label={args.label}
+      buttonLabel={args.buttonLabel}
+      maxSize={args.maxSize}
+      language={args.language}
+      accept={args.accept}
+      disabled={args.disabled}
+      required={args.required}
+      multiple={args.multiple}
+      dragAndDrop={args.dragAndDrop}
+      dragAndDropLabel={args.dragAndDropLabel}
+      dragAndDropInputLabel={args.dragAndDropInputLabel}
+      helperText={args.helperText}
+      errorText={args.errorText}
+      infoText={args.infoText}
       onChange={onChange}
-      accept={accept}
-      disabled={disabled}
-      required={required}
-      multiple={multiple}
-      dragAndDrop={dragAndDrop}
-      dragAndDropLabel={dragAndDropLabel}
-      dragAndDropInputLabel={dragAndDropInputLabel}
-      helperText={helperText}
-      errorText={errorText}
-      infoText={infoText}
     />
   );
 };
@@ -259,5 +233,30 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  id: 'file-input',
+  label: 'Choose files',
+  buttonLabel: '',
+  language: 'en',
+  multiple: false,
+  maxSize: 300 * 1024,
+  accept: '.png,.jpg,.pdf,.json',
+  disabled: false,
+  required: false,
+  helperText: '',
+  errorText: '',
+  infoText: '',
+  dragAndDrop: false,
+  dragAndDropLabel: 'DragAndDropLabel',
+  dragAndDropInputLabel: 'DragAndDropInputLabel',
+};
+
+Playground.argTypes = {
+  language: {
+    options: ['fi', 'en', 'sv'],
+    control: { type: 'radio' },
   },
 };

--- a/packages/react/src/components/imageWithCard/ImageWithCard.stories.tsx
+++ b/packages/react/src/components/imageWithCard/ImageWithCard.stories.tsx
@@ -85,8 +85,8 @@ Playground.parameters = {
 };
 
 Playground.args = {
-  title: 'Title',
-  text: 'Text',
+  title: contentTitle,
+  text: contentText,
   color: 'plain',
   fullWidth: false,
   cardAlignment: 'left',

--- a/packages/react/src/components/imageWithCard/ImageWithCard.stories.tsx
+++ b/packages/react/src/components/imageWithCard/ImageWithCard.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { boolean, radios, text, withKnobs } from '@storybook/addon-knobs';
 import { ArgsTable, Title } from '@storybook/addon-docs/blocks';
 
 import { ImageWithCard } from './ImageWithCard';
@@ -19,7 +18,6 @@ const content = (
 export default {
   component: ImageWithCard,
   title: 'Components/ImageWithCard',
-  decorators: [withKnobs],
   parameters: {
     controls: { hideNoControlsWarning: true },
     layout: 'fullscreen',
@@ -62,31 +60,19 @@ export const SplitFullWidth = () => (
 );
 SplitFullWidth.storyName = 'Split full width';
 
-export const Playground = () => {
-  const cardTitle = text('Title', contentTitle);
-  const cardText = text('Text', contentText);
-  const color = radios(
-    'Color',
-    { plain: 'plain', primary: 'primary', secondary: 'secondary', tertiary: 'tertiary' },
-    'plain',
-  );
-  const fullWidth = boolean('Full width', false);
-  const cardAlignment = radios('Card alignment', { left: 'left', right: 'right' }, 'left');
-  const cardLayout = radios('Card layout', { hover: 'hover', split: 'split' }, null);
+export const Playground = (args) => (
+  <ImageWithCard
+    color={args.color}
+    cardAlignment={args.cardAlignment}
+    fullWidth={args.fullWidth}
+    cardLayout={args.cardLayout}
+    src={imageFile}
+  >
+    <h2 style={{ fontSize: 'var(--fontsize-heading-l)' }}>{args.title}</h2>
+    <p style={{ margin: 'var(--spacing-l) 0' }}>{args.text}</p>
+  </ImageWithCard>
+);
 
-  return (
-    <ImageWithCard
-      color={color}
-      cardAlignment={cardAlignment}
-      fullWidth={fullWidth}
-      cardLayout={cardLayout}
-      src={imageFile}
-    >
-      <h2 style={{ fontSize: 'var(--fontsize-heading-l)' }}>{cardTitle}</h2>
-      <p style={{ margin: 'var(--spacing-l) 0' }}>{cardText}</p>
-    </ImageWithCard>
-  );
-};
 Playground.parameters = {
   previewTabs: {
     'storybook/docs/panel': {
@@ -95,5 +81,29 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  title: 'Title',
+  text: 'Text',
+  color: 'plain',
+  fullWidth: false,
+  cardAlignment: 'left',
+  cardLayout: null,
+};
+
+Playground.argTypes = {
+  color: {
+    options: ['plain', 'primary', 'secondary', 'tertiary'],
+    control: { type: 'radio' },
+  },
+  cardAlignment: {
+    options: ['left', 'right'],
+    control: { type: 'radio' },
+  },
+  cardLayout: {
+    options: ['hover', 'split', null],
+    control: { type: 'radio' },
   },
 };

--- a/packages/react/src/components/koros/Koros.stories.tsx
+++ b/packages/react/src/components/koros/Koros.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { boolean, radios, withKnobs } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { Koros } from './Koros';
@@ -7,7 +6,6 @@ import { Koros } from './Koros';
 export default {
   component: Koros,
   title: 'Components/Koros',
-  decorators: [withKnobs],
   parameters: {
     controls: { hideNoControlsWarning: true },
     docs: {
@@ -103,12 +101,8 @@ export const RotatedInContainer = () => {
 
 export const CustomColor = () => <Koros style={{ fill: 'var(--color-coat-of-arms)' }} />;
 
-export const Playground = () => {
-  const type = radios('Type', { basic: 'basic', beat: 'beat', pulse: 'pulse', wave: 'wave', storm: 'storm' }, 'basic');
-  const flipped = boolean('Flip horizontal', false);
+export const Playground = (args) => <Koros type={args.type} flipHorizontal={args.flipHorizontal} rotate={args.rotate}/>;
 
-  return <Koros type={type} flipHorizontal={flipped} />;
-};
 Playground.parameters = {
   previewTabs: {
     'storybook/docs/panel': {
@@ -117,5 +111,18 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  type: 'basic',
+  flipHorizontal: false,
+  rotate: '',
+};
+
+Playground.argTypes = {
+  type: {
+    options: ['basic', 'beat', 'pulse', 'wave', 'storm'],
+    control: { type: 'radio' },
   },
 };

--- a/packages/react/src/components/koros/Koros.stories.tsx
+++ b/packages/react/src/components/koros/Koros.stories.tsx
@@ -101,7 +101,9 @@ export const RotatedInContainer = () => {
 
 export const CustomColor = () => <Koros style={{ fill: 'var(--color-coat-of-arms)' }} />;
 
-export const Playground = (args) => <Koros type={args.type} flipHorizontal={args.flipHorizontal} rotate={args.rotate}/>;
+export const Playground = (args) => (
+  <Koros type={args.type} flipHorizontal={args.flipHorizontal} rotate={args.rotate} />
+);
 
 Playground.parameters = {
   previewTabs: {

--- a/packages/react/src/components/logo/Logo.stories.tsx
+++ b/packages/react/src/components/logo/Logo.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { radios } from '@storybook/addon-knobs';
 
 import { Logo } from './Logo';
 
@@ -11,9 +10,20 @@ export default {
   },
 };
 
-export const Playground = () => {
-  const language = radios('Language', { fi: 'fi', sv: 'sv', ru: 'ru' }, 'fi');
-  const size = radios('Size', { full: 'full', small: 'small', medium: 'medium', large: 'large' }, 'full');
+export const Playground = (args) => <Logo language={args.language} size={args.size} />;
 
-  return <Logo language={language} size={size} />;
+Playground.args = {
+  language: 'fi',
+  size: 'full',
+};
+
+Playground.argTypes = {
+  language: {
+    options: ['fi', 'sv', 'ru'],
+    control: { type: 'radio' },
+  },
+  size: {
+    options: ['full', 'small', 'medium', 'large'],
+    control: { type: 'radio' },
+  },
 };

--- a/packages/react/src/components/notification/Notification.stories.tsx
+++ b/packages/react/src/components/notification/Notification.stories.tsx
@@ -168,7 +168,7 @@ Playground.parameters = {
 
 Playground.args = {
   label: 'Label',
-  body: 'Content',
+  body: content,
   closeButtonLabelText: 'Close notification',
   type: 'info',
   size: 'default',

--- a/packages/react/src/components/notification/Notification.stories.tsx
+++ b/packages/react/src/components/notification/Notification.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { boolean, number, radios, text, withKnobs } from '@storybook/addon-knobs';
 
 import { Notification, NotificationSizeInline, NotificationSizeToast } from './Notification';
 import { Button } from '../button';
@@ -16,7 +15,7 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
   },
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
 };
 
 export const Default = () => <Notification {...props}>{content}</Notification>;
@@ -110,55 +109,17 @@ export const AutoClose = () => {
   );
 };
 
-export const Playground = () => {
+export const Playground = (args) => {
   const [open, setOpen] = useState(true);
-  const label = text('Label', 'Label');
-  const body = text('Content', content);
-  const closeButtonLabelText = text('Close button label text', 'Close notification');
-  const type = radios(
-    'Type',
-    {
-      info: 'info',
-      success: 'success',
-      alert: 'alert',
-      error: 'error',
-    },
-    'info',
-  );
-  const size = radios(
-    'Size',
-    {
-      default: 'default',
-      small: 'small',
-      large: 'large',
-    },
-    'default',
-  );
-  const position = radios(
-    'Position',
-    {
-      inline: 'inline',
-      'top-left': 'top-left',
-      'top-center': 'top-center',
-      'top-right': 'top-right',
-      'bottom-left': 'bottom-left',
-      'bottom-center': 'bottom-center',
-      'bottom-right': 'bottom-right',
-    },
-    'inline',
-  );
-  const invisible = boolean('Invisible', false);
-  const dismissible = boolean('Dismissible', false);
-  const autoClose = boolean('Close automatically', false);
-  const displayAutoCloseProgress = boolean('Display auto close progress', true);
-  const autoCloseDuration = number('Auto close duration', 6000);
 
   useEffect(() => {
-    if (position === 'inline') setOpen(true);
-  }, [position]);
+    if (args.position === 'inline') setOpen(true);
+  }, [args.position]);
 
   let typedSize;
-  position === 'inline' ? (typedSize = size as NotificationSizeInline) : (typedSize = size as NotificationSizeToast);
+  args.position === 'inline'
+    ? (typedSize = args.size as NotificationSizeInline)
+    : (typedSize = args.size as NotificationSizeToast);
 
   return (
     <>
@@ -175,24 +136,25 @@ export const Playground = () => {
       </Button>
       {open && (
         <Notification
-          autoClose={autoClose}
-          autoCloseDuration={autoCloseDuration}
-          displayAutoCloseProgress={displayAutoCloseProgress}
-          invisible={invisible}
-          label={label}
-          type={type}
+          autoClose={args.autoClose}
+          autoCloseDuration={args.autoCloseDuration}
+          displayAutoCloseProgress={args.displayAutoCloseProgress}
+          invisible={args.invisible}
+          label={args.label}
+          type={args.type}
           onClose={() => setOpen(false)}
-          position={position}
+          position={args.position}
           size={typedSize}
-          dismissible={dismissible}
-          closeButtonLabelText={closeButtonLabelText}
+          dismissible={args.dismissible}
+          closeButtonLabelText={args.closeButtonLabelText}
         >
-          {body}
+          {args.body}
         </Notification>
       )}
     </>
   );
 };
+
 Playground.parameters = {
   previewTabs: {
     'storybook/docs/panel': {
@@ -201,5 +163,34 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  label: 'Label',
+  body: 'Content',
+  closeButtonLabelText: 'Close notification',
+  type: 'info',
+  size: 'default',
+  position: 'inline',
+  invisible: false,
+  dismissible: false,
+  autoClose: false,
+  displayAutoCloseProgress: true,
+  autoCloseDuration: 6000,
+};
+
+Playground.argTypes = {
+  type: {
+    options: ['info', 'success', 'alert', 'error'],
+    control: { type: 'radio' },
+  },
+  size: {
+    options: ['default', 'small', 'large'],
+    control: { type: 'radio' },
+  },
+  position: {
+    options: ['inline', 'top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'],
+    control: { type: 'radio' },
   },
 };

--- a/packages/react/src/components/radioButton/RadioButton.stories.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { color, number } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { RadioButton } from './RadioButton';
@@ -65,122 +64,35 @@ export const Custom = () => {
 };
 Custom.storyName = 'With custom styles';
 
-export const Playground = () => {
+export const Playground = (args) => {
   const [radioValue, setRadioValue] = useState(null);
   const options = ['foo', 'bar', 'baz'];
 
-  const groupSize = 'Size';
-  const groupColor = 'Color';
-  const size = number(
-    'Size',
-    24,
-    {
-      range: true,
-      min: 10,
-      max: 100,
-      step: 1,
-    },
-    groupSize,
-  );
-  const iconScale = number(
-    'Icon scale',
-    0.5,
-    {
-      range: true,
-      min: 0.1,
-      max: 0.9,
-      step: 0.05,
-    },
-    groupSize,
-  );
-  const borderWidth = number(
-    'Border width',
-    2,
-    {
-      range: true,
-      min: 1,
-      max: 10,
-      step: 1,
-    },
-    groupSize,
-  );
-  const outlineWidth = number(
-    'Outline width',
-    3,
-    {
-      range: true,
-      min: 1,
-      max: 10,
-      step: 1,
-    },
-    groupSize,
-  );
-  const fontSize = number(
-    'Font-size',
-    16,
-    {
-      range: true,
-      min: 12,
-      max: 32,
-      step: 1,
-    },
-    groupSize,
-  );
-  const labelPadding = number(
-    'Label padding',
-    8,
-    {
-      range: true,
-      min: 4,
-      max: 32,
-      step: 2,
-    },
-    groupSize,
-  );
-  const background = color('Background - unselected', '#ffffff', groupColor);
-  const backgroundHover = color('Background - hover', '#ffffff', groupColor);
-  const backgroundFocus = color('Background - focus', '#ffffff', groupColor);
-  const backgroundUnselectedDisabled = color('Background - unselected - disabled', '#e5e5e5', groupColor);
-  const backgroundSelectedDisabled = color('Background - selected - disabled', '#ffffff', groupColor);
-  const borderFocus = color('Border - focus', '#1a1a1a', groupColor);
-  const borderSelected = color('Border - selected', '#0000bf', groupColor);
-  const borderSelectedHover = color('Border - selected - hover', '#000098', groupColor);
-  const borderSelectedDisabled = color('Border - selected - disabled', '#cccccc', groupColor);
-  const borderUnselected = color('Border - unselected', '#808080', groupColor);
-  const borderUnselectedHover = color('Border - unselected - hover', '#1a1a1a', groupColor);
-  const borderUnselectedDisabled = color('Border - unselected - disabled', '#e5e5e5', groupColor);
-  const focusOutline = color('Focus outline', '#0072c6', groupColor);
-  const iconUnselected = color('Icon - unselected', 'rgba(0, 0, 0, 0)', groupColor);
-  const iconSelected = color('Icon - selected', '#0000bf', groupColor);
-  const iconDisabled = color('Icon - disabled', '#e5e5e5', groupColor);
-  const labelDefault = color('Label', '#1a1a1a', groupColor);
-  const labelDisabled = color('Label - disabled', '#999898', groupColor);
-
   const styles = {
-    '--size': `${size}px`,
-    '--icon-scale': iconScale,
-    '--border-width': `${borderWidth}px`,
-    '--outline-width': `${outlineWidth}px`,
-    '--label-font-size': `${fontSize}px`,
-    '--label-padding': `${labelPadding}px`,
-    '--background': background,
-    '--background-hover': backgroundHover,
-    '--background-focus': backgroundFocus,
-    '--background-unselected-disabled': backgroundUnselectedDisabled,
-    '--background-selected-disabled': backgroundSelectedDisabled,
-    '--border-color-focus': borderFocus,
-    '--border-color-selected': borderSelected,
-    '--border-color-selected-hover': borderSelectedHover,
-    '--border-color-selected-disabled': borderSelectedDisabled,
-    '--border-color-unselected': borderUnselected,
-    '--border-color-unselected-hover': borderUnselectedHover,
-    '--border-color-unselected-disabled': borderUnselectedDisabled,
-    '--focus-outline-color': focusOutline,
-    '--icon-color-unselected': iconUnselected,
-    '--icon-color-selected': iconSelected,
-    '--icon-color-disabled': iconDisabled,
-    '--label-color': labelDefault,
-    '--label-color-disabled': labelDisabled,
+    '--size': `${args.size}px`,
+    '--icon-scale': args.iconScale,
+    '--border-width': `${args.borderWidth}px`,
+    '--outline-width': `${args.outlineWidth}px`,
+    '--label-font-size': `${args.labelFontSize}px`,
+    '--label-padding': `${args.labelPadding}px`,
+    '--background': args.background,
+    '--background-hover': args.backgroundHover,
+    '--background-focus': args.backgroundFocus,
+    '--background-unselected-disabled': args.backgroundUnselectedDisabled,
+    '--background-selected-disabled': args.backgroundSelectedDisabled,
+    '--border-color-focus': args.borderColorFocus,
+    '--border-color-selected': args.borderColorSelected,
+    '--border-color-selected-hover': args.borderColorSelectedHover,
+    '--border-color-selected-disabled': args.borderColorSelectedDisabled,
+    '--border-color-unselected': args.borderColorUnselected,
+    '--border-color-unselected-hover': args.borderColorUnselectedHover,
+    '--border-color-unselected-disabled': args.borderColorUnselectedDisabled,
+    '--focus-outline-color': args.focusOutlineColor,
+    '--icon-color-unselected': args.iconColorUnselected,
+    '--icon-color-selected': args.iconColorSelected,
+    '--icon-color-disabled': args.iconColorDisabled,
+    '--label-color': args.labelColorDefault,
+    '--label-color-disabled': args.labelColorDisabled,
   } as React.CSSProperties;
 
   return (
@@ -210,4 +122,100 @@ Playground.parameters = {
   docs: {
     disable: true,
   },
+};
+
+Playground.args = {
+  size: 24,
+  iconScale: 0.5,
+  borderWidth: 2,
+  outlineWidth: 3,
+  labelFontSize: 16,
+  labelPadding: 8,
+  background: '#ffffff',
+  backgroundHover: '#ffffff',
+  backgroundFocus: '#ffffff',
+  backgroundUnselectedDisabled: '#e5e5e5',
+  backgroundSelectedDisabled: '#ffffff',
+  borderColorFocus: '#1a1a1a',
+  borderColorSelected: '#0000bf',
+  borderColorSelectedHover: '#000098',
+  borderColorSelectedDisabled: '#cccccc',
+  borderColorUnselected: '#808080',
+  borderColorUnselectedHover: '#1a1a1a',
+  borderColorUnselectedDisabled: '#e5e5e5',
+  focusOutlineColor: '#0072c6',
+  iconColorUnselected: 'rgba(0, 0, 0, 0)',
+  iconColorSelected: '#0000bf',
+  iconColorDisabled: '#e5e5e5',
+  labelColorDefault: '#1a1a1a',
+  labelColorDisabled: '#999898',
+};
+
+Playground.argTypes = {
+  size: {
+    control: {
+      type: 'range',
+      min: 10,
+      max: 100,
+      step: 1,
+    },
+  },
+  iconScale: {
+    control: {
+      type: 'range',
+      min: 0.1,
+      max: 0.9,
+      step: 0.05,
+    },
+  },
+  borderWidth: {
+    control: {
+      type: 'range',
+      min: 1,
+      max: 10,
+      step: 1,
+    },
+  },
+  outlineWidth: {
+    control: {
+      type: 'range',
+      min: 1,
+      max: 10,
+      step: 1,
+    },
+  },
+  labelFontSize: {
+    control: {
+      type: 'range',
+      min: 12,
+      max: 32,
+      step: 1,
+    },
+  },
+  labelPadding: {
+    control: {
+      type: 'range',
+      min: 4,
+      max: 32,
+      step: 2,
+    },
+  },
+  background: { control: { type: 'color' } },
+  backgroundHover: { control: { type: 'color' } },
+  backgroundFocus: { control: { type: 'color' } },
+  backgroundUnselectedDisabled: { control: { type: 'color' } },
+  backgroundSelectedDisabled: { control: { type: 'color' } },
+  borderColorFocus: { control: { type: 'color' } },
+  borderColorSelected: { control: { type: 'color' } },
+  borderColorSelectedHover: { control: { type: 'color' } },
+  borderColorSelectedDisabled: { control: { type: 'color' } },
+  borderColorUnselected: { control: { type: 'color' } },
+  borderColorUnselectedHover: { control: { type: 'color' } },
+  borderColorUnselectedDisabled: { control: { type: 'color' } },
+  focusOutlineColor: { control: { type: 'color' } },
+  iconColorUnselected: { control: { type: 'color' } },
+  iconColorSelected: { control: { type: 'color' } },
+  iconColorDisabled: { control: { type: 'color' } },
+  labelColorDefault: { control: { type: 'color' } },
+  labelColorDisabled: { control: { type: 'color' } },
 };

--- a/packages/react/src/components/section/Section.stories.tsx
+++ b/packages/react/src/components/section/Section.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ArgsTable, Title } from '@storybook/addon-docs/blocks';
-import { radios, text } from '@storybook/addon-knobs';
 
 import { Section } from './Section';
 import imageFile from '../../assets/img/placeholder_1920x1080.jpg';
@@ -103,27 +102,13 @@ export const Multiple = () => (
 );
 Multiple.storyName = 'Multiple sections';
 
-export const Playground = () => {
-  const sectionTitle = text('Title', placeholderTitle);
-  const sectionText = text('Text', placeholderText);
-  const color = radios(
-    'Color',
-    { plain: 'plain', primary: 'primary', secondary: 'secondary', tertiary: 'tertiary' },
-    'plain',
-  );
-  const korosType = radios(
-    'Koros',
-    { none: null, basic: 'basic', beat: 'beat', pulse: 'pulse', wave: 'wave', storm: 'storm' },
-    null,
-  );
+export const Playground = (args) => (
+  <Section color={args.color} korosType={args.korosType}>
+    <h1 style={{ fontSize: 'var(--fontsize-heading-xl)' }}>{args.sectionTitle}</h1>
+    {args.sectionText}
+  </Section>
+);
 
-  return (
-    <Section color={color} korosType={korosType}>
-      <h1 style={{ fontSize: 'var(--fontsize-heading-xl)' }}>{sectionTitle}</h1>
-      {sectionText}
-    </Section>
-  );
-};
 Playground.parameters = {
   previewTabs: {
     'storybook/docs/panel': {
@@ -132,5 +117,22 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  sectionTitle: 'Title',
+  sectionText: 'Text',
+  korosType: null,
+  color: 'plain',
+};
+
+Playground.argTypes = {
+  korosType: {
+    options: [null, 'basic', 'beat', 'pulse', 'wave', 'storm'],
+    control: { type: 'radio' },
+  },
+  color: {
+    options: ['plain', 'primary', 'secondary', 'tertiary'],
   },
 };

--- a/packages/react/src/components/section/Section.stories.tsx
+++ b/packages/react/src/components/section/Section.stories.tsx
@@ -121,8 +121,8 @@ Playground.parameters = {
 };
 
 Playground.args = {
-  sectionTitle: 'Title',
-  sectionText: 'Text',
+  sectionTitle: placeholderTitle,
+  sectionText: placeholderText,
   korosType: null,
   color: 'plain',
 };

--- a/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, useState } from 'react';
-import { withKnobs } from '@storybook/addon-knobs';
 
 import { SelectionGroup } from './SelectionGroup';
 import { Checkbox } from '../checkbox';
@@ -8,7 +7,7 @@ import { RadioButton } from '../radioButton';
 export default {
   component: SelectionGroup,
   title: 'Components/SelectionGroup',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
   parameters: {
     controls: { expanded: true },
   },

--- a/packages/react/src/components/statusLabel/StatusLabel.stories.tsx
+++ b/packages/react/src/components/statusLabel/StatusLabel.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { radios, text, withKnobs } from '@storybook/addon-knobs';
 
 import { StatusLabel } from './StatusLabel';
 import { IconCheckCircle, IconInfoCircle, IconAlertCircle, IconError } from '../../icons';
@@ -10,7 +9,6 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
   },
-  decorators: [withKnobs],
 };
 
 export const Neutral = () => <StatusLabel>Neutral</StatusLabel>;
@@ -49,22 +47,7 @@ export const Icons = () => (
   </>
 );
 
-export const Playground = () => {
-  const label = text('Label', 'Status');
-  const type = radios(
-    'Type',
-    {
-      neutral: 'neutral',
-      info: 'info',
-      success: 'success',
-      alert: 'alert',
-      error: 'error',
-    },
-    'neutral',
-  );
-
-  return <StatusLabel type={type}>{label}</StatusLabel>;
-};
+export const Playground = (args) => <StatusLabel type={args.type}>{args.label}</StatusLabel>;
 
 Playground.parameters = {
   previewTabs: {
@@ -74,5 +57,17 @@ Playground.parameters = {
   },
   docs: {
     disable: true,
+  },
+};
+
+Playground.args = {
+  label: 'Status',
+  type: 'neutral',
+};
+
+Playground.argTypes = {
+  type: {
+    options: ['neutral', 'info', 'success', 'alert', 'error'],
+    control: { type: 'radio' },
   },
 };

--- a/packages/react/src/components/textInput/TextInput.stories.tsx
+++ b/packages/react/src/components/textInput/TextInput.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { TextInput } from './TextInput';
@@ -15,7 +14,7 @@ const textInputProps = {
 export default {
   component: TextInput,
   title: 'Components/TextInput',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
   parameters: {
     controls: { hideNoControlsWarning: true },
     docs: {
@@ -72,48 +71,25 @@ export const UsingRef = () => {
 };
 UsingRef.storyName = 'Using ref';
 
-export const Playground = () => {
-  const groupGeneral = 'General';
-  const groupTooltip = 'Tooltip';
+export const Playground = (args) => (
+  <TextInput
+    id={args.id}
+    label={args.label}
+    helperText={args.helperText}
+    placeholder={args.placeholder}
+    readOnly={args.readOnly}
+    type={args.type}
+    disabled={args.disabled}
+    invalid={args.invalid}
+    errorText={args.errorText}
+    hideLabel={args.hideLabel}
+    required={args.required}
+    tooltipLabel={args.tooltipLabel}
+    tooltipText={args.tooltipText}
+    tooltipButtonLabel={args.tooltipButtonAriaLabelText}
+  />
+);
 
-  const label = text('Label', textInputProps.label, groupGeneral);
-  const placeholder = text('Placeholder', textInputProps.placeholder, groupGeneral);
-  const helperText = text('Helper text', textInputProps.helperText, groupGeneral);
-  const type = text('Type', 'text', groupGeneral);
-  const disabled = boolean('Disabled', false, groupGeneral);
-  const required = boolean('Required', false, groupGeneral);
-  const readOnly = boolean('Read-only', false, groupGeneral);
-  const invalid = boolean('Invalid', false, groupGeneral);
-  const errorText = text('Error text', undefined, groupGeneral);
-  const hideLabel = boolean('Hide label', false, groupGeneral);
-
-  const tooltipLabel = text('Tooltip aria-label', 'Tooltip', groupTooltip);
-  const tooltipText = text(
-    'Tooltip text',
-    'Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.',
-    groupTooltip,
-  );
-  const tooltipButtonLabelText = text('Tooltip trigger button aria-label', 'Tooltip', groupTooltip);
-
-  return (
-    <TextInput
-      {...textInputProps}
-      type={type}
-      label={label}
-      helperText={helperText}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      disabled={disabled}
-      invalid={invalid}
-      errorText={errorText}
-      hideLabel={hideLabel}
-      required={required}
-      tooltipLabel={tooltipLabel}
-      tooltipText={tooltipText}
-      tooltipButtonLabel={tooltipButtonLabelText}
-    />
-  );
-};
 Playground.parameters = {
   previewTabs: {
     'storybook/docs/panel': {
@@ -123,4 +99,19 @@ Playground.parameters = {
   docs: {
     disable: true,
   },
+};
+
+Playground.args = {
+  ...textInputProps,
+  type: 'text',
+  disabled: false,
+  required: false,
+  readOnly: false,
+  invalid: false,
+  errorText: 'Error text',
+  hideLabel: false,
+  tooltipAriaLabel: 'Tooltip',
+  tooltipText:
+    'Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.',
+  tooltipButtonAriaLabelText: 'Tooltip',
 };

--- a/packages/react/src/components/textInput/TextInput.stories.tsx
+++ b/packages/react/src/components/textInput/TextInput.stories.tsx
@@ -108,7 +108,7 @@ Playground.args = {
   required: false,
   readOnly: false,
   invalid: false,
-  errorText: 'Error text',
+  errorText: undefined,
   hideLabel: false,
   tooltipAriaLabel: 'Tooltip',
   tooltipText:

--- a/packages/react/src/components/textarea/TextArea.stories.tsx
+++ b/packages/react/src/components/textarea/TextArea.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { TextArea } from './TextArea';
@@ -15,7 +14,7 @@ const value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 export default {
   component: TextArea,
   title: 'Components/TextArea',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
   parameters: {
     controls: { hideNoControlsWarning: true },
     docs: {
@@ -53,42 +52,21 @@ export const WithTooltip = () => (
 );
 WithTooltip.storyName = 'With tooltip';
 
-export const Playground = () => {
-  const groupGeneral = 'General';
-  const groupTooltip = 'Tooltip';
-
-  const label = text('Label', textAreaProps.label, groupGeneral);
-  const placeholder = text('Placeholder', textAreaProps.placeholder, groupGeneral);
-  const helperText = text('Helper text', textAreaProps.helperText, groupGeneral);
-  const disabled = boolean('Disabled', false, groupGeneral);
-  const required = boolean('Required', false, groupGeneral);
-  const invalid = boolean('Invalid', false, groupGeneral);
-  const hideLabel = boolean('Hide label', false, groupGeneral);
-
-  const tooltipLabel = text('Tooltip aria-label', 'Tooltip', groupTooltip);
-  const tooltipText = text(
-    'Tooltip text',
-    'Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.',
-    groupTooltip,
-  );
-  const tooltipButtonLabelText = text('Tooltip trigger button aria-label', 'Tooltip', groupTooltip);
-
-  return (
-    <TextArea
-      {...textAreaProps}
-      label={label}
-      helperText={helperText}
-      placeholder={placeholder}
-      disabled={disabled}
-      invalid={invalid}
-      hideLabel={hideLabel}
-      required={required}
-      tooltipLabel={tooltipLabel}
-      tooltipText={tooltipText}
-      tooltipButtonLabel={tooltipButtonLabelText}
-    />
-  );
-};
+export const Playground = (args) => (
+  <TextArea
+    id={args.id}
+    label={args.label}
+    helperText={args.helperText}
+    placeholder={args.placeholder}
+    disabled={args.disabled}
+    invalid={args.invalid}
+    hideLabel={args.hideLabel}
+    required={args.required}
+    tooltipLabel={args.tooltipLabel}
+    tooltipText={args.tooltipText}
+    tooltipButtonLabel={args.tooltipButtonLabelText}
+  />
+);
 
 Playground.parameters = {
   previewTabs: {
@@ -99,4 +77,19 @@ Playground.parameters = {
   docs: {
     disable: true,
   },
+};
+
+Playground.args = {
+  ...textAreaProps,
+  type: 'text',
+  disabled: false,
+  required: false,
+  readOnly: false,
+  invalid: false,
+  errorText: 'Error text',
+  hideLabel: false,
+  tooltipAriaLabel: 'Tooltip',
+  tooltipText:
+    'Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.',
+  tooltipButtonAriaLabelText: 'Tooltip',
 };

--- a/packages/react/src/components/toggleButton/ToggleButton.stories.tsx
+++ b/packages/react/src/components/toggleButton/ToggleButton.stories.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { boolean, radios, text, withKnobs } from '@storybook/addon-knobs';
 
 import { ToggleButton } from './ToggleButton';
 
 export default {
   component: ToggleButton,
   title: 'Components/ToggleButton',
-  decorators: [withKnobs, (storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
+  decorators: [(storyFn) => <div style={{ maxWidth: '400px' }}>{storyFn()}</div>],
   parameters: {
     controls: { expanded: true },
   },
@@ -160,36 +159,20 @@ CustomTheme.args = {
 
 CustomTheme.storyName = 'Custom theme';
 
-export const Playground = () => {
-  const id = text('Id', 'toggle-button');
-  const label = text('Label', 'Toggle button');
-  const tooltipLabel = text('TooltipLabel', 'Tooltip label');
-  const tooltipButtonLabel = text('TooltipButtonLabel', 'Tooltip button label');
-  const tooltipText = text('TooltipText', 'Tooltip text');
-  const variant = radios(
-    'Variant',
-    {
-      default: 'default',
-      inline: 'inline',
-    },
-    'default',
-  );
-
-  const value = boolean('Value', true);
-  const [checked, setChecked] = useState(value);
-  const disabled = boolean('Disabled', false);
+export const Playground = (args) => {
+  const [checked, setChecked] = useState(args.value);
 
   return (
     <ToggleButton
-      id={id}
-      label={label}
+      id={args.id}
+      label={args.label}
       checked={checked}
       onChange={() => setChecked(!checked)}
-      disabled={disabled}
-      tooltipLabel={tooltipLabel}
-      tooltipButtonLabel={tooltipButtonLabel}
-      tooltipText={tooltipText}
-      variant={variant}
+      disabled={args.disabled}
+      tooltipLabel={args.tooltipLabel}
+      tooltipButtonLabel={args.tooltipButtonLabel}
+      tooltipText={args.tooltipText}
+      variant={args.variant}
     />
   );
 };
@@ -203,4 +186,21 @@ Playground.parameters = {
     disable: true,
   },
   loki: { skip: true },
+};
+
+Playground.args = {
+  id: 'toggle-button',
+  label: 'Toggle button',
+  tooltipLabel: 'Tooltip label',
+  tooltipButtonLabel: 'Tooltip button label',
+  tooltipText: 'Tooltip text',
+  variant: 'default',
+  disabled: false,
+};
+
+Playground.argTypes = {
+  variant: {
+    options: ['default', 'inline'],
+    control: { type: 'radio' },
+  },
 };


### PR DESCRIPTION
## Description
- Remove deprecated addon-knobs from Storybook
- Replace knobs panel components with addon-control equivalent

### Updated component stories 
Often Playground story required changes but sometimes it was just removing the withKnobs decorator.

- Button
- Card
- Checkbox
- Combobox
- Fieldset
- FileInput
- ImageWithCard
- Koros
- Logo
- Notification
- RadioButton
- Section
- Select
- SelectionGroup
- StatusLabel
- TextArea
- TextInput
- ToggleButton

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1191

## Motivation and Context
- A deprecated library removed (has no support and might cause problems in upgrades) 
- One tab less in Storybook (better performance)
- Downsides: 
   - no ability to group controls like in knobs panel
   - no custom labels (for example, for radio button control options)

## How Has This Been Tested?
- Locally on dev machine

👉 [Storybook Demo](https://city-of-helsinki.github.io/hds-demo/storybook-without-knobs/?path=/story/components-button--primary)
