### PR TITLE
[Fix] FAQ and Accessibility pages now show up in the side navigation

### DIFF
--- a/new-site/src/docs/about/accessibility/hds-accessibility.mdx
+++ b/new-site/src/docs/about/accessibility/hds-accessibility.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/about/accessibility/hds-accessibility'
 title: 'HDS Accessibility'
+nav_title: 'HDS Accessibility'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/about/accessibility/statement.mdx
+++ b/new-site/src/docs/about/accessibility/statement.mdx
@@ -1,6 +1,7 @@
 ---
 slug: '/about/accessibility/statement'
 title: 'Accessibility statement'
+nav_title: 'Accessibility statement'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/getting-started/faq/accessibility.mdx
+++ b/new-site/src/docs/getting-started/faq/accessibility.mdx
@@ -9,7 +9,7 @@ import { Accordion, Link } from 'hds-react';
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
   }}>
-  HDS aims to ensure accessibility in every stage of the component development. HDS components always meet at least WCAG 2.1 AA-level and often also reach the AAA-level. Please refer to the Accessibility section for more information about this process.
+  HDS aims to ensure accessibility in every stage of component development. HDS components always meet at least WCAG 2.1 AA level and often also reach the AAA level. Please refer to the Accessibility section for more information about this process.
 </Accordion>
 
 <Accordion 
@@ -31,7 +31,7 @@ import { Accordion, Link } from 'hds-react';
     '--header-font-size': 'var(--fontsize-heading-xs)',
     '--padding-vertical': 'var(--spacing-s)',
   }}>
-  JAWS is quite very to be tested within European countries. It is more common in English-speaking, non-European countries. JAWS also updates very often and is often incompatible with specific browser versions.
+  JAWS is quite rare to be tested within European countries. It is more common in English-speaking, non-European countries. JAWS also updates very often and is often incompatible with specific browser versions.
 
   Since HDS is fully open-source, we also promote openness in our assistive technology choices. NVDA and VoiceOver are free to use for Windows and Mac users.
 </Accordion>

--- a/new-site/src/docs/getting-started/faq/general.mdx
+++ b/new-site/src/docs/getting-started/faq/general.mdx
@@ -18,7 +18,7 @@ import { Accordion, Link } from 'hds-react';
   </ul>
   Versions 6 months old and newer are supported.
 
-  Note: While these three (3) browsers are officially supported by the HDS, you can still report bugs and request support related to other browsers as well. HDS team will do their best to fix issues to other browsers and versions too.
+  Note: While these three (3) browsers are officially supported by the HDS, you can still report bugs and request support related to other browsers as well. HDS team will do their best to fix issues with other browsers and versions too.
   </p>
 </Accordion>
 

--- a/new-site/src/docs/getting-started/tutorials/abstract-tutorial.mdx
+++ b/new-site/src/docs/getting-started/tutorials/abstract-tutorial.mdx
@@ -1,6 +1,7 @@
 ---
 slug: "/getting-started/tutorials/abstract-tutorial"
 title: "Abstract basics"
+nav_title: 'Abstract basics'
 ---
 
 import { Link } from "hds-react";

--- a/new-site/src/docs/getting-started/tutorials/guide-to-v1.mdx
+++ b/new-site/src/docs/getting-started/tutorials/guide-to-v1.mdx
@@ -1,6 +1,7 @@
 ---
 slug: "/getting-started/tutorials/guide-to-v1"
 title: "Guide to HDS v1"
+nav_title: "Guide to HDS v1"
 ---
 
 import { Link, Notification } from "hds-react";


### PR DESCRIPTION
## Description
FAQ and Accessibility pages were missing from the new documentation site side navigation. This PR fixes that.

## How Has This Been Tested?
Tested by running the new documentation site locally.
