### PR TITLE
[Fix] Incorrect mention about a removed table theme variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Removed
 - [Accordion] Removed deprecated --button-border-color-hover theme variable
-- [Table] Removed deprecated --header-background-color theme variable
+- [Table] Removed deprecated --background-color theme variable
 
 ###  Design kit
 

--- a/site/src/docs/getting-started/hds-2.0/migrating-to-2.0.mdx
+++ b/site/src/docs/getting-started/hds-2.0/migrating-to-2.0.mdx
@@ -40,10 +40,10 @@ First, we have removed two (2) theme properties. These variables are not availab
 | Component                          | Removed theme variable        |
 | ---------------------------------- | ----------------------------- |
 | [Accordion](/components/accordion) | `--button-border-color-hover` |
-| [Table](/components/table)         | `--header-background-color`   |
+| [Table](/components/table)         | `--background-color`          |
 [Table 1:Removed theme variables]|
 
-Secondly, there has been one change to a React component's API. The default value of the Link component's property `size` has been changed from `S` to `M`. If you have used the Link component with the default size, from now on you need to specify that explicitly by using the property `size="S"`.
+Secondly, there has been one change to a React component's API. The default value of the Link component's property `size` has been changed from `S` to `M`. If you have used the Link component with the old default size (small), from now on you need to specify that explicitly by using the property `size="S"`.
 
 ### Updated typography tokens
 HDS typography tokens have been changed to match the new Hel.fi visual identity. The following font size tokens have been changed:


### PR DESCRIPTION
## Description
Fixes incorrect mentions about a removed table theme variable to CHANGELOG and 2.0 migration guide.

## How Has This Been Tested?
Tested by running the documentation site locally.
