### PR TITLE
[Fix] Typography heading examples

### DIFF
--- a/site/src/docs/foundation/design-tokens/typography/index.mdx
+++ b/site/src/docs/foundation/design-tokens/typography/index.mdx
@@ -33,15 +33,14 @@ You can use <Link size="M" href="https://github.com/City-of-Helsinki/helsinki-de
 
 | Heading size          | PX value | REM value | Example                                                |                                                                                                           |
 | --------------------- | -------: | --------: | ------------------------------------------------------ |
-| **Heading XXL**       | 64px     | 4rem      | <h1 class="heading-xxl">Heading XXL</h1>               |
-| **Heading XL**        | 48px     | 3rem      | <h1 class="heading-xl">Heading XL</h1>                 |
-| **Heading XL Mobile** | 40px     | 2.5rem    | <h1 class="heading-xl-mobile">Heading XXL Mobile</h1>  |                                                                                 
-| **Heading L**         | 32px     | 2rem      | <h1 class="heading-l">Heading L</h1>                   |
-| **Heading M**         | 24px     | 1.5rem    | <h1 class="heading-m">Heading M</h1>                   |
-| **Heading S**         | 20px     | 1.25rem   | <h1 class="heading-s">Heading S</h1>                   |
-| **Heading XS**        | 18px     | 1.125rem  | <h1 class="heading-xs">Heading XS</h1>                 |
-| **Heading XXS**       | 16px     | 1rem      | <h1 class="heading-xxs">Heading XSS</h1>               |                                                                                                                                           |
-
+| **Heading XXL**       | 64px     | 4rem      | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL</div>               |
+| **Heading XL**        | 48px     | 3rem      | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL</div>                 |
+| **Heading XL Mobile** | 40px     | 2.5rem    | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XXL Mobile</div>  |                                                                                 
+| **Heading L**         | 32px     | 2rem      | <div class="heading-l" aria-label="Visualised heading L example">Heading L</div>                   |
+| **Heading M**         | 24px     | 1.5rem    | <div class="heading-m" aria-label="Visualised heading M example">Heading M</div>                   |
+| **Heading S**         | 20px     | 1.25rem   | <div class="heading-s" aria-label="Visualised heading S example">Heading S</div>                   |
+| **Heading XS**        | 18px     | 1.125rem  | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS</div>                 |
+| **Heading XXS**       | 16px     | 1rem      | <div class="heading-xxs" aria-label="Visualised heading XXS example">Heading XSS</div>               |                                                                                                                                           |
 [Table 1:Heading sizes]|
 
 ### Heading scales
@@ -49,12 +48,12 @@ The heading font size tokens allow two different heading scales to be used. The 
 
 | Heading level         | Default scale                                   | Small scale                                                 |
 | --------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
-| Heading 1 (`h1`)      | <h1 class="heading-xxl">Heading XXL (64px)</h1> | <h1 class="heading-xl-mobile">Heading XL-Mobile (40px)</h1> |
-| Heading 2 (`h2`)      | <h2 class="heading-xl">Heading XL (48px)</h2>   | <h2 class="heading-l">Heading L (32px)</h2>                 |
-| Heading 3 (`h3`)      | <h3 class="heading-l">Heading L (32px)</h3>     | <h3 class="heading-m">Heading M (24px)</h3>                 |
-| Heading 4 (`h4`)      | <h4 class="heading-m">Heading M (24px)</h4>     | <h4 class="heading-s">Heading S (20px)</h4>                 |
-| Heading 5 (`h5`)      | <h5 class="heading-s">Heading S (20px)</h5>     | <h5 class="heading-xs">Heading XS (18px)</h5>               |
-| Heading 6 (`h6`)      | <h6 class="heading-xs">Heading XS (18px)</h6>   | <h6 class="heading-xxs">Heading XXS (16px)</h6>             |
+| Heading 1 (`h1`)      | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL (64px)</div> | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XL-Mobile (40px)</div> |
+| Heading 2 (`h2`)      | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL (48px)</div>   | <div class="heading-l" aria-label="Visualised heading L example">Heading L (32px)</div>                 |
+| Heading 3 (`h3`)      | <div class="heading-l" aria-label="Visualised heading L example">Heading L (32px)</div>     | <div class="heading-m" aria-label="Visualised heading M example">Heading M (24px)</div>                 |
+| Heading 4 (`h4`)      | <div class="heading-m" aria-label="Visualised heading M example">Heading M (24px)</div>     | <div class="heading-s" aria-label="Visualised heading S example">Heading S (20px)</div>                 |
+| Heading 5 (`h5`)      | <div class="heading-s" aria-label="Visualised heading S example">Heading S (20px)</div>     | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS (18px)</div>               |
+| Heading 6 (`h6`)      | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS (18px)</div>   | <div class="heading-xxs" aria-label="Visualised heading XXS example">Heading XXS (16px)</div>             |
 [Table 2:Heading scales]|
 
 ### Body text sizes


### PR DESCRIPTION
## Description
Fixed 2.0 documentation site typography heading style examples that were not rendering correctly.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1337

## How Has This Been Tested?
Tested by running the documentation site locally.
