### PR TITLE
Fix/html examples render

### DIFF
--- a/new-site/package.json
+++ b/new-site/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
+    "dompurify": "^2.3.6",
     "gatsby": "^4.3.0",
     "gatsby-plugin-image": "^2.3.0",
     "gatsby-plugin-manifest": "^4.3.0",

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
+import DOMPurify from 'dompurify';
 import { Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
 import theme from 'prism-react-renderer/themes/github';
 
@@ -29,11 +30,21 @@ const clearSelection = () => {
   }
 };
 
+const isJsx = (language) => language === 'jsx';
+
 const sanitize = (code) => {
   const trimmedCode = code.trim();
   return trimmedCode.startsWith('{') && trimmedCode.endsWith('}')
     ? trimmedCode.substr(1, trimmedCode.length - 2).trim()
     : trimmedCode;
+};
+
+const HtmlLivePreview = ({ className, code }) => {
+  const sanitizedHtml = () => ({
+    __html: DOMPurify.sanitize(code),
+  });
+
+  return <div className={className} dangerouslySetInnerHTML={sanitizedHtml()} />;
 };
 
 const Editor = ({ onChange, initialCode, code, language }) => {
@@ -176,24 +187,33 @@ export const PlaygroundBlock = (props) => {
       <Tabs>
         <TabList className="playground-block-tabs">
           {codeBlocks.map(({ language }) => (
-            <Tab key={language}>{language === 'jsx' ? 'React' : 'Core'}</Tab>
+            <Tab key={language}>{isJsx(language) ? 'React' : 'Core'}</Tab>
           ))}
         </TabList>
-        {codeBlocks.map(({ code, language }) => (
-          <TabPanel key={language}>
-            <LiveProvider code={sanitize(codeByLanguageState[language])} scope={scopeComponents}>
-              <div className="playground-block-content">
-                <LivePreview className="playground-block-preview" />
-                <EditorWithLive
-                  initialCode={sanitize(code)}
-                  language={language}
-                  onChange={setCodeByLanguage(language)}
-                  code={codeByLanguageState[language]}
-                />
-              </div>
-            </LiveProvider>
-          </TabPanel>
-        ))}
+        {codeBlocks.map(({ code, language }) => {
+          const sanitizedCode = sanitize(codeByLanguageState[language]);
+          const PreviewComponent = () => isJsx(language) ? (
+            <LivePreview className="playground-block-preview" />
+          ) : (
+            <HtmlLivePreview className="playground-block-preview" code={sanitizedCode} />
+          );
+
+          return (
+            <TabPanel key={language}>
+              <LiveProvider code={sanitizedCode} scope={scopeComponents} language={language}>
+                <div className="playground-block-content">
+                  <PreviewComponent />
+                  <EditorWithLive
+                    initialCode={sanitize(code)}
+                    language={language}
+                    onChange={setCodeByLanguage(language)}
+                    code={codeByLanguageState[language]}
+                  />
+                </div>
+              </LiveProvider>
+            </TabPanel>
+          );
+        })}
       </Tabs>
     </div>
   );

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -131,6 +131,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
                 className="playground-block-editor-code-input"
                 textareaId={textAreaId}
                 theme={theme}
+                language={language}
               />
             </div>
           </div>

--- a/new-site/src/docs/elements/components/fieldset/code.mdx
+++ b/new-site/src/docs/elements/components/fieldset/code.mdx
@@ -65,7 +65,6 @@ import { IconCheckCircleFill } from 'hds-react';
       </div>
     </div>
   </fieldset>
-
   <fieldset class="hds-fieldset" style="max-width: 400px">
     <legend class="hds-fieldset-legend">Guardian information</legend>
     <div class="hds-text-input">

--- a/new-site/src/docs/elements/components/fieldset/code.mdx
+++ b/new-site/src/docs/elements/components/fieldset/code.mdx
@@ -3,8 +3,12 @@ slug: '/elements/components/fieldset/code'
 title: 'Fieldset - Code'
 ---
 
-import { Link } from 'hds-react';
-import { IconCheckCircleFill } from 'hds-react';
+import { IconCheckCircleFill, Link } from 'hds-react';
+
+<!---
+TODO: A temporary to fix missing fieldset from core components/all.css
+-->
+import 'hds-core/lib/components/fieldset/fieldset.css';
 
 ## Code
 

--- a/new-site/src/docs/elements/components/fieldset/code.mdx
+++ b/new-site/src/docs/elements/components/fieldset/code.mdx
@@ -4,6 +4,8 @@ title: 'Fieldset - Code'
 ---
 
 import { IconCheckCircleFill, Link } from 'hds-react';
+import Playground from '../../../../components/Playground'
+
 
 <!---
 TODO: A temporary to fix missing fieldset from core components/all.css

--- a/new-site/src/docs/elements/components/fieldset/index.mdx
+++ b/new-site/src/docs/elements/components/fieldset/index.mdx
@@ -4,10 +4,7 @@ title: 'Fieldset'
 ---
 
 import { StatusLabel, Tabs } from 'hds-react';
-import { IconInfoCircle, IconUser } from 'hds-react';
-
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/icon/code.mdx
+++ b/new-site/src/docs/elements/components/icon/code.mdx
@@ -14,6 +14,8 @@ import {
   Link,
 } from 'hds-react';
 
+import Playground from '../../../../components/Playground'
+
 ## Code
 
 ### Code examples

--- a/new-site/src/docs/elements/components/icon/code.mdx
+++ b/new-site/src/docs/elements/components/icon/code.mdx
@@ -30,7 +30,7 @@ import Playground from '../../../../components/Playground'
 ```
 
 ```html
-<i class="hds-icon hds-icon--face-smile" aria-hidden="true"></i>
+<i class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></i>
 ```
 
 </Playground>

--- a/new-site/src/docs/elements/components/icon/index.mdx
+++ b/new-site/src/docs/elements/components/icon/index.mdx
@@ -6,7 +6,6 @@ title: 'Icon'
 import { StatusLabel, Tabs } from 'hds-react';
 
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Playground from '../../../../components/Playground';
 
 import Accessibility from './accessibility.mdx';
 import Code from './code.mdx';

--- a/new-site/src/docs/elements/components/koros/code.mdx
+++ b/new-site/src/docs/elements/components/koros/code.mdx
@@ -158,15 +158,18 @@ import Playground from '../../../../components/Playground';
 ```
 
 ```html
-<div class="hds-koros hds-koros--135deg hds-custom-koros" style="transform-origin: left; position: absolute; left: calc((100% / 1.4) + 43px);">
- <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="100%" height="85">
-   <defs>
-     <pattern id="korosBasic135deg" x="0" y="0" width="106" height="85" patternUnits="userSpaceOnUse">
-       <path transform="scale(5.3)" d="M0,800h20V0c-4.9,0-5,2.6-9.9,2.6S5,0,0,0V800z" />
-     </pattern>
-   </defs>
-   <rect fill="url(#korosBasic135deg)" width="100%" height="85" />
- </svg>
+<div style="--koros-height:85px; --hero-height:300px; --hero-width:500px; background-color: var(--color-silver-light); height: var(--hero-height); max-width: 100%; overflow: hidden; position: relative; width: var(--hero-width);">
+  <div style="background-color: var(--color-coat-of-arms); clip-path: polygon(0 0, var(--hero-height) 0, 0 100%, 0% 100%); height: 100%;"></div>
+  <div class="hds-koros hds-koros--135deg hds-custom-koros" style="fill: var(--color-coat-of-arms); left: calc(-1 * var(--koros-height)); position: absolute; top: var(--koros-height); transform-origin: center center; width: calc(2 * var(--hero-height)); transform: rotate(135deg) translateZ(0px);">
+   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="100%" height="85">
+     <defs>
+       <pattern id="korosBasic135deg" x="0" y="0" width="106" height="85" patternUnits="userSpaceOnUse">
+         <path transform="scale(5.3)" d="M0,800h20V0c-4.9,0-5,2.6-9.9,2.6S5,0,0,0V800z" />
+       </pattern>
+     </defs>
+     <rect fill="url(#korosBasic135deg)" width="100%" height="85" />
+   </svg>
+  </div>
 </div>
 ```
 

--- a/new-site/src/docs/elements/components/logo/code.mdx
+++ b/new-site/src/docs/elements/components/logo/code.mdx
@@ -23,10 +23,6 @@ import Playground from '../../../../components/Playground';
 </>
 ```
 
-```html
-
-```
-
 </Playground>
 
 #### Size variants
@@ -41,10 +37,6 @@ import Playground from '../../../../components/Playground';
 <br /> 
 <Logo language="fi" size="large" />
 </>
-```
-
-```html
-
 ```
 
 </Playground>

--- a/new-site/yarn.lock
+++ b/new-site/yarn.lock
@@ -4771,6 +4771,11 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
+  integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"

--- a/packages/core/src/components/all.css
+++ b/packages/core/src/components/all.css
@@ -2,11 +2,12 @@
 @import "./card/card.css";
 @import "./checkbox/checkbox.css";
 @import "./container/container.css";
+@import "./error-summary/error-summary.css";
+@import "./fieldset/fieldset.css";
 @import "./koros/koros.css";
 @import "./link/link.css";
 @import "./loading-spinner/loading-spinner.css";
 @import "./notification/notification.css";
-@import "./error-summary/error-summary.css";
 @import "./radio-button/radio-button.css";
 @import "./search-input/search-input.css";
 @import "./selection-group/selection-group.css";

--- a/site/docs/components/icons.mdx
+++ b/site/docs/components/icons.mdx
@@ -42,7 +42,7 @@ See the [icon library documentation](/visual-assets/icons "HDS Icons") for more 
 
 #### Core code example:
 ```html
-<i class="hds-icon hds-icon--face-smile" aria-hidden="true"></i>
+<i class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></i>
 ```
 
 #### React code example:


### PR DESCRIPTION
## Description
- Use custom-made dedicated HTML live-preview for core component examples
- Remove empty core examples

### Core package change
- Add missing fieldset import into core's components/all.css 

### Current documentation site change
- Fix core icon example

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1196

## Motivation and Context
- HTML examples did not work properly in React live-preview. They caused syntax errors. 

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/docsite-playground-fixes/elements/components/fieldset)