### PR TITLE
Content/Fix broken site title link

### DIFF
--- a/new-site/.env.development
+++ b/new-site/.env.development
@@ -1,0 +1,1 @@
+SITE_URL=http://localhost:8000

--- a/new-site/.env.production
+++ b/new-site/.env.production
@@ -1,0 +1,1 @@
+SITE_URL=https://hds.hel.fi

--- a/new-site/gatsby-config.js
+++ b/new-site/gatsby-config.js
@@ -1,9 +1,13 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   pathPrefix: process.env.PATH_PREFIX,
   siteMetadata: {
     title: `Helsinki Design System`,
     description: `Documentation for the Helsinki Design System`,
-    siteUrl: `https://hds.hel.fi/`,
+    siteUrl: process.env.SITE_URL,
     menuLinks: [  
       {
         name: 'Getting started',

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -108,6 +108,7 @@ const Layout = ({ children, pageContext }) => {
         siteMetadata {
           title
           description
+          siteUrl
           menuLinks {
             name
             link
@@ -143,6 +144,7 @@ const Layout = ({ children, pageContext }) => {
   const mdxPageData = queryData.allMdx?.edges || [];
   const allPages = mdxPageData.map(({ node }) => ({ ...node.frontmatter, ...node.fields }));
   const siteTitle = siteData?.title || 'Title';
+  const siteUrl = siteData?.siteUrl;
   const description = siteData?.description;
   const footerTitle = siteData?.footerTitle || siteTitle;
   const footerAriaLabel = siteData?.footerAriaLabel;
@@ -187,6 +189,12 @@ const Layout = ({ children, pageContext }) => {
           id="page-header"
           className="pageHeader"
           title={siteTitle}
+          titleAriaLabel="Helsinki: Helsinki Design System"
+          titleUrl={siteUrl}
+          onTitleClick={(event) => {
+            event.preventDefault();
+            navigate('/');
+          }}
           menuToggleAriaLabel="menu"
           skipTo={`#${contentId}`}
           skipToContentLabel="Skip to content"


### PR DESCRIPTION
## Description

Fix broken navigation title link.

The solution has a minor setback. It works perfectly on local and production environments. But in demo environment, the link works nicely when clicked, but the href is incorrect (it points to production env). The reason the link still works is because it uses internal routing by javascript.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1022

How is the issue related? Well, I run lighthouse SEO tests and according to it broken links have negative impact on SEO, so decided to fix it.

## How Has This Been Tested?

- Locally on developers machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-fix-title-link/)

## Screenshots (if appropriate):

<img width="672" alt="image" src="https://user-images.githubusercontent.com/2777633/173352618-928d1c71-d82f-44a7-89e2-60b7a121ed21.png">
