### PR TITLE
Fix/tabs keyboard onclick

### DIFF
--- a/packages/react/src/components/tabs/Tab.tsx
+++ b/packages/react/src/components/tabs/Tab.tsx
@@ -56,6 +56,9 @@ export const Tab = ({ children, className, index, onClick, style }: TabProps) =>
     const isEnter = event.key === 'Enter' || event.keyCode === 13;
     const isSpace = event.key === ' ' || event.keyCode === 32;
     if (isEnter || isSpace) {
+      if (onClick) {
+        onClick();
+      }
       setActiveTab(index);
     }
   };

--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -137,7 +137,7 @@ export const WithCustomOnClickAction = () => {
     setIsLoading(true);
     setTimeout(() => {
       setIsLoading(false);
-    }, 1000);
+    }, 500);
   };
 
   const onTabClick = () => {

--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -128,7 +128,7 @@ export const WithCustomOnClickAction = () => {
     }, 200);
   };
 
-  const onTabClick = (activeIndex) => {
+  const onTabClick = () => {
     mockLoading();
   };
 
@@ -139,8 +139,8 @@ export const WithCustomOnClickAction = () => {
   return (
     <Tabs initiallyActiveTab={0}>
       <Tabs.TabList className="example-tablist">
-        <Tabs.Tab onClick={() => onTabClick(0)}>Basic education</Tabs.Tab>
-        <Tabs.Tab onClick={() => onTabClick(1)}>University</Tabs.Tab>
+        <Tabs.Tab onClick={() => onTabClick()}>Basic education</Tabs.Tab>
+        <Tabs.Tab onClick={() => onTabClick()}>University</Tabs.Tab>
       </Tabs.TabList>
       <Tabs.TabPanel>{isLoading ? 'loading..' : content.education}</Tabs.TabPanel>
       <Tabs.TabPanel>{isLoading ? 'loading..' : content.university}</Tabs.TabPanel>

--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -112,3 +112,46 @@ export const WithCustomTheme = () => {
     </Tabs>
   );
 };
+
+export const WithCustomOnClickAction = () => {
+  const [activeTabIndex, setActiveTabIndex] = React.useState(0);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const content = {
+    education: 'Daytime care for people who cannot be fully independent, such as children or elderly people.',
+    university:
+      'The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically responsible membership of society.',
+  };
+
+  const mockLoading = () => {
+      setIsLoading(true);
+      setTimeout(() => {
+          setIsLoading(false);
+      }, 200);
+  }
+
+  const onTabClick = (activeIndex) => {
+    setActiveTabIndex(activeIndex);
+    mockLoading();
+  };
+
+  React.useEffect(() => {
+    mockLoading();
+  }, []);
+
+  return (
+    <Tabs initiallyActiveTab={activeTabIndex}>
+      <Tabs.TabList className="example-tablist">
+        <Tabs.Tab active={activeTabIndex === 0} onClick={() => onTabClick(0)}>
+          Basic education
+        </Tabs.Tab>
+        <Tabs.Tab active={activeTabIndex === 1} onClick={() => onTabClick(1)}>
+          University
+        </Tabs.Tab>
+      </Tabs.TabList>
+      <Tabs.TabPanel>{isLoading? 'loading..' : content.education}</Tabs.TabPanel>
+      <Tabs.TabPanel>{isLoading? 'loading..' : content.university}</Tabs.TabPanel>
+    </Tabs>
+  );
+};
+
+WithCustomOnClickAction.parameters = { loki: { skip: true } };

--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -123,11 +123,11 @@ export const WithCustomOnClickAction = () => {
   };
 
   const mockLoading = () => {
-      setIsLoading(true);
-      setTimeout(() => {
-          setIsLoading(false);
-      }, 200);
-  }
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 200);
+  };
 
   const onTabClick = (activeIndex) => {
     setActiveTabIndex(activeIndex);
@@ -148,8 +148,8 @@ export const WithCustomOnClickAction = () => {
           University
         </Tabs.Tab>
       </Tabs.TabList>
-      <Tabs.TabPanel>{isLoading? 'loading..' : content.education}</Tabs.TabPanel>
-      <Tabs.TabPanel>{isLoading? 'loading..' : content.university}</Tabs.TabPanel>
+      <Tabs.TabPanel>{isLoading ? 'loading..' : content.education}</Tabs.TabPanel>
+      <Tabs.TabPanel>{isLoading ? 'loading..' : content.university}</Tabs.TabPanel>
     </Tabs>
   );
 };

--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { LoadingSpinner } from '../loadingSpinner';
 import { Tabs } from './Tabs';
 
 export default {
@@ -121,11 +122,22 @@ export const WithCustomOnClickAction = () => {
       'The objective of basic education in Finland is to support pupils&#39; growth towards humanity and ethically responsible membership of society.',
   };
 
+  const LoadingIndicator = () => (
+    <div style={{ alignItems: 'center', display: 'flex', gap: '1rem' }}>
+      <LoadingSpinner
+        loadingText="Tab content is loading"
+        loadingFinishedText="The tab content loading was finished"
+        small
+      />
+      <span>Tab content is loading</span>
+    </div>
+  );
+
   const mockLoading = () => {
     setIsLoading(true);
     setTimeout(() => {
       setIsLoading(false);
-    }, 200);
+    }, 1000);
   };
 
   const onTabClick = () => {
@@ -142,8 +154,8 @@ export const WithCustomOnClickAction = () => {
         <Tabs.Tab onClick={() => onTabClick()}>Basic education</Tabs.Tab>
         <Tabs.Tab onClick={() => onTabClick()}>University</Tabs.Tab>
       </Tabs.TabList>
-      <Tabs.TabPanel>{isLoading ? 'loading..' : content.education}</Tabs.TabPanel>
-      <Tabs.TabPanel>{isLoading ? 'loading..' : content.university}</Tabs.TabPanel>
+      <Tabs.TabPanel>{isLoading ? <LoadingIndicator /> : content.education}</Tabs.TabPanel>
+      <Tabs.TabPanel>{isLoading ? <LoadingIndicator /> : content.university}</Tabs.TabPanel>
     </Tabs>
   );
 };

--- a/packages/react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/tabs/Tabs.stories.tsx
@@ -114,7 +114,6 @@ export const WithCustomTheme = () => {
 };
 
 export const WithCustomOnClickAction = () => {
-  const [activeTabIndex, setActiveTabIndex] = React.useState(0);
   const [isLoading, setIsLoading] = React.useState(false);
   const content = {
     education: 'Daytime care for people who cannot be fully independent, such as children or elderly people.',
@@ -130,7 +129,6 @@ export const WithCustomOnClickAction = () => {
   };
 
   const onTabClick = (activeIndex) => {
-    setActiveTabIndex(activeIndex);
     mockLoading();
   };
 
@@ -139,14 +137,10 @@ export const WithCustomOnClickAction = () => {
   }, []);
 
   return (
-    <Tabs initiallyActiveTab={activeTabIndex}>
+    <Tabs initiallyActiveTab={0}>
       <Tabs.TabList className="example-tablist">
-        <Tabs.Tab active={activeTabIndex === 0} onClick={() => onTabClick(0)}>
-          Basic education
-        </Tabs.Tab>
-        <Tabs.Tab active={activeTabIndex === 1} onClick={() => onTabClick(1)}>
-          University
-        </Tabs.Tab>
+        <Tabs.Tab onClick={() => onTabClick(0)}>Basic education</Tabs.Tab>
+        <Tabs.Tab onClick={() => onTabClick(1)}>University</Tabs.Tab>
       </Tabs.TabList>
       <Tabs.TabPanel>{isLoading ? 'loading..' : content.education}</Tabs.TabPanel>
       <Tabs.TabPanel>{isLoading ? 'loading..' : content.university}</Tabs.TabPanel>

--- a/packages/react/src/components/tabs/Tabs.test.tsx
+++ b/packages/react/src/components/tabs/Tabs.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 import { Tabs } from './Tabs';
@@ -21,6 +22,7 @@ describe('<Tabs /> spec', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
   it('should not have basic accessibility issues', async () => {
     const { container } = render(
       <Tabs>
@@ -34,5 +36,37 @@ describe('<Tabs /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should call onClick when user clicks tab', () => {
+    const onClick = jest.fn();
+    render(
+      <Tabs>
+        <TabList>
+          <Tab onClick={onClick}>Foo</Tab>
+          <Tab onClick={onClick}>Bar</Tab>
+        </TabList>
+        <TabPanel>Fizz</TabPanel>
+        <TabPanel>Buzz</TabPanel>
+      </Tabs>,
+    );
+    userEvent.click(screen.getByLabelText('Foo'));
+    waitFor(() => expect(onClick).toHaveBeenCalled());
+  });
+
+  it('should call onClick when user presses enter on tab', () => {
+    const onClick = jest.fn();
+    render(
+      <Tabs>
+        <TabList>
+          <Tab onClick={onClick}>Foo</Tab>
+          <Tab onClick={onClick}>Bar</Tab>
+        </TabList>
+        <TabPanel>Fizz</TabPanel>
+        <TabPanel>Buzz</TabPanel>
+      </Tabs>,
+    );
+    userEvent.type(screen.getByLabelText('Foo'), '{Enter}');
+    waitFor(() => expect(onClick).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Description
- handle Tab onClick also on enter and space keypresses

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1239

## Motivation and Context
- Tab (without onClick) behaves similarly if the user clicks the mouse or presses enter or space key on Tab. But now only a mouse click triggers a Tab's custom onClick handler if it exists. This causes problems when onClick is used for custom navigation between tabs.

## How Has This Been Tested?
- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/tab-onclick-enter-space/iframe.html?id=components-tabs--with-custom-on-click-action&args=&viewMode=story)