### PR TITLE
Content/Order side nav sub items alphabetically

### DIFF
--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -115,7 +115,7 @@ const Layout = ({ children, pageContext }) => {
         ...subLevelLink,
         uiId: generateUiIdFromPath(subLevelLink.slug, 'side-nav-sub'),
         prefixedLink: withPrefix(subLevelLink.slug),
-      })),
+      })).sort((subLevelLinkA, subLevelLinkB) => subLevelLinkA.title.localeCompare(subLevelLinkB.title)),
   }));
   const footerCopyRightLinks = siteData?.footerCopyrightLinks || [];
   const contentId = 'content';


### PR DESCRIPTION
## Description

Order side nav sub items alphabetically

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1200

## How Has This Been Tested?

- Locally on developers machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/doc-side-nav-order)

## Screenshots (if appropriate):

<img width="253" alt="image" src="https://user-images.githubusercontent.com/2777633/155571552-f7613d5c-d803-40db-8239-3061046ceb19.png">
