### PR TITLE
[Content] Update component statuses for the 2.0 documentation

### DIFF
--- a/new-site/src/docs/components/file-input/tabs.mdx
+++ b/new-site/src/docs/components/file-input/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # FileInput
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>

--- a/new-site/src/docs/components/footer/tabs.mdx
+++ b/new-site/src/docs/components/footer/tabs.mdx
@@ -21,7 +21,7 @@ import PageTabs from '../../../components/PageTabs';
 </LeadParagraph>
 
 <Notification label="A visual rework is coming soon!" className="siteNotification">
-  The HDS team will be unifying the Footer component with the Hel.fi project footer during 2022.
+  The HDS team will be unifying the Footer component with the Hel.fi project footer in the near future.
 </Notification>
 
 <PageTabs pageContext={props.pageContext}>

--- a/new-site/src/docs/components/footer/tabs.mdx
+++ b/new-site/src/docs/components/footer/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # Footer
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>

--- a/new-site/src/docs/components/footer/tabs.mdx
+++ b/new-site/src/docs/components/footer/tabs.mdx
@@ -3,7 +3,7 @@ slug: '/components/footer/tabs'
 title: 'Footer'
 ---
 
-import { StatusLabel } from 'hds-react';
+import { StatusLabel, Notification } from 'hds-react';
 
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
@@ -19,6 +19,10 @@ import PageTabs from '../../../components/PageTabs';
 <LeadParagraph>
   The Footer component is located at the bottom of the page below the main body content. It provides a place for secondary navigation, site-wide actions, and additional information.
 </LeadParagraph>
+
+<Notification label="A visual rework is coming soon!" className="siteNotification">
+  The HDS team will be unifying the Footer component with the Hel.fi project footer during 2022.
+</Notification>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/new-site/src/docs/components/linkbox/tabs.mdx
+++ b/new-site/src/docs/components/linkbox/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # Linkbox
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>

--- a/new-site/src/docs/components/navigation/tabs.mdx
+++ b/new-site/src/docs/components/navigation/tabs.mdx
@@ -3,7 +3,7 @@ slug: '/components/navigation/tabs'
 title: 'Navigation'
 ---
 
-import { StatusLabel } from 'hds-react';
+import { StatusLabel, Notification } from 'hds-react';
 
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
@@ -19,6 +19,10 @@ import PageTabs from '../../../components/PageTabs';
 <LeadParagraph>
   A navigation component is the main way for users to navigate and locate themselves when using a service. It includes some key features present in most services to keep user experience consistent between them.
 </LeadParagraph>
+
+<Notification label="A visual rework is coming soon!" className="siteNotification">
+  The HDS team will be unifying the Navigation component with the Hel.fi project navigation during 2022.
+</Notification>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/new-site/src/docs/components/navigation/tabs.mdx
+++ b/new-site/src/docs/components/navigation/tabs.mdx
@@ -21,7 +21,7 @@ import PageTabs from '../../../components/PageTabs';
 </LeadParagraph>
 
 <Notification label="A visual rework is coming soon!" className="siteNotification">
-  The HDS team will be unifying the Navigation component with the Hel.fi project navigation during 2022.
+  The HDS team will be unifying the Navigation component with the Hel.fi project navigation in the near future.
 </Notification>
 
 <PageTabs pageContext={props.pageContext}>

--- a/new-site/src/docs/components/navigation/tabs.mdx
+++ b/new-site/src/docs/components/navigation/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # Navigation
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>

--- a/new-site/src/docs/components/search-input/tabs.mdx
+++ b/new-site/src/docs/components/search-input/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # SearchInput
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>

--- a/new-site/src/docs/components/side-navigation/tabs.mdx
+++ b/new-site/src/docs/components/side-navigation/tabs.mdx
@@ -21,7 +21,7 @@ import PageTabs from '../../../components/PageTabs';
 </LeadParagraph>
 
 <Notification label="A visual rework is coming soon!" className="siteNotification">
-  The HDS team will be unifying the SideNavigation component with the Hel.fi project side navigation during 2022.
+  The HDS team will be unifying the SideNavigation component with the Hel.fi project side navigation in the near future.
 </Notification>
 
 <PageTabs pageContext={props.pageContext}>

--- a/new-site/src/docs/components/side-navigation/tabs.mdx
+++ b/new-site/src/docs/components/side-navigation/tabs.mdx
@@ -3,7 +3,7 @@ slug: '/components/side-navigation/tabs'
 title: 'SideNavigation'
 ---
 
-import { StatusLabel } from 'hds-react';
+import { StatusLabel, Notification } from 'hds-react';
 
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
@@ -19,6 +19,10 @@ import PageTabs from '../../../components/PageTabs';
 <LeadParagraph>
   A side navigation is an additional navigation element that is located at the left-hand side of the viewport. It provides an extra level of navigation and also can be helpful in situations where the traditional top navigation feels too clumsy. 
 </LeadParagraph>
+
+<Notification label="A visual rework is coming soon!" className="siteNotification">
+  The HDS team will be unifying the SideNavigation component with the Hel.fi project side navigation during 2022.
+</Notification>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/new-site/src/docs/components/side-navigation/tabs.mdx
+++ b/new-site/src/docs/components/side-navigation/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # SideNavigation
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>

--- a/new-site/src/docs/components/stepper/tabs.mdx
+++ b/new-site/src/docs/components/stepper/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # Stepper
 
-<StatusLabel type="info">Stable</StatusLabel>
+<StatusLabel type="alert">Draft</StatusLabel>
 <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>


### PR DESCRIPTION
## Description
Updated component statuses for the new documentation site.
- Firstly, made sure all statuses were up to date (everything was marked as "Stable" in the new doc site)
- Changed DateInput, Dialog, Link and Table from "Draft" to "Stable"
- Added a notification to Navigation, Footer and SideNavigation about the upcoming Hel.fi update

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1322

## How Has This Been Tested?
Tested by running the documentation site locally.
