### PR TITLE
Content/improve focus styles of header anchor links

### DIFF
--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -178,6 +178,15 @@ body {
 .headerAnchor {
   color: var(--color-black-90);
   margin-left: 3px;
+  font-size: 0;
+  vertical-align: middle;
+
+  &:focus {
+    outline: 3px solid var(--color-coat-of-arms);
+    .hdsAnchorIcon {
+      visibility: visible;
+    }
+  }
 }
 
 .hdsAnchorIcon {

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -177,7 +177,8 @@ body {
 
 .headerAnchor {
   color: var(--color-black-90);
-  margin-left: 3px;
+  padding-left: 0 !important;
+  margin-left: 7px;
   font-size: 0;
   vertical-align: middle;
 

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -178,7 +178,7 @@ body {
 .headerAnchor {
   color: var(--color-black-90);
   padding-left: 0 !important;
-  margin-left: 7px;
+  margin-left: var(--spacing-2-xs);
   font-size: 0;
   vertical-align: middle;
 


### PR DESCRIPTION
## Description

Improves the focus styles of header anchor links

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1211

## How Has This Been Tested?

- Locally on developers machine

👉 Demo: https://city-of-helsinki.github.io/hds-demo/doc-anchor-links-to-headers/

## Screenshots (if appropriate):

<img width="148" alt="image" src="https://user-images.githubusercontent.com/2777633/157228098-3877b286-38bd-4da4-8550-52d5442a50bb.png">


