### PR TITLE
Fix Accordion and Stepper component font-sizes

### DIFF
--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -114,10 +114,6 @@ body {
   margin: var(--spacing-l) 0 var(--spacing-3-xs) 0;
 }
 
-.main-content div[role="heading"] {
-  font-size: var(--fontsize-heading-xs);
-}
-
 .front-page-link-list {
   box-sizing: border-box;
   margin: 0 0 var(--spacing-layout-xl);


### PR DESCRIPTION
## Description

Fix Accordion and Stepper component font sizes in the new documentation site.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1347

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-fontsize-fixes/components/accordion)

## Screenshots (if appropriate):

Accordion:

Old:

<img width="963" alt="image" src="https://user-images.githubusercontent.com/2777633/180759129-4d9599f7-1577-43ba-8c2d-957759c9c652.png">

Fixed:

<img width="968" alt="image" src="https://user-images.githubusercontent.com/2777633/180759196-d7d3f2bb-c6e6-4256-8f78-fe52cf91ac6c.png">


Stepper:

Old:

<img width="969" alt="image" src="https://user-images.githubusercontent.com/2777633/180759589-80575e84-7fe6-4b9f-a06b-edbc8e3a9d1b.png">

Fixed:

<img width="981" alt="image" src="https://user-images.githubusercontent.com/2777633/180759712-d54dcc5a-fec1-4ad8-9c65-a55ce3b5e51f.png">

