### PR TITLE
Use correct syntax for providing fallback colors for table colors

### DIFF
--- a/packages/core/src/components/table/table.css
+++ b/packages/core/src/components/table/table.css
@@ -46,7 +46,7 @@
 
 .hds-table--dark {
   /* TODO: --background-color is deprecated. Remove when possible. */
-  --header-background-color: var(--background-color, --color-bus);
+  --header-background-color: var(--background-color, var(--color-bus));
 }
 
 .hds-table.hds-table--dark th {
@@ -57,7 +57,7 @@
 
 .hds-table--light {
   /* TODO: --background-color is deprecated. Remove when possible. */
-  --header-background-color: var(--background-color, --color-silver);
+  --header-background-color: var(--background-color, var(--color-silver));
 }
 
 .hds-table.hds-table--light th {


### PR DESCRIPTION
## Description
- Fix CSS syntax for fallback color
- https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1214

## Motivation and Context
- Core tables do not have background color if it is not set. The header cells are unreadable

## How Has This Been Tested?
- Locally on dev machine

