### PR TITLE
Fix/footer and dialog on new site

### DIFF
--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -17,6 +17,8 @@ import SyntaxHighlighter from './SyntaxHighlighter';
 import Table from './Table';
 import './layout.scss';
 
+const classNames = (...args) => args.filter((e) => e).join(' ');
+
 const components = {
   Playground: PlaygroundBlock,
   pre: SyntaxHighlighter,
@@ -24,6 +26,31 @@ const components = {
   thead: Table.Thead,
   tbody: Table.Tbody,
   th: Table.Th,
+  h1: (props) => (
+    <h1 {...props} className={classNames('page-heading-1')}>
+      {props.children}
+    </h1>
+  ),
+  h2: (props) => (
+    <h2 {...props} className={classNames('page-heading-2')}>
+      {props.children}
+    </h2>
+  ),
+  h3: (props) => (
+    <h3 {...props} className={classNames('page-heading-3')}>
+      {props.children}
+    </h3>
+  ),
+  h4: (props) => (
+    <h4 {...props} className={classNames('page-heading-4')}>
+      {props.children}
+    </h4>
+  ),
+  h5: (props) => (
+    <h4 {...props} className={classNames('page-heading-5')}>
+      {props.children}
+    </h4>
+  ),
 };
 
 const resolveCurrentMenuItem = (menuItems, slugWithPrefix) => {

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -142,7 +142,8 @@ const Layout = ({ children, pageContext }) => {
         ...subLevelLink,
         uiId: generateUiIdFromPath(subLevelLink.slug, 'side-nav-sub'),
         prefixedLink: withPrefix(subLevelLink.slug),
-      })).sort((subLevelLinkA, subLevelLinkB) => subLevelLinkA.title.localeCompare(subLevelLinkB.title)),
+      }))
+      .sort((subLevelLinkA, subLevelLinkB) => subLevelLinkA.title.localeCompare(subLevelLinkB.title)),
   }));
   const footerCopyRightLinks = siteData?.footerCopyrightLinks || [];
   const contentId = 'content';

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, withPrefix, Link as GatsbyLink, navigate } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import { Container, Footer, Navigation, SideNavigation } from 'hds-react';
-import "hds-core";
 import Seo from './seo';
 import { PlaygroundBlock } from './Playground';
 import SyntaxHighlighter from './SyntaxHighlighter';

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -79,23 +79,23 @@ body {
   word-wrap: break-word;
 }
 
-.mainContent h1 {
+.page-heading-1 {
   margin: 0 0 var(--spacing-m) 0;
 }
 
-.mainContent h2 {
+.page-heading-2 {
   margin: var(--spacing-l) 0 var(--spacing-s) 0;
 }
 
-.mainContent h3 {
+.page-heading-3 {
   margin: var(--spacing-l) 0 var(--spacing-xs) 0;
 }
 
-.mainContent h4 {
+.page-heading-4 {
   margin: var(--spacing-l) 0 var(--spacing-2-xs) 0;
 }
 
-.mainContent h5 {
+.page-heading-5 {
   margin: var(--spacing-l) 0 var(--spacing-3-xs) 0;
 }
 


### PR DESCRIPTION
## Description
- Add classes to markdown headings for styling

## Closes
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1199

## Motivation and Context
Previously markdown headings were styled with generic type CSS selectors. This caused the heading styles to leak into the components and broke the styles in Footer and Dialog components (at least).

## How Has This Been Tested?
- Locally on dev machine

[👉 Footer Demo](https://city-of-helsinki.github.io/hds-demo/docsite-heading-fixes/elements/components/footer)
[👉 Dialog Demo](https://city-of-helsinki.github.io/hds-demo/docsite-heading-fixes/elements/components/dialog)