### PR TITLE
Feature/use playground preview

### DIFF
--- a/new-site/src/docs/elements/components/accordion/usage.mdx
+++ b/new-site/src/docs/elements/components/accordion/usage.mdx
@@ -26,7 +26,7 @@ import PlaygroundPreview from '../../../../components/Playground';
 - It is recommended to have accordions closed when the page is loaded.
   - If you need to have the accordion initially open, you can use the `initiallyOpen` property to achieve this.
   - Having an accordion initially open could be needed e.g. when the user returns to a page and you want to retain accordions' states.
-    Accordions should initially be closed when the page is loaded.
+  - Accordions should initially be closed when the page is loaded.
 - Expanding or closing the accordion should only affect the related accordion area. You also should not auto-close or auto-open accordions.
 
 ### Variations

--- a/new-site/src/docs/elements/components/accordion/usage.mdx
+++ b/new-site/src/docs/elements/components/accordion/usage.mdx
@@ -4,21 +4,20 @@ title: 'Accordion - Usage'
 ---
 
 import { Accordion } from 'hds-react';
-import PlaygroundPreview from '../../../../components/Playground'
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
+
 <PlaygroundPreview>
-  <Accordion
-    heading="How to publish data?"
-    style={{ maxWidth: '360px' }}
-  >
+  <Accordion heading="How to publish data?" style={{ maxWidth: '360px' }}>
     To publish your data, open your profile settings and click the button 'Publish'.
   </Accordion>
 </PlaygroundPreview>
 
 ## Principles
+
 - Use accordions to allow the user to quickly glance at the information and then choose to open sections that are interesting to them.
 - **Accordions must be given a header that describes the accordion content.** This header also acts as the label for the expand button. The header level can be chosen depending on the structure of the page.
 - **Do not put essential or must-read information inside accordions.** If the user is expected to open all of the accordions while using the service, then it is likely that the information should not be inside accordions.
@@ -27,44 +26,37 @@ import PlaygroundPreview from '../../../../components/Playground'
 - It is recommended to have accordions closed when the page is loaded.
   - If you need to have the accordion initially open, you can use the `initiallyOpen` property to achieve this.
   - Having an accordion initially open could be needed e.g. when the user returns to a page and you want to retain accordions' states.
-Accordions should initially be closed when the page is loaded.
+    Accordions should initially be closed when the page is loaded.
 - Expanding or closing the accordion should only affect the related accordion area. You also should not auto-close or auto-open accordions.
 
 ### Variations
 
 ### Default
+
 Basic HDS Accordions provide two different visuals to choose from. These implementations are easy to take into use if you do not need any special functionality or styling.
 
 This style is visually less distracting and it works well when there are multiple accordions one below another or nearby.
+
 <PlaygroundPreview>
-  <Accordion
-    heading="How to publish data?"
-    style={{ maxWidth: '360px' }}
-  >
+  <Accordion heading="How to publish data?" style={{ maxWidth: '360px' }}>
     To publish your data, open your profile settings and click the button 'Publish'.
   </Accordion>
 </PlaygroundPreview>
 
----
-
 ### With a card
+
 You can also use HDS Cards as a container for your Accordions. Cards offer the same customizability options as default HDS Cards. To learn more about Cards and their customization, refer to [HDS Card documentation](/components/card).
 
 If you have multiple accordions one below another or many accordions in the same view, consider using the visually more light [default styling variant](#default-accordion) instead of this one.
+
 <PlaygroundPreview>
-  <Accordion
-    card
-    border
-    heading="How to publish data?"
-    style={{ maxWidth: '360px'}}
-  >
+  <Accordion card border heading="How to publish data?" style={{ maxWidth: '360px' }}>
     To publish your data, open your profile settings and click the button 'Publish'.
   </Accordion>
 </PlaygroundPreview>
 
----
-
 ### Custom accordion
+
 If the basic accordion components do not fit your needs, you can build a custom accordion by using HDS provided accordion elements.
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/buttons/usage.mdx
+++ b/new-site/src/docs/elements/components/buttons/usage.mdx
@@ -3,18 +3,21 @@ slug: '/elements/components/buttons/code'
 title: 'Button - Usage'
 ---
 
-import { Accordion, Button, IconAngleRight, IconShare, IconTrash } from 'hds-react';
-import PlaygroundPreview from '../../../../components/Playground'
+import { Accordion, Button, IconAngleRight, IconShare, IconTrash, Notification } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
+
 <PlaygroundPreview>
   <Button>Button</Button>
 </PlaygroundPreview>
 
 ### Principles
-- <b>Buttons are used to trigger an action.</b> Be cautious when using buttons for navigating. In most cases, you should prefer links for this purpose. 
+
+- <b>Buttons are used to trigger an action.</b> Be cautious when using buttons for navigating. In most cases, you should
+  prefer links for this purpose.
 - Button label should always describe the action that the buttons is going to trigger. A good practice is to start the label with a verb and use two-word labels at maximum.
 - Use provided button types to control the visual priority of the view. Priority of the button types is the following: Primary -> Secondary -> Supplementary.
 - In mobile screen sizes, use full-width buttons. In other sizes use buttons that scale according to their content.
@@ -22,106 +25,185 @@ import PlaygroundPreview from '../../../../components/Playground'
 
 ### Variations
 
-<Accordion 
-  heading="Primary button" 
+<Accordion
+  heading="Primary button"
   headingLevel="4"
   initiallyOpen
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary or supplementary buttons instead.
-  <br />
-  <PlaygroundPreview>
+  }}
+>
+  A Primary button is reserved for the most important action on the screen. Primary action is usually either mandatory
+  or essential for the user. Primary buttons are designed to clearly highlight the most important action, and therefore
+  you should avoid having multiple primary buttons on one screen. For less important actions, consider using secondary
+  or supplementary buttons instead.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
     <Button>Primary</Button>
   </PlaygroundPreview>
 </Accordion>
 
-<Accordion 
-  heading="Secondary button" 
-  headingLevel="4" 
+<Accordion
+  heading="Secondary button"
+  headingLevel="4"
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  Secondary buttons are used for actions which are not mandatory or essential for the user. Often screens will include multiple secondary buttons alongside one primary button.
-  <br />
-  <PlaygroundPreview>
+  }}
+>
+  Secondary buttons are used for actions which are not mandatory or essential for the user. Often screens will include
+  multiple secondary buttons alongside one primary button.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
     <Button variant="secondary">Primary</Button>
   </PlaygroundPreview>
 </Accordion>
 
-<Accordion 
-  heading="Supplementary button" 
-  headingLevel="4" 
+<Accordion
+  heading="Supplementary button"
+  headingLevel="4"
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  Supplementary buttons can be used in similar cases as secondary buttons. However, supplementary buttons are meant for actions which are intentionally wanted to be less visible to the user. These kind of actions include i.e. cancel and dismiss functionalities.
-
-  Note! Since supplementary buttons do not have borders, an accompanying icon is required to clearly distinguish them from links and passive text elements.
-  <PlaygroundPreview>
-    <Button variant="supplementary" iconLeft={<IconTrash />}>Supplementary</Button>
+  }}
+>
+  Supplementary buttons can be used in similar cases as secondary buttons. However, supplementary buttons are meant for
+  actions which are intentionally wanted to be less visible to the user. These kind of actions include i.e. cancel and
+  dismiss functionalities. Note! Since supplementary buttons do not have borders, an accompanying icon is required to
+  clearly distinguish them from links and passive text elements.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
+    <Button variant="supplementary" iconLeft={<IconTrash />}>
+      Supplementary
+    </Button>
   </PlaygroundPreview>
 </Accordion>
 
-<Accordion 
-  heading="Icon button" 
-  headingLevel="4" 
+<Accordion
+  heading="Icon button"
+  headingLevel="4"
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  Icons can be added to buttons to make the action easier to understand. Sometimes it can also be beneficial to add icons to make important actions more distinguishable. It is not recommended to use buttons with icons without text label because users interpret icons in different ways. More information on icon usage in the icon guidelines.
-  <PlaygroundPreview>
+  }}
+>
+  Icons can be added to buttons to make the action easier to understand. Sometimes it can also be beneficial to add
+  icons to make important actions more distinguishable. It is not recommended to use buttons with icons without text
+  label because users interpret icons in different ways. More information on icon usage in the icon guidelines.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
     <Button iconLeft={<IconShare />}>Button</Button>
-    <Button iconRight={<IconAngleRight />}>Button</Button>
-    <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />}>Button</Button>
+    <Button iconRight={<IconAngleRight />} style={{ marginLeft: 'var(--spacing-s)' }}>
+      Button
+    </Button>
+    <Button iconLeft={<IconShare />} iconRight={<IconAngleRight />} style={{ marginLeft: 'var(--spacing-s)' }}>
+      Button
+    </Button>
   </PlaygroundPreview>
 </Accordion>
 
-<Accordion 
-  heading="Small button" 
-  headingLevel="4" 
+<Accordion
+  heading="Small button"
+  headingLevel="4"
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  It is recommended to use the standard button size in most cases. If there is a big number of actions in the same view, small buttons can be used instead of the normal sized buttons. Small buttons can be especially useful in mobile screen sizes to ensure uncluttered view with multiple available actions.
-  <PlaygroundPreview>
+  }}
+>
+  It is recommended to use the standard button size in most cases. If there is a big number of actions in the same view,
+  small buttons can be used instead of the normal sized buttons. Small buttons can be especially useful in mobile screen
+  sizes to ensure uncluttered view with multiple available actions.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
     <Button size="small">Primary</Button>
-    <Button variant="secondary" size="small">Secondary</Button>
-    <Button variant="supplementary" size="small">Supplementary</Button>
+    <Button variant="secondary" size="small" style={{ marginLeft: 'var(--spacing-s)' }}>
+      Secondary
+    </Button>
+    <Button variant="supplementary" size="small" style={{ marginLeft: 'var(--spacing-s)' }}>
+      Supplementary
+    </Button>
   </PlaygroundPreview>
 </Accordion>
 
-<Accordion 
-  heading="Utility button" 
-  headingLevel="4" 
+<Accordion
+  heading="Utility button"
+  headingLevel="4"
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  If required, to achieve clearer user interface, you may also use additional utility colours. Different visual styles of these buttons can be used to better inform users of destructive or dangerous actions. To comply with WCAG requirement 1.4.1 Use of Color, these colours are more accessible when paired with an icon.
-  <PlaygroundPreview>
+  }}
+>
+  If required, to achieve clearer user interface, you may also use additional utility colours. Different visual styles
+  of these buttons can be used to better inform users of destructive or dangerous actions. To comply with WCAG
+  requirement 1.4.1 Use of Color, these colours are more accessible when paired with an icon.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
     <Button variant="success">Success</Button>
-    <Button variant="danger">Danger</Button>
+    <Button variant="danger" style={{ marginLeft: 'var(--spacing-s)' }}>
+      Danger
+    </Button>
   </PlaygroundPreview>
 </Accordion>
 
-<Accordion 
-  heading="Loading button" 
-  headingLevel="4" 
+export const LoadingButtonVariant = () => {
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [showNotification, setShowNotification] = React.useState(false);
+  React.useEffect(() => {
+    let timeout;
+    if (isLoading) {
+      timeout = setTimeout(() => {
+        setShowNotification(true);
+        setIsLoading(false);
+      }, 2000);
+    }
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [isLoading]);
+  return (
+    <>
+      <Button
+        isLoading={isLoading}
+        loadingText="Saving form changes"
+        onClick={() => {
+          setShowNotification(false);
+          setIsLoading(true);
+        }}
+      >
+        Save form
+      </Button>
+      {showNotification && (
+        <Notification
+          key={new Date().toString()}
+          position="top-right"
+          displayAutoCloseProgress={false}
+          autoClose
+          dismissible
+          label="Form saved!"
+          type="success"
+          onClose={() => {
+            setShowNotification(false);
+          }}
+        >
+          Saving your form was successful.
+        </Notification>
+      )}
+    </>
+  );
+};
+
+<Accordion
+  heading="Loading button"
+  headingLevel="4"
   theme={{
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
-  }}>
-  If an action triggered by the button press is not immediate, a loading button state should be shown to the user to indicate the loading period.
-
-  When the loading action is triggered at the button press, the button will change its state to loading. After the loading is complete, either the next page loads or if the page stays the same, you should use other methods (such as notifications) to indicate the loading result.
-
-  Note! It is not recommended to use Supplementary buttons for loading actions since it can be difficult for the user to differentiate from the loading state button.
+  }}
+>
+  If an action triggered by the button press is not immediate, a loading button state should be shown to the user to
+  indicate the loading period. When the loading action is triggered at the button press, the button will change its
+  state to loading. After the loading is complete, either the next page loads or if the page stays the same, you should
+  use other methods (such as notifications) to indicate the loading result. Note! It is not recommended to use
+  Supplementary buttons for loading actions since it can be difficult for the user to differentiate from the loading
+  state button.
+  <PlaygroundPreview style={{ marginTop: 'var(--spacing-m)' }}>
+    <LoadingButtonVariant />
+  </PlaygroundPreview>
 </Accordion>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/card/usage.mdx
+++ b/new-site/src/docs/elements/components/card/usage.mdx
@@ -4,17 +4,22 @@ title: 'Card - Usage'
 ---
 
 import { Button, Card, IconAngleRight, IconShare, IconTrash, Link } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<Card
-  border
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-/>
+
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
+  <Card
+    border
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  />
+</PlaygroundPreview>
 
 ## Principles
+
 - **Use Cards sparingly.** While they can drastically improve service's understandability and readability, overusing them may result in confusing and complex user interfaces.
 - **Cards work very well for listing heterogenous content** such as news items, blog posts, or upcoming events.
 - **Cards can also be used to emphasize important content** such as site CTA (Call To Action).
@@ -23,6 +28,7 @@ import { Button, Card, IconAngleRight, IconShare, IconTrash, Link } from 'hds-re
 - Currently, HDS offers base Cards that you can use to build custom Cards for your project's needs. For inspiration and guidelines, you can find custom card examples in <Link size="M" href="https://share.goabstract.com/e6aa2ebd-1a49-4cb1-90ef-a44a6486c28b" external>HDS Example Custom Components - Abstract collection</Link>.
 
 ## Should I use a Card or a Linkbox?
+
 - **Use the [Card component](/elements/components/card) when**
   - the whole Card does not need to be interactable
   - the Card contains multiple interactable elements (e.g. buttons or links)
@@ -33,42 +39,54 @@ import { Button, Card, IconAngleRight, IconShare, IconTrash, Link } from 'hds-re
 ### Variations
 
 ### Empty
+
 Currently, HDS offers empty base Cards. These and other HDS components can be used to create custom Cards for your project. By default, HDS recommends Cards without border style.
 
-<Card />
-<Card border />
-
----
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
+  <Card />
+  <Card border style={{ marginTop: 'var(--spacing-s)' }} />
+</PlaygroundPreview>
 
 ### With heading and body text
-Additionally, HDS offers styling for basic heading and body text inside the Card component. These can be used instead of custom elements.
-<Card
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-/>
-<Card
-  border
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-/>
 
----
+Additionally, HDS offers styling for basic heading and body text inside the Card component. These can be used instead of custom elements.
+
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
+  <Card
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  />
+  <Card
+    style={{ marginTop: 'var(--spacing-s)' }}
+    border
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  />
+</PlaygroundPreview>
 
 ### Using with other HDS components
+
 Custom Cards can be easily built by using other HDS components and typography inside the Card.
 
-<Card
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
->
-  <Button variant="secondary" theme="black" role="link">Button</Button>
-</Card>
-<Card
-  border
-  heading="Card"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
->
-  <Button variant="secondary" theme="black" role="link">Button</Button>
-</Card>
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
+  <Card
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <Button variant="secondary" theme="black" role="link">
+      Button
+    </Button>
+  </Card>
+  <Card
+    style={{ marginTop: 'var(--spacing-s)' }}
+    border
+    heading="Card"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+  >
+    <Button variant="secondary" theme="black" role="link">
+      Button
+    </Button>
+  </Card>
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/checkbox/usage.mdx
+++ b/new-site/src/docs/elements/components/checkbox/usage.mdx
@@ -4,6 +4,7 @@ title: 'Checkbox - Usage'
 ---
 
 import { Checkbox } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
@@ -19,7 +20,7 @@ export const CheckBoxExample = () => {
   };
   return (
     <>
-      <Checkbox label="Label" id="checkbox" checked={checkedItems['checkbox']} onChange={onChange} />
+      <Checkbox label="Label" id="checkbox-unchecked" checked={checkedItems['checkbox-unchecked']} onChange={onChange} />
       <Checkbox label="Label" id="checkbox-checked" checked={checkedItems['checkbox-checked']} onChange={onChange} />
       <Checkbox
         label="Label"
@@ -39,7 +40,9 @@ export const CheckBoxExample = () => {
   );
 };
 
-<CheckBoxExample />
+<PlaygroundPreview>
+  <CheckBoxExample />
+</PlaygroundPreview>
 
 ## Principles
 
@@ -50,10 +53,6 @@ export const CheckBoxExample = () => {
 - Checkboxes should not have any immediate effects. The checkbox selection takes effect when the user presses a submit button (e.g. in a form). If you need the selection to have an immediate effect, use [HDS Toggle button component](/components/toggle) instead. Also see [guidelines for choosing between radio buttons, checkboxes, and toggles.](/guidelines/checkboxes-radiobuttons-toggles)
 
 ### Variations
-
-### Checkbox with label
-
----
 
 ### Checkbox group
 

--- a/new-site/src/docs/elements/components/date-input/usage.mdx
+++ b/new-site/src/docs/elements/components/date-input/usage.mdx
@@ -4,90 +4,101 @@ title: 'DateInput - Usage'
 ---
 
 import { DateInput, Link } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<div style={{maxWidth: '400px'}}>
-  <DateInput 
-    helperText="Use format D.M.YYYY"
-    id="date"
-    initialMonth={new Date()}
-    label="Choose a date"
-    language="en"
-    onChange={function noRefCheck(){}}
-    required
-  />
-</div>
+
+<PlaygroundPreview>
+  <div style={{ maxWidth: '400px' }}>
+    <DateInput
+      helperText="Use format D.M.YYYY"
+      id="date"
+      initialMonth={new Date()}
+      label="Choose a date"
+      language="en"
+      onChange={function noRefCheck() {}}
+      required
+    />
+  </div>
+</PlaygroundPreview>
 
 ### Principles
-- Only use a date input when you can expect the user to input a specific date. If it can be difficult for the user to determine which date they should choose or if the selected date can be vague, let the user choose, for example, a week, month or a date range. 
-    - When selecting weeks or months, it is usually better to use <Link size="M" href="/components/dropdown#select">the dropdown select component</Link>.
+
+- Only use a date input when you can expect the user to input a specific date. If it can be difficult for the user to determine which date they should choose or if the selected date can be vague, let the user choose, for example, a week, month or a date range.
+  - When selecting weeks or months, it is usually better to use <Link size="M" href="/components/dropdown#select">the dropdown select component</Link>.
 - Pay close attention to the date input label. It should clearly describe the date the user is expected to input. A good label describes the input, such as "Arrival date".
 - The date input should be provided with an assistive text which tells the user the expected date format. Avoid relying on a placeholder text alone because it will disappear when the user starts typing. The recommended way to show the expected format is to use the assistive text below the input.
-    - As specified in <Link size="M" href="/guidelines/data-formats">the data format guidelines</Link>, Helsinki services will always use D.M.YYYY format. Do not use the English date format even if the user is using English locale.
+  - As specified in <Link size="M" href="/guidelines/data-formats">the data format guidelines</Link>, Helsinki services will always use D.M.YYYY format. Do not use the English date format even if the user is using English locale.
 - When asking for date ranges, you should use two separate date inputs instead of using one input or picker for both dates.
 - HDS Date picker acts as a modal. This means that clicking outside of the date picker closes it. Closing the picker this way also cancels the selection made in the date picker.
 
 #### When to use the date picker?
+
 - **Use the date picker** (calendar) when it is useful for the user to see how the selected date is related to other dates and/or which weekday it is.
 - **Do not use the date picker** if the date is easily remembered or is obvious for the user or if the date is further into the past or the future. Date of birth is an example of a situation where the date picker should not be used.
 
 ### Variations
 
 ### Date input with a picker
+
 Out of the box, HDS date input will include an openable date picker which allows the user to select the date via a calendar view. The date can be also inputted manually, which is the recommended setup for most use cases.
 
-<div style={{maxWidth: '400px'}}>
-  <DateInput 
-    helperText="Use format D.M.YYYY"
-    id="date"
-    initialMonth={new Date()}
-    label="Choose a date"
-    language="en"
-    onChange={function noRefCheck(){}}
-    required
-  />
-</div>
-
----
+<PlaygroundPreview>
+  <div style={{ maxWidth: '400px' }}>
+    <DateInput
+      helperText="Use format D.M.YYYY"
+      id="date"
+      initialMonth={new Date()}
+      label="Choose a date"
+      language="en"
+      onChange={function noRefCheck() {}}
+      required
+    />
+  </div>
+</PlaygroundPreview>
 
 ### Date input without a confirmation
+
 **Note!** Since this variant closes the date picker immediately after selection, it violates <Link size="M" href="https://www.w3.org/TR/WCAG21/#on-input" external>WCAG 3.2.2 On Input guideline</Link>. Therefore, this variant should only be used in administration and intranet type of services.
 
 The default HDS date picker requires a confirmation after the date has been selected from the calendar. If your service is mostly desktop or meant for administration, the confirmation can be disabled with `disableConfirmation` prop to allow more fluid ser experience when selecting multiple dates in a row.
 
 In all other types of services, it is recommended to not disable the confirmation step.
 
-<div style={{maxWidth: '400px'}}>
-  <DateInput
-    disableConfirmation
-    helperText="Use format D.M.YYYY"
-    id="date"
-    initialMonth={new Date()}
-    label="Choose a date"
-    language="en"
-    onChange={function noRefCheck(){}}
-    required
-  />
-</div>
-
----
+<PlaygroundPreview>
+  <div style={{ maxWidth: '400px' }}>
+    <DateInput
+      disableConfirmation
+      helperText="Use format D.M.YYYY"
+      id="date"
+      initialMonth={new Date()}
+      label="Choose a date"
+      language="en"
+      onChange={function noRefCheck() {}}
+      required
+    />
+  </div>
+</PlaygroundPreview>
 
 ### Date input without a picker
+
 It is possible to disable the date picker functionality by supplying a `disableDatePicker` prop to the input. To learn when the date picker should be hidden, see [when to use date picker](#when-to-use-the-date-picker) above.
 
-<div style={{maxWidth: '400px'}}>
-  <DateInput
-    disableDatePicker
-    helperText="Use format D.M.YYYY"
-    id="date"
-    initialMonth={new Date()}
-    label="Choose a date"
-    language="en"
-    onChange={function noRefCheck(){}}
-    required
-  />
-</div>
+<PlaygroundPreview>
+  <div style={{ maxWidth: '400px' }}>
+    <DateInput
+      disableDatePicker
+      helperText="Use format D.M.YYYY"
+      id="date"
+      initialMonth={new Date()}
+      label="Choose a date"
+      language="en"
+      onChange={function noRefCheck() {}}
+      required
+    />
+  </div>
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/dialog/usage.mdx
+++ b/new-site/src/docs/elements/components/dialog/usage.mdx
@@ -3,7 +3,8 @@ slug: '/elements/components/dialog/code'
 title: 'Dialog - Usage'
 ---
 
-import { Dialog, Button, IconInfoCircle } from 'hds-react';
+import { Dialog, Button, IconInfoCircle, IconTrash } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
@@ -14,11 +15,11 @@ export const DialogExample = () => {
   const openInfoDialogButtonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const close = () => setIsOpen(false);
-  const titleId = "info-dialog-title";
-  const descriptionId = "info-dialog-content";
+  const titleId = 'info-dialog-title';
+  const descriptionId = 'info-dialog-content';
   return (
     <>
-      <div ref={dialogTargetRef}/>
+      <div ref={dialogTargetRef} />
       <Button ref={openInfoDialogButtonRef} onClick={() => setIsOpen(true)}>
         Open Info dialog
       </Button>
@@ -35,49 +36,52 @@ export const DialogExample = () => {
         <Dialog.Header
           id={titleId}
           title="Terms of service have changed"
-          iconLeft={<IconInfoCircle aria-hidden="true"/>}
+          iconLeft={<IconInfoCircle aria-hidden="true" />}
         />
         <Dialog.Content>
           <p id={descriptionId} className="text-body">
-            Please note that the terms of this service have changed. You can review the changes in the user
-            settings.</p>
+            Please note that the terms of this service have changed. You can review the changes in the user settings.
+          </p>
         </Dialog.Content>
         <Dialog.ActionButtons>
-          <Button onClick={close}>
-            Close
-          </Button>
+          <Button onClick={close}>Close</Button>
         </Dialog.ActionButtons>
       </Dialog>
     </>
-  )
+  );
 };
 
-<DialogExample/>
+<PlaygroundPreview>
+  <DialogExample />
+</PlaygroundPreview>
 
 ## Principles
+
 - Dialogs capture the browser focus and the user is forced to react to the dialog.
-    - To emphasize this, a dark screen overlay must be used to cover the view content behind the dialog element.
+  - To emphasize this, a dark screen overlay must be used to cover the view content behind the dialog element.
 - **Dialogs are a very intrusive pattern and they should only be used when the immediate actions or focus from the user are needed.**
 - Be careful when including a separate close ("x") icon in the dialog. If there are more than one action available in the dialog, it can be ambiguous for the user which action is triggered when the close icon is pressed.
-    - Generally, it is a good practise to omit the close icon if the dialog has more than one action available.
+  - Generally, it is a good practise to omit the close icon if the dialog has more than one action available.
 - If your dialog contains form elements, follow [HDS form](/patterns/forms) and [form validation patterns](/patterns/form-validation) similarly as you would in a regular forms.
 - As dialogs always contain buttons, pay close attention that the button labels describe the action it is going to trigger. You can read more information about this in the [HDS Button documentation page](/components/button).
-    - Following the same guidelines as the HDS Form pattern, dialog action buttons are placed at the left side of the dialog and the primary action will be the first one from the left.
-    - If some of the actions are destructive or irreversible, the button order should be reversed so so that the destructive actions are last in the button list. See [Danger dialog example](#danger-dialog) for more information.
+  - Following the same guidelines as the HDS Form pattern, dialog action buttons are placed at the left side of the dialog and the primary action will be the first one from the left.
+  - If some of the actions are destructive or irreversible, the button order should be reversed so so that the destructive actions are last in the button list. See [Danger dialog example](#danger-dialog) for more information.
 - Opening a dialog should be always triggered by the user. Do not open dialogs without user action.
-    - Also make sure that the dialog is related to the current context.
+  - Also make sure that the dialog is related to the current context.
   - It is not recommended to open dialogs on top of other dialogs. However, this is supported by HDS Dialogs if it is needed.
 
 ### When to use each dialog type?
-| Type                           | When to use it?                                                                                                     | Example
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [Info](#info-dialog)           | Important information needs to be conveyed to the user. Only requires acknowledgment and no choices from the user. | Informing the user about changed terms of use.
-| [Confirm](#confirm-dialog)     | An action is required from the user.                                                                                | Confirming that the user wants to continue even though all form fields are not filled.
-| [Danger](#danger-dialog)       | An action is required from the user while **the action results are destructive**.                                   | Confirming that the user wants to delete a blog post.
+
+| Type                       | When to use it?                                                                                                    | Example                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [Info](#info-dialog)       | Important information needs to be conveyed to the user. Only requires acknowledgment and no choices from the user. | Informing the user about changed terms of use.                                         |
+| [Confirm](#confirm-dialog) | An action is required from the user.                                                                               | Confirming that the user wants to continue even though all form fields are not filled. |
+| [Danger](#danger-dialog)   | An action is required from the user while **the action results are destructive**.                                  | Confirming that the user wants to delete a blog post.                                  |
 
 ### Variations
 
 ### Info dialog
+
 Info dialogs are used to convey important information to the user. Info dialogs only include one button which the user can use to acknowledge the information.
 
 ---

--- a/new-site/src/docs/elements/components/dialog/usage.mdx
+++ b/new-site/src/docs/elements/components/dialog/usage.mdx
@@ -84,19 +84,255 @@ export const DialogExample = () => {
 
 Info dialogs are used to convey important information to the user. Info dialogs only include one button which the user can use to acknowledge the information.
 
----
+export const InfoDialogExample = () => {
+  const openInfoDialogButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const close = () => setIsOpen(false);
+  const titleId = 'info-dialog-title';
+  const descriptionId = 'info-dialog-content';
+  return (
+    <>
+      <Button ref={openInfoDialogButtonRef} onClick={() => setIsOpen(true)}>
+        Open Info dialog
+      </Button>
+      <Dialog
+        id="info-dialog"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        isOpen={isOpen}
+        close={close}
+        closeButtonLabelText="Close info dialog"
+        focusAfterCloseRef={openInfoDialogButtonRef}
+      >
+        <Dialog.Header
+          id={titleId}
+          title="Terms of service have changed"
+          iconLeft={<IconInfoCircle aria-hidden="true" />}
+        />
+        <Dialog.Content>
+          <p id={descriptionId} className="text-body">
+            Please note that the terms of this service have changed. You can review the changes in the user settings.
+          </p>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button onClick={close}>Close</Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <InfoDialogExample />
+</PlaygroundPreview>
 
 ### Confirm dialog
+
 Confirm dialogs are used when an action is required from the user. Confirm dialogs always include at least two actions; one primary action (e.g. Confirm) and one secondary action (e.g. Cancel). However, more than two actions are allowed if it is needed.
 
----
+export const ConfirmDialogExample = () => {
+  const openConfirmationDialogButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const close = () => setIsOpen(false);
+  const titleId = 'confirmation-dialog-title';
+  const descriptionId = 'confirmation-dialog-info';
+  return (
+    <>
+      <Button ref={openConfirmationDialogButtonRef} onClick={() => setIsOpen(true)}>
+        Open Confirmation dialog
+      </Button>
+      <Dialog
+        id="confirmation-dialog"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        isOpen={isOpen}
+        focusAfterCloseRef={openConfirmationDialogButtonRef}
+      >
+        <Dialog.Header
+          id={titleId}
+          title="Are you sure you want to continue?"
+          iconLeft={<IconQuestionCircle aria-hidden="true" />}
+        />
+        <Dialog.Content>
+          <p id={descriptionId} className="text-body">
+            You have not filled all form fields. Do you still want to continue? You can later return to edit this form.
+            Saved forms can be accessed in your personal profile.
+          </p>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button onClick={close}>Continue</Button>
+          <Button onClick={close} variant="secondary">
+            Cancel
+          </Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <ConfirmDialogExample />
+</PlaygroundPreview>
 
 ### Danger dialog
+
 Danger dialog is a variant of a confirm dialog. They are used in similar use cases but Danger dialogs are meant for situations where the action user is going to choose may be destructive or otherwise irreversible or very critical. Danger dialog emphasizes this by using HDS error status colours. Also, it reverses the action button order so that the destructive action is last in the button list.
 
----
+export const DangerDialogExample = () => {
+  const openDeleteDialogButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const close = () => setIsOpen(false);
+  const titleId = 'delete-dialog-title';
+  const descriptionId = 'delete-dialog-info';
+  return (
+    <>
+      <Button ref={openDeleteDialogButtonRef} onClick={() => setIsOpen(true)}>
+        Open Delete dialog
+      </Button>
+      <Dialog
+        variant="danger"
+        id="delete-dialog"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        isOpen={isOpen}
+        focusAfterCloseRef={openDeleteDialogButtonRef}
+      >
+        <Dialog.Header
+          id={titleId}
+          title="Are you sure you want to delete this blog post?"
+          iconLeft={<IconAlertCircle aria-hidden="true" />}
+        />
+        <Dialog.Content>
+          <p id={descriptionId} className="text-body">
+            The blog post will be deleted immediately. Deletion is permanent and it cannot be reverted.
+          </p>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button onClick={close} theme="black" variant="secondary">
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            iconLeft={<IconTrash aria-hidden="true" />}
+            onClick={() => {
+              // Add confirm operations here
+              close();
+            }}
+          >
+            Delete the blog post
+          </Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <DangerDialogExample />
+</PlaygroundPreview>
 
 ### Scrollable dialog
+
 While not recommended, HDS supports scrollable dialogs if there is a large amount of content (e.g. terms of use). **It is recommended to consider other options than a dialog to present the same data since it can be difficult for the user to form a clear understanding of the presented content.**
+
+export const ScrollableDialogExample = () => {
+  const termsDialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
+  const openTermsDialogButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const close = () => setIsOpen(false);
+  const titleId = 'terms-dialog-title';
+  const descriptionId = 'terms-dialog-info';
+  return (
+    <>
+      <div ref={termsDialogTargetRef} />
+      <Button ref={openTermsDialogButtonRef} onClick={() => setIsOpen(true)}>
+        Open Terms dialog
+      </Button>
+      <Dialog
+        id="terms-dialog"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        isOpen={isOpen}
+        focusAfterCloseRef={openTermsDialogButtonRef}
+        targetElement={termsDialogTargetRef.current}
+        scrollable
+      >
+        <Dialog.Header
+          id={titleId}
+          title="Do you accept the terms of service?"
+          iconLeft={<IconAlertCircle aria-hidden="true" />}
+        />
+        <Dialog.Content>
+          <h3 id={descriptionId}>Terms of service</h3>
+          <p className="text-body">
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+            aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+            dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+            sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+            suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in
+            ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas
+            nulla pariatur?
+          </p>
+          <p className="text-body">
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+            aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+            dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+            sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+            suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in
+            ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas
+            nulla pariatur?
+          </p>
+          <p className="text-body">
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+            aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+            dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+            sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+            suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in
+            ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas
+            nulla pariatur?
+          </p>
+          <p className="text-body">
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+            aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+            dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+            sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+            suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in
+            ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas
+            nulla pariatur?
+          </p>
+          <p className="text-body">
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+            aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+            dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+            sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+            magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+            suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in
+            ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas
+            nulla pariatur?
+          </p>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button onClick={close}>Accept terms</Button>
+          <Button onClick={close} variant="secondary">
+            Cancel
+          </Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <ScrollableDialogExample />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/dropdown/usage.mdx
+++ b/new-site/src/docs/elements/components/dropdown/usage.mdx
@@ -105,23 +105,162 @@ export const SelectExample = () => {
 
 Select dropdown serves in most use cases when the user needs to select one of 4 to 7 options. If there are 8 or more options available, consider using [Combobox](#combobox-single-selection) to allow filtering.
 
----
+export const SingleSelectVariation = () => {
+  const options = [{ label: 'Plutonium' }, { label: 'Americium' }, { label: 'Copernicium' }, { label: 'Berkelium' }];
+  return (
+    <>
+      <Select required label="Label" helper="Assistive text" placeholder="Placeholder" options={options} />
+      <Select
+        disabled
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        options={options}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+      <Select
+        invalid
+        required
+        label="Label"
+        error="Error description"
+        placeholder="Placeholder"
+        options={options}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+      <Select
+        required
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        icon={<IconUser />}
+        options={[{ label: 'Adam' }, { label: 'Caitlyn' }, { label: 'Jack' }, { label: 'Sally' }]}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <SingleSelectVariation />
+</PlaygroundPreview>
 
 ### Select (multi-selection)
+
 Select multi-selection variant allows the user to select one or more options simultaneously. Note! Select dropdown does not feature filtering options by typing. When this feature is needed or there are a large number of options available, consider using consider using [Combobox](#combobox-multi-selection).
 
 Multi-select also supports icon if needed.
 
----
+<PlaygroundPreview>
+  <Select
+    multiselect
+    required
+    label="Label"
+    placeholder="Placeholder"
+    helper="Assistive text"
+    options={[{ label: 'Plutonium' }, { label: 'Americium' }, { label: 'Copernicium' }, { label: 'Berkelium' }]}
+    clearButtonAriaLabel="Clear all selections"
+    selectedItemRemoveButtonAriaLabel="Remove ${value}"
+  />
+</PlaygroundPreview>
 
 ### Combobox (single selection)
+
 Combobox dropdown serves in most use cases when the user needs to select one from 8 or more options (up to hundreds of options). Combobox variant features filtering options by typing.
 
----
+export const SingleComboboxVariation = () => {
+  const options = [
+    { label: 'Americium' },
+    { label: 'Berkelium' },
+    { label: 'Californium' },
+    { label: 'Copernicium' },
+    { label: 'Einsteinium' },
+    { label: 'Fermium' },
+    { label: 'Mendelevium' },
+    { label: 'Plutonium' },
+  ];
+  return (
+    <>
+      <Combobox
+        required
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        toggleButtonAriaLabel="Toggle menu"
+        options={options}
+      />
+      <Combobox
+        disabled
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        toggleButtonAriaLabel="Toggle menu"
+        options={options}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+      <Combobox
+        invalid
+        required
+        label="Label"
+        error="Error description"
+        placeholder="Placeholder"
+        toggleButtonAriaLabel="Toggle menu"
+        options={options}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+      <Combobox
+        required
+        label="Label"
+        helper="Assistive text"
+        placeholder="Placeholder"
+        toggleButtonAriaLabel="Toggle menu"
+        icon={<IconUser />}
+        options={[
+          { label: 'Adam' },
+          { label: 'Allie' },
+          { label: 'Bob' },
+          { label: 'Caitlyn' },
+          { label: 'Jack' },
+          { label: 'Olivia' },
+          { label: 'Sally' },
+          { label: 'Sam' },
+        ]}
+        style={{ marginTop: 'var(--spacing-xs)' }}
+      />
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <SingleComboboxVariation />
+</PlaygroundPreview>
 
 ### Combobox (multi-selection)
+
 Combobox multi-select variant allows the user to select one or more options simultaneously. Combobox variant features filtering options by typing.
 
 Multi-select also supports icon if needed.
+
+<PlaygroundPreview>
+  <Combobox
+    multiselect
+    required
+    label="Label"
+    helper="Assistive text"
+    placeholder="Placeholder"
+    options={[
+      { label: 'Americium' },
+      { label: 'Berkelium' },
+      { label: 'Californium' },
+      { label: 'Copernicium' },
+      { label: 'Einsteinium' },
+      { label: 'Fermium' },
+      { label: 'Mendelevium' },
+      { label: 'Plutonium' },
+    ]}
+    clearButtonAriaLabel="Clear all selections"
+    selectedItemRemoveButtonAriaLabel="Remove ${value}"
+    toggleButtonAriaLabel="Toggle menu"
+  />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/dropdown/usage.mdx
+++ b/new-site/src/docs/elements/components/dropdown/usage.mdx
@@ -4,11 +4,12 @@ title: 'Dropdown - Usage'
 ---
 
 import { Button, Combobox, IconInfoCircle, IconUser, Select } from 'hds-react';
-import Playground from '../../../../components/Playground';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
-### Example
+### Example (Select)
+
 export const SelectExample = () => {
   const options = [{ label: 'Plutonium' }, { label: 'Americium' }, { label: 'Copernicium' }, { label: 'Berkelium' }];
   return (
@@ -41,41 +42,49 @@ export const SelectExample = () => {
         style={{ marginTop: 'var(--spacing-xs)' }}
       />
     </>
-  )
+  );
 };
 
-<SelectExample />
+<PlaygroundPreview>
+  <SelectExample />
+</PlaygroundPreview>
 
-<Combobox
-  multiselect
-  required
-  label="Label"
-  helper="Assistive text"
-  placeholder="Placeholder"
-  options={[
-    { label: 'Americium' },
-    { label: 'Berkelium' },
-    { label: 'Californium' },
-    { label: 'Copernicium' },
-    { label: 'Einsteinium' },
-    { label: 'Fermium' },
-    { label: 'Mendelevium' },
-    { label: 'Plutonium' },
-  ]}
-  clearButtonAriaLabel="Clear all selections"
-  selectedItemRemoveButtonAriaLabel="Remove ${value}"
-  toggleButtonAriaLabel="Toggle menu"
-/>
+### Example (Combobox)
+
+<PlaygroundPreview>
+  <Combobox
+    multiselect
+    required
+    label="Label"
+    helper="Assistive text"
+    placeholder="Placeholder"
+    options={[
+      { label: 'Americium' },
+      { label: 'Berkelium' },
+      { label: 'Californium' },
+      { label: 'Copernicium' },
+      { label: 'Einsteinium' },
+      { label: 'Fermium' },
+      { label: 'Mendelevium' },
+      { label: 'Plutonium' },
+    ]}
+    clearButtonAriaLabel="Clear all selections"
+    selectedItemRemoveButtonAriaLabel="Remove ${value}"
+    toggleButtonAriaLabel="Toggle menu"
+  />
+</PlaygroundPreview>
 
 ### Principles
+
 - **A label should always be provided with dropdowns.** Aim for labels that are short, concise and easy to understand.
-- Dropdowns usually have four (4) or more options. When having only 2-3 options, it is usually better to use [radio buttons](/components/radio-button "Radio button documentation") or [checkboxes](/components/checkbox "Checkbox documentation"). Also, if options need to be easily comparable (for example, product pricing), prefer radio buttons over dropdown.
+- Dropdowns usually have four (4) or more options. When having only 2-3 options, it is usually better to use [radio buttons](/components/radio-button 'Radio button documentation') or [checkboxes](/components/checkbox 'Checkbox documentation'). Also, if options need to be easily comparable (for example, product pricing), prefer radio buttons over dropdown.
 - It is recommended to set a default option for a single selection dropdown. If the default option is also the recommended option, you can mark the option with a text "_(recommended)_".
 - If your dropdown has 8 or more options, consider using the [Combobox](#combobox-single-selection) variant which offers filtering options by typing.
 - Try to avoid dropdown options that span over one line. Aim for short texts for all options.
 - If possible, do input validation client-side in real-time and provide the user with immediate feedback after selection.
 
 #### Should I use Select or Combobox?
+
 - **Use Select variant when**
   - there are less than 8 options
   - the user does not need to be able to filter options by typing
@@ -84,6 +93,7 @@ export const SelectExample = () => {
   - the user needs to be able to filter options by typing
 
 #### Icon or no icon?
+
 - **Use an icon when**
   - there is a clear added value to using an icon
   - when the icon is not just for illustrative purposes
@@ -92,6 +102,7 @@ export const SelectExample = () => {
 ### Variations
 
 ### Select (single selection)
+
 Select dropdown serves in most use cases when the user needs to select one of 4 to 7 options. If there are 8 or more options available, consider using [Combobox](#combobox-single-selection) to allow filtering.
 
 ---

--- a/new-site/src/docs/elements/components/fieldset/usage.mdx
+++ b/new-site/src/docs/elements/components/fieldset/usage.mdx
@@ -4,23 +4,28 @@ title: 'Fieldset - Usage'
 ---
 
 import { Fieldset, TextInput } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<Fieldset heading="Applicant information" style={{ maxWidth: '400px' }}>
-  <TextInput id="first-name" name="first-name" label="First name" />
-  <TextInput id="last-name" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
-  <TextInput
-    id="social-security-number"
-    name="social-security-number"
-    label="Social security number"
-    placeholder="Eg. 111299-1234"
-    style={{ marginTop: '12px' }}
-  />
-</Fieldset>
+
+<PlaygroundPreview>
+  <Fieldset heading="Applicant information" style={{ maxWidth: '400px' }}>
+    <TextInput id="first-name" name="first-name" label="First name" />
+    <TextInput id="last-name" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
+    <TextInput
+      id="social-security-number"
+      name="social-security-number"
+      label="Social security number"
+      placeholder="Eg. 111299-1234"
+      style={{ marginTop: '12px' }}
+    />
+  </Fieldset>
+</PlaygroundPreview>
 
 ### Principles
+
 - The Fieldset component should only contain form elements such as input fields and form controls. See [HDS Form pattern documentation](/patterns/forms) for more information about available form elements.
   - It is recommended that Fieldsets always contain at least two (2) form elements.
 - As a rule of thumb, if a group of form elements require a heading, the usage of a Fieldset is recommended.
@@ -34,37 +39,41 @@ import { Fieldset, TextInput } from 'hds-react';
 ### Variations
 
 ### Default
+
 The default HDS Fieldset is a visually light since it omits the borders that are present in the default HTML fieldset. It is well suited for forms with a relatively low amount of fields where input groups are easily perceivable even without Fieldset borders.
 
-<Fieldset heading="Applicant information" style={{ maxWidth: '400px' }}>
-  <TextInput id="first-name" name="first-name" label="First name" />
-  <TextInput id="last-name" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
-  <TextInput
-    id="social-security-number"
-    name="social-security-number"
-    label="Social security number"
-    placeholder="Eg. 111299-1234"
-    style={{ marginTop: '12px' }}
-  />
-</Fieldset>
-
----
+<PlaygroundPreview>
+  <Fieldset heading="Applicant information" style={{ maxWidth: '400px' }}>
+    <TextInput id="first-name" name="first-name" label="First name" />
+    <TextInput id="last-name" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
+    <TextInput
+      id="social-security-number"
+      name="social-security-number"
+      label="Social security number"
+      placeholder="Eg. 111299-1234"
+      style={{ marginTop: '12px' }}
+    />
+  </Fieldset>
+</PlaygroundPreview>
 
 ### With border
+
 This Fieldset variant includes visual borders that are often present in the default HTML fieldsets. The borders help to distinguish groups from each other and they are useful when the form contains a large amount of form elements.
 
 Border variant is also useful when the form contains multiple form elements with a same label. For example, when the same contact information is asked for multiple different people in the same form.
 
-<Fieldset heading="Applicant information" border style={{ maxWidth: '400px' }}>
-  <TextInput id="first-name" name="first-name" label="First name" />
-  <TextInput id="last-name" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
-  <TextInput
-    id="social-security-number"
-    name="social-security-number"
-    label="Social security number"
-    placeholder="Eg. 111299-1234"
-    style={{ marginTop: '12px' }}
-  />
-</Fieldset>
+<PlaygroundPreview>
+  <Fieldset heading="Applicant information" border style={{ maxWidth: '400px' }}>
+    <TextInput id="first-name" name="first-name" label="First name" />
+    <TextInput id="last-name" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
+    <TextInput
+      id="social-security-number"
+      name="social-security-number"
+      label="Social security number"
+      placeholder="Eg. 111299-1234"
+      style={{ marginTop: '12px' }}
+    />
+  </Fieldset>
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/file-input/usage.mdx
+++ b/new-site/src/docs/elements/components/file-input/usage.mdx
@@ -4,6 +4,7 @@ title: 'FileInput - Usage'
 ---
 
 import { FileInput } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
@@ -24,8 +25,9 @@ export const FileInputExample = () => {
   );
 };
 
-<FileInputExample />
-
+<PlaygroundPreview>
+  <FileInputExample />
+</PlaygroundPreview>
 
 ### Principles
 
@@ -47,10 +49,47 @@ export const FileInputExample = () => {
 
 In its default form, the HDS FileInput offers a button-like element that opens a file browser native to the user's current device. Selected files are presented in a list below the input and files can be removed from the listing separately.
 
----
+export const FileInputDefault = () => {
+  const [file, setFile] = React.useState([]);
+  console.log('selected file', file);
+  return (
+    <FileInput
+      id="file-input-default"
+      label="Choose a file"
+      language="en"
+      maxSize={1.5 * 1024 * 1024}
+      accept=".png,.jpg"
+      onChange={setFile}
+    />
+  );
+};
+
+<PlaygroundPreview>
+  <FileInputDefault />
+</PlaygroundPreview>
 
 ### With drag and drop
 
 If in some cases having the ability to drag and drop files onto the page could help the user, this can be enabled with the `dragAndDrop` property. Note that the traditional file input is still included below the drag and drop area. Therefore this property does not weaken the accessibility of the component.
+
+export const FileInputDragAndDrop = () => {
+  const [files, setFiles] = React.useState([]);
+  console.log('selected files', files);
+  return (
+    <FileInput
+      multiple
+      dragAndDrop
+      id="file-input-drag-and-drop"
+      label="Drag and drop files here"
+      language="en"
+      accept=".png,.jpg"
+      onChange={setFiles}
+    />
+  );
+};
+
+<PlaygroundPreview>
+  <FileInputDragAndDrop />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/footer/usage.mdx
+++ b/new-site/src/docs/elements/components/footer/usage.mdx
@@ -3,115 +3,118 @@ slug: '/elements/components/footer/code'
 title: 'Footer - Usage'
 ---
 
-import {
-  Footer,
-  IconFacebook,
-  IconTwitter,
-  IconInstagram,
-  IconYoutube,
-  IconTiktok,
-  Link,
-} from 'hds-react';
+import { Footer, IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok, Link } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
-  <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-  </Footer.Navigation>
-  <Footer.Utilities backToTopLabel="Back to top">
-    <Footer.SoMe>
-      <Footer.Item icon={<IconFacebook />} />
-      <Footer.Item icon={<IconTwitter />} />
-      <Footer.Item icon={<IconInstagram />} />
-      <Footer.Item icon={<IconYoutube />} />
-      <Footer.Item icon={<IconTiktok />} />
-    </Footer.SoMe>
-    <Footer.Item label="Contact us" />
-    <Footer.Item label="Give feedback" />
-  </Footer.Utilities>
-  <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved">
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-  </Footer.Base>
-</Footer>
+
+<PlaygroundPreview>
+  <Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
+    <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+    </Footer.Navigation>
+    <Footer.Utilities backToTopLabel="Back to top">
+      <Footer.SoMe>
+        <Footer.Item icon={<IconFacebook />} />
+        <Footer.Item icon={<IconTwitter />} />
+        <Footer.Item icon={<IconInstagram />} />
+        <Footer.Item icon={<IconYoutube />} />
+        <Footer.Item icon={<IconTiktok />} />
+      </Footer.SoMe>
+      <Footer.Item label="Contact us" />
+      <Footer.Item label="Give feedback" />
+    </Footer.Utilities>
+    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved">
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+    </Footer.Base>
+  </Footer>
+</PlaygroundPreview>
 
 Footer stays consistent throughout the site and is often the place where users scroll to if they feel lost or don't find what they are looking for. It's a good place provide the user an additional way to navigate the service and to information that is hard to find through primary navigation, for example contact info, copyright and legal statements. The footer can also be used to engage the user with actions and links to social media.
 
 ### Principles
+
 - **It is strongly recommended to always include the footer component in your service and on every page of the service.**
 - Always position the footer to the bottom of the page.
 - Footer component is built to follow HDS [breakpoint tokens](/design-tokens/breakpoints). While it is recommended to follow HDS breakpoint tokens, you may alter footer width to fit your service's needs.
 - Keep the order of footer sections (navigation, utility, base) and actions consistent. Do not change the default order without a good reason.
-- The footer navigation should follow the same structure and labelling as the primary navigation. All top level pages included in the primary navigation should also be visible in footer navigation.  
+- The footer navigation should follow the same structure and labelling as the primary navigation. All top level pages included in the primary navigation should also be visible in footer navigation.
 - If sub-pages are included in the footer, they should also follow the same structure and labelling as in the primary navigation. All same-level sub-pages should be visible.
 
 ### Variations
 
 The Footer consists of three sections: navigation, utility and base. Each section is customisable to fit the needs of the service. **It is recommended that the footer includes at least navigation and base sections.** The Utility section can be omitted entirely if not needed. Parts of the sections can also be hidden.
+
 - **Navigation section** contains the Helsinki framed logo, the name of the service and footer navigation. Navigation section variations for more information about customising the footer navigation.
 - **Utility section** contains links and actions not listed in main navigation, for example, social media icons, and links to contact info, feedback, or back to top.
 - **Base section** is used for supplementary information, For example copyright information and links to other meta information, e.g. accessibility statement, privacy policy, terms of use, etc.
 
 ### Default
-The default footer uses the black text colour variant and includes all three sections. 
-- The navigation section shows the Helsinki framed logo, service name, and navigation. Navigation is optimised for up to eight menu items. 
+
+The default footer uses the black text colour variant and includes all three sections.
+
+- The navigation section shows the Helsinki framed logo, service name, and navigation. Navigation is optimised for up to eight menu items.
 - Utility section is optimised to display up to five social media icons and three action links. An icon can be added to action links.
 - Base section includes a text field for copyright or other meta information and is optimised for up to five supplementary links, depending on link length.
 
-<Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
-  <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-    <Footer.Item label="Item" />
-  </Footer.Navigation>
-  <Footer.Utilities backToTopLabel="Back to top">
-    <Footer.SoMe>
-      <Footer.Item icon={<IconFacebook />} />
-      <Footer.Item icon={<IconTwitter />} />
-      <Footer.Item icon={<IconInstagram />} />
-      <Footer.Item icon={<IconYoutube />} />
-      <Footer.Item icon={<IconTiktok />} />
-    </Footer.SoMe>
-    <Footer.Item label="Contact us" />
-    <Footer.Item label="Give feedback" />
-  </Footer.Utilities>
-  <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved">
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-    <Footer.Item label="Link" />
-  </Footer.Base>
-</Footer>
-
----
+<PlaygroundPreview>
+  <Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
+    <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+      <Footer.Item label="Item" />
+    </Footer.Navigation>
+    <Footer.Utilities backToTopLabel="Back to top">
+      <Footer.SoMe>
+        <Footer.Item icon={<IconFacebook />} />
+        <Footer.Item icon={<IconTwitter />} />
+        <Footer.Item icon={<IconInstagram />} />
+        <Footer.Item icon={<IconYoutube />} />
+        <Footer.Item icon={<IconTiktok />} />
+      </Footer.SoMe>
+      <Footer.Item label="Contact us" />
+      <Footer.Item label="Give feedback" />
+    </Footer.Utilities>
+    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved">
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+      <Footer.Item label="Link" />
+    </Footer.Base>
+  </Footer>
+</PlaygroundPreview>
 
 ### Navigation section variations
+
 Navigation section two different layout options:
+
 - **Default navigation** includes only the main level navigation items. The layout is optimised for up to eight menu items.
 - **Minimal navigation** includes only the main level navigation items. The layout is optimised for up to four menu items.
 - **Sitemap navigation** includes also second-level sub-pages. Sitemap can be used in footer to help the user find pages quickly from a complicated page hierarchy.
 - The navigation can also be hidden altogether.
 
-<Footer title="Default" footerAriaLabel="HDS Footer">
-  <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
+<PlaygroundPreview>
+  <Footer title="Default" footerAriaLabel="HDS Footer">
+    <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
@@ -120,22 +123,22 @@ Navigation section two different layout options:
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
-  </Footer.Navigation>
-</Footer>
-<br />
-<Footer title="Minimal" footerAriaLabel="HDS Footer">
-  <Footer.Navigation variant="minimal" navigationAriaLabel="HDS Footer navigation">
+    </Footer.Navigation>
+  </Footer>
+  <br />
+  <Footer title="Minimal" footerAriaLabel="HDS Footer">
+    <Footer.Navigation variant="minimal" navigationAriaLabel="HDS Footer navigation">
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
       <Footer.Item label="Item" />
-  </Footer.Navigation>
-</Footer>
-<br />
-<Footer title="Sitemap" footerAriaLabel="HDS Footer">
-  <Footer.Navigation variant="sitemap" navigationAriaLabel="HDS Footer navigation">
-    {[1, 2, 3, 4].map((key) =>
-       <Footer.ItemGroup key={key}>
+    </Footer.Navigation>
+  </Footer>
+  <br />
+  <Footer title="Sitemap" footerAriaLabel="HDS Footer">
+    <Footer.Navigation variant="sitemap" navigationAriaLabel="HDS Footer navigation">
+      {[1, 2, 3, 4].map((key) => (
+        <Footer.ItemGroup key={key}>
           <Footer.Item label="Item" />
           <Footer.Item subItem label="Sub item" />
           <Footer.Item subItem label="Sub item" />
@@ -143,11 +146,12 @@ Navigation section two different layout options:
           <Footer.Item subItem label="Sub item" />
           <Footer.Item subItem label="Sub item" />
           <Footer.Item subItem label="Sub item" />
-      </Footer.ItemGroup>
-    )}
-  </Footer.Navigation>
-</Footer>
-<br />
-<Footer title="Hidden" footerAriaLabel="HDS Footer" />
+        </Footer.ItemGroup>
+      ))}
+    </Footer.Navigation>
+  </Footer>
+  <br />
+  <Footer title="Hidden" footerAriaLabel="HDS Footer" />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/icon/usage.mdx
+++ b/new-site/src/docs/elements/components/icon/usage.mdx
@@ -3,17 +3,21 @@ slug: '/elements/components/icon/code'
 title: 'Icon - Usage'
 ---
 
-import { Link } from 'hds-react';
-import { IconFaceSmile } from 'hds-react';
+import { IconFaceSmile, Link } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<IconFaceSmile aria-hidden="true" />
+
+<PlaygroundPreview>
+  <IconFaceSmile aria-hidden="true" />
+</PlaygroundPreview>
 
 See the <Link size="M" href="visual-assets/icons">the icon library</Link> to browse a full list of HDS icons.
 
 ## Principles
+
 - **An icon should always serve a distinct, easily understandable purpose.** Icons should not be used solely for decoration.
 - **An icon should preferably be accompanied with a text label to give context for interpretation.** The meaning of icons by them self can be ambiguous and change depending on the context. Label can be omitted only if the meaning of the icon is commonly established, or can be easily interpreted from the context, e.g. volume buttons in video playback.
 - **An icon and its related content or label should have the same meaning.** Conflicting and ambivalent interpretations can have a negative effect on usability and accessibility.
@@ -22,17 +26,18 @@ See the <Link size="M" href="visual-assets/icons">the icon library</Link> to bro
 
 ### Default
 
-<IconFaceSmile aria-hidden="true" />
-
----
+<PlaygroundPreview>
+  <IconFaceSmile aria-hidden="true" />
+</PlaygroundPreview>
 
 ### Icon sizes
-<>
-<IconFaceSmile size="xs" aria-hidden="true" />
-<IconFaceSmile size="s" aria-hidden="true" />
-<IconFaceSmile size="m" aria-hidden="true" />
-<IconFaceSmile size="l" aria-hidden="true" />
-<IconFaceSmile size="xl" aria-hidden="true" />
-</>
+
+<PlaygroundPreview>
+  <IconFaceSmile size="xs" aria-hidden="true" />
+  <IconFaceSmile size="s" aria-hidden="true" />
+  <IconFaceSmile size="m" aria-hidden="true" />
+  <IconFaceSmile size="l" aria-hidden="true" />
+  <IconFaceSmile size="xl" aria-hidden="true" />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/koros/code.mdx
+++ b/new-site/src/docs/elements/components/koros/code.mdx
@@ -121,7 +121,7 @@ import Playground from '../../../../components/Playground';
 
 ```jsx
 {() => {
-  const rootStyle = { '--koros-height': '85px', '--hero-height': '300px', '--hero-width': '500px' };
+  const rootStyle = { '--koros-height': '85px', '--hero-height': '300px', '--hero-width': '100%' };
   return (
     <div
       style={{

--- a/new-site/src/docs/elements/components/koros/usage.mdx
+++ b/new-site/src/docs/elements/components/koros/usage.mdx
@@ -4,13 +4,18 @@ title: 'Koros - Usage'
 ---
 
 import { Koros, Link } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<Koros type="basic" />
+
+<PlaygroundPreview>
+  <Koros type="basic" />
+</PlaygroundPreview>
 
 ### Principles
+
 - Koros width should always match the screen width.
 - Koros is a very powerful visual element. Use them sparingly in one view.
 - Koros should only be used as filled. Do not use empty fill koros with borders.
@@ -21,22 +26,23 @@ import { Koros, Link } from 'hds-react';
 ### Variations
 
 #### Default
+
 There are six Koro styles. An added visual interest is brought to the identity by means of the Koros. Using Koros adds high visual impact and makes the user interface recognisable as part of Helsinki city services.
 You can read more about using Koros in <Link href="https://brand.hel.fi/en/wave-motifs/" external>Helsinki Visual Identity Guidelines - Wave motifs</Link>.
 
-<Koros type="basic" />
-<br />
-<Koros type="beat" />
-<br />
-<Koros type="pulse" />
-<br />
-<Koros type="wave" />
-<br />
-<Koros type="storm" />
-<br />
-<Koros type="calm" />
-
----
+<PlaygroundPreview>
+  <Koros type="basic" />
+  <br />
+  <Koros type="beat" />
+  <br />
+  <Koros type="pulse" />
+  <br />
+  <Koros type="wave" />
+  <br />
+  <Koros type="storm" />
+  <br />
+  <Koros type="calm" />
+</PlaygroundPreview>
 
 #### Angled
 Koro shapes can be angled in 45 degree increments. The allowed angle properties are `45deg`, `90deg`, `135deg`, `180deg`, `225deg`, `270deg` and `315deg`. Angles outside of these options should be avoided.

--- a/new-site/src/docs/elements/components/koros/usage.mdx
+++ b/new-site/src/docs/elements/components/koros/usage.mdx
@@ -45,6 +45,47 @@ You can read more about using Koros in <Link href="https://brand.hel.fi/en/wave-
 </PlaygroundPreview>
 
 #### Angled
+
 Koro shapes can be angled in 45 degree increments. The allowed angle properties are `45deg`, `90deg`, `135deg`, `180deg`, `225deg`, `270deg` and `315deg`. Angles outside of these options should be avoided.
+
+export const AngledVariation = () => {
+  const rootStyle = { '--koros-height': '85px', '--hero-height': '300px', '--hero-width': '100%' };
+  return (
+    <div
+      style={{
+        ...rootStyle,
+        backgroundColor: 'var(--color-silver-light)',
+        height: 'var(--hero-height)',
+        maxWidth: '100%',
+        overflow: 'hidden',
+        position: 'relative',
+        width: 'var(--hero-width)',
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: 'var(--color-coat-of-arms)',
+          clipPath: 'polygon(0 0, var(--hero-height) 0, 0 100%, 0% 100%)',
+          height: '100%',
+        }}
+      />
+      <Koros
+        style={{
+          fill: 'var(--color-coat-of-arms)',
+          left: 'calc(-1 * var(--koros-height))',
+          position: 'absolute',
+          top: 'var(--koros-height)',
+          transformOrigin: 'center',
+          width: 'calc(2 * var(--hero-height))',
+        }}
+        rotate="135deg"
+      />
+    </div>
+  );
+};
+
+<PlaygroundPreview>
+  <AngledVariation />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/link/usage.mdx
+++ b/new-site/src/docs/elements/components/link/usage.mdx
@@ -3,62 +3,72 @@ slug: '/elements/components/link/code'
 title: 'Link - Usage'
 ---
 
-import { Link } from 'hds-react';
-import { IconDocument, IconPhone, IconEnvelope, IconPhoto  } from 'hds-react';
+import { IconDocument, IconPhone, IconEnvelope, IconPhoto, Link } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
-      Link to HDS
-</Link>
+
+<PlaygroundPreview>
+  <Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
+    Link to HDS
+  </Link>
+</PlaygroundPreview>
 
 ### Principles
+
 - Too many links will clutter a page and make it difficult for users to identify their next steps. This is especially true for inline links, which should be used sparingly.
 - Use links when you want users to:
-    - Navigate to a different page
-    - Navigate to an entirely different site
-    - Jump to an element on the same page
-    - Link to emails or phone numbers
+  - Navigate to a different page
+  - Navigate to an entirely different site
+  - Jump to an element on the same page
+  - Link to emails or phone numbers
 - HDS Link supports a link with an external icon. Use the `external` prop when you wish to navigate to an entirely different site.
 - HDS Link supports a link that opens in a new tab. Use the `openInNewTab` prop when you wish to open the link in a new tab.
-    - Generally, links should not open in a new tab. However, this can be desirable if the user is in a middle of a process, e.g. filling a form.
+  - Generally, links should not open in a new tab. However, this can be desirable if the user is in a middle of a process, e.g. filling a form.
 
 ### Variations
 
 #### Default
+
 These links are the default link variant. Inline links are used within a sentence or paragraph and are underlined.
 
 The underlining helps differentiate them from the text they are placed next to and makes it clear users can interact with them. Inline links should not be used on their own.
 
 <p style={{ fontSize: '14px' }}>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-  magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-  <Link href="https://github.com/City-of-Helsinki/helsinki-design-system" external openInExternalDomainAriaLabel="Opens a different website">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+  aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+  <Link
+    href="https://github.com/City-of-Helsinki/helsinki-design-system"
+    external
+    openInExternalDomainAriaLabel="Opens a different website"
+  >
     HDS Github
   </Link>
-  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-  pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-  laborum.
+  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </p>
 
 ---
 
 #### Standalone
+
 Standalone links are used on their own or directly after the content, and they are underlined. If you wish not to have an underline, consider using a button instead.
 
 Standalone links should not be used within sentences or paragraphs.
 
-<Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
-  Link to HDS
-</Link>
-
----
+<PlaygroundPreview>
+  <Link href="https://hds.hel.fi/" size="M" style={{ display: 'block', width: 'fit-content' }}>
+    Link to HDS
+  </Link>
+</PlaygroundPreview>
 
 #### Internal and external links
+
 All HDS links can either be internal or external. Internal links point to the currently active website. External links navigate to an entirely different site. You can also make the link open in a new tab.
 
-<>
+<PlaygroundPreview>
 <Link 
   href="https://hds.hel.fi/" 
   size="M" 
@@ -67,9 +77,10 @@ All HDS links can either be internal or external. Internal links point to the cu
   Internal link
 </Link>
 
-<Link 
-  href="https://github.com/City-of-Helsinki/helsinki-design-system" 
-  size="M" 
+
+<Link
+  href="https://github.com/City-of-Helsinki/helsinki-design-system"
+  size="M"
   external
   openInExternalDomainAriaLabel="Opens a different website."
   style={{ display: 'block', width: 'fit-content' }}
@@ -87,28 +98,48 @@ All HDS links can either be internal or external. Internal links point to the cu
   style={{ display: 'block', width: 'fit-content' }}>
   Link that opens in a new tab
 </Link>
-</>
+</PlaygroundPreview>
 
----
 
 #### Links with icons
+
 HDS Links can be paired with an icon. This can be useful if the link has unusual target such as a phone number, an email address (mailto link), a PDF document or a photo.
 
 Note! These icons are meant to describe the link target. If you need a directional icon for the link (e.g. an arrow), you should instead use [a supplementary button](/components/button#supplementary-button) with `role="link"`.
 
-<>
-<Link iconLeft={<IconDocument size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-      Document link
-</Link>
-<Link iconLeft={<IconPhone size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Phone link
-</Link>
-<Link iconLeft={<IconEnvelope size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Email link
-</Link>
-<Link iconLeft={<IconPhoto size="s" aria-hidden />} size="M" href="/#" style={{ display: 'block', width: 'fit-content' }}>
-  Photo link
-</Link>
-</>
+<PlaygroundPreview>
+  <Link
+    iconLeft={<IconDocument size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Document link
+  </Link>
+  <Link
+    iconLeft={<IconPhone size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Phone link
+  </Link>
+  <Link
+    iconLeft={<IconEnvelope size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Email link
+  </Link>
+  <Link
+    iconLeft={<IconPhoto size="s" aria-hidden />}
+    size="M"
+    href="/#"
+    style={{ display: 'block', width: 'fit-content' }}
+  >
+    Photo link
+  </Link>
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/linkbox/usage.mdx
+++ b/new-site/src/docs/elements/components/linkbox/usage.mdx
@@ -3,18 +3,21 @@ slug: '/elements/components/linkbox/code'
 title: 'Linkbox - Usage'
 ---
 
-import { Linkbox } from 'hds-react';
-import { Link } from 'hds-react';
+import { Link, Linkbox } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
 
-<Linkbox linkboxAriaLabel="Linkbox: Helsinki Design System" linkAriaLabel="HDS" href="https://hds.hel.fi" withBorder>
-  <div style={{ height: '106px' }} />
-</Linkbox>
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
+  <Linkbox linkboxAriaLabel="Linkbox: Helsinki Design System" linkAriaLabel="HDS" href="https://hds.hel.fi" withBorder>
+    <div style={{ height: '106px' }} />
+  </Linkbox>
+</PlaygroundPreview>
 
 ### Principles
+
 - **Linkbox must always be interactable in its entirety.** This means that Linkboxes must not include multiple interactable elements (e.g. buttons or multiple links). The Linkbox element only gets focused once.
 - To emphasize its interactability, the Linkbox includes a mandatory icon. Depending on the link type the icon is either an arrow or an external link icon. Do not remove or modify these icons.
   - To read more about HDS recommendations about links, see [HDS Link documentation](/elements/components/link).
@@ -22,6 +25,7 @@ import { Link } from 'hds-react';
 - **Use Linkboxes sparingly.** While they can drastically improve service's understandability and readability, overusing them may result in confusing and complex user interfaces.
 
 #### Should I use a Linkbox or a Card?
+
 - **Use the Linkbox component when**
   - the whole element needs to be interactable
   - the element does not include multiple interactable elements
@@ -32,32 +36,42 @@ import { Link } from 'hds-react';
 ### Variations
 
 #### Empty
+
 The default empty Linkbox variant can be used to build Linkboxes with custom content.
 
-<div>
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
   <div style={{ width: '320px' }}>
     <Linkbox linkboxAriaLabel="Linkbox: Helsinki Design System" linkAriaLabel="HDS" href="https://hds.hel.fi">
       <div style={{ height: '106px' }} />
     </Linkbox>
   </div>
   <div style={{ width: '320px', marginTop: 'var(--spacing-s)' }}>
-    <Linkbox linkboxAriaLabel="Linkbox: Helsinki Design System" linkAriaLabel="HDS" href="https://hds.hel.fi" withBorder>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      withBorder
+    >
       <div style={{ height: '106px' }} />
     </Linkbox>
   </div>
   <div style={{ width: '320px', marginTop: 'var(--spacing-s)' }}>
-    <Linkbox linkboxAriaLabel="Linkbox: Helsinki Design System" linkAriaLabel="HDS" href="https://hds.hel.fi" noBackground>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      noBackground
+    >
       <div style={{ height: '106px' }} />
     </Linkbox>
   </div>
-</div>
-
----
+</PlaygroundPreview>
 
 #### With heading and body text
+
 Additionally, HDS offers styling for basic heading and body text inside the Linkbox component. These can be used instead of custom elements.
 
-<div>
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
   <div style={{ width: '320px' }}>
     <Linkbox
       linkboxAriaLabel="Linkbox: Helsinki Design System"
@@ -87,20 +101,19 @@ Additionally, HDS offers styling for basic heading and body text inside the Link
       noBackground
     />
   </div>
-</div>
-
----
+</PlaygroundPreview>
 
 #### Internal and external Linkboxes
+
 Depending on the link type the icon is either an arrow or an external link icon. Use the property `external` to alter the icon depending on the link type. You can also add `openInNewTab` property to make the link open in a new browser tab.
 
-<div>
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
   <div style={{ width: '320px' }}>
     <Linkbox
       linkboxAriaLabel="Linkbox: Helsinki Design System"
       linkAriaLabel="HDS"
-      href="https://hds.hel.fi" 
-      heading="Internal link" 
+      href="https://hds.hel.fi"
+      heading="Internal link"
       text="This link points to a page belonging to the same website as the current page."
       withBorder
     />
@@ -110,7 +123,7 @@ Depending on the link type the icon is either an arrow or an external link icon.
       linkboxAriaLabel="Linkbox: Helsinki Design System"
       linkAriaLabel="HDS"
       href="https://hds.hel.fi"
-      heading="External link" 
+      heading="External link"
       text="This link points to another page."
       external
       withBorder
@@ -122,21 +135,20 @@ Depending on the link type the icon is either an arrow or an external link icon.
       linkAriaLabel="HDS"
       external
       href="https://hds.hel.fi"
-      heading="External link" 
+      heading="External link"
       openInNewTab
       text="This link points to another page and opens in a new tab."
       external
       withBorder
     />
   </div>
-</div>
-
----
+</PlaygroundPreview>
 
 #### With image
+
 HDS offers styling for a Linkbox with an image as its content.
 
-<div>
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
   <div style={{ maxWidth: '384px' }}>
     <Linkbox
       linkboxAriaLabel="Linkbox: Helsinki Design System"
@@ -144,9 +156,9 @@ HDS offers styling for a Linkbox with an image as its content.
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      imgProps={{ src: "../../static/assets/placeholders/image/image-m@3x.png", width: 384, height: 245 }}
+      imgProps={{ src: '../../static/assets/placeholders/image/image-m@3x.png', width: 384, height: 245 }}
     />
   </div>
-</div>
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/loading-spinner/usage.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/usage.mdx
@@ -4,15 +4,20 @@ title: 'LoadingSpinner - Usage'
 ---
 
 import { LoadingSpinner } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<LoadingSpinner />
+
+<PlaygroundPreview>
+  <LoadingSpinner />
+</PlaygroundPreview>
 
 The loading spinner do not provide details about nature of the processing but it reassures the user that their action is being processed.
 
 ### Principles
+
 - **Use the loading spinner only if the wait time is anticipated to be longer than three seconds.** A spinner that only quickly flashes in view can confuse the user.
 - Display the loading spinner in the same area and contextual level where the processing is taking place. For example, if only the loader indicates that data is being retrieved for a specific content area, display the spinner in that same area.
 - If possible, provide a descriptive visual label for the action being processed with the loading spinner.
@@ -20,38 +25,39 @@ The loading spinner do not provide details about nature of the processing but it
 ### Variations
 
 #### Default
-The loading spinner comes in two sizes: 
-- Medium (64px) is used for larger content areas and for full-screen loading 
+
+The loading spinner comes in two sizes:
+
+- Medium (64px) is used for larger content areas and for full-screen loading
 - Small (24px) can be used for indicating more local changes in content.
 
-<>
+<PlaygroundPreview>
   <LoadingSpinner />
   <br />
   <LoadingSpinner small />
-</>
-
----
+</PlaygroundPreview>
 
 #### Customized loading spinner
+
 The colour of the spinner can be customised to fit the colour theme of the service. HDS Loading spinner even supports shifting between multiple colours. Colour shifting should be used sparingly and only if the theme of the service calls for it.
 
 Note! When using multicolour loading spinners, at least half of the colours must have sufficient contrast `3:1` against the spinner background.
 
-<>
-<LoadingSpinner
-  theme={{
-    '--spinner-color': 'var(--color-tram)',
-  }}
+<PlaygroundPreview>
+  <LoadingSpinner
+    theme={{
+      '--spinner-color': 'var(--color-tram)',
+    }}
   />
   <br />
-<LoadingSpinner
-  multicolor
-  theme={{
-    '--spinner-color-stage1': 'var(--color-coat-of-arms)',
-    '--spinner-color-stage2': 'var(--color-tram)',
-    '--spinner-color-stage3': 'var(--color-metro)'
-  }}
-/>
-</>
+  <LoadingSpinner
+    multicolor
+    theme={{
+      '--spinner-color-stage1': 'var(--color-coat-of-arms)',
+      '--spinner-color-stage2': 'var(--color-tram)',
+      '--spinner-color-stage3': 'var(--color-metro)',
+    }}
+  />
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;

--- a/new-site/src/docs/elements/components/logo/usage.mdx
+++ b/new-site/src/docs/elements/components/logo/usage.mdx
@@ -4,16 +4,21 @@ title: 'Logo - Usage'
 ---
 
 import { Link, Logo } from 'hds-react';
+import PlaygroundPreview from '../../../../components/Playground';
 
 ## Usage
 
 ### Example
-<Logo language="fi" size="medium" />
+
+<PlaygroundPreview>
+  <Logo language="fi" size="medium" />
+</PlaygroundPreview>
 
 The logo is used to identify the site or application as an official City of Helsinki service.
 See the <Link size="M" href="/elements/visual-assets/logo">logo visual asset documentation</Link> for more information about principles of using the City of Helsinki logo.
 
 ### Principles
+
 - Logo is automatically included in HDS Navigation and HDS Footer (not yet released) components. **Use the Logo component sparingly in other parts of the service.**
 - **You should include the service name next to the logo.** This helps the user more easily identify which city service they are currently using.
 - HDS Logo component includes translations for both Finnish and Swedish. **Use translation depending on the locale the user has chosen.** Swedish and Scandinavian languages use the `sv` variant while other languages use `fi` variant.
@@ -23,23 +28,27 @@ See the <Link size="M" href="/elements/visual-assets/logo">logo visual asset doc
 ### Variations
 
 #### Default
+
 The Helsinki logo component is offered in three (3) languages.
-<>
+
+<PlaygroundPreview>
   <Logo language="fi" size="medium" />
-  <br />   
+  <br />
   <Logo language="sv" size="medium" />
-  <br /> 
+  <br />
   <Logo language="ru" size="medium" />
-</>
+</PlaygroundPreview>
 
 #### Sizes
+
 The component includes three (3) size variants to fit the context.
-<>
+
+<PlaygroundPreview>
   <Logo language="fi" size="small" />
-  <br />   
+  <br />
   <Logo language="fi" size="medium" />
-  <br /> 
+  <br />
   <Logo language="fi" size="large" />
-</>
+</PlaygroundPreview>
 
 export default ({ children }) => <>{children}</>;


### PR DESCRIPTION
## Description
- Wrap examples with PlaygroundPreview component in usage pages A-L
- Add missing examples into usage pages A-L

## Related Issue

## Motivation and Context
PlaygroundPreview component separates examples from other page content

## How Has This Been Tested?
- Locally on dev machine

👉 [Demo Card](https://city-of-helsinki.github.io/hds-demo/docsite-component-preview-vol2/elements/components/card)
👉 [Demo DateInput](https://city-of-helsinki.github.io/hds-demo/docsite-component-preview-vol2/elements/components/date-input)
