### PR TITLE
Feature/docs component preview

### DIFF
--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -22,6 +22,14 @@ Playground.propTypes = {
 
 export default Playground;
 
+const playgroundPreviewClassName = 'playground-block-preview';
+
+export const PlaygroundPreview = ({ children, ...props }) => (
+  <div {...props} className={playgroundPreviewClassName}>
+    {children}
+  </div>
+);
+
 const clearSelection = () => {
   if (window.getSelection) {
     window.getSelection().removeAllRanges();
@@ -39,12 +47,12 @@ const sanitize = (code) => {
     : trimmedCode;
 };
 
-const HtmlLivePreview = ({ className, code }) => {
+const HtmlLivePreview = ({ code }) => {
   const sanitizedHtml = () => ({
     __html: DOMPurify.sanitize(code),
   });
 
-  return <div className={className} dangerouslySetInnerHTML={sanitizedHtml()} />;
+  return <PlaygroundPreview dangerouslySetInnerHTML={sanitizedHtml()} />;
 };
 
 const Editor = ({ onChange, initialCode, code, language }) => {
@@ -193,11 +201,12 @@ export const PlaygroundBlock = (props) => {
         </TabList>
         {codeBlocks.map(({ code, language }) => {
           const sanitizedCode = sanitize(codeByLanguageState[language]);
-          const PreviewComponent = () => isJsx(language) ? (
-            <LivePreview className="playground-block-preview" />
-          ) : (
-            <HtmlLivePreview className="playground-block-preview" code={sanitizedCode} />
-          );
+          const PreviewComponent = () =>
+            isJsx(language) ? (
+              <LivePreview className={playgroundPreviewClassName} />
+            ) : (
+              <HtmlLivePreview code={sanitizedCode} />
+            );
 
           return (
             <TabPanel key={language}>

--- a/new-site/src/components/Playground.js
+++ b/new-site/src/components/Playground.js
@@ -24,10 +24,14 @@ export default Playground;
 
 const playgroundPreviewClassName = 'playground-block-preview';
 
-export const PlaygroundPreview = ({ children, ...props }) => (
-  <div {...props} className={playgroundPreviewClassName}>
+const PlaygroundPreviewComponent = ({ children, className, ...props }) => (
+  <div {...props} className={`${playgroundPreviewClassName} ${className ?? ''}`}>
     {children}
   </div>
+);
+
+export const PlaygroundPreview = ({ ...props }) => (
+  <PlaygroundPreviewComponent className="playground-block-preview-light" {...props} />
 );
 
 const clearSelection = () => {
@@ -52,7 +56,7 @@ const HtmlLivePreview = ({ code }) => {
     __html: DOMPurify.sanitize(code),
   });
 
-  return <PlaygroundPreview dangerouslySetInnerHTML={sanitizedHtml()} />;
+  return <PlaygroundPreviewComponent dangerouslySetInnerHTML={sanitizedHtml()} />;
 };
 
 const Editor = ({ onChange, initialCode, code, language }) => {

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 
 @import '~hds-design-tokens/lib/all.scss';
+@import './utils';
 
 .playground-block {
   --focus-border-width: 2px;
@@ -18,7 +19,18 @@
 
 .playground-block-preview {
   border: 2px solid var(--color-black-50);
-  padding: var(--spacing-l);
+
+  @include small-screen {
+    padding: var(--spacing-s);
+  }
+
+  @include medium-screen {
+    padding: var(--spacing-m);
+  }
+
+  @include medium-and-above-screen {
+    padding: var(--spacing-l)
+  }
 }
 
 .playground-block-editor {

--- a/new-site/src/components/Playground.scss
+++ b/new-site/src/components/Playground.scss
@@ -5,6 +5,7 @@
 
 .playground-block {
   --focus-border-width: 2px;
+  --playground-component-border-color: var(--color-black-50);
   margin: var(--spacing-l) 0;
 }
 
@@ -18,7 +19,7 @@
 }
 
 .playground-block-preview {
-  border: 2px solid var(--color-black-50);
+  border: 2px solid var(--playground-component-border-color);
 
   @include small-screen {
     padding: var(--spacing-s);
@@ -29,13 +30,17 @@
   }
 
   @include medium-and-above-screen {
-    padding: var(--spacing-l)
+    padding: var(--spacing-l);
   }
+}
+
+.playground-block-preview-light {
+  --playground-component-border-color: var(--color-black-30);
 }
 
 .playground-block-editor {
   background-color: var(--color-black-5);
-  border: 2px solid var(--color-black-50);
+  border: 2px solid var(--playground-component-border-color);
   border-top: 0 none;
 }
 

--- a/new-site/src/components/_utils.scss
+++ b/new-site/src/components/_utils.scss
@@ -1,0 +1,21 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+@mixin small-screen {
+  @media (max-width: $breakpoint-s) {
+    @content;
+  }
+}
+
+@mixin medium-screen {
+  @media (max-width: $breakpoint-m) {
+    @content;
+  }
+}
+
+$breakpoint-medium-above: $breakpoint-m + 1px;
+
+@mixin medium-and-above-screen {
+  @media (min-width: $breakpoint-medium-above) {
+    @content;
+  }
+}

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -11,7 +11,7 @@ import { useStaticQuery, graphql, withPrefix, Link as GatsbyLink, navigate } fro
 import { MDXProvider } from '@mdx-js/react';
 import { Container, Footer, Navigation, SideNavigation } from 'hds-react';
 import Seo from './seo';
-import { PlaygroundBlock } from './Playground';
+import { PlaygroundBlock, PlaygroundPreview } from './Playground';
 import SyntaxHighlighter from './SyntaxHighlighter';
 import Table from './Table';
 import './layout.scss';
@@ -20,6 +20,7 @@ const classNames = (...args) => args.filter((e) => e).join(' ');
 
 const components = {
   Playground: PlaygroundBlock,
+  PlaygroundPreview: PlaygroundPreview,
   pre: SyntaxHighlighter,
   table: Table,
   thead: Table.Thead,

--- a/new-site/src/docs/elements/components/accordion/usage.mdx
+++ b/new-site/src/docs/elements/components/accordion/usage.mdx
@@ -43,7 +43,7 @@ This style is visually less distracting and it works well when there are multipl
   >
     To publish your data, open your profile settings and click the button 'Publish'.
   </Accordion>
-<PlaygroundPreview>
+</PlaygroundPreview>
 
 ---
 
@@ -51,14 +51,16 @@ This style is visually less distracting and it works well when there are multipl
 You can also use HDS Cards as a container for your Accordions. Cards offer the same customizability options as default HDS Cards. To learn more about Cards and their customization, refer to [HDS Card documentation](/components/card).
 
 If you have multiple accordions one below another or many accordions in the same view, consider using the visually more light [default styling variant](#default-accordion) instead of this one.
-<Accordion 
-  card 
-  border
-  heading="How to publish data?"
-  style={{ maxWidth: '360px'}}
->
-  To publish your data, open your profile settings and click the button 'Publish'.
-</Accordion>
+<PlaygroundPreview>
+  <Accordion
+    card
+    border
+    heading="How to publish data?"
+    style={{ maxWidth: '360px'}}
+  >
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+</PlaygroundPreview>
 
 ---
 

--- a/new-site/src/docs/elements/components/accordion/usage.mdx
+++ b/new-site/src/docs/elements/components/accordion/usage.mdx
@@ -4,16 +4,19 @@ title: 'Accordion - Usage'
 ---
 
 import { Accordion } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground'
 
 ## Usage
 
 ### Example
-<Accordion
-  heading="How to publish data?"
-  style={{ maxWidth: '360px' }}
->
-  To publish your data, open your profile settings and click the button 'Publish'.
-</Accordion>
+<PlaygroundPreview>
+  <Accordion
+    heading="How to publish data?"
+    style={{ maxWidth: '360px' }}
+  >
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+</PlaygroundPreview>
 
 ## Principles
 - Use accordions to allow the user to quickly glance at the information and then choose to open sections that are interesting to them.
@@ -33,12 +36,14 @@ Accordions should initially be closed when the page is loaded.
 Basic HDS Accordions provide two different visuals to choose from. These implementations are easy to take into use if you do not need any special functionality or styling.
 
 This style is visually less distracting and it works well when there are multiple accordions one below another or nearby.
-<Accordion
-  heading="How to publish data?"
-  style={{ maxWidth: '360px' }}
->
-  To publish your data, open your profile settings and click the button 'Publish'.
-</Accordion>
+<PlaygroundPreview>
+  <Accordion
+    heading="How to publish data?"
+    style={{ maxWidth: '360px' }}
+  >
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+<PlaygroundPreview>
 
 ---
 

--- a/new-site/src/docs/elements/components/buttons/usage.mdx
+++ b/new-site/src/docs/elements/components/buttons/usage.mdx
@@ -4,11 +4,14 @@ title: 'Button - Usage'
 ---
 
 import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground'
 
 ## Usage
 
 ### Example
-<Button>Button</Button>
+<PlaygroundPreview>
+  <Button>Button</Button>
+</PlaygroundPreview>
 
 ### Principles
 - <b>Buttons are used to trigger an action.</b> Be cautious when using buttons for navigating. In most cases, you should prefer links for this purpose. 
@@ -29,7 +32,9 @@ import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-rea
   }}>
   A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
   <br />
-  <Button>Primary</Button>
+  <PlaygroundPreview>
+    <Button>Primary</Button>
+  </PlaygroundPreview>
 </Accordion>
 
 <Accordion 
@@ -41,7 +46,9 @@ import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-rea
   }}>
   Secondary buttons are used for actions which are not mandatory or essential for the user. Often screens will include multiple secondary buttons alongside one primary button.
   <br />
-  <Button variant="secondary">Primary</Button>
+  <PlaygroundPreview>
+    <Button variant="secondary">Primary</Button>
+  </PlaygroundPreview>
 </Accordion>
 
 <Accordion 
@@ -54,7 +61,9 @@ import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-rea
   Supplementary buttons can be used in similar cases as secondary buttons. However, supplementary buttons are meant for actions which are intentionally wanted to be less visible to the user. These kind of actions include i.e. cancel and dismiss functionalities.
 
   Note! Since supplementary buttons do not have borders, an accompanying icon is required to clearly distinguish them from links and passive text elements.
-  <Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+  <PlaygroundPreview>
+    <Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+  </PlaygroundPreview>
 </Accordion>
 
 <Accordion 
@@ -65,9 +74,11 @@ import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-rea
     '--padding-vertical': 'var(--spacing-s)',
   }}>
   Icons can be added to buttons to make the action easier to understand. Sometimes it can also be beneficial to add icons to make important actions more distinguishable. It is not recommended to use buttons with icons without text label because users interpret icons in different ways. More information on icon usage in the icon guidelines.
-  <Button iconLeft={<IconShare />}>Button</Button>
-  <Button iconRight={<IconAngleRight />}>Button</Button>
-  <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>Button</Button>
+  <PlaygroundPreview>
+    <Button iconLeft={<IconShare />}>Button</Button>
+    <Button iconRight={<IconAngleRight />}>Button</Button>
+    <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>Button</Button>
+  </PlaygroundPreview>
 </Accordion>
 
 <Accordion 
@@ -78,9 +89,11 @@ import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-rea
     '--padding-vertical': 'var(--spacing-s)',
   }}>
   It is recommended to use the standard button size in most cases. If there is a big number of actions in the same view, small buttons can be used instead of the normal sized buttons. Small buttons can be especially useful in mobile screen sizes to ensure uncluttered view with multiple available actions.
-  <Button size="small">Primary</Button>
-  <Button variant="secondary" size="small">Secondary</Button>
-  <Button variant="supplementary" size="small">Supplementary</Button>
+  <PlaygroundPreview>
+    <Button size="small">Primary</Button>
+    <Button variant="secondary" size="small">Secondary</Button>
+    <Button variant="supplementary" size="small">Supplementary</Button>
+  </PlaygroundPreview>
 </Accordion>
 
 <Accordion 
@@ -91,8 +104,10 @@ import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-rea
     '--padding-vertical': 'var(--spacing-s)',
   }}>
   If required, to achieve clearer user interface, you may also use additional utility colours. Different visual styles of these buttons can be used to better inform users of destructive or dangerous actions. To comply with WCAG requirement 1.4.1 Use of Color, these colours are more accessible when paired with an icon.
-  <Button variant="success">Success</Button>
-  <Button variant="danger">Danger</Button>
+  <PlaygroundPreview>
+    <Button variant="success">Success</Button>
+    <Button variant="danger">Danger</Button>
+  </PlaygroundPreview>
 </Accordion>
 
 <Accordion 


### PR DESCRIPTION
## Description
- Add a component to frame component examples

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1195

## Motivation and Context
- A bordered element gives more structure on the page. Previously it was difficult to find where the example started and ended
 
## How Has This Been Tested?
- Locally on dev machine

👉 [Accordion Demo](https://city-of-helsinki.github.io/hds-demo/docsite-component-preview/elements/components/accordion)
👉 [Button Demo](https://city-of-helsinki.github.io/hds-demo/docsite-component-preview/elements/components/buttons)