### PR TITLE
[Feature] Disable wrapping Dialog.ActionButtons children

### DIFF
--- a/packages/react/.loki/reference/chrome_iphone7_Components_Dialog_With_long_button_labels.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Dialog_With_long_button_labels.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fa688b2cbd301145388d7f884cd8d5788c9e9ae44039e6cb871fc5521f7c747
-size 45953
+oid sha256:0c92aa405ce31721c09211fb1562ad9df9db14ccef51327eccc730a387262508
+size 45938

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Dialog_With_long_button_labels.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Dialog_With_long_button_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fa688b2cbd301145388d7f884cd8d5788c9e9ae44039e6cb871fc5521f7c747
+size 45953

--- a/packages/react/.loki/reference/chrome_laptop_Components_Dialog_With_long_button_labels.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Dialog_With_long_button_labels.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ca296400787b8ff9b109d9b0fd07fac3dda47dd36e5d2ce50b4f98d749b0632
-size 23095
+oid sha256:88d45c00bb1b05b0e37865e91cf36ea6169b0011ade49446ca35b53d309dfc40
+size 21335

--- a/packages/react/.loki/reference/chrome_laptop_Components_Dialog_With_long_button_labels.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Dialog_With_long_button_labels.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9df3579afdad496dd5d185072e0470f7ec8527059edeb5cd2ff297d349bfa08e
-size 23111
+oid sha256:7ca296400787b8ff9b109d9b0fd07fac3dda47dd36e5d2ce50b4f98d749b0632
+size 23095

--- a/packages/react/.loki/reference/chrome_laptop_Components_Dialog_With_long_button_labels.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Dialog_With_long_button_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9df3579afdad496dd5d185072e0470f7ec8527059edeb5cd2ff297d349bfa08e
+size 23111

--- a/packages/react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/dialog/Dialog.stories.tsx
@@ -420,6 +420,66 @@ ScrollableConfirmation.parameters = {
   loki: { skip: false },
 };
 
+// This dialog story is part of Loki's visual regression tests. It is open by default, and it is not part of the Storybooks' docs section.
+export const LongButtonLabels = (args) => {
+  const dialogTargetElement = document.getElementById('root'); // Because of the story regression tests, we need to render the dialog into the root element
+  const openDialogButtonRef = useRef(null);
+  const [open, setOpen] = useState<boolean>(true);
+  const close = () => setOpen(false);
+  const titleId = 'dialog-with-long-labels-title';
+
+  return (
+    <>
+      <Button ref={openDialogButtonRef} onClick={() => setOpen(true)}>
+        Open dialog
+      </Button>
+      <Dialog
+        id={args.id}
+        aria-labelledby={titleId}
+        isOpen={open}
+        focusAfterCloseRef={openDialogButtonRef}
+        targetElement={dialogTargetElement}
+      >
+        <Dialog.Header id={titleId} title="Confirm dialog" iconLeft={<IconAlertCircle aria-hidden="true" />} />
+        <Dialog.Content>
+          <h3>Are you sure you want to continue?</h3>
+        </Dialog.Content>
+        <Dialog.ActionButtons>
+          <Button
+            onClick={() => {
+              // Add confirm operations here
+              close();
+            }}
+          >
+            Confirm this thing now with a long label
+          </Button>
+          <Button onClick={close} variant="secondary">
+            Cancel and go back to the beginning
+          </Button>
+        </Dialog.ActionButtons>
+      </Dialog>
+    </>
+  );
+};
+
+LongButtonLabels.storyName = 'With long button labels';
+
+LongButtonLabels.args = {
+  id: 'dialog-with-long-button-labels',
+};
+
+LongButtonLabels.parameters = {
+  previewTabs: {
+    'storybook/docs/panel': {
+      hidden: true,
+    },
+  },
+  docs: {
+    disable: true,
+  },
+  loki: { skip: false },
+};
+
 // This dialog story is not part of the Storybooks' docs section.
 export const ConfirmationWithTerms = (args) => {
   const openConfirmationButtonRef = useRef(null);

--- a/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.module.scss
+++ b/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.module.scss
@@ -20,13 +20,14 @@
 @media medium-up {
   .dialogActionButtons {
     display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-s);
 
     > * {
       width: auto;
     }
 
     > * + * {
-      margin-left: var(--spacing-s);
       margin-top: 0;
     }
   }

--- a/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.module.scss
+++ b/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.module.scss
@@ -6,6 +6,7 @@
   @include dialogComponentSidePaddings;
   padding-bottom: var(--spacing-m);
   padding-top: var(--spacing-s);
+  display: block;
 
   > * {
     width: 100%;
@@ -18,6 +19,8 @@
 
 @media medium-up {
   .dialogActionButtons {
+    display: flex;
+
     > * {
       width: auto;
     }

--- a/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.tsx
+++ b/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.tsx
@@ -7,7 +7,7 @@ export type DialogActionButtonProps = React.PropsWithChildren<{
   /**
    * className for custom styling
    */
-  className: string;
+  className?: string;
 }>;
 
 export const DialogActionButtons = ({ children, className }: DialogActionButtonProps) => {

--- a/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.tsx
+++ b/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 
 import styles from './DialogActionButtons.module.scss';
+import classNames from '../../../utils/classNames';
 
-export type DialogActionButtonProps = React.PropsWithChildren<Record<string, unknown>>;
+export type DialogActionButtonProps = React.PropsWithChildren<{
+  /**
+   * className for custom styling
+   */
+  className: string;
+}>;
 
-export const DialogActionButtons = ({ children }: DialogActionButtonProps) => {
-  return <div className={styles.dialogActionButtons}>{children}</div>;
+export const DialogActionButtons = ({ children, className }: DialogActionButtonProps) => {
+  return <div className={classNames(styles.dialogActionButtons, className)}>{children}</div>;
 };
 
 DialogActionButtons.componentName = 'DialogActionButtons';


### PR DESCRIPTION
## Description

This PR fixes wrapping of `Dialog.ActionButton` children. 

Dialog ActionButtons were not designed for wrapping content into multiple lines (see screenshots). With wrapping content, some margins were applied incorrectly. Therefore, this pr fixes wrapping with flex wrap and a proper gap for desktop. Mobile behaviour states the same.

Also, this pr introduces a `className` prop that can be given to `Dialog.ActionButton` component for custom styling.

## Related Issue

HDS-1257: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1257


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

This has been tested locally using Storybook.

## Screenshots (if appropriate):

### Before this PR

![Screenshot 2022-04-29 at 15 55 06](https://user-images.githubusercontent.com/631969/165950481-615d44b4-f40f-413a-90e0-e94b611d96ee.png)

### After this PR

<img width="580" alt="image" src="https://user-images.githubusercontent.com/2777633/166453314-92b99aff-561e-4254-a614-95cd5f06b7ef.png">


### Mobile (unchanged)

![Screenshot 2022-04-29 at 15 56 10](https://user-images.githubusercontent.com/631969/165950588-1b1f1cdf-7f9c-42c2-893d-c0699bc3a496.png)
