### PR TITLE
Fix/external link labels

### DIFF
--- a/site/src/components/ExternalLink.js
+++ b/site/src/components/ExternalLink.js
@@ -2,13 +2,15 @@ import React from 'react';
 import { Link } from 'hds-react';
 import PropTypes from 'prop-types';
 
-const ExternalLink = ({ href, children, openInNewTab, size }) => {
-  const openInNewTabProps = openInNewTab ? { openInNewTab, openInNewTabAriaLabel: 'Opens in a new tab.' } : {};
+const ExternalLink = ({ href, children, openInNewTab, openInNewTabAriaLabel, openInExternalDomainAriaLabel, size }) => {
+  const openInNewTabProps = openInNewTab
+    ? { openInNewTab, openInNewTabAriaLabel: openInNewTabAriaLabel || 'Opens in a new tab.' }
+    : {};
 
   return (
     <Link
       href={href}
-      openInExternalDomainAriaLabel="Opens a different website."
+      openInExternalDomainAriaLabel={openInExternalDomainAriaLabel || 'Opens a different website.'}
       external
       {...openInNewTabProps}
       size={size}
@@ -22,6 +24,8 @@ ExternalLink.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   openInNewTab: PropTypes.bool,
+  openInNewTabAriaLabel: PropTypes.string.isRequired,
+  openInExternalDomainAriaLabel: PropTypes.string.isRequired,
   size: PropTypes.string,
 };
 

--- a/site/src/components/FrontPageLinkList.js
+++ b/site/src/components/FrontPageLinkList.js
@@ -10,6 +10,7 @@ const FrontPageLinkList = () => {
       linkboxAriaLabel: 'Brand guidelines',
       linkAriaLabel: 'Go to the Brand guidelines page',
       href: 'https://brand.hel.fi/',
+      openInExternalDomainAriaLabel: 'Opens a different website.',
       external: true,
       imgProps: {
         src: '/images/homepage/brand-guidelines.svg',

--- a/site/src/components/LinkboxList.js
+++ b/site/src/components/LinkboxList.js
@@ -17,6 +17,7 @@ const LinkboxList = ({ data, className }) => (
             linkboxAriaLabel={item.linkboxAriaLabel}
             linkAriaLabel={item.linkAriaLabel}
             href={item.href}
+            openInExternalDomainAriaLabel={item.openInExternalDomainAriaLabel}
             external={item.external}
             heading={item.name}
             text={item.text}
@@ -41,6 +42,7 @@ LinkboxList.propTypes = {
       linkboxAriaLabel: PropTypes.string.isRequired,
       href: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired,
+      openInExternalDomainAriaLabel: PropTypes.string,
       external: PropTypes.bool,
       imgProps: PropTypes.shape({
         src: PropTypes.string.isRequired,

--- a/site/src/docs/components/linkbox/code.mdx
+++ b/site/src/docs/components/linkbox/code.mdx
@@ -102,6 +102,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
       href="https://hds.hel.fi"
       heading="External link" 
       text="This link points to another page."
+      openInExternalDomainAriaLabel="Opens a different website."
       external
       withBorder
     />
@@ -110,11 +111,12 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
     <Linkbox
       linkboxAriaLabel="Linkbox: Helsinki Design System"
       linkAriaLabel="HDS"
-      external
       href="https://hds.hel.fi"
       heading="External link" 
       openInNewTab
+      openInNewTabAriaLabel="Opens in a new tab."
       text="This link points to another page and opens in a new tab."
+      openInExternalDomainAriaLabel="Opens a different website."
       external
       withBorder
     />

--- a/site/src/docs/components/linkbox/index.mdx
+++ b/site/src/docs/components/linkbox/index.mdx
@@ -129,6 +129,7 @@ Depending on the link type the icon is either an arrow or an external link icon.
       href="https://hds.hel.fi"
       heading="External link"
       text="This link points to another page."
+      openInExternalDomainAriaLabel="Opens a different website."
       external
       withBorder
     />
@@ -137,11 +138,12 @@ Depending on the link type the icon is either an arrow or an external link icon.
     <Linkbox
       linkboxAriaLabel="Linkbox: Helsinki Design System"
       linkAriaLabel="HDS"
-      external
       href="https://hds.hel.fi"
       heading="External link"
       openInNewTab
+      openInNewTabAriaLabel="Opens in a new tab."
       text="This link points to another page and opens in a new tab."
+      openInExternalDomainAriaLabel="Opens a different website."
       external
       withBorder
     />


### PR DESCRIPTION
## Description
- Fix front page brand link external aria label
- Fix Linkbox component examples 

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1336

## Motivation and Context
- Ensure that aria-labels are using only english in the page links and in code examples
 
## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/docs-external-links/)