### PR TITLE
Fix/new doc site in safari

### DIFF
--- a/new-site/src/components/LiveErrorCore.js
+++ b/new-site/src/components/LiveErrorCore.js
@@ -1,45 +1,42 @@
 import React, { useState, useEffect } from 'react';
-import { StaticConfigLoader, HtmlValidate } from 'html-validate/dist/cjs/browser';
 import { default as html5 } from 'html-validate/elements/html5.json';
 
 import './LiveErrorCore.scss';
 
 // https://stackoverflow.com/a/65896524
-const testRegexpLookAheadLookBehind = () => {
+const supportsRegexpLookBehind = () => {
   try {
-    return (
-      'foobarfoofoo'
-        .replace(new RegExp('(?<=foo)foo', 'g'), 'ahead')
-        .replace(new RegExp('foo(?!bar)', 'g'), 'behind') === 'foobarbehindahead'
-    );
+    return 'foobarfoofoo'.replace(new RegExp('(?<=foo)foo', 'g'), 'behind') === 'foobarfoobehind';
   } catch (error) {
     return false;
   }
 };
 
-const getValidator = () => {
-  const loader = new StaticConfigLoader({
-    extends: ['html-validate:standard'],
-    elements: [html5],
-  });
-  return new HtmlValidate(loader);
-};
-
-/*
- Html-validate library uses regexp lookbehind feature which is not supported in Safari at the moment (17.5.2022).
- We need to disable validation in browsers which do not support lookbehind.
- - https://caniuse.com/js-regexp-lookbehind
- - https://gitlab.com/html-validate/html-validate/-/issues/147
- */
-
-const htmlValidate = testRegexpLookAheadLookBehind() ? getValidator() : undefined;
-const isValidatorSupported = !!htmlValidate;
-
 const LiveErrorCore = ({ code }) => {
   const [error, setError] = useState(null);
+  const [htmlValidate, setHtmlValidate] = useState(undefined);
+
+  /*
+    TODO: Remove lookbehind support test and async import once Safari supports regexp lookbehind.
+    Html-validate library uses regexp lookbehind feature which is not supported in Safari at the moment (17.5.2022).
+    We need to disable validation in browsers that do not support lookbehind.
+    - https://caniuse.com/js-regexp-lookbehind
+    - https://gitlab.com/html-validate/html-validate/-/issues/147
+ */
+  useEffect(() => {
+    if (supportsRegexpLookBehind()) {
+      import('html-validate/dist/cjs/browser').then(({ StaticConfigLoader, HtmlValidate }) => {
+        const loader = new StaticConfigLoader({
+          extends: ['html-validate:standard'],
+          elements: [html5],
+        });
+        setHtmlValidate(new HtmlValidate(loader));
+      });
+    }
+  }, []);
 
   useEffect(() => {
-    if (isValidatorSupported) {
+    if (htmlValidate) {
       const report = htmlValidate.validateString(code);
       if (report.valid) {
         setError(null);
@@ -49,7 +46,7 @@ const LiveErrorCore = ({ code }) => {
     }
   }, [code]);
 
-  if (!isValidatorSupported) {
+  if (!htmlValidate) {
     return null;
   }
   if (!error) {

--- a/new-site/src/components/LiveErrorCore.js
+++ b/new-site/src/components/LiveErrorCore.js
@@ -19,10 +19,10 @@ const LiveErrorCore = ({ code }) => {
   /*
     TODO: Remove lookbehind support test and async import once Safari supports regexp lookbehind.
     Html-validate library uses regexp lookbehind feature which is not supported in Safari at the moment (17.5.2022).
-    We need to disable validation in browsers that do not support lookbehind.
+    We need to disable validation in unsupported browsers to make the site render.
     - https://caniuse.com/js-regexp-lookbehind
     - https://gitlab.com/html-validate/html-validate/-/issues/147
- */
+  */
   useEffect(() => {
     if (supportsRegexpLookBehind()) {
       import('html-validate/dist/cjs/browser').then(({ StaticConfigLoader, HtmlValidate }) => {

--- a/new-site/src/components/LiveErrorCore.js
+++ b/new-site/src/components/LiveErrorCore.js
@@ -1,33 +1,61 @@
 import React, { useState, useEffect } from 'react';
-import { StaticConfigLoader, HtmlValidate } from "html-validate/dist/cjs/browser";
-import { default as html5 } from "html-validate/elements/html5.json";
+import { StaticConfigLoader, HtmlValidate } from 'html-validate/dist/cjs/browser';
+import { default as html5 } from 'html-validate/elements/html5.json';
 
-import './LiveErrorCore.scss'
+import './LiveErrorCore.scss';
 
-const loader = new StaticConfigLoader({
-  extends: ["html-validate:standard"],
-  elements: [html5],
-});
-const htmlvalidate = new HtmlValidate(loader);
+// https://stackoverflow.com/a/65896524
+const testRegexpLookAheadLookBehind = () => {
+  try {
+    return (
+      'foobarfoofoo'
+        .replace(new RegExp('(?<=foo)foo', 'g'), 'ahead')
+        .replace(new RegExp('foo(?!bar)', 'g'), 'behind') === 'foobarbehindahead'
+    );
+  } catch (error) {
+    return false;
+  }
+};
 
-const LiveErrorCore = ({code}) => {
+const getValidator = () => {
+  const loader = new StaticConfigLoader({
+    extends: ['html-validate:standard'],
+    elements: [html5],
+  });
+  return new HtmlValidate(loader);
+};
+
+/*
+ Html-validate library uses regexp lookbehind feature which is not supported in Safari at the moment (17.5.2022).
+ We need to disable validation in browsers which do not support lookbehind.
+ - https://caniuse.com/js-regexp-lookbehind
+ - https://gitlab.com/html-validate/html-validate/-/issues/147
+ */
+
+const htmlValidate = testRegexpLookAheadLookBehind() ? getValidator() : undefined;
+const isValidatorSupported = !!htmlValidate;
+
+const LiveErrorCore = ({ code }) => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    const report = htmlvalidate.validateString(code);
-    if (report.valid) {
-      setError(null);
-    } else {
-      setError(report.results[0].messages[0]);
+    if (isValidatorSupported) {
+      const report = htmlValidate.validateString(code);
+      if (report.valid) {
+        setError(null);
+      } else {
+        setError(report.results[0].messages[0]);
+      }
     }
-  }, [code])
+  }, [code]);
 
+  if (!isValidatorSupported) {
+    return null;
+  }
   if (!error) {
     return null;
   }
-  return (
-    <pre className="live-error-core">SyntaxError: {`${error.message} (${error.line}:${error.column})`}</pre>
-  );
+  return <pre className="live-error-core">SyntaxError: {`${error.message} (${error.line}:${error.column})`}</pre>;
 };
 
 export default LiveErrorCore;

--- a/new-site/yarn.lock
+++ b/new-site/yarn.lock
@@ -7282,20 +7282,20 @@ hastscript@^6.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-hds-core@1.12.0, hds-core@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.12.0.tgz#6dc8be76bfe8552fd3d0ff19c42ee550570f4c09"
-  integrity sha512-xRpTxK0hWiztUGLqk4xHs77adAGolvPdEW3u4zpC5RYPzh+gjIQte/qFZVJ74zO8Trtu+xf4ULRgQyN+TK1/+w==
+hds-core@1.14.0, hds-core@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.14.0.tgz#d11fd1047b2f96d022c02e333b0390a586c5204a"
+  integrity sha512-MSH2BgVHOHW+I6gIjs5xNw32QL/P9Mn7+mcc1TvR8hF5GJDWa2mAh0vqaD1SXFfY34/cGr7wJ05V74GDZ6+8XA==
 
-hds-design-tokens@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-1.12.0.tgz#72439164cc918963d76587c6b905cea2c73a1734"
-  integrity sha512-y4F8Ir2cKXgP5DKTyuoWPv9tp7ordrA3cmrEATMIWSQuBmHeLmV4U4T3tjMFdLzavCHh01B+qPolpuzmTe/gHg==
+hds-design-tokens@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-1.14.0.tgz#4f1ef58715f5ec5c3c60e28d75adb94986540d02"
+  integrity sha512-98TrThjUVc/Ot/plsYpABGz9R5moAqGTbGUK63oPdEBQaWtoHlp17NCXsexfujCgOPOuQ4zgTApA/zAVHQOSHw==
 
-hds-react@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-1.12.0.tgz#994be7138e1a06270ef82d064ec02e5eed18789a"
-  integrity sha512-HCMLTPni88hAZD1ZZo0POj4D9pZ5leEloMVzEVJpUiaZ537H0J2tCGsUX1KPiKTtxxFwFmYd5H6Y0ljTGORxPA==
+hds-react@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-1.14.0.tgz#7038dda3ce1c7e27fe5b4a3911878b0efab51b69"
+  integrity sha512-gB73Ayn8Kox3KJH54KbG5idJD2sSdyGxYA8hOcYku8uGY+6O+K1a/fpZb7WJFWG5bB2S+ofncgMm80UvCSFJGg==
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/styled-base" "^11.0.0"
@@ -7304,7 +7304,7 @@ hds-react@^1.12.0:
     "@react-aria/visually-hidden" "3.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "1.12.0"
+    hds-core "1.14.0"
     lodash.isequal "4.5.0"
     lodash.isfunction "3.0.9"
     lodash.uniqueid "4.0.1"


### PR DESCRIPTION
## Description
- Disable the Playground component's Core code validation when regexp lookbehind is not supported

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1240

## Motivation and Context
- Documentation site's Playground component validates Core code with html-validate library. The validation broke the client-side javascript in the Safari browser. Safari does not support regexp lookbehind which is used in html-validate implementation.
- https://gitlab.com/html-validate/html-validate/-/issues/147

## How Has This Been Tested?
- locally on the dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-safari-fix/)
