### PR TITLE
[Content] Accordion closeButton documentation

### DIFF
--- a/new-site/src/docs/components/accordion/code.mdx
+++ b/new-site/src/docs/components/accordion/code.mdx
@@ -42,6 +42,20 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 </Playground>
 
 
+#### With the close button hidden
+
+<Playground>
+
+
+```jsx
+<Accordion card border heading="How to publish data?" style={{ maxWidth: '360px' }}>
+  To publish your data, open your profile settings and click the button 'Publish'.
+</Accordion>
+```
+
+</Playground>
+
+
 #### Custom accordion
 
 <Playground>
@@ -107,10 +121,11 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 Note! You can find the full list of properties in the <Link size="M" href="/storybook/react/?path=/docs/components-accordion--default" external>React Storybook.</Link>
 
-| Property        | Description                                                                | Values      | Default value |
-| --------------- | -------------------------------------------------------------------------- | ----------- | ------------- |
-| `heading`       | Heading of the accordion                                                   | -           | -             |
-| `headingLevel`  | Sets the aria-level of the accordion header.                               | 1-6         | 2             |
-| `border`        | If set to true, a border will be drawn around the accordion card.          | true, false | false         |
-| `card`          | If set to true, the accordion will use HDS Card as its background element. | true, false | false         |
-| `initiallyOpen` | If set to true, the accordion will be initially opened.                    | true, false | false         |
+| Property        | Description                                                                    | Values    | Default value |
+| --------------- | ------------------------------------------------------------------------------ | --------- | ------------- |
+| `heading`       | Heading of the accordion                                                       | -         | -             |
+| `headingLevel`  | Sets the aria-level of the accordion header.                                   | 1-6       | 2             |
+| `border`        | If set to true, a border will be drawn around the accordion card.              | `boolean` | false         |
+| `card`          | If set to true, the accordion will use HDS Card as its background element.     | `boolean` | false         |
+| `closeButton`   | If set to true, a close button is shown at the bottom of an expanded accordion | `boolean` | true          |
+| `initiallyOpen` | If set to true, the accordion will be initially opened.                        | `boolean` | false         |

--- a/new-site/src/docs/components/accordion/index.mdx
+++ b/new-site/src/docs/components/accordion/index.mdx
@@ -26,6 +26,8 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 - **Accordions must be given a header that describes the accordion content.** This header also acts as the label for the expand button. The header level can be chosen depending on the structure of the page.
 - **Do not put essential or must-read information inside accordions.** If the user is expected to open all of the accordions while using the service, then it is likely that the information should not be inside accordions.
   - Accordions work well when the user usually needs only part of the information. You may also consider placing parts of lower importance inside accordions while the most important parts are always visible.
+- By default, accordions include a close button that is visible at the bottom of an expanded accordion. This is meant to allow the user to close the accordion quickly if needed.
+  - The close button can be hidden with the `closeButton` property. While it is recommended to include the button, it can be left out in accordions with very little content.
 - Do not use accordions to create step-by-step forms. You must not expect that the user opens all accordions in a specific order.
 - It is recommended to have accordions closed when the page is loaded.
   - If you need to have the accordion initially open, you can use the `initiallyOpen` property to achieve this.
@@ -57,6 +59,16 @@ If you have multiple accordions one below another or many accordions in the same
   <Accordion card border heading="How to publish data?" style={{ maxWidth: '360px' }}>
     To publish your data, open your profile settings and click the button 'Publish'.
   </Accordion>
+</PlaygroundPreview>
+
+#### With the close button hidden
+
+In accordions that have very little content the close button does not offer much utility to the user. In these cases the button can be hidden with the `closeButton` property.
+
+<PlaygroundPreview>
+  <Accordion heading="How to publish data?" style={{ maxWidth: '360px' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>  
 </PlaygroundPreview>
 
 #### Custom accordion

--- a/new-site/src/docs/components/accordion/index.mdx
+++ b/new-site/src/docs/components/accordion/index.mdx
@@ -4,7 +4,7 @@ title: 'Accordion'
 navTitle: 'Accordion'
 ---
 
-import { Accordion } from 'hds-react';
+import { Accordion, useAccordion, Button, Card, Select, IconAngleDown, IconAngleUp } from 'hds-react';
 import PlaygroundPreview from '../../../components/Playground';
 import TabsLayout from './tabs.mdx';
 
@@ -74,3 +74,49 @@ In accordions that have very little content the close button does not offer much
 #### Custom accordion
 
 If the basic accordion components do not fit your needs, you can build a custom accordion by using HDS provided accordion elements.
+
+export const AccordionExample = () => {
+  const initiallyOpen = false;
+  const { isOpen, buttonProps, contentProps } = useAccordion({ initiallyOpen });
+  const icon = isOpen ? <IconAngleUp aria-hidden /> : <IconAngleDown aria-hidden />;
+  return (
+    <>
+      <Button iconLeft={icon} {...buttonProps}>
+        Advanced filters
+      </Button>
+      <Card border aria-label="Advanced filters" style={{ marginTop: 'var(--spacing-m)' }} {...contentProps}>
+        <Select
+          multiselect
+          label="Filter by event category"
+          placeholder="No selected categories"
+          options={[{ label: 'Culture & arts' }, { label: 'Sports' }, { label: 'Museums' }, { label: 'Music' }]}
+          clearButtonAriaLabel="Clear all selections"
+          selectedItemRemoveButtonAriaLabel="Remove"
+          style={{ maxWidth: '360px' }}
+        />
+        <Select
+          multiselect
+          label="Filter by event location"
+          placeholder="No selected locations"
+          options={[
+            { label: 'Haaga' },
+            { label: 'Herttoniemi' },
+            { label: 'Kallio' },
+            { label: 'Kamppi' },
+            { label: 'Laajasalo' },
+            { label: 'Lauttasaari' },
+            { label: 'Mellunkylä' },
+            { label: 'Pasila' },
+          ]}
+          clearButtonAriaLabel="Clear all selections"
+          selectedItemRemoveButtonAriaLabel="Remove"
+          style={{ maxWidth: '360px', marginTop: 'var(--spacing-s)' }}
+        />
+      </Card>
+    </>
+  );
+};
+
+<PlaygroundPreview>
+  <AccordionExample />
+</PlaygroundPreview>


### PR DESCRIPTION
Note! This branch is missing the new accordion and it should be rebased with master after the [accordion update](https://github.com/City-of-Helsinki/helsinki-design-system/pull/716) has been merged.

## Description
Adds documentation for the new accordion feature, closeButton. Also adds a missing "Usage" page example of a custom accordion.

## How Has This Been Tested?
Tested by running the documentation locally.
