### PR TITLE
Fix/remove docsite x scrollbar

### DIFF
--- a/new-site/src/components/Hero.scss
+++ b/new-site/src/components/Hero.scss
@@ -3,23 +3,11 @@
 .hero-container {
   --koros-height: 145px;
   --hero-height: 520px;
-  --hero-small-left: calc((100vw - 100%) / 2);
-  --hero-large-content-left: calc((100vw - var(--container-width-xl)) / 2);
 
   background-color: var(--color-coat-of-arms);
   box-sizing: border-box;
   position: relative;
-  left: calc(var(--spacing-s) * -1);
-  width: calc(100vw - var(--spacing-s) + 1px);
-
-  @include medium-and-above-screen {
-    left: calc(var(--spacing-m) * -1);
-  }
-
-  @include x-large-and-above-screen {
-    left: calc(var(--hero-large-content-left) * -1);
-    width: calc(100vw - var(--spacing-2-xs));
-  }
+  width: 100%;
 }
 
 .hero-bg-image {
@@ -33,7 +21,7 @@
     aspect-ratio: unset;
     height: 100%;
     margin-top: 0;
-    left: var(--hero-large-content-left);
+    left: calc((100% - var(--breakpoint-xl)) / 2);
     right: 0;
     position: absolute;
     top: 0;
@@ -44,7 +32,7 @@
   margin: 0 auto;
 
   @include x-large-and-above-screen {
-    max-width: var(--container-width-xl);
+    max-width: var(--breakpoint-xl);
   }
 }
 
@@ -74,7 +62,7 @@
     clip-path: polygon(0 0, var(--triangle-top-corner-x) 0, 0 var(--triangle-bottom-corner-x), 0% 50%);
     left: auto;
     max-width: initial;
-    padding: var(--spacing-layout-m) 0 var(--spacing-layout-m);
+    padding: var(--spacing-l) var(--spacing-m);
     width: 67%;
 
     &:after {

--- a/new-site/src/components/Hero.scss
+++ b/new-site/src/components/Hero.scss
@@ -7,7 +7,6 @@
   background-color: var(--color-coat-of-arms);
   box-sizing: border-box;
   position: relative;
-  width: 100%;
 }
 
 .hero-bg-image {

--- a/new-site/src/components/Hero.scss
+++ b/new-site/src/components/Hero.scss
@@ -4,14 +4,22 @@
   --koros-height: 145px;
   --hero-height: 520px;
   --hero-small-left: calc((100vw - 100%) / 2);
-  --hero-large-content-padding: var(--spacing-s);
-  --hero-large-content-left: calc((100vw + (2 * var(--hero-large-content-padding)) - var(--container-width-xl)) / 2);
+  --hero-large-content-left: calc((100vw - var(--container-width-xl)) / 2);
 
   background-color: var(--color-coat-of-arms);
   box-sizing: border-box;
   position: relative;
-  left: calc(var(--hero-small-left) * -1);
-  width: 100vw;
+  left: calc(var(--spacing-s) * -1);
+  width: calc(100vw - var(--spacing-s) + 1px);
+
+  @include medium-and-above-screen {
+    left: calc(var(--spacing-m) * -1);
+  }
+
+  @include x-large-and-above-screen {
+    left: calc(var(--hero-large-content-left) * -1);
+    width: calc(100vw - var(--spacing-2-xs));
+  }
 }
 
 .hero-bg-image {
@@ -62,15 +70,11 @@
   position: relative;
   z-index: 3;
 
-  @include small-medium-and-above-screen {
-    padding: var(--spacing-m);
-  }
-
   @include x-large-and-above-screen {
     clip-path: polygon(0 0, var(--triangle-top-corner-x) 0, 0 var(--triangle-bottom-corner-x), 0% 50%);
     left: auto;
     max-width: initial;
-    padding: var(--spacing-layout-m) 0 var(--spacing-layout-m) var(--hero-large-content-padding);
+    padding: var(--spacing-layout-m) 0 var(--spacing-layout-m);
     width: 67%;
 
     &:after {

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -99,7 +99,7 @@ const isMatchingParentLink = (link, slug) => {
 };
 
 const Layout = ({ children, pageContext }) => {
-  const { title: pageTitle, slug: pageSlug, custom_layout: customLayout } = pageContext.frontmatter;
+  const { title: pageTitle, slug: pageSlug, customLayout } = pageContext.frontmatter;
   const pageSlugWithPrefix = withPrefix(pageSlug);
 
   const queryData = useStaticQuery(graphql`

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -226,7 +226,7 @@ const Layout = ({ children, pageContext }) => {
             ))}
           </Navigation.Row>
         </Navigation>
-        <div className={customLayout ? 'custom-page-content' : 'page-content'}>
+        <div className={customLayout ? undefined : 'page-content'}>
           {uiSubMenuLinks.length > 0 && (
             <aside className="side-content" key="side-navigation">
               <SideNavigation

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -99,7 +99,7 @@ const isMatchingParentLink = (link, slug) => {
 };
 
 const Layout = ({ children, pageContext }) => {
-  const { title: pageTitle, slug: pageSlug } = pageContext.frontmatter;
+  const { title: pageTitle, slug: pageSlug, custom_layout: customLayout } = pageContext.frontmatter;
   const pageSlugWithPrefix = withPrefix(pageSlug);
 
   const queryData = useStaticQuery(graphql`
@@ -226,7 +226,7 @@ const Layout = ({ children, pageContext }) => {
             ))}
           </Navigation.Row>
         </Navigation>
-        <div className={`page-content ${pageSlug === '/' ? 'front-page-content' : ''}`}>
+        <div className={customLayout ? 'custom-page-content' : 'page-content'}>
           {uiSubMenuLinks.length > 0 && (
             <aside className="side-content" key="side-navigation">
               <SideNavigation
@@ -275,9 +275,13 @@ const Layout = ({ children, pageContext }) => {
               </SideNavigation>
             </aside>
           )}
-          <main id={contentId} className="main-content">
+          {customLayout ? (
             <MDXProvider components={components}>{children}</MDXProvider>
-          </main>
+          ) : (
+            <main id={contentId} className="main-content">
+              <MDXProvider components={components}>{children}</MDXProvider>
+            </main>
+          )}
         </div>
         <Footer id="page-footer" className="page-footer" title={footerTitle} footerAriaLabel={footerAriaLabel}>
           <Footer.Base copyrightHolder="Copyright">

--- a/new-site/src/components/layout.js
+++ b/new-site/src/components/layout.js
@@ -79,7 +79,7 @@ const generateUiIdFromPath = (path, prefix) => {
   return `${prefix}-${pathStr}`;
 };
 
-const isNavPage = (page) => page.slug && page.nav_title;
+const isNavPage = (page) => page.slug && page.navTitle;
 const splitPathIntoParts = (path) => path.split('/').filter((l) => !!l);
 const isLinkParentForPage = (parentPath, level) => (page) => {
   const pathParts = splitPathIntoParts(page.slug);
@@ -132,7 +132,7 @@ const Layout = ({ children, pageContext }) => {
             frontmatter {
               title
               slug
-              nav_title
+              navTitle
             }
           }
         }
@@ -257,11 +257,11 @@ const Layout = ({ children, pageContext }) => {
                             },
                           })}
                     >
-                      {subLevels.map(({ nav_title, slug, prefixedLink: prefixedSubLevelLink, uiId }) => (
+                      {subLevels.map(({ navTitle, slug, prefixedLink: prefixedSubLevelLink, uiId }) => (
                         <SideNavigation.SubLevel
                           key={uiId}
                           href={prefixedSubLevelLink}
-                          label={nav_title}
+                          label={navTitle}
                           active={pageSlugWithPrefix === prefixedSubLevelLink || isMatchingParentLink(slug, pageSlug)}
                           onClick={(e) => {
                             e.preventDefault();

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -167,13 +167,6 @@ body {
     padding-left: 0;
     padding-right: 0;
   }
-
-  &.custom-page-content {
-    flex-direction: column;
-    max-width: 100%;
-    margin: 0 auto;
-    padding: 0;
-  }
 }
 
 .side-content {

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -168,8 +168,11 @@ body {
     padding-right: 0;
   }
 
-  &.front-page-content {
-    padding-top: 0;
+  &.custom-page-content {
+    flex-direction: column;
+    max-width: 100%;
+    margin: 0 auto;
+    padding: 0;
   }
 }
 

--- a/new-site/src/docs/about/accessibility/hds-accessibility.mdx
+++ b/new-site/src/docs/about/accessibility/hds-accessibility.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/about/accessibility/hds-accessibility'
 title: 'HDS Accessibility'
-nav_title: 'HDS Accessibility'
+navTitle: 'HDS Accessibility'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/about/accessibility/statement.mdx
+++ b/new-site/src/docs/about/accessibility/statement.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/about/accessibility/statement'
 title: 'Accessibility statement'
-nav_title: 'Accessibility statement'
+navTitle: 'Accessibility statement'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/components/accordion/index.mdx
+++ b/new-site/src/docs/components/accordion/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/accordion'
 title: 'Accordion'
-nav_title: 'Accordion'
+navTitle: 'Accordion'
 ---
 
 import { Accordion } from 'hds-react';

--- a/new-site/src/docs/components/buttons/index.mdx
+++ b/new-site/src/docs/components/buttons/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/buttons'
 title: 'Button'
-nav_title: 'Button'
+navTitle: 'Button'
 ---
 
 import { Button, IconAngleRight, IconShare, IconTrash, IconSaveDisketteFill, Notification } from 'hds-react';

--- a/new-site/src/docs/components/card/index.mdx
+++ b/new-site/src/docs/components/card/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/card'
 title: 'Card'
-nav_title: 'Card'
+navTitle: 'Card'
 ---
 
 import { Button, Card, IconAngleRight, IconShare, IconTrash } from 'hds-react';

--- a/new-site/src/docs/components/checkbox/index.mdx
+++ b/new-site/src/docs/components/checkbox/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/checkbox'
 title: 'Checkbox'
-nav_title: 'Checkbox'
+navTitle: 'Checkbox'
 ---
 
 import { useReducer } from 'react';

--- a/new-site/src/docs/components/date-input/index.mdx
+++ b/new-site/src/docs/components/date-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/date-input'
 title: 'DateInput'
-nav_title: 'DateInput'
+navTitle: 'DateInput'
 ---
 
 import { DateInput } from 'hds-react';

--- a/new-site/src/docs/components/dialog/index.mdx
+++ b/new-site/src/docs/components/dialog/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/dialog'
 title: 'Dialog'
-nav_title: 'Dialog'
+navTitle: 'Dialog'
 ---
 
 import { Dialog, Button, IconInfoCircle, IconTrash } from 'hds-react';

--- a/new-site/src/docs/components/dropdown/index.mdx
+++ b/new-site/src/docs/components/dropdown/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/dropdown'
 title: 'Dropdown'
-nav_title: 'Dropdown'
+navTitle: 'Dropdown'
 ---
 
 import { Combobox, Select } from 'hds-react';

--- a/new-site/src/docs/components/fieldset/index.mdx
+++ b/new-site/src/docs/components/fieldset/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/fieldset'
 title: 'Fieldset'
-nav_title: 'Fieldset'
+navTitle: 'Fieldset'
 ---
 
 import { Fieldset, TextInput } from 'hds-react';

--- a/new-site/src/docs/components/file-input/index.mdx
+++ b/new-site/src/docs/components/file-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/file-input'
 title: 'FileInput'
-nav_title: 'FileInput'
+navTitle: 'FileInput'
 ---
 
 import { FileInput } from 'hds-react';

--- a/new-site/src/docs/components/footer/index.mdx
+++ b/new-site/src/docs/components/footer/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/footer'
 title: 'Footer'
-nav_title: 'Footer'
+navTitle: 'Footer'
 ---
 
 import { Footer, IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok } from 'hds-react';

--- a/new-site/src/docs/components/icon/index.mdx
+++ b/new-site/src/docs/components/icon/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/icon'
 title: 'Icon'
-nav_title: 'Icon'
+navTitle: 'Icon'
 ---
 
 import { IconFaceSmile, IconPlusCircle } from 'hds-react';

--- a/new-site/src/docs/components/koros/index.mdx
+++ b/new-site/src/docs/components/koros/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/koros'
 title: 'Koros'
-nav_title: 'Koros'
+navTitle: 'Koros'
 ---
 
 import { Koros } from 'hds-react';

--- a/new-site/src/docs/components/link/index.mdx
+++ b/new-site/src/docs/components/link/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/link'
 title: 'Link'
-nav_title: 'Link'
+navTitle: 'Link'
 ---
 
 import { IconDocument, IconPhone, IconEnvelope, IconPhoto } from 'hds-react';

--- a/new-site/src/docs/components/linkbox/index.mdx
+++ b/new-site/src/docs/components/linkbox/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/linkbox'
 title: 'Linkbox'
-nav_title: 'Linkbox'
+navTitle: 'Linkbox'
 ---
 
 import { Linkbox } from 'hds-react';

--- a/new-site/src/docs/components/loading-spinner/index.mdx
+++ b/new-site/src/docs/components/loading-spinner/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/loading-spinner'
 title: 'LoadingSpinner'
-nav_title: 'LoadingSpinner'
+navTitle: 'LoadingSpinner'
 ---
 
 import { LoadingSpinner } from 'hds-react';

--- a/new-site/src/docs/components/logo/index.mdx
+++ b/new-site/src/docs/components/logo/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/logo'
 title: 'Logo'
-nav_title: 'Logo'
+navTitle: 'Logo'
 ---
 
 import { Logo } from 'hds-react';

--- a/new-site/src/docs/components/navigation/index.mdx
+++ b/new-site/src/docs/components/navigation/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/navigation'
 title: 'Navigation'
-nav_title: 'Navigation'
+navTitle: 'Navigation'
 ---
 
 import { Navigation } from 'hds-react';

--- a/new-site/src/docs/components/notification/index.mdx
+++ b/new-site/src/docs/components/notification/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/notification'
 title: 'Notification'
-nav_title: 'Notification'
+navTitle: 'Notification'
 ---
 
 import { Notification, Button } from 'hds-react';

--- a/new-site/src/docs/components/number-input/index.mdx
+++ b/new-site/src/docs/components/number-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/number-input'
 title: 'NumberInput'
-nav_title: 'NumberInput'
+navTitle: 'NumberInput'
 ---
 
 import { NumberInput } from 'hds-react';

--- a/new-site/src/docs/components/pagination/index.mdx
+++ b/new-site/src/docs/components/pagination/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/pagination'
 title: 'Pagination'
-nav_title: 'Pagination'
+navTitle: 'Pagination'
 ---
 
 import PlaygroundPreview from '../../../components/Playground';

--- a/new-site/src/docs/components/password-input/index.mdx
+++ b/new-site/src/docs/components/password-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/password-input'
 title: 'PasswordInput'
-nav_title: 'PasswordInput'
+navTitle: 'PasswordInput'
 ---
 
 import { PasswordInput, Button, IconEye, IconEyeCrossed } from 'hds-react';

--- a/new-site/src/docs/components/phone-input/index.mdx
+++ b/new-site/src/docs/components/phone-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/phone-input'
 title: 'PhoneInput'
-nav_title: 'PhoneInput'
+navTitle: 'PhoneInput'
 ---
 
 import { PhoneInput, Combobox } from 'hds-react';

--- a/new-site/src/docs/components/radio-button/index.mdx
+++ b/new-site/src/docs/components/radio-button/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/radio-button'
 title: 'RadioButton'
-nav_title: 'RadioButton'
+navTitle: 'RadioButton'
 ---
 
 import { RadioButton, SelectionGroup } from 'hds-react';

--- a/new-site/src/docs/components/search-input/index.mdx
+++ b/new-site/src/docs/components/search-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/search-input'
 title: 'SearchInput'
-nav_title: 'SearchInput'
+navTitle: 'SearchInput'
 ---
 
 import { SearchInput } from 'hds-react';

--- a/new-site/src/docs/components/selection-group/index.mdx
+++ b/new-site/src/docs/components/selection-group/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/selection-group'
 title: 'SelectionGroup'
-nav_title: 'SelectionGroup'
+navTitle: 'SelectionGroup'
 ---
 
 import { SelectionGroup, Checkbox, RadioButton } from 'hds-react';

--- a/new-site/src/docs/components/side-navigation/index.mdx
+++ b/new-site/src/docs/components/side-navigation/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/side-navigation'
 title: 'SideNavigation'
-nav_title: 'SideNavigation'
+navTitle: 'SideNavigation'
 ---
 
 import { SideNavigation, IconHome, IconMap, IconCogwheel } from 'hds-react';

--- a/new-site/src/docs/components/status-label/index.mdx
+++ b/new-site/src/docs/components/status-label/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/status-label'
 title: 'StatusLabel'
-nav_title: 'StatusLabel'
+navTitle: 'StatusLabel'
 ---
 
 import { StatusLabel, IconInfoCircle, IconCheckCircle, IconAlertCircle, IconError } from 'hds-react';

--- a/new-site/src/docs/components/stepper/index.mdx
+++ b/new-site/src/docs/components/stepper/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/stepper'
 title: 'Stepper'
-nav_title: 'Stepper'
+navTitle: 'Stepper'
 ---
 
 import { useReducer } from 'react';

--- a/new-site/src/docs/components/table/index.mdx
+++ b/new-site/src/docs/components/table/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/table'
 title: 'Table'
-nav_title: 'Table'
+navTitle: 'Table'
 ---
 
 import { useState } from 'react';

--- a/new-site/src/docs/components/tabs/index.mdx
+++ b/new-site/src/docs/components/tabs/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/tabs'
 title: 'Tabs'
-nav_title: 'Tabs'
+navTitle: 'Tabs'
 ---
 
 import { Tabs } from 'hds-react';

--- a/new-site/src/docs/components/tag/index.mdx
+++ b/new-site/src/docs/components/tag/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/tag'
 title: 'Tag'
-nav_title: 'Tag'
+navTitle: 'Tag'
 ---
 
 import { Tag } from 'hds-react';

--- a/new-site/src/docs/components/text-area/index.mdx
+++ b/new-site/src/docs/components/text-area/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/text-area'
 title: 'TextArea'
-nav_title: 'TextArea'
+navTitle: 'TextArea'
 ---
 
 import { TextArea } from 'hds-react';

--- a/new-site/src/docs/components/text-input/index.mdx
+++ b/new-site/src/docs/components/text-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/text-input'
 title: 'TextInput'
-nav_title: 'TextInput'
+navTitle: 'TextInput'
 ---
 
 import { TextInput } from 'hds-react';

--- a/new-site/src/docs/components/time-input/index.mdx
+++ b/new-site/src/docs/components/time-input/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/time-input'
 title: 'TimeInput'
-nav_title: 'TimeInput'
+navTitle: 'TimeInput'
 ---
 
 import { TimeInput, Select } from 'hds-react';

--- a/new-site/src/docs/components/toggle-button/index.mdx
+++ b/new-site/src/docs/components/toggle-button/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/toggle-button'
 title: 'ToggleButton'
-nav_title: 'ToggleButton'
+navTitle: 'ToggleButton'
 ---
 
 import { ToggleButton } from 'hds-react';

--- a/new-site/src/docs/components/tooltip/index.mdx
+++ b/new-site/src/docs/components/tooltip/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/components/tooltip'
 title: 'Tooltip'
-nav_title: 'Tooltip'
+navTitle: 'Tooltip'
 ---
 
 import { Tooltip } from 'hds-react';

--- a/new-site/src/docs/foundation/design-tokens/breakpoints/index.mdx
+++ b/new-site/src/docs/foundation/design-tokens/breakpoints/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/foundation/design-tokens/breakpoints'
 title: 'Breakpoint tokens - Usage'
-nav_title: 'Breakpoints'
+navTitle: 'Breakpoints'
 ---
 
 import TabsLayout from './tabs.mdx';

--- a/new-site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/new-site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/foundation/design-tokens/colour'
 title: 'Colour tokens - Usage'
-nav_title: 'Colour'
+navTitle: 'Colour'
 ---
 
 import ColorExample from '../../../../components/examples/ColorExample';

--- a/new-site/src/docs/foundation/design-tokens/spacing/index.mdx
+++ b/new-site/src/docs/foundation/design-tokens/spacing/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/foundation/design-tokens/spacing'
 title: 'Spacing tokens - Usage'
-nav_title: 'Spacing'
+navTitle: 'Spacing'
 ---
 
 import TabsLayout from './tabs.mdx';

--- a/new-site/src/docs/foundation/design-tokens/typography/index.mdx
+++ b/new-site/src/docs/foundation/design-tokens/typography/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/foundation/design-tokens/typography'
 title: 'Typography tokens - Usage'
-nav_title: 'Typography'
+navTitle: 'Typography'
 ---
 
 import TabsLayout from './tabs.mdx';

--- a/new-site/src/docs/foundation/guidelines/checkbox-radiobutton-toggle.mdx
+++ b/new-site/src/docs/foundation/guidelines/checkbox-radiobutton-toggle.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/guidelines/checkbox-radiobutton-toggle"
 title: "Checkboxes, radio buttons, or toggles?"
-nav_title: 'Checkboxes, radio buttons, or toggles?'
+navTitle: 'Checkboxes, radio buttons, or toggles?'
 ---
 
 import { Notification, Checkbox, RadioButton, ToggleButton, SelectionGroup, Link } from "hds-react";

--- a/new-site/src/docs/foundation/guidelines/data-formats.mdx
+++ b/new-site/src/docs/foundation/guidelines/data-formats.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/guidelines/data-formats"
 title: "Data formats"
-nav_title: "Data formats"
+navTitle: "Data formats"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/foundation/guidelines/grid.mdx
+++ b/new-site/src/docs/foundation/guidelines/grid.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/guidelines/grid"
 title: "Grid"
-nav_title: "Grid"
+navTitle: "Grid"
 ---
 
 import { Notification } from "hds-react";

--- a/new-site/src/docs/foundation/guidelines/inclusivity.mdx
+++ b/new-site/src/docs/foundation/guidelines/inclusivity.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/guidelines/inclusivity"
 title: "Inclusivity"
-nav_title: "Inclusivity"
+navTitle: "Inclusivity"
 ---
 
 import { StatusLabel, Link } from "hds-react";

--- a/new-site/src/docs/foundation/guidelines/localisation.mdx
+++ b/new-site/src/docs/foundation/guidelines/localisation.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/guidelines/localisation"
 title: "Localisation"
-nav_title: "Localisation"
+navTitle: "Localisation"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/foundation/guidelines/photography.mdx
+++ b/new-site/src/docs/foundation/guidelines/photography.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/guidelines/photography"
 title: "Photography"
-nav_title: "Photography"
+navTitle: "Photography"
 ---
 
 import { Link } from "hds-react";

--- a/new-site/src/docs/foundation/visual-assets/favicon.mdx
+++ b/new-site/src/docs/foundation/visual-assets/favicon.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/visual-assets/favicon"
 title: "Favicon"
-nav_title: "Favicon"
+navTitle: "Favicon"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/foundation/visual-assets/icons/index.mdx
+++ b/new-site/src/docs/foundation/visual-assets/icons/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/visual-assets/icons"
 title: "Icons"
-nav_title: "Icons"
+navTitle: "Icons"
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/foundation/visual-assets/icons/tabs.mdx
+++ b/new-site/src/docs/foundation/visual-assets/icons/tabs.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/visual-assets/icons/tabs"
 title: "Icons"
-nav_title: "Icons"
+navTitle: "Icons"
 ---
 
 import LeadParagraph from '../../../../components/LeadParagraph';

--- a/new-site/src/docs/foundation/visual-assets/logo.mdx
+++ b/new-site/src/docs/foundation/visual-assets/logo.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/visual-assets/logo"
 title: "Logo"
-nav_title: "Logo"
+navTitle: "Logo"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/foundation/visual-assets/placeholders.mdx
+++ b/new-site/src/docs/foundation/visual-assets/placeholders.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/visual-assets/placeholders"
 title: "Placeholders"
-nav_title: "Placeholders"
+navTitle: "Placeholders"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/foundation/visual-assets/wave-motifs.mdx
+++ b/new-site/src/docs/foundation/visual-assets/wave-motifs.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/foundation/visual-assets/wave-motifs"
 title: "Wave motifs"
-nav_title: "Wave motifs"
+navTitle: "Wave motifs"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/getting-started/contributing/before-contributing.mdx
+++ b/new-site/src/docs/getting-started/contributing/before-contributing.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/getting-started/contributing/before-contributing'
 title: 'Before contributing'
-nav_title: 'Before contributing'
+navTitle: 'Before contributing'
 ---
 
 import { Link, Notification } from 'hds-react';

--- a/new-site/src/docs/getting-started/contributing/design.mdx
+++ b/new-site/src/docs/getting-started/contributing/design.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/getting-started/contributing/design'
 title: 'Design'
-nav_title: 'Design'
+navTitle: 'Design'
 ---
 
 import { Link, Notification } from 'hds-react';

--- a/new-site/src/docs/getting-started/contributing/documentation.mdx
+++ b/new-site/src/docs/getting-started/contributing/documentation.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/getting-started/contributing/documentation'
 title: 'Documentation'
-nav_title: 'Documentation'
+navTitle: 'Documentation'
 
 ---
 

--- a/new-site/src/docs/getting-started/contributing/icons.mdx
+++ b/new-site/src/docs/getting-started/contributing/icons.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/getting-started/contributing/icons'
 title: 'Icons'
-nav_title: 'Icons'
+navTitle: 'Icons'
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/getting-started/contributing/implementation.mdx
+++ b/new-site/src/docs/getting-started/contributing/implementation.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/getting-started/contributing/implementation'
 title: 'Implementation'
-nav_title: 'Implementation'
+navTitle: 'Implementation'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/getting-started/hds-2.0/migrating-to-2.0.mdx
+++ b/new-site/src/docs/getting-started/hds-2.0/migrating-to-2.0.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/getting-started/hds-2.0/migrating-to-2.0"
 title: "Migrating to HDS 2.0"
-nav_title: "Migrating to HDS 2.0"
+navTitle: "Migrating to HDS 2.0"
 ---
 
 import { Notification } from "hds-react";

--- a/new-site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
+++ b/new-site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/getting-started/hds-2.0/what-is-hds-2.0"
 title: "What is HDS 2.0"
-nav_title: "What is HDS 2.0"
+navTitle: "What is HDS 2.0"
 ---
 
 import LeadParagraph from '../../../components/LeadParagraph';

--- a/new-site/src/docs/getting-started/tutorials/abstract-tutorial.mdx
+++ b/new-site/src/docs/getting-started/tutorials/abstract-tutorial.mdx
@@ -1,7 +1,7 @@
 ---
 slug: "/getting-started/tutorials/abstract-tutorial"
 title: "Abstract basics"
-nav_title: 'Abstract basics'
+navTitle: 'Abstract basics'
 ---
 
 import { Link } from "hds-react";

--- a/new-site/src/docs/index.mdx
+++ b/new-site/src/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/'
 title: 'Home page'
-custom_layout: 'front-page'
+customLayout: true
 ---
 
 import { Button, Container } from 'hds-react';

--- a/new-site/src/docs/index.mdx
+++ b/new-site/src/docs/index.mdx
@@ -1,10 +1,11 @@
 ---
 slug: '/'
 title: 'Home page'
+custom_layout: 'front-page'
 ---
 
-import { Button } from 'hds-react';
-import { navigate, withPrefix } from 'gatsby';
+import { Button, Container } from 'hds-react';
+import { navigate } from 'gatsby';
 import Hero from '../components/Hero';
 import Image from '../components/Image';
 import FrontPageLinksList from '../components/FrontPageLinkList';
@@ -27,6 +28,7 @@ import FrontPageLinksList from '../components/FrontPageLinkList';
   </Button>
 </Hero>
 
-<FrontPageLinksList />
-
-<Image size="M" src="/images/getting-started/structure-graph.svg" alt="Helsinki Design System structure graph" style="display:block;width:100%;min-width:600px;max-width:915px;margin:0 auto;" />
+<Container style={{ margin: '0 auto'}}>
+  <FrontPageLinksList />
+  <Image size="M" src="/images/getting-started/structure-graph.svg" alt="Helsinki Design System structure graph" style="display:block;width:100%;min-width:600px;max-width:915px;margin:0 auto;" />
+</Container>

--- a/new-site/src/docs/patterns/forms/form-building.mdx
+++ b/new-site/src/docs/patterns/forms/form-building.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/patterns/forms/form-building'
 title: 'Building forms'
-nav_title: 'Building forms'
+navTitle: 'Building forms'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/patterns/forms/form-multi-page.mdx
+++ b/new-site/src/docs/patterns/forms/form-multi-page.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/patterns/forms/form-multi-page'
 title: 'Multi-page forms'
-nav_title: 'Multi-page forms'
+navTitle: 'Multi-page forms'
 ---
 
 import { Link } from 'hds-react';

--- a/new-site/src/docs/patterns/forms/form-validation.mdx
+++ b/new-site/src/docs/patterns/forms/form-validation.mdx
@@ -1,7 +1,7 @@
 ---
 slug: '/patterns/forms/form-validation'
 title: 'Form validation'
-nav_title: 'Form validation'
+navTitle: 'Form validation'
 ---
 
 import { Link, StatusLabel } from 'hds-react';


### PR DESCRIPTION
## Description
- Add ability use custom layout instead of predefined page-content
- Fix frontpage layout hacks with 100vw. Remove use of 100vw.
- Unify naming convention: nav_title -> navTitle

## Motivation and Context
- It is easier to maintain custom front-page when it completely uses its own custom layout

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/docsite-frontpage/)