### PR TITLE
[Fix] Make DialogContent scrollable only if scrollable prop is true

### DIFF
--- a/packages/react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/dialog/Dialog.stories.tsx
@@ -7,6 +7,14 @@ import { Dialog } from './Dialog';
 import { IconAlertCircle, IconInfoCircle, IconPlusCircle, IconTrash } from '../../icons';
 import { DateInput } from '../dateInput';
 
+const argTypes = {
+  variant: {
+    options: ['primary', 'danger'],
+    control: { type: 'radio' },
+    defaultValue: 'primary',
+  },
+};
+
 export default {
   component: Dialog,
   title: 'Components/Dialog',
@@ -16,7 +24,13 @@ export default {
   },
   args: {
     id: 'example-dialog',
+    scrollable: false,
+    boxShadow: false,
+    theme: {},
+    style: {},
+    closeButtonLabelText: 'Close',
   },
+  argTypes,
 };
 
 export const Default = (args) => {
@@ -33,12 +47,17 @@ export const Default = (args) => {
       </Button>
       <Dialog
         id={args.id}
+        scrollable={args.scrollable}
+        boxShadow={args.boxShadow}
+        theme={args.theme}
+        style={args.style}
+        variant={args.variant}
+        closeButtonLabelText={args.closeButtonLabelText}
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
         isOpen={open}
         focusAfterCloseRef={openButtonRef}
         close={close}
-        closeButtonLabelText="Close"
       >
         <Dialog.Header id={titleId} title="Add new item" iconLeft={<IconPlusCircle aria-hidden="true" />} />
         <Dialog.Content>

--- a/packages/react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/dialog/Dialog.stories.tsx
@@ -5,6 +5,7 @@ import { TextArea } from '../textarea/TextArea';
 import { TextInput } from '../textInput/TextInput';
 import { Dialog } from './Dialog';
 import { IconAlertCircle, IconInfoCircle, IconPlusCircle, IconTrash } from '../../icons';
+import { DateInput } from '../dateInput';
 
 export default {
   component: Dialog,
@@ -58,6 +59,8 @@ export const Default = (args) => {
             placeholder="E.g. Item 1 is the first item of the system."
             required
           />
+          <br />
+          <DateInput id="item-date" label="Item date" required helperText="Use format D.M.YYYY" />
         </Dialog.Content>
         <Dialog.ActionButtons>
           <Button

--- a/packages/react/src/components/dialog/dialogContent/DialogContent.module.scss
+++ b/packages/react/src/components/dialog/dialogContent/DialogContent.module.scss
@@ -4,10 +4,10 @@
 .dialogContent {
   @include dialogComponentSidePaddings;
   padding-bottom: var(--spacing-2-xs);
-  overflow-y: auto;
 }
 
 .dialogContentScrollable {
   border-top: 1px solid;
   border-bottom: 1px solid;
+  overflow-y: auto;
 }


### PR DESCRIPTION
## Description

Enable scrolling on `DialogContent` only if `scrollable` prop is defined.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1241

## Motivation and Context

Using a `DateInput` inside `DialogContent` opens the date picker inside the dialog content, making it scrollable whether the dialog is defined as scrollable or not. After this fix, the date picker opens over the dialog as expected.

## How Has This Been Tested?

Tested locally in Storybook with non-scrollable and scrollable content.

## Screenshots

With `scrollable` set to true and false:

https://user-images.githubusercontent.com/8843354/171940992-f5334877-4530-42b6-b152-9cc1b51ec121.mov


