### PR TITLE
Remove volatile css-module declaration

### DIFF
--- a/packages/react/src/components/navigation/Navigation.module.scss
+++ b/packages/react/src/components/navigation/Navigation.module.scss
@@ -304,7 +304,6 @@
 
 @media x-large-up {
   .title {
-    composes: heading-s from 'hds-core/lib/utils/helpers.css';
     height: calc(100% - var(--spacing-xs) * 2);
 
     > span {


### PR DESCRIPTION
## Description
- Remove heading-s CSS-module class from Navigation Title

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1344

## Motivation and Context
- CSS-modules add both classes when a class is composed of an imported class. 
In this case, both classes were added to the built HTML even though the composition was done inside a SASS media query. 
This can alter the Navigation title's font size per build as the order of class declarations can change. Only local-scoped classes can be composed as one class.
- https://github.com/css-modules/css-modules#composition
- https://github.com/css-modules/css-modules#composing-from-other-files

## How Has This Been Tested?
- locally on dev machine

[Fixed Demo](https://city-of-helsinki.github.io/hds-demo/navigation-title-volatile-font-styles/?path=/story/components-navigation--default)
vs
[HDS production](https://hds.hel.fi/storybook/react/iframe.html?id=components-navigation--default&args=&viewMode=story)

[Broken build where the font size is large all the time](https://city-of-helsinki.github.io/hds-demo/cookie-consent/iframe.html?id=components-navigation--default&args=&viewMode=story)

Fixed demo has only one class, Navigation_title, but the production also has helpers_heading-s -class. 