### PR TITLE
Feature/Add analytics and cookie consent views to doc site

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -220,6 +220,8 @@ module.exports = {
         siteUrl: 'https://hds.hel.fi',
         matomoJsScript: 'piwik.min.js',
         matomoPhpScript: 'tracker.php',
+        requireConsent: true,
+        requireCookieConsent: true,
       }
     }
   ],

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
     title: `Helsinki Design System`,
     description: `Documentation for the Helsinki Design System`,
     siteUrl: process.env.SITE_URL,
-    menuLinks: [  
+    menuLinks: [
       {
         name: 'Getting started',
         link: '/getting-started',
@@ -210,6 +210,16 @@ module.exports = {
       options: {
         sitemap: null,
         policy: [{userAgent: '*', disallow: '/v1'}]
+      }
+    },
+    {
+      resolve: 'gatsby-plugin-matomo',
+      options: {
+        siteId: '831',
+        matomoUrl: 'https://webanalytics.digiaiiris.com/js',
+        siteUrl: 'https://hds.hel.fi',
+        matomoJsScript: 'piwik.min.js',
+        matomoPhpScript: 'tracker.php',
       }
     }
   ],

--- a/site/package.json
+++ b/site/package.json
@@ -17,6 +17,7 @@
     "gatsby": "^4.17.0",
     "gatsby-plugin-image": "^2.17.0",
     "gatsby-plugin-manifest": "^4.17.0",
+    "gatsby-plugin-matomo": "^0.13.0",
     "gatsby-plugin-mdx": "^3.17.0",
     "gatsby-plugin-offline": "^5.17.0",
     "gatsby-plugin-react-helmet": "^5.17.0",

--- a/site/src/components/cookies/commonCookieConsent.js
+++ b/site/src/components/cookies/commonCookieConsent.js
@@ -1,0 +1,41 @@
+const isAnalyticsInitialized = () => typeof window !== 'undefined' && window._paq;
+
+const getCookieConsent = (language, setLanguage) => ({
+  siteName: 'Helsinki Design System',
+  currentLanguage: language,
+  ...(setLanguage
+    ? {
+        language: {
+          onLanguageChange: setLanguage,
+        },
+      }
+    : {}),
+  optionalCookies: {
+    cookies: [
+      {
+        commonGroup: 'statistics',
+        commonCookie: 'matomo',
+      },
+    ],
+  },
+  onAllConsentsGiven: (consents) => {
+    if (isAnalyticsInitialized()) {
+      if (consents.matomo && window._paq) {
+        window._paq.push(['setConsentGiven']);
+        window._paq.push(['setCookieConsentGiven']);
+      }
+    }
+  },
+  onConsentsParsed: (consents) => {
+    if (isAnalyticsInitialized()) {
+      if (consents.matomo === undefined) {
+        window._paq.push(['requireConsent']);
+        window._paq.push(['requireCookieConsent']);
+      } else if (consents.matomo === false) {
+        window._paq.push(['forgetConsentGiven']);
+      }
+    }
+  },
+});
+
+export default getCookieConsent;

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -5,12 +5,13 @@
  * See: https://www.gatsbyjs.com/docs/use-static-query/
  */
 
-import "hds-core";
+import 'hds-core';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, withPrefix, Link as GatsbyLink, navigate } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
-import { Footer, Link, Navigation, SideNavigation, IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import { CookieModal, Footer, Link, Navigation, SideNavigation, IconCheckCircleFill, IconCrossCircle } from 'hds-react';
+import getCookieConsent from './cookies/commonCookieConsent';
 import Seo from './Seo';
 import { PlaygroundBlock, PlaygroundPreview } from './Playground';
 import SyntaxHighlighter from './SyntaxHighlighter';
@@ -176,6 +177,9 @@ const Layout = ({ children, pageContext }) => {
       .sort(sortByPageTitle),
   }));
   const contentId = 'content';
+  const headerId = 'page-header';
+  const [language, setLanguage] = React.useState('en');
+
   const NavigationTitle = () => (
     <div className="page-header-title">
       <div>{siteTitle}</div>
@@ -202,9 +206,12 @@ const Layout = ({ children, pageContext }) => {
           },
         ]}
       />
+      {!pageSlug.includes('/cookie-settings') && (
+        <CookieModal contentSource={{ ...getCookieConsent(language, setLanguage), focusTargetSelector: headerId }} />
+      )}
       <div className="page text-body">
         <Navigation
-          id="page-header"
+          id={headerId}
           className="pageHeader"
           title={<NavigationTitle />}
           titleAriaLabel="Helsinki: Helsinki Design System"

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -295,6 +295,7 @@ const Layout = ({ children, pageContext }) => {
         </div>
         <Footer id="page-footer" className="page-footer" title={footerTitle} footerAriaLabel={footerAriaLabel}>
           <Footer.Base copyrightHolder="Copyright">
+            <Footer.Item label="Cookie Settings" href={withPrefix('/cookie-settings')} />
             <Footer.Item label="Contribution" href={withPrefix('/getting-started/contributing/before-contributing')} />
             <Footer.Item label="Accessibility" href={withPrefix('/about/accessibility/statement')} />
             <Footer.Item label="GitHub" href="https://github.com/City-of-Helsinki/helsinki-design-system" />

--- a/site/src/docs/cookie-settings.mdx
+++ b/site/src/docs/cookie-settings.mdx
@@ -1,0 +1,9 @@
+---
+slug: '/cookie-settings'
+title: 'Cookie Settings'
+---
+
+import { CookiePage } from 'hds-react';
+import getCookieConsent from '../components/cookies/commonCookieConsent';
+
+<CookiePage contentSource={getCookieConsent('en')} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11358,7 +11358,12 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cookie@^0.4.1, cookie@~0.4.1:
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -21188,7 +21193,12 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.0.7, nwsapi@^2.1.3, nwsapi@^2.2.0:
+nwsapi@^2.0.7:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
+  integrity sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==
+
+nwsapi@^2.1.3, nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15043,6 +15043,11 @@ gatsby-plugin-manifest@^4.17.0:
     semver "^7.3.7"
     sharp "^0.30.3"
 
+gatsby-plugin-matomo@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.13.0.tgz#abf1bd561f3ca35c57b8bbbd5d8e87579ba17886"
+  integrity sha512-zwmxcwOoDi3hjNQoUJehoC5XwQKgR+bArAAvArGJWHlJqv7G688tlmKgbIGqEUj3aFSdyWAzAM7QhEt68buMNw==
+
 gatsby-plugin-mdx@^3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.17.0.tgz#6df646cae67662fceb92ff5016c12347786ba10a"


### PR DESCRIPTION
## Description

- Add matomo configurations for the new doc site
- Add cookie-consent modal
- Add cookie settings page

Depends on #789 

## Related Issues
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1023
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1325

## Motivation and Context
Adds an analytics and required cookie managing forms into documentation site.

## How Has This Been Tested?
- Locally on developers machine. Verified entry logs from matomo site (digiaiiris.com)

[Demo](https://city-of-helsinki.github.io/hds-demo/docs-cookie-settings-analytics/)
