### PR TITLE
Fix/docsite images

### DIFF
--- a/new-site/src/components/Image.js
+++ b/new-site/src/components/Image.js
@@ -1,18 +1,14 @@
 import React from 'react';
-import { withPrefix } from 'gatsby'
+import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
+
+import './Image.scss';
 
 const Image = ({ src, alt = 'Image', style = {}, viewable, ...rest }) => {
   const image = (
-    <img
-      alt={alt}
-      src={withPrefix(src)}
-      style={{
-        maxWidth: '100%',
-        ...style,
-      }}
-      {...rest}
-    />
+    <div className="image-container">
+      <img className="image-container-image" alt={alt} src={withPrefix(src)} {...rest} />
+    </div>
   );
 
   return viewable ? (

--- a/new-site/src/components/Image.js
+++ b/new-site/src/components/Image.js
@@ -5,18 +5,18 @@ import PropTypes from 'prop-types';
 import './Image.scss';
 
 const Image = ({ src, alt = 'Image', style = {}, viewable, ...rest }) => {
-  const image = (
-    <div className="image-container">
-      <img className="image-container-image" alt={alt} src={withPrefix(src)} {...rest} />
-    </div>
-  );
+  const image = <img className="image-container-image" alt={alt} src={withPrefix(src)} {...rest} />;
 
-  return viewable ? (
-    <a href={withPrefix(src)} title={alt}>
-      {image}
-    </a>
-  ) : (
-    image
+  return (
+    <div className="image-container">
+      {viewable ? (
+        <a className="image-container-link" href={withPrefix(src)} title={alt}>
+          {image}
+        </a>
+      ) : (
+        image
+      )}
+    </div>
   );
 };
 

--- a/new-site/src/components/Image.js
+++ b/new-site/src/components/Image.js
@@ -16,7 +16,7 @@ const Image = ({ src, alt = 'Image', style = {}, viewable, ...rest }) => {
   );
 
   return viewable ? (
-    <a href={src} title={alt}>
+    <a href={withPrefix(src)} title={alt}>
       {image}
     </a>
   ) : (

--- a/new-site/src/components/Image.scss
+++ b/new-site/src/components/Image.scss
@@ -6,6 +6,18 @@
 
 .image-container-link {
   display: block;
+  position: relative;
+
+  &:focus:after {
+    border: 3px solid var(--color-coat-of-arms);
+    box-sizing: border-box;
+    content: '';
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
 }
 
 .image-container-image {

--- a/new-site/src/components/Image.scss
+++ b/new-site/src/components/Image.scss
@@ -1,0 +1,13 @@
+@import '~hds-design-tokens/lib/all.scss';
+
+.image-container {
+  overflow-x: auto;
+}
+
+.image-container-image {
+  max-width: max(#{$breakpoint-m},100%);
+
+  @media screen and (min-width: $breakpoint-m) {
+    max-width: 100%;
+  }
+}

--- a/new-site/src/components/Image.scss
+++ b/new-site/src/components/Image.scss
@@ -5,23 +5,28 @@
 }
 
 .image-container-link {
-  display: block;
+  display: flex;
   position: relative;
+  width: max-content;
+
+  @media screen and (min-width: $breakpoint-m) {
+    width: 100%;
+  }
 
   &:focus:after {
     border: 3px solid var(--color-coat-of-arms);
     box-sizing: border-box;
     content: '';
-    height: 100%;
+    bottom: 0;
     left: 0;
     position: absolute;
     top: 0;
-    width: 100%;
+    right: 0;
   }
 }
 
 .image-container-image {
-  max-width: max(#{$breakpoint-m},100%);
+  max-width: $breakpoint-m;
 
   @media screen and (min-width: $breakpoint-m) {
     max-width: 100%;

--- a/new-site/src/components/Image.scss
+++ b/new-site/src/components/Image.scss
@@ -4,6 +4,10 @@
   overflow-x: auto;
 }
 
+.image-container-link {
+  display: block;
+}
+
 .image-container-image {
   max-width: max(#{$breakpoint-m},100%);
 


### PR DESCRIPTION
## Description
- Fix image links in the new doc site
- Let images reserve more space if needed (horizontal overflow) on smaller screens

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1277

## Motivation and Context
- Some larger diagram images are hard to read in smaller screen sizes

## How Has This Been Tested?
- locally in dev machine

## Demos
- [Large image](https://city-of-helsinki.github.io/hds-demo/docsite-image-fix/getting-started)
- [Large diagram image](https://city-of-helsinki.github.io/hds-demo/docsite-image-fix/getting-started/contributing/before-contributing)