### PR TITLE
Call updateState to ensure useMobile hook to initialize state

### DIFF
--- a/packages/react/src/hooks/useMobile.tsx
+++ b/packages/react/src/hooks/useMobile.tsx
@@ -10,6 +10,7 @@ export const useMobile = (): boolean => {
     const updateState = () => setIsMobile(checkIfMobile());
 
     window.addEventListener('resize', updateState);
+    updateState();
 
     return () => window.removeEventListener('resize', updateState);
   }, []);


### PR DESCRIPTION
## Description
- Call useMobile updateState on useEffect

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-889
- https://github.com/City-of-Helsinki/helsinki-design-system/issues/493

## Motivation and Context
- The state of useMobile hook is false when the page is loaded. This causes the search input to be hidden and variants do not have correct styles in mobile Navigation. It also causes that the SideNavigation is missing the aria-hidden attribute.

## How Has This Been Tested?
- locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/use-mobile-demo/iframe.html?id=components-navigation--default&args=&viewMode=story)
☝️ Test in mobile screen size and open navigation to see the missing search input