### PR TITLE
Fix/sidenavigation mobile keyboard navigation

### DIFF
--- a/packages/react/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.tsx
@@ -73,6 +73,7 @@ export const SideNavigation = ({
   const [activeParentLevel, setActiveParentLevel] = React.useState<number>();
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
   const isMobile = useMobile();
+  const shouldRenderMenu = !isMobile || !mobileMenuOpen;
 
   const mainLevels = React.Children.map(children, (child, index) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'MainLevel') {
@@ -143,16 +144,17 @@ export const SideNavigation = ({
         >
           {toggleButtonLabel}
         </Button>
-        <ul
-          {...{
-            className: classNames(styles.mainLevelList, mobileMenuOpen && styles.open),
-            'aria-label': toggleButtonLabel,
-            'aria-hidden': isMobile && !mobileMenuOpen,
-          }}
-          id={menuId}
-        >
-          {mainLevels}
-        </ul>
+        {shouldRenderMenu && (
+          <ul
+            {...{
+              className: classNames(styles.mainLevelList, mobileMenuOpen && styles.open),
+              'aria-label': toggleButtonLabel,
+            }}
+            id={menuId}
+          >
+            {mainLevels}
+          </ul>
+        )}
       </nav>
     </SideNavigationContext.Provider>
   );

--- a/packages/react/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.tsx
@@ -73,7 +73,7 @@ export const SideNavigation = ({
   const [activeParentLevel, setActiveParentLevel] = React.useState<number>();
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
   const isMobile = useMobile();
-  const shouldRenderMenu = !isMobile || !mobileMenuOpen;
+  const shouldRenderMenu = !(isMobile && !mobileMenuOpen);
 
   const mainLevels = React.Children.map(children, (child, index) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'MainLevel') {

--- a/packages/react/src/components/sideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/packages/react/src/components/sideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -45,7 +45,6 @@ exports[`<SideNavigation /> spec renders the component 1`] = `
       </div>
     </button>
     <ul
-      aria-hidden="false"
       aria-label="Navigate to page"
       class="mainLevelList"
       id="sideNavigation-menu"


### PR DESCRIPTION
## Description
- render Sidenavigation's menu only when the screen is larger than the mobile or when the menu is open in mobile screen sizes
- Depends on #717

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1241

## Motivation and Context
- When the user navigates Sidenavigation with a keyboard on a small screen (for example with close zoom), the focus moves from the open-menu button to the first hidden SideNavigation menu button. This will confuse the user if the purpose was to navigate next to the page content.

## How Has This Been Tested?
- locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/sidenavigation-mobile-fix/iframe.html?id=components-sidenavigation--default&args=&viewMode=story)