### PR TITLE
Fix/docsite content

### DIFF
--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -152,6 +152,7 @@ body {
 
 .page-content {
   --side-content-min-width: 230px;
+
   box-sizing: border-box;
   flex: 1;
   margin: 0 auto;

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -196,12 +196,12 @@ body {
   .main-content {
     flex: 1;
     padding: 0 0 var(--spacing-m);
-    max-width: calc(100% - var(--side-content-min-width));
   }
 
   .side-content + .main-content {
     border-left: 1px solid var(--page-border-color);
     padding: 0 var(--spacing-m) var(--spacing-m);
+    max-width: calc(100% - var(--side-content-min-width));
   }
 }
 

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -177,6 +177,7 @@ body {
 }
 
 .main-content {
+  box-sizing: border-box;
   overflow: visible;
   width: 100%;
 }

--- a/new-site/src/components/layout.scss
+++ b/new-site/src/components/layout.scss
@@ -151,6 +151,7 @@ body {
 }
 
 .page-content {
+  --side-content-min-width: 230px;
   box-sizing: border-box;
   flex: 1;
   margin: 0 auto;
@@ -171,7 +172,7 @@ body {
 
 .side-content {
   margin-bottom: auto;
-  min-width: 230px;
+  min-width: var(--side-content-min-width);
 }
 
 .main-content {
@@ -193,6 +194,7 @@ body {
   .main-content {
     flex: 1;
     padding: 0 0 var(--spacing-m);
+    max-width: calc(100% - var(--side-content-min-width));
   }
 
   .side-content + .main-content {

--- a/new-site/src/docs/index.mdx
+++ b/new-site/src/docs/index.mdx
@@ -28,7 +28,7 @@ import FrontPageLinksList from '../components/FrontPageLinkList';
   </Button>
 </Hero>
 
-<Container style={{ margin: '0 auto'}}>
+<Container style={{ margin: '0 auto var(--spacing-layout-l)'}}>
   <FrontPageLinksList />
   <Image size="M" src="/images/getting-started/structure-graph.svg" alt="Helsinki Design System structure graph" style="display:block;width:100%;min-width:600px;max-width:915px;margin:0 auto;" />
 </Container>


### PR DESCRIPTION
## Description
- Set max-width for main-content in large views
- Add bottom margin for front-page content

## Motivation and Context
- After fixing the overflow cut issue by setting "overflow:visible" for the main content, the Playground component uses all the horizontal space even beyond the container boundaries.
Now, there is a calculated max-width for main content which prevents uncontrolled horizontal content stretching.

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/docsite-content-fix/components/accordion/code)