### PR TITLE
Navigation shelf [Feature]

### DIFF
--- a/packages/react/src/components/navigation/Navigation.interface.ts
+++ b/packages/react/src/components/navigation/Navigation.interface.ts
@@ -6,7 +6,7 @@
  *
  * `inline` - items will be displayed in the header
  */
-export type NavigationVariant = 'default' | 'inline';
+export type NavigationVariant = 'default' | 'inline' | 'inlineShelf';
 
 export type NavigationTheme = 'light' | 'dark' | NavigationCustomTheme;
 

--- a/packages/react/src/components/navigation/Navigation.module.scss
+++ b/packages/react/src/components/navigation/Navigation.module.scss
@@ -174,6 +174,15 @@
   }
 }
 
+// mobile shelf
+.mobileShelf {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  border-bottom: 1px solid var(--header-divider-color);
+  font-size: var(--fontsize-body-s);
+}
+
 /* MEDIA */
 
 @media x-small-only {

--- a/packages/react/src/components/navigation/Navigation.stories.tsx
+++ b/packages/react/src/components/navigation/Navigation.stories.tsx
@@ -442,16 +442,16 @@ export const Shelf = ({ ...args }) => {
       {/* NAVIGATION ACTIONS */}
       <Navigation.Actions>
         <Navigation.Row variant="inlineShelf" key="languages">
-          <Navigation.Item href="#" hrefLang="fi" label="Suomeksi" active />
-          <Navigation.Item href="#" hrefLang="sv" label="På svenska" />
-          <Navigation.Item href="#" hrefLang="en" label="In English" />
+          <Navigation.Item href="#" hrefLang="fi" label="Suomi" active />
+          <Navigation.Item href="#" hrefLang="sv" label="Svenska" />
+          <Navigation.Item href="#" hrefLang="en" label="English" />
           <Navigation.Dropdown label="🌐" key="theme_dropdown">
             <Navigation.Item href="#" hrefLang="und" label="Arabic" />
             <Navigation.Item href="#" hrefLang="und" label="Chinese" />
           </Navigation.Dropdown>
         </Navigation.Row>
         <Button size="small" key="navigation_button" iconRight={<IconArrowTopRight size="l" />}>
-          Button text
+          Oma-asionti
         </Button>
       </Navigation.Actions>
     </Navigation>

--- a/packages/react/src/components/navigation/Navigation.stories.tsx
+++ b/packages/react/src/components/navigation/Navigation.stories.tsx
@@ -8,7 +8,8 @@ import { NavigationUser } from './navigationUser/NavigationUser';
 import { NavigationSearch } from './navigationSearch/NavigationSearch';
 import { NavigationLanguageSelector } from './navigationLanguageSelector/NavigationLanguageSelector';
 import { NavigationDropdown } from './navigationDropdown/NavigationDropdown';
-import { IconSignout } from '../../icons';
+import { IconArrowTopRight, IconSignout } from '../../icons';
+import { Button } from '../button';
 
 type LanguageOption = {
   label: string;
@@ -418,4 +419,64 @@ export const Example = ({ userName, ...args }) => {
       </Navigation>
     </>
   );
+};
+
+export const Shelf = ({ ...args }) => {
+  return (
+    // @ts-ignore
+    <Navigation {...args}>
+      {/* NAVIGATION ROW */}
+      <Navigation.Row>
+        <Navigation.Item href="#" label="Link" active onClick={(e) => e.preventDefault()} />
+        <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+        <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+        <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+        <Navigation.Dropdown label="Dropdown">
+          <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+          <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+          <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+          <Navigation.Item href="#" label="Link" onClick={(e) => e.preventDefault()} />
+        </Navigation.Dropdown>
+      </Navigation.Row>
+
+      {/* NAVIGATION ACTIONS */}
+      <Navigation.Actions>
+        <Navigation.Row variant="inlineShelf" key="languages">
+          <Navigation.Item href="#" hrefLang="fi" label="Suomeksi" active />
+          <Navigation.Item href="#" hrefLang="sv" label="På svenska" />
+          <Navigation.Item href="#" hrefLang="en" label="In English" />
+          <Navigation.Dropdown label="🌐" key="theme_dropdown">
+            <Navigation.Item href="#" hrefLang="und" label="Arabic" />
+            <Navigation.Item href="#" hrefLang="und" label="Chinese" />
+          </Navigation.Dropdown>
+        </Navigation.Row>
+        <Button size="small" key="navigation_button" iconRight={<IconArrowTopRight size="l" />}>
+          Button text
+        </Button>
+      </Navigation.Actions>
+    </Navigation>
+  );
+};
+
+Shelf.storyName = 'Shelf';
+Shelf.args = {
+  theme: {
+    // '--header-background-color': 'var(--color-metro)',
+    // '--header-color': 'var(--color-black-90)',
+    '--header-divider-color': 'var(--color-black-20)',
+    // '--header-focus-outline-color': 'var(--color-black)',
+    // '--mobile-menu-background-color': 'var(--color-white)',
+    // '--mobile-menu-color': 'var(--color-black-90)',
+    '--navigation-row-background-color': 'var(--color-white)',
+    // '--navigation-row-color': 'var(--color-black-90)',
+    // '--navigation-row-focus-outline-color': 'var(--color-coat-of-arms)',
+  },
+  shelved: ['languages', 'navigation_button'],
+};
+Shelf.argTypes = {
+  theme: {
+    control: {
+      type: 'object',
+    },
+  },
 };

--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -261,7 +261,11 @@ export const Navigation = ({
               {mobileMenuOpen ? <IconCross aria-hidden /> : <IconMenuHamburger aria-hidden />}
             </button>
           </HeaderWrapper>
-          {mobileShelf && <div id="hds-mobile-shelf">{mobileShelf}</div>}
+          {mobileShelf && (
+            <div id="hds-mobile-shelf" className={styles.mobileShelf}>
+              {mobileShelf}
+            </div>
+          )}
           {mobileMenuOpen && (
             <div id="hds-mobile-menu" className={styles.mobileMenu}>
               {mobileMenuChildren}

--- a/packages/react/src/components/navigation/navigationDropdown/NavigationDropdown.module.scss
+++ b/packages/react/src/components/navigation/navigationDropdown/NavigationDropdown.module.scss
@@ -27,7 +27,7 @@
 }
 
 @media small-down {
-  .dropdownItem.dropdownItem {
+  .dropdownItem.dropdownItem:not(.shelved) {
     align-items: flex-start;
     border-radius: 0;
     flex-direction: column;

--- a/packages/react/src/components/navigation/navigationItem/NavigationItem.module.scss
+++ b/packages/react/src/components/navigation/navigationItem/NavigationItem.module.scss
@@ -1,6 +1,7 @@
 @import "../../../styles/common";
 @import "../../button/button.common";
 @import "../navigation.common";
+
 @value x-small-down, small-down, small-only, medium-only, medium-up, large-only, large-up, x-large-only, x-large-up from "../../../styles/breakpoints.css";
 
 %item {
@@ -84,9 +85,28 @@
 
 @media small-down {
   .rowItem {
-    height: var(--spacing-xl);
-    padding: var(--spacing-2-xs);
+    &:not(.shelved) {
+      height: var(--spacing-xl);
+      padding: var(--spacing-2-xs);
+    }
+    &.shelved {
+      padding: var(--spacing-4-xs);
+      position: relative;
 
+      // active + hover styles
+      &:hover:not(:focus)::after,
+      &:active::after,
+      &.active::after {
+        background-color: var(--item-active-color);
+        bottom: 0;
+        content: '';
+        height: var(--spacing-3-xs);
+        left: 0;
+        pointer-events: none;
+        position: absolute;
+        width: 100%;
+      }
+    }
     &:focus {
       box-shadow: 0 0 0 var(--header-focus-outline-width) var(--item-focus-outline-color);
     }
@@ -94,7 +114,7 @@
 
   .rowItem,
   .dropdownItem {
-    &:not(:first-child) {
+    &:not(:first-child):not(.shelved) {
       margin-top: var(--spacing-2-xs);
     }
   }
@@ -156,4 +176,3 @@
     width: max-content;
   }
 }
-

--- a/packages/react/src/components/navigation/navigationRow/NavigationRow.module.scss
+++ b/packages/react/src/components/navigation/navigationRow/NavigationRow.module.scss
@@ -12,8 +12,14 @@
 
 @media small-down {
   .navigation {
+    &:not(.shelf) {
     flex-direction: column;
     padding: var(--spacing-s) var(--spacing-2-xs);
+    }
+    &.shelf {
+      // padding: var(--spacing-s) var(--spacing-2-xs);
+      border-bottom: 1px solid var(--header-divider-color);
+    }
   }
 }
 

--- a/packages/react/src/components/navigation/navigationRow/NavigationRow.module.scss
+++ b/packages/react/src/components/navigation/navigationRow/NavigationRow.module.scss
@@ -17,8 +17,10 @@
     padding: var(--spacing-s) var(--spacing-2-xs);
     }
     &.shelf {
-      // padding: var(--spacing-s) var(--spacing-2-xs);
-      border-bottom: 1px solid var(--header-divider-color);
+      padding: var(--spacing-3-xs) var(--spacing-2-xs);
+      display: inline-flex;
+      --item-active-color: var(--header-color);
+      --item-focus-outline-height-adjust: var(--header-focus-outline-width);
     }
   }
 }

--- a/packages/react/src/components/navigation/navigationRow/NavigationRow.tsx
+++ b/packages/react/src/components/navigation/navigationRow/NavigationRow.tsx
@@ -29,6 +29,7 @@ export const NavigationRow = ({ variant = 'default', children }: NavigationRowPr
     const reactElement = child as React.ReactElement;
     const isActive = reactElement.props.active;
     const isDropdown = (reactElement.type as FCWithName).componentName === 'NavigationDropdown';
+    const isShelved = variant === 'inlineShelf';
 
     return isValidElement(child)
       ? cloneElement(child, {
@@ -36,6 +37,7 @@ export const NavigationRow = ({ variant = 'default', children }: NavigationRowPr
             !isDropdown && itemStyles.rowItem,
             isDropdown && itemStyles.dropdownItem,
             isActive && itemStyles.active,
+            isShelved && itemStyles.shelved,
             child.props.className || '',
           ),
         })

--- a/packages/react/src/components/navigation/navigationRow/NavigationRow.tsx
+++ b/packages/react/src/components/navigation/navigationRow/NavigationRow.tsx
@@ -43,7 +43,15 @@ export const NavigationRow = ({ variant = 'default', children }: NavigationRowPr
   });
 
   return (
-    <nav className={classNames(styles.navigation, variant === 'default' && styles.subNav)}>{childrenWithClassName}</nav>
+    <nav
+      className={classNames(
+        styles.navigation,
+        variant === 'default' && styles.subNav,
+        variant === 'inlineShelf' && styles.shelf,
+      )}
+    >
+      {childrenWithClassName}
+    </nav>
   );
 };
 NavigationRow.componentName = 'NavigationRow';


### PR DESCRIPTION
## Description

Adds a navigation shelf to the mobile navigation.
New NavigationRow variant "inlineShelf" added, which modifies mainly the mobile styles for the row and row items to keep it as a row.
Added new input parameter "shelved" to Navigation component, which defines items to be moved to the shelf in mobile.
Modified rearrangeChildrenForMobile to facilitate shelving.
Added inline function "moveComponentToShelf" to facilitate moving the items to shelf.
New story Shelf added to the preview the component variant.  
Small style changes to help shelf look ok.

This is a PoC and needs more work.

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1318

## Motivation and Context

Employment services designs, which is based on some combination of HDS and the new Drupal frontends and the previous employment services site, define the header region with some unique solutions that don't work out-of-the box with the current HDS navigation components. This should rectify that, without breaking existing uses.

## How Has This Been Tested?

Storybook story

## Screenshots (if appropriate):
<img width="403" alt="Screenshot 2022-05-23 at 14 40 02" src="https://user-images.githubusercontent.com/5700863/169811557-75496a00-959a-4ba1-a496-04e00f60151c.png">


[👉 Demo](https://city-of-helsinki.github.io/hds-demo/navigation-shelf/?path=/story/components-navigation--shelf)