### PR TITLE
Feature/whole page is viewable when cookie modal is open

### DIFF
--- a/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
+++ b/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
@@ -158,7 +158,7 @@ export const ModalVersion = (args) => {
     return (
       <div>
         <div style={{ height: '100vh' }}>&nbsp;</div>
-        <p style={{ opacity: '0' }}>Bottom page</p>
+        <p>Bottom page</p>
       </div>
     );
   };
@@ -292,7 +292,7 @@ export const FinnishModalVersion = (args) => {
     return (
       <div>
         <div style={{ height: '100vh' }}>&nbsp;</div>
-        <p style={{ opacity: '0' }}>Bottom page</p>
+        <p>Bottom page</p>
       </div>
     );
   };

--- a/packages/react/src/components/cookieConsent/content/Content.tsx
+++ b/packages/react/src/components/cookieConsent/content/Content.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Buttons } from '../buttons/Buttons';
 import { IconAngleDown, IconAngleUp } from '../../../icons';
@@ -15,7 +15,8 @@ import { LanguageSwitcher } from '../languageSwitcher/LanguageSwitcher';
 import classNames from '../../../utils/classNames';
 import { useEscKey } from '../useEscKey';
 
-export function Content(): React.ReactElement {
+type ContentProps = { onContentChange: () => void };
+export function Content({ onContentChange }: ContentProps): React.ReactElement {
   const { isOpen, buttonProps, contentProps, closeAccordion } = useAccordion({
     initiallyOpen: false,
   });
@@ -34,6 +35,16 @@ export function Content(): React.ReactElement {
         styles.hiddenWithoutFocus,
       );
 
+  const [hasFocus, setHasFocus] = useState(false);
+
+  const eventHandlers = useMemo(
+    () => ({
+      onFocus: () => setHasFocus(true),
+      onBlur: () => setHasFocus(false),
+    }),
+    [],
+  );
+
   const setFocusToTitle = useCallback(() => {
     if (titleRef.current) {
       titleRef.current.focus();
@@ -44,6 +55,10 @@ export function Content(): React.ReactElement {
     setFocusToTitle();
   }, [setFocusToTitle]);
 
+  useEffect(() => {
+    onContentChange();
+  }, [hasFocus, isOpen]);
+
   useEscKey(closeAccordion);
 
   return (
@@ -51,6 +66,7 @@ export function Content(): React.ReactElement {
       className={classNames(styles.content, isOpen ? '' : styles.shrinkOnBlur)}
       id="cookie-consent-content"
       tabIndex={-1}
+      {...eventHandlers}
     >
       <div className={styles.mainContent} data-testid="cookie-consent-information">
         <span className={styles.emulatedH1} role="heading" aria-level={1} tabIndex={-1} ref={titleRef}>

--- a/packages/react/src/components/cookieConsent/cookieModal/CookieModal.test.tsx
+++ b/packages/react/src/components/cookieConsent/cookieModal/CookieModal.test.tsx
@@ -165,12 +165,14 @@ describe('<Modal /> ', () => {
       expect(onLanguageChange).toHaveBeenLastCalledWith('sv');
     });
 
-    it('will render html-container only when modal is visible', async () => {
+    it('will render HTML elements into page only when modal is visible', async () => {
       const result = renderCookieConsent(defaultConsentData);
       verifyElementExistsByTestId(result, dataTestIds.htmlContainer);
+      verifyElementExistsByTestId(result, dataTestIds.htmlPlaceholder);
       clickElement(result, dataTestIds.approveButton);
       await waitFor(() => {
         verifyElementDoesNotExistsByTestId(result, dataTestIds.htmlContainer);
+        verifyElementDoesNotExistsByTestId(result, dataTestIds.htmlPlaceholder);
       });
     });
   });

--- a/packages/react/src/components/cookieConsent/cookieModal/__snapshots__/CookieModal.test.tsx.snap
+++ b/packages/react/src/components/cookieConsent/cookieModal/__snapshots__/CookieModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<ModalContent /> spec renders the component 1`] = `
 <body>
   <div
     data-testid="html-cookie-consent-container"
-    id="HdsCookieConsentContainer"
+    id="HdsCookieConsentModalContainer"
   >
     <div
       class="container modal animateIn"
@@ -965,5 +965,11 @@ exports[`<ModalContent /> spec renders the component 1`] = `
       </button>
     </div>
   </div>
+  <div
+    aria-hidden="true"
+    data-testid="html-cookie-consent-placeholder"
+    id="HdsCookieConsentModalPlaceholder"
+    style="height: 0px;"
+  />
 </body>
 `;

--- a/packages/react/src/components/cookieConsent/test.util.ts
+++ b/packages/react/src/components/cookieConsent/test.util.ts
@@ -122,6 +122,7 @@ export async function openAccordion(result: RenderResult, testId: string): Promi
 export const commonTestProps = {
   dataTestIds: {
     htmlContainer: 'html-cookie-consent-container',
+    htmlPlaceholder: 'html-cookie-consent-placeholder',
     container: 'cookie-consent',
     languageSwitcher: 'cookie-consent-language-switcher',
     approveButton: 'cookie-consent-approve-button',


### PR DESCRIPTION
## Description
- Add placeholder for CookieConsent modal in bottom of the page

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1345

## Motivation and Context
- Now the user is able to see the whole page (including foooter) when Cookie Consent modal is visible

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/cookie-consent-placeholder/)