### PR TITLE
Fix/imports and markdown

### DIFF
--- a/new-site/gatsby-browser.js
+++ b/new-site/gatsby-browser.js
@@ -7,3 +7,4 @@
 import 'hds-core/lib/base.css';
 import 'hds-core/lib/icons/all.css';
 import 'hds-core/lib/icons/icon.css';
+import 'hds-core/lib/components/all.css';

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -153,9 +153,9 @@ Editor.propTypes = {
 
 const EditorWithLive = withLive(Editor);
 
-export const PlaygroundBlock = ({ children }) => {
+export const PlaygroundBlock = (props) => {
   const scopeComponents = useMDXScope();
-  const codeBlocks = React.Children.map(children, ({ props }) => {
+  const codeBlocks = React.Children.toArray(props.children).map(({ props }) => {
     const childrenProps = props.children.props;
     return {
       code: childrenProps.children,
@@ -199,17 +199,21 @@ export const PlaygroundBlock = ({ children }) => {
   );
 };
 
-PlaygroundBlock.propTypes = {
-  children: PropTypes.arrayOf(
-    PropTypes.shape({
+const CodeBlockShape = PropTypes.shape({
+  props: PropTypes.shape({
+    children: PropTypes.shape({
       props: PropTypes.shape({
-        children: PropTypes.shape({
-          props: PropTypes.shape({
-            children: PropTypes.string.isRequired,
-            className: PropTypes.string.isRequired,
-          }),
-        }),
+        children: PropTypes.string.isRequired,
+        className: PropTypes.string.isRequired,
       }),
     }),
-  ),
+  }),
+});
+
+PlaygroundBlock.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(CodeBlockShape),
+    PropTypes.objectOf(CodeBlockShape),
+    PropTypes.node,
+  ]),
 };

--- a/new-site/src/components/Table.js
+++ b/new-site/src/components/Table.js
@@ -15,7 +15,7 @@ const Table = (props) => {
   const thead = (props.children || []).find(({ props }) => props.originalType === 'thead');
   const tbody = (props.children || []).find(({ props }) => props.originalType === 'tbody');
   const tbodyRows = tbody.props?.children || [];
-  const [rows, captionString] = tbodyRows.reduce(
+  const [rows, captionString] = React.Children.toArray(tbodyRows).reduce(
     (acc, row, i, arr) => {
       if (
         i >= arr.length - 1 &&

--- a/new-site/src/docs/elements/components/accordion/code.mdx
+++ b/new-site/src/docs/elements/components/accordion/code.mdx
@@ -3,10 +3,18 @@ slug: '/elements/components/accordion/code'
 title: 'Accordion - Code'
 ---
 
-import { Link } from 'hds-react';
-
-import { Accordion, useAccordion, Button, Card, Select, Combobox } from 'hds-react';
-import { IconAngleDown, IconAngleUp, IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import {
+  Accordion,
+  useAccordion,
+  Button,
+  Card,
+  Select,
+  IconAngleDown,
+  IconAngleUp,
+  IconCheckCircleFill,
+  IconCrossCircle,
+  Link,
+} from 'hds-react';
 
 import Playground from '../../../../components/Playground';
 
@@ -27,10 +35,6 @@ import Playground from '../../../../components/Playground';
 </Accordion>
 ```
 
-```html
-
-```
-
 </Playground>
 
 #### With a card
@@ -46,10 +50,6 @@ import Playground from '../../../../components/Playground';
 >
     To publish your data, open your profile settings and click the button 'Publish'.
 </Accordion>
-```
-
-```html
-
 ```
 
 </Playground>
@@ -109,11 +109,8 @@ import Playground from '../../../../components/Playground';
             </Card>
         </>
     );
-}}
-```
-
-```html
-
+  }
+}
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/accordion/customisation.mdx
+++ b/new-site/src/docs/elements/components/accordion/customisation.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/accordion/customisation'
 title: 'Accordion - Customisation'
 ---
 
-import { Button, Link } from 'hds-react';
-import { IconArrowRight } from 'hds-react';
+import { Accordion } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Customisation
 

--- a/new-site/src/docs/elements/components/accordion/index.mdx
+++ b/new-site/src/docs/elements/components/accordion/index.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/accordion'
 title: 'Accordion'
 ---
 
-import { Accordion, StatusLabel, Tabs } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
 

--- a/new-site/src/docs/elements/components/accordion/usage.mdx
+++ b/new-site/src/docs/elements/components/accordion/usage.mdx
@@ -3,9 +3,7 @@ slug: '/elements/components/accordion/code'
 title: 'Accordion - Usage'
 ---
 
-import { Button, Accordion } from 'hds-react';
-import { IconAngleRight, IconShare, IconTrash } from 'hds-react';
-import Playground from '../../../../components/Playground';
+import { Accordion } from 'hds-react';
 
 ## Usage
 

--- a/new-site/src/docs/elements/components/buttons/code.mdx
+++ b/new-site/src/docs/elements/components/buttons/code.mdx
@@ -3,8 +3,7 @@ slug: '/elements/components/buttons/code'
 title: 'Button - Code'
 ---
 
-import { Button, Link, Notification, Table } from 'hds-react';
-import { IconTrash, IconAngleRight, IconShare } from 'hds-react';
+import { Button, IconTrash, IconAngleRight, Link, Notification, IconShare } from 'hds-react';
 import PropertyTable from './components/properties';
 import PackageTable from './components/packages';
 import Playground from '../../../../components/Playground';
@@ -12,14 +11,14 @@ import Playground from '../../../../components/Playground';
 ## Code
 
 ### Packages
+
 <PackageTable />
 
-
-### Code examples 
+### Code examples
 
 #### Primary
-<Playground>
 
+<Playground>
 
 ```jsx
 <Button>Primary</Button>
@@ -33,9 +32,10 @@ import Playground from '../../../../components/Playground';
 
 </Playground>
 
-#### Secondary
-<Playground>
 
+#### Secondary
+
+<Playground>
 
 ```jsx
 <Button variant="secondary">Secondary</Button>
@@ -49,12 +49,15 @@ import Playground from '../../../../components/Playground';
 
 </Playground>
 
+
 #### Supplementary
+
 <Playground>
 
-
 ```jsx
-<Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+<Button variant="supplementary" iconLeft={<IconTrash />}>
+  Supplementary
+</Button>
 ```
 
 ```html
@@ -66,15 +69,18 @@ import Playground from '../../../../components/Playground';
 
 </Playground>
 
-#### Icon button
-<Playground>
 
+#### Icon button
+
+<Playground>
 
 ```jsx
 <div>
   <Button iconLeft={<IconShare />}>Button</Button>
   <Button iconRight={<IconAngleRight />}>Button</Button>
-  <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>Button</Button>
+  <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>
+    Button
+  </Button>
 </div>
 ```
 
@@ -98,18 +104,23 @@ import Playground from '../../../../components/Playground';
 </div>
 ```
 
-
 </Playground>
 
+
 #### Small button
+
 <Playground>
 
 
 ```jsx
 <div>
   <Button size="small">Primary</Button>
-  <Button variant="secondary" size="small">Secondary</Button>
-  <Button variant="supplementary" size="small">Supplementary</Button>
+  <Button variant="secondary" size="small">
+    Secondary
+  </Button>
+  <Button variant="supplementary" size="small">
+    Supplementary
+  </Button>
 </div>
 ```
 
@@ -131,7 +142,9 @@ import Playground from '../../../../components/Playground';
 
 </Playground>
 
+
 #### Utility button
+
 <Playground>
 
 
@@ -156,39 +169,43 @@ import Playground from '../../../../components/Playground';
 
 </Playground>
 
+
 #### Loading button
+
 <Playground>
 
 
 ```jsx
-{() => {
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [showNotification, setShowNotification] = React.useState(false);
-  React.useEffect(() => {
-    let timeout;
-    if (isLoading) {
-      timeout = setTimeout(() => {
-        setShowNotification(true);
-        setIsLoading(false);
-      }, 2000);
-    }
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [isLoading]);
-  return (
-    <>
-      <Button
-        isLoading={isLoading}
-        loadingText="Saving form changes"
-        onClick={() => {
-          setShowNotification(false);
-          setIsLoading(true);
-        }}>
-        Save form
-      </Button>
-      {showNotification
-      && <Notification
+{
+  () => {
+    const [isLoading, setIsLoading] = React.useState(false);
+    const [showNotification, setShowNotification] = React.useState(false);
+    React.useEffect(() => {
+      let timeout;
+      if (isLoading) {
+        timeout = setTimeout(() => {
+          setShowNotification(true);
+          setIsLoading(false);
+        }, 2000);
+      }
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [isLoading]);
+    return (
+      <>
+        <Button
+          isLoading={isLoading}
+          loadingText="Saving form changes"
+          onClick={() => {
+            setShowNotification(false);
+            setIsLoading(true);
+          }}
+        >
+          Save form
+        </Button>
+        {showNotification && (
+          <Notification
             key={new Date().toString()}
             position="top-right"
             displayAutoCloseProgress={false}
@@ -197,20 +214,20 @@ import Playground from '../../../../components/Playground';
             label="Form saved!"
             type="success"
             onClose={() => {
-              setShowNotification(false)
-            }}>
+              setShowNotification(false);
+            }}
+          >
             Saving your form was successful.
-        </Notification>}
-    </>
-  )
-}}
-```
-
-```html
-
+          </Notification>
+        )}
+      </>
+    );
+  }
+}
 ```
 
 </Playground>
+
 
 <PropertyTable />
 

--- a/new-site/src/docs/elements/components/buttons/customisation.mdx
+++ b/new-site/src/docs/elements/components/buttons/customisation.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/buttons/customisation'
 title: 'Button - Customisation'
 ---
 
-import { Button, Link, Notification } from 'hds-react';
-import { IconArrowRight } from 'hds-react';
+import { Button, IconArrowRight, Notification } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Customisation
 

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -5,8 +5,6 @@ title: 'Button'
 
 import { StatusLabel, Tabs } from 'hds-react';
 
-import 'hds-core/lib/components/button/button.css';
-
 import LeadParagraph from '../../../../components/LeadParagraph';
 
 import Accessibility from './accessibility.mdx';

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/buttons'
 title: 'Button'
 ---
 
-import { Button, StatusLabel, Tabs } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 
 import 'hds-core/lib/components/button/button.css';
 

--- a/new-site/src/docs/elements/components/buttons/usage.mdx
+++ b/new-site/src/docs/elements/components/buttons/usage.mdx
@@ -3,9 +3,7 @@ slug: '/elements/components/buttons/code'
 title: 'Button - Usage'
 ---
 
-import { Button, Accordion } from 'hds-react';
-import { IconAngleRight, IconShare, IconTrash } from 'hds-react';
-import Playground from '../../../../components/Playground';
+import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-react';
 
 ## Usage
 

--- a/new-site/src/docs/elements/components/card/code.mdx
+++ b/new-site/src/docs/elements/components/card/code.mdx
@@ -3,18 +3,15 @@ slug: '/elements/components/card/code'
 title: 'Card - Code'
 ---
 
-import { Link } from 'hds-react';
-
-import { Card, Button } from 'hds-react';
-import { IconAngleDown, IconAngleUp, IconCheckCircleFill, IconCrossCircle } from 'hds-react';
-
+import { Button, Card, IconAngleDown, IconAngleUp, IconCheckCircleFill, IconCrossCircle, Link } from 'hds-react';
 import Playground from '../../../../components/Playground';
 
 ## Code
 
-### Code examples 
+### Code examples
 
 #### Empty
+
 <Playground>
 
 
@@ -26,29 +23,39 @@ import Playground from '../../../../components/Playground';
 ```
 
 ```html
-<div>
-  <div class="hds-card"></div>
-  <div class="hds-card hds-card--border"></div>
-</div>
+  <div class="hds-card">
+    <div class="hds-card__body">
+      <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
+      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+    </div>
+  </div>
+  <div class="hds-card hds-card--border">
+    <div class="hds-card__body">
+      <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
+      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+    </div>
+  </div>
 ```
 
 </Playground>
+
 
 #### With heading and body text
+
 <Playground>
 
 
 ```jsx
 <>
-<Card
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-/>
-<Card
-  border
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-/>
+  <Card
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  />
+  <Card
+    border
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  />
 </>
 ```
 
@@ -57,40 +64,52 @@ import Playground from '../../../../components/Playground';
   <div class="hds-card">
     <div class="hds-card__body">
       <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
-      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+      <div class="hds-card__text">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+      </div>
     </div>
   </div>
 
   <div class="hds-card hds-card--border">
     <div class="hds-card__body">
       <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
-      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+      <div class="hds-card__text">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+      </div>
     </div>
   </div>
 </div>
 ```
 
 </Playground>
+
 
 #### Using with other HDS components
+
 <Playground>
 
 
 ```jsx
 <>
-<Card
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
->
-  <Button variant="secondary" theme="black" role="link">Button</Button>
-</Card>
-<Card
-  border
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
->
-  <Button variant="secondary" theme="black" role="link">Button</Button>
-</Card>
+  <Card
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <Button variant="secondary" theme="black" role="link">
+      Button
+    </Button>
+  </Card>
+  <Card
+    border
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <Button variant="secondary" theme="black" role="link">
+      Button
+    </Button>
+  </Card>
 </>
 ```
 
@@ -99,7 +118,10 @@ import Playground from '../../../../components/Playground';
   <div class="hds-card">
     <div class="hds-card__body">
       <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
-      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+      <div class="hds-card__text">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+      </div>
     </div>
     <button type="button" class="hds-button hds-button--secondary hds-button--theme-black" role="link">
       <span class="hds-button__label">Button</span>
@@ -109,7 +131,10 @@ import Playground from '../../../../components/Playground';
   <div class="hds-card hds-card--border">
     <div class="hds-card__body">
       <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
-      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+      <div class="hds-card__text">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+      </div>
     </div>
     <button type="button" class="hds-button hds-button--secondary hds-button--theme-black" role="link">
       <span class="hds-button__label">Button</span>
@@ -119,22 +144,23 @@ import Playground from '../../../../components/Playground';
 ```
 
 </Playground>
-
 
 
 ### Packages
-| Package           | Included                      | Storybook link                                                                                                                      | Source link   |
-| ----------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| **HDS React**     | <IconCheckCircleFill /> Yes   | <Link size="M" external href="/storybook/react/?path=?path=/story/components-card--empty">View in Storybook</Link>  | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/card/Card.tsx">View source</Link> |
-| **HDS Core**      | <IconCheckCircleFill /> Yes   | <Link size="M" external href="/storybook/core/?path=/story/components-card--empty">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/card">View source</Link> |
+
+| Package       | Included                    | Storybook link                                                                                                     | Source link                                                                                                                                                          |
+| ------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **HDS React** | <IconCheckCircleFill /> Yes | <Link size="M" external href="/storybook/react/?path=?path=/story/components-card--empty">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/card/Card.tsx">View source</Link> |
+| **HDS Core**  | <IconCheckCircleFill /> Yes | <Link size="M" external href="/storybook/core/?path=/story/components-card--empty">View in Storybook</Link>        | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/card">View source</Link>           |
 
 ### Properties
+
 Note! You can find the full list of properties in the <Link size="M" href="/storybook/react/?path=?path=/story/components-card--empty" external>React Storybook.</Link>
 
-| Property                   | Description                                                                | Values      | Default value |
-| -------------------------- | -------------------------------------------------------------------------- | ----------- | ------------- |
-| `heading`                  | Heading of the Card (uses the built-in heading)                            | -           | -             |
-| `text`                     | Content text of the Card (uses the built-in text)                          | -            | -             |
-| `border`                   | If set to true, a border will be drawn around the card.                    | true, false | false         |
+| Property  | Description                                             | Values      | Default value |
+| --------- | ------------------------------------------------------- | ----------- | ------------- |
+| `heading` | Heading of the Card (uses the built-in heading)         | -           | -             |
+| `text`    | Content text of the Card (uses the built-in text)       | -           | -             |
+| `border`  | If set to true, a border will be drawn around the card. | true, false | false         |
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/card/code.mdx
+++ b/new-site/src/docs/elements/components/card/code.mdx
@@ -23,16 +23,18 @@ import Playground from '../../../../components/Playground';
 ```
 
 ```html
-  <div class="hds-card">
-    <div class="hds-card__body">
-      <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
-      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+  <div>
+    <div class="hds-card">
+      <div class="hds-card__body">
+        <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
+        <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+      </div>
     </div>
-  </div>
-  <div class="hds-card hds-card--border">
-    <div class="hds-card__body">
-      <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
-      <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+    <div class="hds-card hds-card--border">
+      <div class="hds-card__body">
+        <div class="hds-card__heading" role="heading" aria-level="2">Card</div>
+        <div class="hds-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+      </div>
     </div>
   </div>
 ```

--- a/new-site/src/docs/elements/components/card/customisation.mdx
+++ b/new-site/src/docs/elements/components/card/customisation.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/card/customisation'
 title: 'Card - Customisation'
 ---
 
-import { Card, Link } from 'hds-react';
-import { IconArrowRight } from 'hds-react';
+import { Card } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Customisation
 
@@ -39,10 +39,6 @@ You can use the `theme` property to customise the component. See all available t
     '--padding-vertical': 'var(--spacing-m)'
   }}
 />
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/card/index.mdx
+++ b/new-site/src/docs/elements/components/card/index.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/card'
 title: 'Card'
 ---
 
-import { Card, StatusLabel, Tabs } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
 

--- a/new-site/src/docs/elements/components/card/usage.mdx
+++ b/new-site/src/docs/elements/components/card/usage.mdx
@@ -3,9 +3,7 @@ slug: '/elements/components/card/code'
 title: 'Card - Usage'
 ---
 
-import { Card, Button, Accordion } from 'hds-react';
-import { IconAngleRight, IconShare, IconTrash } from 'hds-react';
-import Playground from '../../../../components/Playground';
+import { Button, Card, IconAngleRight, IconShare, IconTrash, Link } from 'hds-react';
 
 ## Usage
 

--- a/new-site/src/docs/elements/components/checkbox/code.mdx
+++ b/new-site/src/docs/elements/components/checkbox/code.mdx
@@ -7,7 +7,7 @@ import { IconAngleDown, IconAngleUp, IconCheckCircleFill, IconCrossCircle, Link,
 
 import Playground from '../../../../components/Playground';
 
-## Codes
+## Code
 
 ### Code examples 
 

--- a/new-site/src/docs/elements/components/checkbox/code.mdx
+++ b/new-site/src/docs/elements/components/checkbox/code.mdx
@@ -3,20 +3,16 @@ slug: '/elements/components/checkbox/code'
 title: 'Checkbox - Code'
 ---
 
-import { Link } from 'hds-react';
-
-import { Card, SelectionGroup } from 'hds-react';
-import { IconAngleDown, IconAngleUp, IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import { IconAngleDown, IconAngleUp, IconCheckCircleFill, IconCrossCircle, Link, SelectionGroup } from 'hds-react';
 
 import Playground from '../../../../components/Playground';
 
-## Code
+## Codes
 
 ### Code examples 
 
 #### Checkbox with label
 <Playground>
-
 
 ```jsx
 {() => {
@@ -61,7 +57,6 @@ import Playground from '../../../../components/Playground';
 
 #### Checkbox group
 <Playground>
-
 
 ```jsx
 {() => {
@@ -113,7 +108,6 @@ import Playground from '../../../../components/Playground';
 ```
 
 </Playground>
-
 
 
 ### Packages

--- a/new-site/src/docs/elements/components/checkbox/customisation.mdx
+++ b/new-site/src/docs/elements/components/checkbox/customisation.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/checkbox/customisation'
 title: 'Checkbox - Customisation'
 ---
 
-import { Card, Link, Notification } from 'hds-react';
-import { IconArrowRight } from 'hds-react';
+import { Checkbox, Link, Notification } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Customisation
 
@@ -35,7 +35,7 @@ You can use the `style` property to customise the component. See all available t
 
 ```jsx
 {() => {
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = React.useState(false);
   const customStyles = {
     '--size': '40px',
     '--icon-scale': 0.6,
@@ -47,9 +47,7 @@ You can use the `style` property to customise the component. See all available t
     '--border-color-selected-hover': 'var(--color-success-dark)',
     '--border-color-selected-focus': 'var(--color-success)',
     '--focus-outline-color': 'var(--color-black-20)',
-  }
-  as
-  React.CSSProperties;
+  };
   return (
     <Checkbox
       id="checkbox5"

--- a/new-site/src/docs/elements/components/checkbox/index.mdx
+++ b/new-site/src/docs/elements/components/checkbox/index.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/checkbox'
 title: 'Checkbox'
 ---
 
-import { Card, StatusLabel, Tabs } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
 

--- a/new-site/src/docs/elements/components/checkbox/usage.mdx
+++ b/new-site/src/docs/elements/components/checkbox/usage.mdx
@@ -3,35 +3,66 @@ slug: '/elements/components/checkbox/code'
 title: 'Checkbox - Usage'
 ---
 
-import { Checkbox, Card, Button, Accordion } from 'hds-react';
-import { IconAngleRight, IconShare, IconTrash } from 'hds-react';
-import Playground from '../../../../components/Playground';
+import { Checkbox } from 'hds-react';
 
 ## Usage
 
 ### Example
-<Checkbox label="Checkbox" id="checkbox" />
+
+export const CheckBoxExample = () => {
+  const [checkedItems, setCheckedItems] = React.useState({
+    'checkbox-checked': true,
+    'checkbox-checked-disabled': true,
+  });
+  const onChange = (event) => {
+    setCheckedItems({ ...checkedItems, [event.target.id]: event.target.checked });
+  };
+  return (
+    <>
+      <Checkbox label="Label" id="checkbox" checked={checkedItems['checkbox']} onChange={onChange} />
+      <Checkbox label="Label" id="checkbox-checked" checked={checkedItems['checkbox-checked']} onChange={onChange} />
+      <Checkbox
+        label="Label"
+        id="checkbox-disabled"
+        checked={checkedItems['checkbox-disabled']}
+        onChange={onChange}
+        disabled
+      />
+      <Checkbox
+        label="Label"
+        id="checkbox-checked-disabled"
+        checked={checkedItems['checkbox-checked-disabled']}
+        onChange={onChange}
+        disabled
+      />
+    </>
+  );
+};
+
+<CheckBoxExample />
 
 ## Principles
+
 - If the user can only select one option from a list, use [radio buttons](/components/radio-button) instead.
 - Checkbox label should always clearly describe what will happen if the specific option is chosen. A good practice is to keep labels a maximum of three words long.
 - Checkboxes work independently from each other. This means that checking one option should never affect other checkboxes.
-- If Checkboxes are related to each other, use [HDS Selection group](/components/selection-group) to achieve that. 
+- If Checkboxes are related to each other, use [HDS Selection group](/components/selection-group) to achieve that.
 - Checkboxes should not have any immediate effects. The checkbox selection takes effect when the user presses a submit button (e.g. in a form). If you need the selection to have an immediate effect, use [HDS Toggle button component](/components/toggle) instead. Also see [guidelines for choosing between radio buttons, checkboxes, and toggles.](/guidelines/checkboxes-radiobuttons-toggles)
 
 ### Variations
 
 ### Checkbox with label
 
-
 ---
 
 ### Checkbox group
+
 Related checkboxes can be grouped together with the Selection group component. See [HDS Selection group page](/components/selection-group) for full documentation.
 
 ---
 
 ### Using with other HDS components
+
 Custom Cards can be easily built by using other HDS components and typography inside the Card.
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/date-input/code.mdx
+++ b/new-site/src/docs/elements/components/date-input/code.mdx
@@ -3,8 +3,7 @@ slug: '/elements/components/date-input/code'
 title: 'DateInput - Code'
 ---
 
-import { DateInput, Link, Card, SelectionGroup } from 'hds-react';
-import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import { DateInput, IconCheckCircleFill, IconCrossCircle, Link } from 'hds-react';
 
 import Playground from '../../../../components/Playground';
 
@@ -30,10 +29,6 @@ import Playground from '../../../../components/Playground';
 </div>
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Date input without a confirmation
@@ -55,10 +50,6 @@ import Playground from '../../../../components/Playground';
 </div>
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Date input without a picker
@@ -68,7 +59,6 @@ import Playground from '../../../../components/Playground';
 ```jsx
 <div style={{maxWidth: '400px'}}>
   <DateInput
-    confirmDate
     disableDatePicker
     helperText="Use format D.M.YYYY"
     id="date"
@@ -79,10 +69,6 @@ import Playground from '../../../../components/Playground';
     required
   />
 </div>
-```
-
-```html
-
 ```
 
 </Playground>
@@ -125,10 +111,6 @@ import Playground from '../../../../components/Playground';
     required
   />
 </div>
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/date-input/customisation.mdx
+++ b/new-site/src/docs/elements/components/date-input/customisation.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/date-input/customisation'
 title: 'DateInput - Customisation'
 ---
 
-import { Card, Link, Notification } from 'hds-react';
-import { IconArrowRight } from 'hds-react';
+import { DateInput } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Customisation
 
@@ -19,13 +19,18 @@ You can use the `style` property to customise the component. See all available t
 ### Customisation example
 <Playground>
 
-
 ```jsx
-
-```
-
-```html
-
+<div style={{maxWidth: '400px'}}>
+  <DateInput
+    helperText="Use format D.M.YYYY"
+    id="date"
+    initialMonth={new Date()}
+    label="Choose a date"
+    language="en"
+    onChange={function noRefCheck(){}}
+    required
+  />
+</div>
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/date-input/index.mdx
+++ b/new-site/src/docs/elements/components/date-input/index.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/date-input'
 title: 'DateInput'
 ---
 
-import { Card, StatusLabel, Tabs } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
 

--- a/new-site/src/docs/elements/components/date-input/usage.mdx
+++ b/new-site/src/docs/elements/components/date-input/usage.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/date-input/code'
 title: 'DateInput - Usage'
 ---
 
-import { DateInput } from 'hds-react';
+import { DateInput, Link } from 'hds-react';
 
 ## Usage
 
@@ -79,7 +79,6 @@ It is possible to disable the date picker functionality by supplying a `disableD
 
 <div style={{maxWidth: '400px'}}>
   <DateInput
-    confirmDate
     disableDatePicker
     helperText="Use format D.M.YYYY"
     id="date"

--- a/new-site/src/docs/elements/components/dialog/code.mdx
+++ b/new-site/src/docs/elements/components/dialog/code.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/dialog/code'
 title: 'Dialog - Code'
 ---
 
-import { Link } from 'hds-react';
-import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import { Dialog, Button, IconCheckCircleFill, IconCrossCircle, IconInfoCircle, Link, TextArea, TextInput } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 
@@ -12,7 +12,6 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 
 #### Info dialog
 <Playground>
-
 
 ```jsx
 {() => {
@@ -58,15 +57,10 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Confirm dialog
 <Playground>
-
 
 ```jsx
 {() => {
@@ -114,15 +108,10 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Danger dialog
 <Playground>
-
 
 ```jsx
 {() => {
@@ -178,15 +167,10 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Scrollable dialog
 <Playground>
-
 
 ```jsx
 {() => {
@@ -288,15 +272,10 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 #### Dialog with custom content
 <Playground>
-
 
 ```jsx
 {() => {
@@ -360,10 +339,6 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
     </>
   )
 }}
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/dialog/customisation.mdx
+++ b/new-site/src/docs/elements/components/dialog/customisation.mdx
@@ -3,26 +3,64 @@ slug: '/elements/components/dialog/customisation'
 title: 'Dialog - Customisation'
 ---
 
+import { Button, IconInfoCircle } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
 ## Customisation
 
 ### Customisation properties
+
 You can use the `theme` property to customise the component. See all available theme variables in the table below.
 
-| Theme variable                           | Description                                             |
-| ---------------------------------------- | ------------------------------------------------------- |
-| `--size`                                 | Size of the checkbox                                    |
-
+| Theme variable | Description          |
+| -------------- | -------------------- |
+| `--size`       | Size of the checkbox |
 
 ### Customisation example
+
 <Playground>
 
-
 ```jsx
-
-```
-
-```html
-
+{() => {
+  const dialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
+  const openInfoDialogButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const close = () => setIsOpen(false);
+  const titleId = 'info-dialog-title';
+  const descriptionId = 'info-dialog-content';
+  return (
+    <>
+      <div ref={dialogTargetRef} />
+      <Button ref={openInfoDialogButtonRef} onClick={() => setIsOpen(true)}>
+        Open Info dialog
+      </Button>
+      <Dialog
+        id="info-dialog"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        isOpen={isOpen}
+        close={close}
+        closeButtonLabelText="Close info dialog"
+        focusAfterCloseRef={openInfoDialogButtonRef}
+        targetElement={dialogTargetRef.current}
+      >
+        <Dialog.Header
+          id={titleId}
+          title="Terms of service have changed"
+          iconLeft={<IconInfoCircle aria-hidden="true" />}
+        />
+        <Dialog.Content>
+          <p id={descriptionId} className="text-body">
+            Please note that the terms of this service have changed. You can review the changes in the user settings.
+          </p>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button onClick={close}>Close</Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  );
+}}
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/dialog/usage.mdx
+++ b/new-site/src/docs/elements/components/dialog/usage.mdx
@@ -3,18 +3,56 @@ slug: '/elements/components/dialog/code'
 title: 'Dialog - Usage'
 ---
 
+import { Dialog, Button, IconInfoCircle } from 'hds-react';
+
 ## Usage
 
 ### Example
-<DateInput 
-  helperText="Use format D.M.YYYY"
-  id="date"
-  initialMonth={new Date()}
-  label="Choose a date"
-  language="en"
-  onChange={function noRefCheck(){}}
-  required
-/>
+
+export const DialogExample = () => {
+  const dialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
+  const openInfoDialogButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const close = () => setIsOpen(false);
+  const titleId = "info-dialog-title";
+  const descriptionId = "info-dialog-content";
+  return (
+    <>
+      <div ref={dialogTargetRef}/>
+      <Button ref={openInfoDialogButtonRef} onClick={() => setIsOpen(true)}>
+        Open Info dialog
+      </Button>
+      <Dialog
+        id="info-dialog"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        isOpen={isOpen}
+        close={close}
+        closeButtonLabelText="Close info dialog"
+        focusAfterCloseRef={openInfoDialogButtonRef}
+        targetElement={dialogTargetRef.current}
+      >
+        <Dialog.Header
+          id={titleId}
+          title="Terms of service have changed"
+          iconLeft={<IconInfoCircle aria-hidden="true"/>}
+        />
+        <Dialog.Content>
+          <p id={descriptionId} className="text-body">
+            Please note that the terms of this service have changed. You can review the changes in the user
+            settings.</p>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button onClick={close}>
+            Close
+          </Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  )
+};
+
+<DialogExample/>
 
 ## Principles
 - Dialogs capture the browser focus and the user is forced to react to the dialog.

--- a/new-site/src/docs/elements/components/dropdown/code.mdx
+++ b/new-site/src/docs/elements/components/dropdown/code.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/dropdown/code'
 title: 'Dropdown - Code'
 ---
 
-import { Link } from 'hds-react';
-import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import { Combobox, IconCheckCircleFill, IconCrossCircle, IconUser, Link, Select } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 
@@ -51,10 +51,6 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Select (multi-selection)
@@ -77,10 +73,6 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
   clearButtonAriaLabel="Clear all selections"
   selectedItemRemoveButtonAriaLabel="Remove ${value}"
 />
-```
-
-```html
-
 ```
 
 </Playground>
@@ -147,10 +139,6 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### Combobox (multi-selection)
@@ -178,10 +166,6 @@ import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
   selectedItemRemoveButtonAriaLabel="Remove ${value}"
   toggleButtonAriaLabel="Toggle menu"
 />
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/dropdown/customisation.mdx
+++ b/new-site/src/docs/elements/components/dropdown/customisation.mdx
@@ -3,6 +3,9 @@ slug: '/elements/components/dropdown/customisation'
 title: 'Dropdown - Customisation'
 ---
 
+import { IconUser, Select } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
 ## Customisation
 
 ### Customisation properties
@@ -16,13 +19,23 @@ You can use the `theme` property to customise the component. See all available t
 ### Customisation example
 <Playground>
 
-
 ```jsx
-
-```
-
-```html
-
+{() => {
+  const options = [{ label: 'Plutonium' }, { label: 'Americium' }, { label: 'Copernicium' }, { label: 'Berkelium' }];
+  return (
+    <>
+      <Select
+        required
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        icon={<IconUser />}
+        options={[{ label: 'Adam' }, { label: 'Caitlyn' }, { label: 'Jack' }, { label: 'Sally' }]}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+    </>
+  )
+}}
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/dropdown/index.mdx
+++ b/new-site/src/docs/elements/components/dropdown/index.mdx
@@ -3,11 +3,8 @@ slug: '/elements/components/dropdown'
 title: 'Dropdown'
 ---
 
-import { Select, Combobox, StatusLabel, Tabs } from 'hds-react';
-import { IconInfoCircle, IconUser } from 'hds-react';
-
+import { StatusLabel, Tabs } from 'hds-react';
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/dropdown/usage.mdx
+++ b/new-site/src/docs/elements/components/dropdown/usage.mdx
@@ -3,17 +3,68 @@ slug: '/elements/components/dropdown/code'
 title: 'Dropdown - Usage'
 ---
 
+import { Button, Combobox, IconInfoCircle, IconUser, Select } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
 ## Usage
 
 ### Example
-<DateInput 
-  helperText="Use format D.M.YYYY"
-  id="date"
-  initialMonth={new Date()}
-  label="Choose a date"
-  language="en"
-  onChange={function noRefCheck(){}}
+export const SelectExample = () => {
+  const options = [{ label: 'Plutonium' }, { label: 'Americium' }, { label: 'Copernicium' }, { label: 'Berkelium' }];
+  return (
+    <>
+      <Select required label="Label" helper="Assistive text" placeholder="Placeholder" options={options} />
+      <Select
+        disabled
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        options={options}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+      <Select
+        invalid
+        required
+        label="Label"
+        error="Error description"
+        placeholder="Placeholder"
+        options={options}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+      <Select
+        required
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        icon={<IconUser />}
+        options={[{ label: 'Adam' }, { label: 'Caitlyn' }, { label: 'Jack' }, { label: 'Sally' }]}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+    </>
+  )
+};
+
+<SelectExample />
+
+<Combobox
+  multiselect
   required
+  label="Label"
+  helper="Assistive text"
+  placeholder="Placeholder"
+  options={[
+    { label: 'Americium' },
+    { label: 'Berkelium' },
+    { label: 'Californium' },
+    { label: 'Copernicium' },
+    { label: 'Einsteinium' },
+    { label: 'Fermium' },
+    { label: 'Mendelevium' },
+    { label: 'Plutonium' },
+  ]}
+  clearButtonAriaLabel="Clear all selections"
+  selectedItemRemoveButtonAriaLabel="Remove ${value}"
+  toggleButtonAriaLabel="Toggle menu"
 />
 
 ### Principles

--- a/new-site/src/docs/elements/components/fieldset/accessibility.mdx
+++ b/new-site/src/docs/elements/components/fieldset/accessibility.mdx
@@ -2,6 +2,7 @@
 slug: '/elements/components/fieldset/accessibility'
 title: 'Fieldset - Accessibility'
 ---
+import { Link } from 'hds-react';
 
 ## Accessibility
 

--- a/new-site/src/docs/elements/components/fieldset/index.mdx
+++ b/new-site/src/docs/elements/components/fieldset/index.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/fieldset'
 title: 'Fieldset'
 ---
 
-import { Select, Combobox, StatusLabel, Tabs } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 import { IconInfoCircle, IconUser } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';

--- a/new-site/src/docs/elements/components/file-input/code.mdx
+++ b/new-site/src/docs/elements/components/file-input/code.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/file-input/code'
 title: 'FileInput - Code'
 ---
 
-import { Link } from 'hds-react';
-import { IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import { FileInput, IconCheckCircleFill, IconCrossCircle, Link } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 

--- a/new-site/src/docs/elements/components/file-input/code.mdx
+++ b/new-site/src/docs/elements/components/file-input/code.mdx
@@ -29,10 +29,6 @@ import Playground from '../../../../components/Playground';
 }}
 ```
 
-```html
-
-```
-
 </Playground>
 
 ### With drag and drop
@@ -53,10 +49,6 @@ import Playground from '../../../../components/Playground';
     onChange={setFiles}
   />
 }}
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/file-input/customisation.mdx
+++ b/new-site/src/docs/elements/components/file-input/customisation.mdx
@@ -3,6 +3,9 @@ slug: '/elements/components/file-input/customisation'
 title: 'FileInput - Customisation'
 ---
 
+import { FileInput } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
 ## Customisation
 
 ### Customisation properties
@@ -16,14 +19,20 @@ You can use the `theme` property to customise the component. See all available t
 ### Customisation example
 <Playground>
 
-
-```jsx
-
-```
-
-```html
-
-```
+  ```jsx
+  {() => {
+    const [file, setFile] = React.useState([]);
+    console.log('selected file', file);
+    return <FileInput
+      id="file-input"
+      label="Choose a file"
+      language="en"
+      maxSize={1.5 * 1024 * 1024}
+      accept=".png,.jpg"
+      onChange={setFile}
+    />
+  }}
+  ```
 
 </Playground>
 

--- a/new-site/src/docs/elements/components/file-input/usage.mdx
+++ b/new-site/src/docs/elements/components/file-input/usage.mdx
@@ -8,16 +8,27 @@ import { FileInput } from 'hds-react';
 ## Usage
 
 ### Example
-<FileInput
-  multiple
-  dragAndDrop
-  id="file-input"
-  label="Drag and drop files here"
-  language="en"
-  accept=".png,.jpg"
-/>
+
+export const FileInputExample = () => {
+  const [file, setFile] = React.useState([]);
+  console.log('selected file', file);
+  return (
+    <FileInput
+      id="file-input"
+      label="Choose a file"
+      language="en"
+      maxSize={1.5 * 1024 * 1024}
+      accept=".png,.jpg"
+      onChange={setFile}
+    />
+  );
+};
+
+<FileInputExample />
+
 
 ### Principles
+
 - A label should always be provided with a FileInput. It should clearly describe what the user is expected to select.
 - The helper text below the FileInput describes the file requirements to the user. It lists accepted file formats as well as the maximum size of a single file.
   - Note that the helper text is generated automatically from the `accept` and `maxSize` properties.
@@ -25,7 +36,7 @@ import { FileInput } from 'hds-react';
 - One FileInput can be configured to accept one or multiple files.
   - Make sure labels of the input indicate the number of expected files to the user.
   - A FileInput allowing multiple files fits well for situations where all the files are related to each other (e.g. multiple photos from the same event).
-  - If the user has to upload multiple files that are not related to each other, prefer using multiple file uploads - one for each file. 
+  - If the user has to upload multiple files that are not related to each other, prefer using multiple file uploads - one for each file.
 - Dragging and dropping files can be allowed by using the `dragAndDrop` property.
 - The FileInput uses an info text element to inform the user about the status of the component. You can read more about the usage of the info text element in the [HDS Form validation pattern documentation page](/patterns/form-validation#3-info-message).
 - The FileInput component resolves human-readable file size abbreviations based on a binary system. The file size texts are shown after the selected file name and in maxSize messages if maxSize validation is used.
@@ -33,11 +44,13 @@ import { FileInput } from 'hds-react';
 ### Variations
 
 ### Default
+
 In its default form, the HDS FileInput offers a button-like element that opens a file browser native to the user's current device. Selected files are presented in a list below the input and files can be removed from the listing separately.
 
 ---
 
 ### With drag and drop
+
 If in some cases having the ability to drag and drop files onto the page could help the user, this can be enabled with the `dragAndDrop` property. Note that the traditional file input is still included below the drag and drop area. Therefore this property does not weaken the accessibility of the component.
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/footer/code.mdx
+++ b/new-site/src/docs/elements/components/footer/code.mdx
@@ -3,9 +3,18 @@ slug: '/elements/components/footer/code'
 title: 'Footer - Code'
 ---
 
-import { Footer } from 'hds-react';
-import { Link } from 'hds-react';
-import { IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, IconCheckCircleFill } from 'hds-react';
+import {
+  Footer,
+  IconFacebook,
+  IconTwitter,
+  IconInstagram,
+  IconYoutube,
+  IconTiktok,
+  IconCheckCircleFill,
+  IconCrossCircle,
+  Link,
+} from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 
@@ -46,10 +55,6 @@ import { IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, Icon
         <Footer.Item label="Link" />
       </Footer.Base>
   </Footer>
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/footer/customisation.mdx
+++ b/new-site/src/docs/elements/components/footer/customisation.mdx
@@ -3,57 +3,63 @@ slug: '/elements/components/footer/customisation'
 title: 'Footer - Customisation'
 ---
 
-import { Footer } from 'hds-react';
-import { IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, IconCheckCircleFill } from 'hds-react';
+import {
+  Footer,
+  IconFacebook,
+  IconTwitter,
+  IconInstagram,
+  IconYoutube,
+  IconTiktok,
+  IconCheckCircleFill,
+  Link,
+} from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Customisation
 
 ### Customisation properties
+
 You can use the `theme` property to customise the component. See all available theme variables in the table below.
 
-| Theme variable                           | Description                                             |
-| ---------------------------------------- | ------------------------------------------------------- |
-| `--footer-background`                    | Colour of the Footer background                         |
-| `--footer-color`                         | Colour of the Footer elements (such as text and icons)  |
-| `--footer-divider-color`                 | Colour of the divider line between Footer sections      |
-| `--footer-focus-outline-color'`          | Colour of the Footer element focus border               |
-
+| Theme variable                  | Description                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| `--footer-background`           | Colour of the Footer background                        |
+| `--footer-color`                | Colour of the Footer elements (such as text and icons) |
+| `--footer-divider-color`        | Colour of the divider line between Footer sections     |
+| `--footer-focus-outline-color'` | Colour of the Footer element focus border              |
 
 ### Customisation example
-<Playground>
 
+<Playground>
 
 ```jsx
 <Footer
-    title="Helsinki Design System"
-    footerAriaLabel="HDS Footer"
-    theme={{
-        '--footer-background': 'var(--color-engel)',
-        '--footer-color': 'var(--color-black-90)',
-        '--footer-divider-color': 'var(--color-black-90)',
-        '--footer-focus-outline-color': 'var(--color-black-90)',
-    }}
-  >
-    <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-        <Footer.Item label="Item" />
-        <Footer.Item label="Item" />
-        <Footer.Item label="Item" />
-        <Footer.Item label="Item" />
-        <Footer.Item label="Item" />
-        <Footer.Item label="Item" />
-    </Footer.Navigation>
-    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved">
-      <Footer.Item label="Link" />
-      <Footer.Item label="Link" />
-      <Footer.Item label="Link" />
-    </Footer.Base>
-  </Footer>
-```
-
-```html
-
+  title="Helsinki Design System"
+  footerAriaLabel="HDS Footer"
+  theme={{
+    '--footer-background': 'var(--color-engel)',
+    '--footer-color': 'var(--color-black-90)',
+    '--footer-divider-color': 'var(--color-black-90)',
+    '--footer-focus-outline-color': 'var(--color-black-90)',
+  }}
+>
+  <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
+    <Footer.Item label="Item" />
+    <Footer.Item label="Item" />
+    <Footer.Item label="Item" />
+    <Footer.Item label="Item" />
+    <Footer.Item label="Item" />
+    <Footer.Item label="Item" />
+  </Footer.Navigation>
+  <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved">
+    <Footer.Item label="Link" />
+    <Footer.Item label="Link" />
+    <Footer.Item label="Link" />
+  </Footer.Base>
+</Footer>
 ```
 
 </Playground>
+
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/footer/index.mdx
+++ b/new-site/src/docs/elements/components/footer/index.mdx
@@ -3,11 +3,9 @@ slug: '/elements/components/footer'
 title: 'Footer'
 ---
 
-import { Select, Combobox, StatusLabel, Tabs } from 'hds-react';
-import { IconInfoCircle, IconUser } from 'hds-react';
+import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/footer/usage.mdx
+++ b/new-site/src/docs/elements/components/footer/usage.mdx
@@ -3,7 +3,15 @@ slug: '/elements/components/footer/code'
 title: 'Footer - Usage'
 ---
 
-import { Footer } from 'hds-react';
+import {
+  Footer,
+  IconFacebook,
+  IconTwitter,
+  IconInstagram,
+  IconYoutube,
+  IconTiktok,
+  Link,
+} from 'hds-react';
 
 ## Usage
 

--- a/new-site/src/docs/elements/components/icon/code.mdx
+++ b/new-site/src/docs/elements/components/icon/code.mdx
@@ -3,15 +3,23 @@ slug: '/elements/components/icon/code'
 title: 'Icon - Code'
 ---
 
-import { Footer } from 'hds-react';
-import { Link } from 'hds-react';
-import { IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, IconCheckCircleFill } from 'hds-react';
+import {
+  Footer,
+  IconFacebook,
+  IconTwitter,
+  IconInstagram,
+  IconYoutube,
+  IconTiktok,
+  IconCheckCircleFill,
+  Link,
+} from 'hds-react';
 
 ## Code
 
-### Code examples 
+### Code examples
 
 #### Default
+
 <Playground>
 
 
@@ -26,37 +34,39 @@ import { IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, Icon
 </Playground>
 
 
-
 ### Icon sizes
+
 <Playground>
 
 
 ```jsx
 <>
-<IconFaceSmile size="xs" aria-hidden="true" />
-<IconFaceSmile size="s" aria-hidden="true" />
-<IconFaceSmile size="m" aria-hidden="true" />
-<IconFaceSmile size="l" aria-hidden="true" />
-<IconFaceSmile size="xl" aria-hidden="true" />
+  <IconFaceSmile size="xs" aria-hidden="true" />
+  <IconFaceSmile size="s" aria-hidden="true" />
+  <IconFaceSmile size="m" aria-hidden="true" />
+  <IconFaceSmile size="l" aria-hidden="true" />
+  <IconFaceSmile size="xl" aria-hidden="true" />
 </>
 ```
 
 ```html
 <div>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-xs" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-m" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-l" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-xl" aria-hidden="true"></i>
+  <i class="hds-icon hds-icon--face-smile hds-icon--size-xs" aria-hidden="true"></i>
+  <i class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></i>
+  <i class="hds-icon hds-icon--face-smile hds-icon--size-m" aria-hidden="true"></i>
+  <i class="hds-icon hds-icon--face-smile hds-icon--size-l" aria-hidden="true"></i>
+  <i class="hds-icon hds-icon--face-smile hds-icon--size-xl" aria-hidden="true"></i>
 </div>
 ```
 
 </Playground>
 
+
 ### Packages
-| Package           | Included                      | Storybook link                                                                                                                      | Source link   |
-| ----------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| **HDS React**     | <IconCheckCircleFill /> Yes   | <Link size="M" external href="/storybook/react/?path=/docs/icons">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/icons">View source</Link> |
-| **HDS Core**      | <IconCheckCircleFill /> Yes     | <Link size="M" external href="/storybook/core/?path=/story/icons">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/icons">View source</Link> |
+
+| Package       | Included                    | Storybook link                                                                             | Source link                                                                                                                                       |
+| ------------- | --------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **HDS React** | <IconCheckCircleFill /> Yes | <Link size="M" external href="/storybook/react/?path=/docs/icons">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/icons">View source</Link> |
+| **HDS Core**  | <IconCheckCircleFill /> Yes | <Link size="M" external href="/storybook/core/?path=/story/icons">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/icons">View source</Link>  |
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/icon/customisation.mdx
+++ b/new-site/src/docs/elements/components/icon/customisation.mdx
@@ -3,8 +3,7 @@ slug: '/elements/components/icon/customisation'
 title: 'Icon - Customisation'
 ---
 
-import { Footer } from 'hds-react';
-import { IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, IconCheckCircleFill } from 'hds-react';
+import { Footer, IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, IconCheckCircleFill } from 'hds-react';
 
 ## Customisation
 

--- a/new-site/src/docs/elements/components/koros/code.mdx
+++ b/new-site/src/docs/elements/components/koros/code.mdx
@@ -3,7 +3,8 @@ slug: '/elements/components/koros/code'
 title: 'Koros - Code'
 ---
 
-import { Link } from 'hds-react';
+import { Koros, Link, IconCheckCircleFill } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 
@@ -11,7 +12,6 @@ import { Link } from 'hds-react';
 
 #### Default
 <Playground>
-
 
 ```jsx
 <>
@@ -118,7 +118,6 @@ import { Link } from 'hds-react';
 
 ### Angled
 <Playground>
-
 
 ```jsx
 {() => {

--- a/new-site/src/docs/elements/components/koros/usage.mdx
+++ b/new-site/src/docs/elements/components/koros/usage.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/koros/code'
 title: 'Koros - Usage'
 ---
 
-import { Koros } from 'hds-react';
+import { Koros, Link } from 'hds-react';
 
 ## Usage
 
@@ -21,7 +21,8 @@ import { Koros } from 'hds-react';
 ### Variations
 
 #### Default
-There are six Koro styles. An added visual interest is brought to the identity by means of the Koros. Using Koros adds high visual impact and makes the user interface recognisable as part of Helsinki city services. You can read more about using Koros in <Link href="https://brand.hel.fi/en/wave-motifs/" external>Helsinki Visual Identity Guidelines - Wave motifs</Link>.
+There are six Koro styles. An added visual interest is brought to the identity by means of the Koros. Using Koros adds high visual impact and makes the user interface recognisable as part of Helsinki city services.
+You can read more about using Koros in <Link href="https://brand.hel.fi/en/wave-motifs/" external>Helsinki Visual Identity Guidelines - Wave motifs</Link>.
 
 <Koros type="basic" />
 <br />

--- a/new-site/src/docs/elements/components/link/code.mdx
+++ b/new-site/src/docs/elements/components/link/code.mdx
@@ -3,26 +3,31 @@ slug: '/elements/components/link/code'
 title: 'Link - Code'
 ---
 
-import { Link } from 'hds-react';
+import { Link, IconCheckCircleFill, IconDocument, IconEnvelope, IconPhone, IconPhoto } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 
-### Code examples 
+### Code examples
 
 #### Inline
+
 <Playground>
 
 
 ```jsx
 <p style={{ fontSize: '14px' }}>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-  magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-  <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external openInExternalDomainAriaLabel="Opens a different website">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+  aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+  <Link
+    href="https://github.com/City-of-Helsinki/helsinki-design-system"
+    external
+    openInExternalDomainAriaLabel="Opens a different website"
+  >
     HDS Github
   </Link>
-  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-  pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-  laborum.
+  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </p>
 ```
 
@@ -39,14 +44,16 @@ import { Link } from 'hds-react';
 
 </Playground>
 
+
 ### Standalone
+
 <Playground>
 
 
 ```jsx
 <Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
   Link to HDS
-</Link> 
+</Link>
 ```
 
 ```html
@@ -55,40 +62,39 @@ import { Link } from 'hds-react';
 
 </Playground>
 
+
 ### Internal and external links
+
 <Playground>
 
 
 ```jsx
 <>
-<Link 
-  href="https://hds.hel.fi/" 
-  size="M" 
-  style={{ display: 'block', width: 'fit-content' }}
->
-  Internal link
-</Link>
+  <Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
+    Internal link
+  </Link>
 
-<Link 
-  href="https://github.com/City-of-Helsinki/helsinki-design-system" 
-  size="M" 
-  external
-  openInExternalDomainAriaLabel="Opens a different website."
-  style={{ display: 'block', width: 'fit-content' }}
->
-  External link
-</Link>
+  <Link
+    href="https://github.com/City-of-Helsinki/helsinki-design-system"
+    size="M"
+    external
+    openInExternalDomainAriaLabel="Opens a different website."
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    External link
+  </Link>
 
-<Link 
-  href="https://github.com/City-of-Helsinki/helsinki-design-system" 
-  size="M" 
-  external 
-  openInNewTab
-  openInExternalDomainAriaLabel="Opens a different website."
-  openInNewTabAriaLabel="Opens in a new tab."
-  style={{ display: 'block', width: 'fit-content' }}>
-  Link that opens in a new tab
-</Link>
+  <Link
+    href="https://github.com/City-of-Helsinki/helsinki-design-system"
+    size="M"
+    external
+    openInNewTab
+    openInExternalDomainAriaLabel="Opens a different website."
+    openInNewTabAriaLabel="Opens in a new tab."
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Link that opens in a new tab
+  </Link>
 </>
 ```
 
@@ -96,68 +102,115 @@ import { Link } from 'hds-react';
 <p>
   <a href="https://hds.hel.fi/" class="hds-link hds-link--medium" style="display:block;">Internal link</a>
 
-  <a href="https://github.com/City-of-Helsinki/helsinki-design-system" class="hds-link hds-link--medium" aria-label="Opens a different website.">
-    External link <i class="hds-icon icon hds-icon--link-external hds-icon--size-s vertical-align-small-or-medium-icon" aria-hidden="true"></i>
+  <a
+    href="https://github.com/City-of-Helsinki/helsinki-design-system"
+    class="hds-link hds-link--medium"
+    aria-label="Opens a different website."
+  >
+    External link
+    <i
+      class="hds-icon icon hds-icon--link-external hds-icon--size-s vertical-align-small-or-medium-icon"
+      aria-hidden="true"
+    ></i>
   </a>
 
-  <a href="https://github.com/City-of-Helsinki/helsinki-design-system" class="hds-link hds-link--medium" rel="noopener" target="_blank" aria-label="Opens a different website. Opens in a new tab.">
-    Link that opens in a new tab <i class="hds-icon icon hds-icon--link-external hds-icon--size-xs vertical-align-small-or-medium-icon" aria-hidden="true"></i>
+  <a
+    href="https://github.com/City-of-Helsinki/helsinki-design-system"
+    class="hds-link hds-link--medium"
+    rel="noopener"
+    target="_blank"
+    aria-label="Opens a different website. Opens in a new tab."
+  >
+    Link that opens in a new tab
+    <i
+      class="hds-icon icon hds-icon--link-external hds-icon--size-xs vertical-align-small-or-medium-icon"
+      aria-hidden="true"
+    ></i>
   </a>
 </p>
 ```
 
 </Playground>
 
+
 ### Links with icons
+
 <Playground>
 
 
 ```jsx
 <>
-<Link iconLeft={<IconDocument size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Document link
-</Link>
-<Link iconLeft={<IconPhone size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Phone link
-</Link>
-<Link iconLeft={<IconEnvelope size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Email link
-</Link>
-<Link iconLeft={<IconPhoto size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Photo link
-</Link>
+  <Link
+    iconLeft={<IconDocument size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Document link
+  </Link>
+  <Link
+    iconLeft={<IconPhone size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Phone link
+  </Link>
+  <Link
+    iconLeft={<IconEnvelope size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Email link
+  </Link>
+  <Link
+    iconLeft={<IconPhoto size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Photo link
+  </Link>
 </>
 ```
 
 ```html
 <p>
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--document hds-icon--size-s" aria-hidden="true"></i></span>Document link
+    <span class="hds-icon-left"><i class="hds-icon hds-icon--document hds-icon--size-s" aria-hidden="true"></i></span>
+    Document link
   </a>
 
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--phone hds-icon--size-s" aria-hidden="true"></i></span>Phone link
+    <span class="hds-icon-left"><i class="hds-icon hds-icon--phone hds-icon--size-s" aria-hidden="true"></i></span>
+    Phone link
   </a>
 
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--envelope hds-icon--size-s" aria-hidden="true"></i></span>Envelope link
+    <span class="hds-icon-left"><i class="hds-icon hds-icon--envelope hds-icon--size-s" aria-hidden="true"></i></span>
+    Envelope link
   </a>
 
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--photo hds-icon--size-s" aria-hidden="true"></i></span>Photo link
+    <span class="hds-icon-left"><i class="hds-icon hds-icon--photo hds-icon--size-s" aria-hidden="true"></i></span>
+    Photo link
   </a>
 </p>
 ```
 
 </Playground>
 
+
 ### Packages
-| Package           | Included                      | Storybook link                                                                                                                      | Source link   |
-| ----------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| **HDS React**     | <IconCheckCircleFill /> Yes   | <Link size="M" external href="/storybook/react/?path=/story/components-link--default">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/components/link">View source</Link> |
-| **HDS Core**      | <IconCheckCircleFill /> Yes   | <Link size="M" external href="/storybook/core/?path=/story/components-link--default">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/link">View source</Link> |
+
+| Package       | Included                    | Storybook link                                                                                                 | Source link                                                                                                                                                 |
+| ------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **HDS React** | <IconCheckCircleFill /> Yes | <Link size="M" external href="/storybook/react/?path=/story/components-link--default">View in Storybook</Link> | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/components/link">View source</Link> |
+| **HDS Core**  | <IconCheckCircleFill /> Yes | <Link size="M" external href="/storybook/core/?path=/story/components-link--default">View in Storybook</Link>  | <Link size="M" external href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/link">View source</Link>  |
 
 ### Properties
+
 Note! You can find the full list of properties in the <Link size="M" href="/storybook/react/?path=/story/components-link--default" external>React Storybook.</Link>
 
 | Property                        | Description                                                                    | Values              | Default value |

--- a/new-site/src/docs/elements/components/linkbox/code.mdx
+++ b/new-site/src/docs/elements/components/linkbox/code.mdx
@@ -3,7 +3,7 @@ slug: '/elements/components/linkbox/code'
 title: 'Linkbox - Code'
 ---
 
-import { Link } from 'hds-react';
+import { Link, IconCrossCircle, IconCheckCircleFill } from 'hds-react';
 
 ## Code
 
@@ -11,7 +11,6 @@ import { Link } from 'hds-react';
 
 #### Empty
 <Playground>
-
 
 ```jsx
 <div style={{ backgroundColor: 'var(--color-black-5)', padding: 'var(--spacing-s)' }}>
@@ -31,10 +30,6 @@ import { Link } from 'hds-react';
     </Linkbox>
   </div>
 </div>
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/linkbox/customisation.mdx
+++ b/new-site/src/docs/elements/components/linkbox/customisation.mdx
@@ -13,17 +13,5 @@ You can use the `theme` property to customise the component. See all available t
 | `--size`                                 | Size of the checkbox                                    |
 
 ### Customisation example
-<Playground>
-
-
-```jsx
-
-```
-
-```html
-
-```
-
-</Playground>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/linkbox/index.mdx
+++ b/new-site/src/docs/elements/components/linkbox/index.mdx
@@ -3,10 +3,9 @@ slug: '/elements/components/linkbox'
 title: 'Linkbox'
 ---
 
-import { StatusLabel, Tabs } from 'hds-react';
+import { Linkbox, StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/linkbox/usage.mdx
+++ b/new-site/src/docs/elements/components/linkbox/usage.mdx
@@ -9,9 +9,10 @@ import { Link } from 'hds-react';
 ## Usage
 
 ### Example
-<Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
-      Link to HDS
-</Link>
+
+<Linkbox linkboxAriaLabel="Linkbox: Helsinki Design System" linkAriaLabel="HDS" href="https://hds.hel.fi" withBorder>
+  <div style={{ height: '106px' }} />
+</Linkbox>
 
 ### Principles
 - **Linkbox must always be interactable in its entirety.** This means that Linkboxes must not include multiple interactable elements (e.g. buttons or multiple links). The Linkbox element only gets focused once.

--- a/new-site/src/docs/elements/components/loading-spinner/accessibility.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/accessibility.mdx
@@ -3,6 +3,8 @@ slug: '/elements/components/loading-spinner/accessibility'
 title: 'LoadingSpinner - Accessibility'
 ---
 
+import { Link } from 'hds-react';
+
 ## Accessibility
 
 ### Pay attention to

--- a/new-site/src/docs/elements/components/loading-spinner/code.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/code.mdx
@@ -3,7 +3,8 @@ slug: '/elements/components/loading-spinner/code'
 title: 'LoadingSpinner - Code'
 ---
 
-import { Link } from 'hds-react';
+import { IconCheckCircleFill, Link, LoadingSpinner } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 

--- a/new-site/src/docs/elements/components/loading-spinner/customisation.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/customisation.mdx
@@ -3,6 +3,9 @@ slug: '/elements/components/loading-spinner/customisation'
 title: 'LoadingSpinner - Customisation'
 ---
 
+import { LoadingSpinner } from 'hds-react';
+import Playground from '../../../../components/Playground';
+
 ## Customisation
 
 ### Customisation properties

--- a/new-site/src/docs/elements/components/loading-spinner/index.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/index.mdx
@@ -6,7 +6,6 @@ title: 'LoadingSpinner'
 import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/loading-spinner/usage.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/usage.mdx
@@ -4,7 +4,6 @@ title: 'LoadingSpinner - Usage'
 ---
 
 import { LoadingSpinner } from 'hds-react';
-import { Link } from 'hds-react';
 
 ## Usage
 

--- a/new-site/src/docs/elements/components/logo/code.mdx
+++ b/new-site/src/docs/elements/components/logo/code.mdx
@@ -3,8 +3,8 @@ slug: '/elements/components/logo/code'
 title: 'Logo - Code'
 ---
 
-import { Logo } from 'hds-react';
-import { Link } from 'hds-react';
+import { IconCheckCircleFill, IconCrossCircle, Link, Logo } from 'hds-react';
+import Playground from '../../../../components/Playground';
 
 ## Code
 
@@ -12,7 +12,6 @@ import { Link } from 'hds-react';
 
 #### Default
 <Playground>
-
 
 ```jsx
 <>

--- a/new-site/src/docs/elements/components/logo/index.mdx
+++ b/new-site/src/docs/elements/components/logo/index.mdx
@@ -6,7 +6,6 @@ title: 'Logo'
 import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/logo/usage.mdx
+++ b/new-site/src/docs/elements/components/logo/usage.mdx
@@ -3,15 +3,15 @@ slug: '/elements/components/logo/code'
 title: 'Logo - Usage'
 ---
 
-import { Logo } from 'hds-react';
-import { Link } from 'hds-react';
+import { Link, Logo } from 'hds-react';
 
 ## Usage
 
 ### Example
-<LoadingSpinner />
+<Logo language="fi" size="medium" />
 
-The loading spinner do not provide details about nature of the processing but it reassures the user that their action is being processed.
+The logo is used to identify the site or application as an official City of Helsinki service.
+See the <Link size="M" href="/elements/visual-assets/logo">logo visual asset documentation</Link> for more information about principles of using the City of Helsinki logo.
 
 ### Principles
 - Logo is automatically included in HDS Navigation and HDS Footer (not yet released) components. **Use the Logo component sparingly in other parts of the service.**


### PR DESCRIPTION
## Description
- Fix component pages examples markdown and imports

## Motivation and Context
- Get rid of console.errors 
- Fix broken examples 
- Add examples with component states

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/docsite-fixes/elements/components/accordion)