### PR TITLE
Fix/manifest icon path

### DIFF
--- a/new-site/gatsby-config.js
+++ b/new-site/gatsby-config.js
@@ -193,12 +193,12 @@ module.exports = {
         display: `minimal-ui`,
         icons: [
           {
-            src: "static/favicon/transparent_light_favicon_package/android-chrome-192x192.png",
+            src: `${process.env.PATH_PREFIX ? process.env.PATH_PREFIX : ''}/favicon/transparent_light_favicon_package/android-chrome-192x192.png`,
             sizes: "192x192",
             type: "image/png"
           },
           {
-            src: "static/favicon/transparent_light_favicon_package/android-chrome-256x256.png",
+            src: `${process.env.PATH_PREFIX ? process.env.PATH_PREFIX : ''}/favicon/transparent_light_favicon_package/android-chrome-256x256.png`,
             sizes: "256x256",
             type: "image/png"
           }

--- a/new-site/gatsby-config.js
+++ b/new-site/gatsby-config.js
@@ -193,12 +193,12 @@ module.exports = {
         display: `minimal-ui`,
         icons: [
           {
-            src: `${process.env.PATH_PREFIX ? process.env.PATH_PREFIX : ''}/favicon/transparent_light_favicon_package/android-chrome-192x192.png`,
+            src: `/favicon/transparent_light_favicon_package/android-chrome-192x192.png`,
             sizes: "192x192",
             type: "image/png"
           },
           {
-            src: `${process.env.PATH_PREFIX ? process.env.PATH_PREFIX : ''}/favicon/transparent_light_favicon_package/android-chrome-256x256.png`,
+            src: `/favicon/transparent_light_favicon_package/android-chrome-256x256.png`,
             sizes: "256x256",
             type: "image/png"
           }


### PR DESCRIPTION
## Description

Fix manifest icon path

## Motivation and Context

Android-chrome icons were not found due to wrong path.

## How Has This Been Tested?

- Locally on dev machine.

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-manifest-icon-path-fix/)

