### PR TITLE
[Content] 2.0 design guide improvements

### DIFF
--- a/site/src/docs/getting-started/hds-2.0/fi/mika-on-hds-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/fi/mika-on-hds-2.0.mdx
@@ -38,7 +38,7 @@ HDS Breakpoint -ohjeistukset ovat muuttuneet. Breakpoint-arvot ovat pysyneet enn
 
 ### Muita pienempiä muutoksia
 - Supplementary-painikkeen välistysmuutokset
-- Linkki-komponentin oletuskoko muutettu koosta S kokoon Merkittävin
+- Linkki-komponentin oletuskoko muutettu koosta S kokoon M
 - Harmaasävyn väriarvoja on hieman muutettu
 - Teemamuuttujat, jotka on aikaisemmin merkitty vanhentuneiksi on poistettu
 
@@ -50,6 +50,15 @@ HDS-tiimi jatkaa V1-versioiden tukemista ainakin vuoden 2022 loppuun saakka. Uus
 ### HDS V1 dokumentaatio
 
 <p>Etsitkö HDS V1 dokumentaatiota? Löydät sen täältä: <Link size="M" href="https://hds.hel.fi/v1" openInNewTab>HDS V1 dokumentaatio</Link>.</p>
+
+### Miten HDS V1 -kirjastoa käytetään Abstractissa?
+HDS versiota 1 on mahdollista käyttää, jos projektisi ei aio siirtyä käyttämään HDS 2.0 -versiota vielä hetkeen. Olemme julkaisseet <Link href="https://share.goabstract.com/e0a49189-f9f7-470f-956b-c7217b576fb0" external>erillisen Abstract-projektin</Link>, joka sisältää HDS:n kirjastotiedostot viimeisimmästä version 1 päivityksestä (1.15). Voit linkittää projektiisi nämä kirjastot, jos haluat vielä jatkaa version 1 käyttöä.
+
+Abstract ei valitettavasti tarjoa helppoa keinoa kahden eri kirjastoversion välillä vaihtamiseen. Testiemme mukaan suositeltu tapa vaihtaa kirjastojen välillä on:
+1. Linkitä HDS v1 -kirjastot projektiisi.
+2. Poista HDS v2 linkitykset projektistasi.
+
+Komponenttien linkit katkeavat V2-kirjastoon, mutta komponentit eivät irtoa (detach) master-komponentista. Tämän ansiosta kaikki yliajot (override) pysyvät ennallaan. Tämän jälkeen voit joko korvata symbolien linkit V1-symboleilla tai jättää ne ennalleen.
 
 ## Miten HDS-versiot tulevat toimimaan jatkossa?
 HDS-projektin versiointi tulee pysymään ennallaan 2.0-päivityksen jälkeen. Seuraamme <Link size="M" href="https://semver.org/" external>semanttista versiointia (englanniksi)</Link> ja rikkovia muutoksia julkaistaan vain suurissa päivityksissä. Aiomme kuitenkin tehdä suuria julkaisuja enemmän tulevaisuudessa. Seuraava suuri julkaisu, HDS 3.0, on arvioitu julkaistavan syksyllä 2022.

--- a/site/src/docs/getting-started/hds-2.0/fi/mika-on-hds-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/fi/mika-on-hds-2.0.mdx
@@ -54,11 +54,13 @@ HDS-tiimi jatkaa V1-versioiden tukemista ainakin vuoden 2022 loppuun saakka. Uus
 ### Miten HDS V1 -kirjastoa käytetään Abstractissa?
 HDS versiota 1 on mahdollista käyttää, jos projektisi ei aio siirtyä käyttämään HDS 2.0 -versiota vielä hetkeen. Olemme julkaisseet <Link href="https://share.goabstract.com/e0a49189-f9f7-470f-956b-c7217b576fb0" external>erillisen Abstract-projektin</Link>, joka sisältää HDS:n kirjastotiedostot viimeisimmästä version 1 päivityksestä (1.15). Voit linkittää projektiisi nämä kirjastot, jos haluat vielä jatkaa version 1 käyttöä.
 
-Abstract ei valitettavasti tarjoa helppoa keinoa kahden eri kirjastoversion välillä vaihtamiseen. Testiemme mukaan suositeltu tapa vaihtaa kirjastojen välillä on:
-1. Linkitä HDS v1 -kirjastot projektiisi.
-2. Poista HDS v2 linkitykset projektistasi.
-
-Komponenttien linkit katkeavat V2-kirjastoon, mutta komponentit eivät irtoa (detach) master-komponentista. Tämän ansiosta kaikki yliajot (override) pysyvät ennallaan. Tämän jälkeen voit joko korvata symbolien linkit V1-symboleilla tai jättää ne ennalleen.
+Abstract ei valitettavasti tarjoa helppoa keinoa kahden eri kirjastoversion välillä vaihtamiseen. Vaihtamista voi kuitenkin sujuvoittaa käyttämällä <Link href="https://ashung.github.io/Automate-Sketch/" external>Automate Sketch-lisäosaa</Link>.
+1. Asenna <Link href="https://ashung.github.io/Automate-Sketch/" external>Automate-lisäosa</Link> Sketchiin.
+2. Poista projektisi linkitykset HDS-kirjastoihin Abstractissa.
+3. Linkitä <Link href="https://share.goabstract.com/e0a49189-f9f7-470f-956b-c7217b576fb0" external>HDS v1 -kirjastot</Link> projektiisi Abstractissa. Katso <Link href="getting-started/tutorials/abstract-tutorial#how-to-link-hds-libraries-to-a-project">Abstract oppaamme</Link>, jos tarvitset lisätietoja kirjastojen linkittämisestä.
+4. Avaa Abstractissa Sketch-dokumentti, joka käyttää HDS-kirjastojen komponentteja.
+5. Avaa Sketchissä "Plugins" -valikko ja valitse "Automate" → "Library" → "Replace library". Tämä korvaa symboli- ja tyyliviitteet HDS v1 kirjaston vastineilla. Muista tehdä commit muutoksista!
+6. Toista vaiheet 4 ja 5 jokaiselle Sketch-dokumentille projektissasi.
 
 Vaihtoehtoinen tapa on <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">ladata halutun HDS-version design kit -paketti julkaisulistasta</Link>. Tämä tapa ei ole suositeltu, mikäli projektia käytetään Abstractin kautta.
 

--- a/site/src/docs/getting-started/hds-2.0/fi/mika-on-hds-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/fi/mika-on-hds-2.0.mdx
@@ -60,5 +60,7 @@ Abstract ei valitettavasti tarjoa helppoa keinoa kahden eri kirjastoversion väl
 
 Komponenttien linkit katkeavat V2-kirjastoon, mutta komponentit eivät irtoa (detach) master-komponentista. Tämän ansiosta kaikki yliajot (override) pysyvät ennallaan. Tämän jälkeen voit joko korvata symbolien linkit V1-symboleilla tai jättää ne ennalleen.
 
+Vaihtoehtoinen tapa on <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">ladata halutun HDS-version design kit -paketti julkaisulistasta</Link>. Tämä tapa ei ole suositeltu, mikäli projektia käytetään Abstractin kautta.
+
 ## Miten HDS-versiot tulevat toimimaan jatkossa?
 HDS-projektin versiointi tulee pysymään ennallaan 2.0-päivityksen jälkeen. Seuraamme <Link size="M" href="https://semver.org/" external>semanttista versiointia (englanniksi)</Link> ja rikkovia muutoksia julkaistaan vain suurissa päivityksissä. Aiomme kuitenkin tehdä suuria julkaisuja enemmän tulevaisuudessa. Seuraava suuri julkaisu, HDS 3.0, on arvioitu julkaistavan syksyllä 2022.

--- a/site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
@@ -52,5 +52,14 @@ HDS breakpoint guidelines have been changed. While the breakpoint token values h
 
 <p>Looking for HDS V1 documentation? Find it here: <Link size="M" href="https://hds.hel.fi/v1" openInNewTab>HDS V1 documentation</Link>.</p>
 
+### How to keep using the HDS V1 in Abstract?
+It is possible to keep using HDS version 1 if your project is not planning to update to 2.0 soon. We have released <Link href="https://share.goabstract.com/e0a49189-f9f7-470f-956b-c7217b576fb0" external>a separate Abstract project</Link> which contains library files of the latest version 1 release 1.15. You can link these libraries to your project and keep using components from them if you wish to keep using version 1. 
+
+Unfortunately, Abstract does not offer any easy way of swapping between the version 1 and the version 2 libraries. In our testing, the most recommended way of doing this is:
+1. Link HDS v1 libraries to your project.
+2. Unlink HDS v2 libraries from your project.
+
+Components' links to the original v2 library will break during this project but components will not detach which means all of your overrides will stay intact. After this, you can either replace your symbol links or leave them as they are.
+
 ## How HDS will be versioned in the future?
 The HDS versioning will stay the same after the 2.0 update. We will follow <Link size="M" href="https://semver.org/" external>semantic versioning</Link> and breaking changes can only be introduced in major releases. However, we are planning to release major releases more often in the future. The next major release, HDS 3.0, is currently planned to be released in autumn 2022.

--- a/site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
@@ -61,5 +61,7 @@ Unfortunately, Abstract does not offer any easy way of swapping between the vers
 
 Components' links to the original v2 library will break during this project but components will not detach which means all of your overrides will stay intact. After this, you can either replace your symbol links or leave them as they are.
 
+An alternative method is to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">download a specific HDS version design kit from the release list</Link>. This is not recommended if you project is used via Abstract.
+
 ## How HDS will be versioned in the future?
 The HDS versioning will stay the same after the 2.0 update. We will follow <Link size="M" href="https://semver.org/" external>semantic versioning</Link> and breaking changes can only be introduced in major releases. However, we are planning to release major releases more often in the future. The next major release, HDS 3.0, is currently planned to be released in autumn 2022.

--- a/site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/what-is-hds-2.0.mdx
@@ -50,18 +50,21 @@ HDS breakpoint guidelines have been changed. While the breakpoint token values h
 
 ### HDS V1 documentation
 
-<p>Looking for HDS V1 documentation? Find it here: <Link size="M" href="https://hds.hel.fi/v1" openInNewTab>HDS V1 documentation</Link>.</p>
+Looking for HDS V1 documentation? Find it here: <Link size="M" href="https://hds.hel.fi/v1" openInNewTab>HDS V1 documentation</Link>.
 
 ### How to keep using the HDS V1 in Abstract?
 It is possible to keep using HDS version 1 if your project is not planning to update to 2.0 soon. We have released <Link href="https://share.goabstract.com/e0a49189-f9f7-470f-956b-c7217b576fb0" external>a separate Abstract project</Link> which contains library files of the latest version 1 release 1.15. You can link these libraries to your project and keep using components from them if you wish to keep using version 1. 
 
-Unfortunately, Abstract does not offer any easy way of swapping between the version 1 and the version 2 libraries. In our testing, the most recommended way of doing this is:
-1. Link HDS v1 libraries to your project.
-2. Unlink HDS v2 libraries from your project.
+Unfortunately, Abstract does not offer any easy way of swapping between the version 1 and the version 2 libraries. However, you can make the process smoother by using an external Sketch plugin, <Link href="https://ashung.github.io/Automate-Sketch/" external>Automate</Link>.
 
-Components' links to the original v2 library will break during this project but components will not detach which means all of your overrides will stay intact. After this, you can either replace your symbol links or leave them as they are.
+1. Install the <Link href="https://ashung.github.io/Automate-Sketch/" external>Automate plugin</Link> to your Sketch.
+2. Remove linked HDS libraries from your project in Abstract.
+3. Link <Link href="https://share.goabstract.com/e0a49189-f9f7-470f-956b-c7217b576fb0" external>HDS v1 libraries</Link> to your project in Abstract. Take a look at our <Link href="getting-started/tutorials/abstract-tutorial#how-to-link-hds-libraries-to-a-project">Abstract tutorial</Link> if you need more info about linking libraries.
+4. In Abstract, open a Sketch document that is using components from HDS libraries.
+5. In Sketch, Open the "Plugins" menu and select "Automate" → "Library" → "Replace library" to replace symbol and style with their HDS v1 library counterparts. Remember to commit these changes!
+6. Repeat steps 4 and 5 for each Sketch document in your project.
 
-An alternative method is to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">download a specific HDS version design kit from the release list</Link>. This is not recommended if you project is used via Abstract.
+An alternative method is to <Link href="https://github.com/City-of-Helsinki/helsinki-design-system/releases">download a specific HDS version design kit from the release list</Link>. This is not recommended if your project is used via Abstract.
 
 ## How HDS will be versioned in the future?
 The HDS versioning will stay the same after the 2.0 update. We will follow <Link size="M" href="https://semver.org/" external>semantic versioning</Link> and breaking changes can only be introduced in major releases. However, we are planning to release major releases more often in the future. The next major release, HDS 3.0, is currently planned to be released in autumn 2022.


### PR DESCRIPTION
## Description
Adds some improvements to the 2.0 design guide. Mostly information about using older HDS libraries in design files if needed.

## How Has This Been Tested?
Tested by running the documentation site locally.
