### PR TITLE
Feature/clearable in single select

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.module.scss
+++ b/packages/react/src/components/dropdown/combobox/Combobox.module.scss
@@ -68,6 +68,14 @@
   // don't add additional right padding if toggle button is hidden
   &.noToggle {
     padding-right: var(--spacing-s);
+
+    &.withClearButton {
+      padding-right: calc(var(--spacing-l) + var(--icon-size));
+    }
+  }
+
+  &.withClearButton {
+    padding-right: calc(var(--spacing-2-xl) + var(--icon-size));
   }
 
   &::placeholder {

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -52,6 +52,7 @@ export default {
     label: 'Element',
     helper: 'Choose an element',
     placeholder: 'Placeholder',
+    clearButtonAriaLabel: 'Clear selection',
     options,
     onBlur: action('onBlur'),
     onChange: (change) => action('onChange')(change),
@@ -61,6 +62,13 @@ export default {
 };
 
 export const Default = (args) => <Combobox {...args} />;
+
+export const WithClearButton = (args) => <Combobox {...args} />;
+WithClearButton.storyName = 'With clear button';
+WithClearButton.args = {
+  clearable: true,
+};
+WithClearButton.parameters = { loki: { skip: true } };
 
 export const Multiselect = (args) => <Combobox {...args} />;
 Multiselect.storyName = 'Multi-select';

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -9,11 +9,10 @@ import { useVirtual } from 'react-virtual';
 import 'hds-core';
 
 import styles from './Combobox.module.scss';
-import selectStyles from '../select/Select.module.scss';
 import { FieldLabel } from '../../../internal/field-label/FieldLabel';
 import classNames from '../../../utils/classNames';
-import { IconAlertCircleFill, IconAngleDown, IconCrossCircle } from '../../../icons';
-import { SelectedItems } from '../../../internal/selectedItems/SelectedItems';
+import { IconAlertCircleFill, IconAngleDown } from '../../../icons';
+import { ClearButton, SelectedItems } from '../../../internal/selectedItems/SelectedItems';
 import { multiSelectReducer, onMultiSelectStateChange, SelectCustomTheme, SelectProps } from '../select';
 import { DROPDOWN_MENU_ITEM_HEIGHT, getIsInSelectedOptions } from '../dropdownUtils';
 import { DropdownMenu } from '../../../internal/dropdownMenu/DropdownMenu';
@@ -510,17 +509,14 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
           <IconAngleDown className={styles.angleIcon} aria-hidden />
         </button>
         {showClearButtonForSingleSelect && (
-          <button
-            type="button"
-            className={classNames(selectStyles.clearButton, !showToggleButton && selectStyles.noToggle)}
-            onClick={() => {
+          <ClearButton
+            toggleButtonHidden={!showToggleButton}
+            onClear={() => {
               resetCombobox();
               toggleButtonRef.current.focus();
             }}
-            aria-label={props.clearButtonAriaLabel}
-          >
-            <IconCrossCircle />
-          </button>
+            clearButtonAriaLabel={props.clearButtonAriaLabel}
+          />
         )}
         {/* MENU */}
         <DropdownMenu<OptionType>

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -9,9 +9,10 @@ import { useVirtual } from 'react-virtual';
 import 'hds-core';
 
 import styles from './Combobox.module.scss';
+import selectStyles from '../select/Select.module.scss';
 import { FieldLabel } from '../../../internal/field-label/FieldLabel';
 import classNames from '../../../utils/classNames';
-import { IconAlertCircleFill, IconAngleDown } from '../../../icons';
+import { IconAlertCircleFill, IconAngleDown, IconCrossCircle } from '../../../icons';
 import { SelectedItems } from '../../../internal/selectedItems/SelectedItems';
 import { multiSelectReducer, onMultiSelectStateChange, SelectCustomTheme, SelectProps } from '../select';
 import { DROPDOWN_MENU_ITEM_HEIGHT, getIsInSelectedOptions } from '../dropdownUtils';
@@ -181,6 +182,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     getToggleButtonProps,
     highlightedIndex,
     isOpen,
+    reset: resetCombobox,
     selectedItem,
     selectItem,
     closeMenu,
@@ -251,6 +253,8 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
       return changes;
     },
   });
+
+  const showClearButtonForSingleSelect = clearable && !props.multiselect && selectedItem;
 
   const setSelectedItems = (itemToBeSelected: OptionType) => {
     getIsInSelectedOptions(selectedItems, itemToBeSelected)
@@ -376,6 +380,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
         !showToggleButton && styles.noToggle,
         hasFocus && selectedItems.length > 0 && styles.adjustSpacing,
         props.icon && props.multiselect && styles.inputWithIcon,
+        clearable && !props.multiselect && selectedItem && styles.withClearButton,
       )}
       autoCorrect="off"
       autoComplete="off"
@@ -500,6 +505,16 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
         >
           <IconAngleDown className={styles.angleIcon} aria-hidden />
         </button>
+        {showClearButtonForSingleSelect && (
+          <button
+            type="button"
+            className={classNames(selectStyles.clearButton, !showToggleButton && selectStyles.noToggle)}
+            onClick={() => resetCombobox()}
+            aria-label={props.clearButtonAriaLabel}
+          >
+            <IconCrossCircle />
+          </button>
+        )}
         {/* MENU */}
         <DropdownMenu<OptionType>
           getItemProps={(item, index, selected, optionDisabled, virtualRow) =>

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -122,6 +122,8 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   const inputRef = useRef<HTMLInputElement>();
   // menu ref
   const menuRef = React.useRef<HTMLUListElement>();
+  // toggle button ref
+  const toggleButtonRef = React.useRef<HTMLButtonElement>(null);
   // whether active focus is within the dropdown
   const [hasFocus, setFocus] = useState<boolean>(false);
   // Tracks whether any combobox item is being clicked
@@ -462,6 +464,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             onClear={() => {
               reset();
               setInputValue('');
+              toggleButtonRef.current.focus();
             }}
             onRemove={removeSelectedItem}
             optionLabelField={optionLabelField}
@@ -501,6 +504,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             'aria-label': `${label}: ${toggleButtonAriaLabel}`,
             'aria-expanded': isOpen,
             ...(invalid && { 'aria-invalid': true }),
+            ref: toggleButtonRef,
           })}
         >
           <IconAngleDown className={styles.angleIcon} aria-hidden />
@@ -509,7 +513,10 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
           <button
             type="button"
             className={classNames(selectStyles.clearButton, !showToggleButton && selectStyles.noToggle)}
-            onClick={() => resetCombobox()}
+            onClick={() => {
+              resetCombobox();
+              toggleButtonRef.current.focus();
+            }}
             aria-label={props.clearButtonAriaLabel}
           >
             <IconCrossCircle />

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -382,7 +382,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
         !showToggleButton && styles.noToggle,
         hasFocus && selectedItems.length > 0 && styles.adjustSpacing,
         props.icon && props.multiselect && styles.inputWithIcon,
-        clearable && !props.multiselect && selectedItem && styles.withClearButton,
+        showClearButtonForSingleSelect && styles.withClearButton,
       )}
       autoCorrect="off"
       autoComplete="off"

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -84,7 +84,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     catchEscapeKey,
     circularNavigation = false,
     className,
-    clearable = true,
+    clearable = props.multiselect,
     disabled = false,
     error,
     getA11ySelectionMessage = () => '',

--- a/packages/react/src/components/dropdown/select/Select.module.scss
+++ b/packages/react/src/components/dropdown/select/Select.module.scss
@@ -50,6 +50,10 @@
   padding-right: var(--spacing-layout-xs);
 }
 
+.buttonLabel.buttonLabelWithClearButton {
+  padding-right: var(--spacing-3-xl);
+}
+
 /**
  * ICON
  */
@@ -124,5 +128,24 @@
     &:focus:not(:active) .angleIcon {
       @extend %dropdownFocusOutline;
     }
+  }
+}
+
+.clearButton {
+  @extend %buttonReset;
+  display: flex;
+  outline: none;
+  position: absolute;
+  right: calc(var(--border-width) * -1);
+  top: 0;
+  transform: translate(calc(var(--spacing-2-xl) * -1), calc(var(--menu-item-height) / 2 - 50%));
+  z-index: 1;
+
+  &:focus {
+    box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-outline-color);
+  }
+
+  &.noToggle {
+    transform: translate(calc(var(--spacing-s) * -1), calc(var(--menu-item-height) / 2 - 50%));
   }
 }

--- a/packages/react/src/components/dropdown/select/Select.module.scss
+++ b/packages/react/src/components/dropdown/select/Select.module.scss
@@ -130,22 +130,3 @@
     }
   }
 }
-
-.clearButton {
-  @extend %buttonReset;
-  display: flex;
-  outline: none;
-  position: absolute;
-  right: calc(var(--border-width) * -1);
-  top: 0;
-  transform: translate(calc(var(--spacing-2-xl) * -1), calc(var(--menu-item-height) / 2 - 50%));
-  z-index: 1;
-
-  &:focus {
-    box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-outline-color);
-  }
-
-  &.noToggle {
-    transform: translate(calc(var(--spacing-s) * -1), calc(var(--menu-item-height) / 2 - 50%));
-  }
-}

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -41,6 +41,7 @@ export default {
     label: 'Element',
     helper: 'Choose an element',
     placeholder: 'Placeholder',
+    clearButtonAriaLabel: 'Clear selection',
     options,
     onBlur: action('onBlur'),
     onChange: (change) => action('onChange')(change),
@@ -49,6 +50,13 @@ export default {
 };
 
 export const Default = (args) => <Select {...args} />;
+
+export const WithClearButton = (args) => <Select {...args} />;
+WithClearButton.storyName = 'With clear button';
+WithClearButton.args = {
+  clearable: true,
+};
+WithClearButton.parameters = { loki: { skip: true } };
 
 export const Multiselect = (args) => <Select {...args} />;
 Multiselect.storyName = 'Multi-select';

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -78,10 +78,6 @@ export type CommonSelectProps<OptionType> = {
    */
   clearable?: boolean;
   /**
-   * The aria-label for the clear button
-   */
-  clearButtonAriaLabel: string;
-  /**
    * If `true`, the dropdown will be disabled
    */
   disabled?: boolean;
@@ -179,6 +175,10 @@ export type CommonSelectProps<OptionType> = {
 
 export type SingleSelectProps<OptionType> = CommonSelectProps<OptionType> & {
   /**
+   * The aria-label for the clear button
+   */
+  clearButtonAriaLabel?: string;
+  /**
    * When `true`, enables selecting multiple values
    */
   multiselect?: false;
@@ -197,6 +197,10 @@ export type SingleSelectProps<OptionType> = CommonSelectProps<OptionType> & {
 };
 
 export type MultiSelectProps<OptionType> = CommonSelectProps<OptionType> & {
+  /**
+   * The aria-label for the clear button
+   */
+  clearButtonAriaLabel: string;
   /**
    * When `true`, enables selecting multiple values
    */
@@ -297,7 +301,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   const {
     circularNavigation = false,
     className,
-    clearable = true,
+    clearable = props.multiselect,
     disabled = false,
     error,
     getA11ySelectionMessage = () => '',

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -18,7 +18,7 @@ import 'hds-core';
 import styles from './Select.module.scss';
 import { FieldLabel } from '../../../internal/field-label/FieldLabel';
 import classNames from '../../../utils/classNames';
-import { IconAlertCircle, IconAngleDown } from '../../../icons';
+import { IconAlertCircle, IconAngleDown, IconCrossCircle } from '../../../icons';
 import { SelectedItems } from '../../../internal/selectedItems/SelectedItems';
 import { DROPDOWN_MENU_ITEM_HEIGHT, getIsInSelectedOptions } from '../dropdownUtils';
 import { DropdownMenu } from '../../../internal/dropdownMenu/DropdownMenu';
@@ -77,6 +77,10 @@ export type CommonSelectProps<OptionType> = {
    * Flag for whether the clear selections button should be displayed
    */
   clearable?: boolean;
+  /**
+   * The aria-label for the clear button
+   */
+  clearButtonAriaLabel: string;
   /**
    * If `true`, the dropdown will be disabled
    */
@@ -197,10 +201,6 @@ export type MultiSelectProps<OptionType> = CommonSelectProps<OptionType> & {
    * When `true`, enables selecting multiple values
    */
   multiselect: true;
-  /**
-   * The aria-label for the clear button
-   */
-  clearButtonAriaLabel: string;
   /**
    * Value(s) that should be selected when the dropdown is initialized
    */
@@ -376,6 +376,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
     isOpen,
     selectedItem,
     selectItem,
+    reset: resetSelect,
   } = useSelect<OptionType>({
     circularNavigation,
     id,
@@ -441,11 +442,24 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
     getDropdownProps({}, { suppressRefError: true });
   }
 
+  const showClearButtonForSingleSelect = clearable && !props.multiselect && selectedItem;
+
   // returns the toggle button label based on the dropdown mode
   const getButtonLabel = (): React.ReactNode => {
     let buttonLabel = selectedItem?.[optionLabelField] || placeholder;
     if (props.multiselect) buttonLabel = selectedItems.length > 0 ? null : placeholder;
-    return buttonLabel && <span className={styles.buttonLabel}>{buttonLabel}</span>;
+    return (
+      buttonLabel && (
+        <span
+          className={classNames(
+            styles.buttonLabel,
+            showClearButtonForSingleSelect && styles.buttonLabelWithClearButton,
+          )}
+        >
+          {buttonLabel}
+        </span>
+      )
+    );
   };
 
   // screen readers should read the labels in the following order:
@@ -526,6 +540,16 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
           {getButtonLabel()}
           <IconAngleDown className={styles.angleIcon} aria-hidden />
         </button>
+        {showClearButtonForSingleSelect && (
+          <button
+            type="button"
+            className={styles.clearButton}
+            onClick={() => resetSelect()}
+            aria-label={props.clearButtonAriaLabel}
+          >
+            <IconCrossCircle />
+          </button>
+        )}
         {/* MENU */}
         <DropdownMenu<OptionType>
           getItemProps={(item, index, selected, optionDisabled, virtualRow) =>

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -334,7 +334,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   // menu ref
   const menuRef = React.useRef<HTMLUListElement>();
   // toggle button ref
-  const toggleButtonRef = React.useRef(null);
+  const toggleButtonRef = React.useRef<HTMLButtonElement>(null);
   // whether active focus is within the dropdown
   const [hasFocus, setFocus] = useState<boolean>(false);
   // virtualize menu items to increase performance

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -333,6 +333,8 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   const selectedItemsContainerRef = useRef<HTMLDivElement>();
   // menu ref
   const menuRef = React.useRef<HTMLUListElement>();
+  // toggle button ref
+  const toggleButtonRef = React.useRef(null);
   // whether active focus is within the dropdown
   const [hasFocus, setFocus] = useState<boolean>(false);
   // virtualize menu items to increase performance
@@ -513,7 +515,10 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
             dropdownId={id}
             getSelectedItemProps={getSelectedItemProps}
             hideItems={!hasFocus}
-            onClear={() => reset()}
+            onClear={() => {
+              reset();
+              toggleButtonRef.current.focus();
+            }}
             onRemove={removeSelectedItem}
             optionLabelField={optionLabelField}
             removeButtonAriaLabel={props.selectedItemRemoveButtonAriaLabel}
@@ -530,10 +535,11 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
             'aria-owns': getMenuProps().id,
             'aria-labelledby': buttonAriaLabel,
             // add downshift dropdown props when multiselect is enabled
-            ...(props.multiselect && { ...getDropdownProps({ preventKeyAction: isOpen }) }),
+            ...(props.multiselect && { ...getDropdownProps({ preventKeyAction: isOpen, ref: toggleButtonRef }) }),
             ...(invalid && { 'aria-invalid': true }),
             disabled,
             className: classNames(styles.button, showPlaceholder && styles.placeholder),
+            ...(!props.multiselect && { ref: toggleButtonRef }),
           })}
         >
           {showIcon && (
@@ -548,7 +554,10 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
           <button
             type="button"
             className={styles.clearButton}
-            onClick={() => resetSelect()}
+            onClick={() => {
+              toggleButtonRef.current.focus();
+              resetSelect();
+            }}
             aria-label={props.clearButtonAriaLabel}
           >
             <IconCrossCircle />

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -18,8 +18,8 @@ import 'hds-core';
 import styles from './Select.module.scss';
 import { FieldLabel } from '../../../internal/field-label/FieldLabel';
 import classNames from '../../../utils/classNames';
-import { IconAlertCircle, IconAngleDown, IconCrossCircle } from '../../../icons';
-import { SelectedItems } from '../../../internal/selectedItems/SelectedItems';
+import { IconAlertCircle, IconAngleDown } from '../../../icons';
+import { ClearButton, SelectedItems } from '../../../internal/selectedItems/SelectedItems';
 import { DROPDOWN_MENU_ITEM_HEIGHT, getIsInSelectedOptions } from '../dropdownUtils';
 import { DropdownMenu } from '../../../internal/dropdownMenu/DropdownMenu';
 import getIsElementFocused from '../../../utils/getIsElementFocused';
@@ -551,17 +551,13 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
           <IconAngleDown className={styles.angleIcon} aria-hidden />
         </button>
         {showClearButtonForSingleSelect && (
-          <button
-            type="button"
-            className={styles.clearButton}
-            onClick={() => {
-              toggleButtonRef.current.focus();
+          <ClearButton
+            onClear={() => {
               resetSelect();
+              toggleButtonRef.current.focus();
             }}
-            aria-label={props.clearButtonAriaLabel}
-          >
-            <IconCrossCircle />
-          </button>
+            clearButtonAriaLabel={props.clearButtonAriaLabel}
+          />
         )}
         {/* MENU */}
         <DropdownMenu<OptionType>

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -155,6 +155,27 @@ const handleItemHiding = (
   }
 };
 
+type ClearButtonProps = {
+  onClear: () => void;
+  clearButtonAriaLabel: string;
+  toggleButtonHidden?: boolean;
+  onFocus?: () => void;
+};
+
+export const ClearButton = ({ toggleButtonHidden, onClear, clearButtonAriaLabel, onFocus }: ClearButtonProps) => {
+  return (
+    <button
+      type="button"
+      className={classNames(styles.clearButton, toggleButtonHidden && styles.noToggle)}
+      onClick={onClear}
+      aria-label={clearButtonAriaLabel}
+      onFocus={onFocus && onFocus}
+    >
+      <IconCrossCircle />
+    </button>
+  );
+};
+
 export const SelectedItems = <OptionType,>({
   activeIndex,
   className,
@@ -262,11 +283,10 @@ export const SelectedItems = <OptionType,>({
       </div>
       {/* CLEAR BUTTON */}
       {clearable && (
-        <button
-          type="button"
-          className={classNames(styles.clearButton, toggleButtonHidden && styles.noToggle)}
-          onClick={onClear}
-          aria-label={clearButtonAriaLabel}
+        <ClearButton
+          toggleButtonHidden={toggleButtonHidden}
+          onClear={onClear}
+          clearButtonAriaLabel={clearButtonAriaLabel}
           onFocus={() => {
             // manually set the tabindex of the first selected item to "0",
             // when the clear button is focused, and the activeIndex is -1.
@@ -275,9 +295,7 @@ export const SelectedItems = <OptionType,>({
               (containerEl?.childNodes[0] as HTMLDivElement).setAttribute('tabindex', '0');
             }
           }}
-        >
-          <IconCrossCircle />
-        </button>
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Description

Adds clear button to Select and Combobox in single select mode.

Bonus: Focus Select/Combobox after clear button is pressed

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-827
https://github.com/City-of-Helsinki/helsinki-design-system/issues/358

Closes #358 

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Locally on developers machine

## Screenshots (if appropriate):

<img width="466" alt="image" src="https://user-images.githubusercontent.com/2777633/154485676-8d62ae2a-35ef-46e3-b183-66f4cd69733b.png">


## Demo:

https://city-of-helsinki.github.io/hds-demo/clear-button-for-single-select/?path=/story/components-dropdowns-combobox--with-clear-button
