### PR TITLE
Fix/sidenavigation pages

### DIFF
--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -112,6 +112,7 @@ const Layout = ({ children, pageContext }) => {
             frontmatter {
               title
               slug
+              nav_title
             }
           }
         }
@@ -139,11 +140,11 @@ const Layout = ({ children, pageContext }) => {
     uiId: generateUiIdFromPath(subMenuLink.link, 'side-nav'),
     subLevels: allPages
       .filter((page) => {
-        if (!page.slug) {
+        if (!page.slug || !page.nav_title) {
           return false;
         }
-        const levels = page.slug.split('/').filter((l) => !!l);
-        return levels.length === 3 && subMenuLink.link.includes(levels[1]);
+        const pathParts = page.slug.split('/').filter((l) => !!l);
+        return pathParts.slice(0, -1).every((pathPart) => subMenuLink.link.includes(pathPart));
       })
       .map((subLevelLink) => ({
         ...subLevelLink,
@@ -207,11 +208,11 @@ const Layout = ({ children, pageContext }) => {
                             },
                           })}
                     >
-                      {subLevels.map(({ title, slug, prefixedLink, uiId }) => (
+                      {subLevels.map(({ nav_title, slug, prefixedLink, uiId }) => (
                         <SideNavigation.SubLevel
                           key={uiId}
                           href={prefixedLink}
-                          label={title}
+                          label={nav_title}
                           active={pageSlugWithPrefix.startsWith(prefixedLink)}
                           onClick={(e) => {
                             e.preventDefault();

--- a/new-site/src/docs/elements/components/accordion/index.mdx
+++ b/new-site/src/docs/elements/components/accordion/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/accordion'
 title: 'Accordion'
+nav_title: 'Accordion'
 ---
 
 import { Accordion } from 'hds-react';

--- a/new-site/src/docs/elements/components/buttons/index.mdx
+++ b/new-site/src/docs/elements/components/buttons/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/buttons'
 title: 'Button'
+nav_title: 'Button'
 ---
 
 import { Button, IconAngleRight, IconShare, IconTrash, IconSaveDisketteFill, Notification } from 'hds-react';

--- a/new-site/src/docs/elements/components/card/index.mdx
+++ b/new-site/src/docs/elements/components/card/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/card'
 title: 'Card'
+nav_title: 'Card'
 ---
 
 import { Button, Card, IconAngleRight, IconShare, IconTrash } from 'hds-react';

--- a/new-site/src/docs/elements/components/checkbox/index.mdx
+++ b/new-site/src/docs/elements/components/checkbox/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/checkbox'
 title: 'Checkbox'
+nav_title: 'Checkbox'
 ---
 
 import { Checkbox, SelectionGroup } from 'hds-react';

--- a/new-site/src/docs/elements/components/date-input/index.mdx
+++ b/new-site/src/docs/elements/components/date-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/date-input'
 title: 'DateInput'
+nav_title: 'DateInput'
 ---
 
 import { DateInput } from 'hds-react';

--- a/new-site/src/docs/elements/components/dialog/index.mdx
+++ b/new-site/src/docs/elements/components/dialog/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/dialog'
 title: 'Dialog'
+nav_title: 'Dialog'
 ---
 
 import { Dialog, Button, IconInfoCircle, IconTrash } from 'hds-react';

--- a/new-site/src/docs/elements/components/dropdown/index.mdx
+++ b/new-site/src/docs/elements/components/dropdown/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/dropdown'
 title: 'Dropdown'
+nav_title: 'Dropdown'
 ---
 
 import { Combobox, Select } from 'hds-react';

--- a/new-site/src/docs/elements/components/fieldset/index.mdx
+++ b/new-site/src/docs/elements/components/fieldset/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/fieldset'
 title: 'Fieldset'
+nav_title: 'Fieldset'
 ---
 
 import { Fieldset, TextInput } from 'hds-react';

--- a/new-site/src/docs/elements/components/file-input/index.mdx
+++ b/new-site/src/docs/elements/components/file-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/file-input'
 title: 'FileInput'
+nav_title: 'FileInput'
 ---
 
 import { FileInput } from 'hds-react';

--- a/new-site/src/docs/elements/components/footer/index.mdx
+++ b/new-site/src/docs/elements/components/footer/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/footer'
 title: 'Footer'
+nav_title: 'Footer'
 ---
 
 import { Footer, IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok } from 'hds-react';

--- a/new-site/src/docs/elements/components/icon/index.mdx
+++ b/new-site/src/docs/elements/components/icon/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/icon'
 title: 'Icon'
+nav_title: 'Icon'
 ---
 
 import { IconFaceSmile } from 'hds-react';

--- a/new-site/src/docs/elements/components/koros/index.mdx
+++ b/new-site/src/docs/elements/components/koros/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/koros'
 title: 'Koros'
+nav_title: 'Koros'
 ---
 
 import { Koros } from 'hds-react';

--- a/new-site/src/docs/elements/components/link/index.mdx
+++ b/new-site/src/docs/elements/components/link/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/link'
 title: 'Link'
+nav_title: 'Link'
 ---
 
 import { IconDocument, IconPhone, IconEnvelope, IconPhoto } from 'hds-react';

--- a/new-site/src/docs/elements/components/linkbox/index.mdx
+++ b/new-site/src/docs/elements/components/linkbox/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/linkbox'
 title: 'Linkbox'
+nav_title: 'Linkbox'
 ---
 
 import { Linkbox } from 'hds-react';

--- a/new-site/src/docs/elements/components/loading-spinner/index.mdx
+++ b/new-site/src/docs/elements/components/loading-spinner/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/loading-spinner'
 title: 'LoadingSpinner'
+nav_title: 'LoadingSpinner'
 ---
 
 import { LoadingSpinner } from 'hds-react';

--- a/new-site/src/docs/elements/components/logo/index.mdx
+++ b/new-site/src/docs/elements/components/logo/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/logo'
 title: 'Logo'
+nav_title: 'Logo'
 ---
 
 import { Logo } from 'hds-react';

--- a/new-site/src/docs/elements/components/navigation/index.mdx
+++ b/new-site/src/docs/elements/components/navigation/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/navigation'
 title: 'Navigation'
+nav_title: 'Navigation'
 ---
 
 import { Navigation } from 'hds-react';

--- a/new-site/src/docs/elements/components/notification/index.mdx
+++ b/new-site/src/docs/elements/components/notification/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/notification'
 title: 'Notification'
+nav_title: 'Notification'
 ---
 
 import { Notification, Button } from 'hds-react';

--- a/new-site/src/docs/elements/components/number-input/index.mdx
+++ b/new-site/src/docs/elements/components/number-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/number-input'
 title: 'NumberInput'
+nav_title: 'NumberInput'
 ---
 
 import { NumberInput } from 'hds-react';

--- a/new-site/src/docs/elements/components/password-input/index.mdx
+++ b/new-site/src/docs/elements/components/password-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/password-input'
 title: 'PasswordInput'
+nav_title: 'PasswordInput'
 ---
 
 import { PasswordInput, Button, IconEye, IconEyeCrossed } from 'hds-react';

--- a/new-site/src/docs/elements/components/phone-input/index.mdx
+++ b/new-site/src/docs/elements/components/phone-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/phone-input'
 title: 'PhoneInput'
+nav_title: 'PhoneInput'
 ---
 
 import { PhoneInput, Combobox } from 'hds-react';

--- a/new-site/src/docs/elements/components/radio-button/index.mdx
+++ b/new-site/src/docs/elements/components/radio-button/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/radio-button'
 title: 'RadioButton'
+nav_title: 'RadioButton'
 ---
 
 import { RadioButton, SelectionGroup } from 'hds-react';

--- a/new-site/src/docs/elements/components/search-input/index.mdx
+++ b/new-site/src/docs/elements/components/search-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/search-input'
 title: 'SearchInput'
+nav_title: 'SearchInput'
 ---
 
 import { SearchInput } from 'hds-react';

--- a/new-site/src/docs/elements/components/selection-group/index.mdx
+++ b/new-site/src/docs/elements/components/selection-group/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/selection-group'
 title: 'SelectionGroup'
+nav_title: 'SelectionGroup'
 ---
 
 import { SelectionGroup, Checkbox, RadioButton } from 'hds-react';

--- a/new-site/src/docs/elements/components/side-navigation/index.mdx
+++ b/new-site/src/docs/elements/components/side-navigation/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/side-navigation'
 title: 'SideNavigation'
+nav_title: 'SideNavigation'
 ---
 
 import { SideNavigation, IconHome, IconMap, IconCogwheel } from 'hds-react';

--- a/new-site/src/docs/elements/components/status-label/index.mdx
+++ b/new-site/src/docs/elements/components/status-label/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/status-label'
 title: 'StatusLabel'
+nav_title: 'StatusLabel'
 ---
 
 import { StatusLabel, IconInfoCircle, IconCheckCircle, IconAlertCircle, IconError } from 'hds-react';

--- a/new-site/src/docs/elements/components/stepper/index.mdx
+++ b/new-site/src/docs/elements/components/stepper/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/stepper'
 title: 'Stepper'
+nav_title: 'Stepper'
 ---
 
 import { useReducer } from 'react';

--- a/new-site/src/docs/elements/components/table/index.mdx
+++ b/new-site/src/docs/elements/components/table/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/table'
 title: 'Table'
+nav_title: 'Table'
 ---
 
 import { useState } from 'react';

--- a/new-site/src/docs/elements/components/tabs/index.mdx
+++ b/new-site/src/docs/elements/components/tabs/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/tabs'
 title: 'Tabs'
+nav_title: 'Tabs'
 ---
 
 import { Tabs } from 'hds-react';

--- a/new-site/src/docs/elements/components/tag/index.mdx
+++ b/new-site/src/docs/elements/components/tag/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/tag'
 title: 'Tag'
+nav_title: 'Tag'
 ---
 
 import { Tag } from 'hds-react';

--- a/new-site/src/docs/elements/components/text-area/index.mdx
+++ b/new-site/src/docs/elements/components/text-area/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/text-area'
 title: 'TextArea'
+nav_title: 'TextArea'
 ---
 
 import { TextArea } from 'hds-react';

--- a/new-site/src/docs/elements/components/text-input/index.mdx
+++ b/new-site/src/docs/elements/components/text-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/text-input'
 title: 'TextInput'
+nav_title: 'TextInput'
 ---
 
 import { TextInput } from 'hds-react';

--- a/new-site/src/docs/elements/components/time-input/index.mdx
+++ b/new-site/src/docs/elements/components/time-input/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/time-input'
 title: 'TimeInput'
+nav_title: 'TimeInput'
 ---
 
 import { TimeInput, Select } from 'hds-react';

--- a/new-site/src/docs/elements/components/toggle-button/index.mdx
+++ b/new-site/src/docs/elements/components/toggle-button/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/toggle-button'
 title: 'ToggleButton'
+nav_title: 'ToggleButton'
 ---
 
 import { ToggleButton } from 'hds-react';

--- a/new-site/src/docs/elements/components/tooltip/index.mdx
+++ b/new-site/src/docs/elements/components/tooltip/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/components/tooltip'
 title: 'Tooltip'
+nav_title: 'Tooltip'
 ---
 
 import { Tooltip } from 'hds-react';

--- a/new-site/src/docs/elements/design-tokens/breakpoints/index.mdx
+++ b/new-site/src/docs/elements/design-tokens/breakpoints/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/design-tokens/breakpoints'
 title: 'Breakpoints'
+nav_title: 'Breakpoints'
 ---
 
 import { StatusLabel, Tabs } from 'hds-react';

--- a/new-site/src/docs/elements/design-tokens/colour/index.mdx
+++ b/new-site/src/docs/elements/design-tokens/colour/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/design-tokens/colour'
 title: 'Colour'
+nav_title: 'Colour'
 ---
 
 import { StatusLabel, Tabs } from 'hds-react';

--- a/new-site/src/docs/elements/design-tokens/spacing/index.mdx
+++ b/new-site/src/docs/elements/design-tokens/spacing/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/design-tokens/spacing'
 title: 'Spacing'
+nav_title: 'Spacing'
 ---
 
 import { StatusLabel, Tabs } from 'hds-react';

--- a/new-site/src/docs/elements/design-tokens/typography/index.mdx
+++ b/new-site/src/docs/elements/design-tokens/typography/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/elements/design-tokens/typography'
 title: 'Typography'
+nav_title: 'Typography'
 ---
 
 import { StatusLabel, Tabs } from 'hds-react';

--- a/new-site/src/docs/elements/visual-assets/icons.mdx
+++ b/new-site/src/docs/elements/visual-assets/icons.mdx
@@ -1,6 +1,7 @@
 ---
 slug: "/elements/visual-assets/icons"
 title: "Icons"
+nav_title: "Icons"
 ---
 
 # Icons

--- a/new-site/src/docs/elements/visual-assets/logo.mdx
+++ b/new-site/src/docs/elements/visual-assets/logo.mdx
@@ -1,6 +1,7 @@
 ---
 slug: "/elements/visual-assets/logo"
 title: "Logo"
+nav_title: "Logo"
 ---
 
 # Logo Overview

--- a/new-site/src/docs/getting-started/contributing/before-contributing.mdx
+++ b/new-site/src/docs/getting-started/contributing/before-contributing.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/getting-started/contributing/before-contributing'
 title: 'Before contributing'
+nav_title: 'Before contributing'
 ---
 
 import { Link, Notification } from 'hds-react';

--- a/new-site/src/docs/getting-started/contributing/design.mdx
+++ b/new-site/src/docs/getting-started/contributing/design.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/getting-started/contributing/design'
 title: 'Design'
+nav_title: 'Design'
 ---
 
 import { Link, Notification } from 'hds-react';

--- a/new-site/src/docs/getting-started/contributing/documentation.mdx
+++ b/new-site/src/docs/getting-started/contributing/documentation.mdx
@@ -1,6 +1,8 @@
 ---
 slug: '/getting-started/contributing/documentation'
 title: 'Documentation'
+nav_title: 'Documentation'
+
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/getting-started/contributing/icons.mdx
+++ b/new-site/src/docs/getting-started/contributing/icons.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/getting-started/contributing/icons'
 title: 'Icons'
+nav_title: 'Icons'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/getting-started/contributing/implementation.mdx
+++ b/new-site/src/docs/getting-started/contributing/implementation.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/getting-started/contributing/implementation'
 title: 'Implementation'
+nav_title: 'Implementation'
 ---
 
 import { Link } from 'hds-react';


### PR DESCRIPTION
## Description
- Use nav_title page metadata to resolve SideNavigation mainLevels and subLevels from pages based on how many levels are there in the path (2 or 3)

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1223

## Motivation and Context
- A dedicated metadata property adds control of what page links are included in the SideNavigation
- Metadata also makes it a bit easier to change SideNavigation configuration

## How Has This Been Tested?
- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docs-sidenavigation-pages/elements)