### PR TITLE
Content/Add Linkbox size variants to documentation site

### DIFF
--- a/site/src/docs/components/linkbox/code.mdx
+++ b/site/src/docs/components/linkbox/code.mdx
@@ -130,7 +130,6 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ### With image
 <Playground>
 
-
 ```jsx
 <div style={{ backgroundColor: 'var(--color-black-5)', padding: 'var(--spacing-s)' }}>
   <div style={{ maxWidth: '384px' }}>
@@ -146,6 +145,48 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 </div>
 ```
 
+</Playground>
+
+### Linkbox size variants
+<Playground>
+
+```jsx
+<div style={{ backgroundColor: 'var(--color-black-5)', padding: 'var(--spacing-s)' }}>
+  <div style={{ maxWidth: '284px' }}>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      heading="Linkbox title"
+      text="Linkbox text"
+      size="small"
+      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 284, height: 181 }}
+    />
+  </div>
+  <div style={{ maxWidth: '384px', marginTop: 'var(--spacing-s)' }}>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      heading="Linkbox title"
+      text="Linkbox text"
+      size="medium"
+      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 384, height: 245 }}
+    />
+  </div>
+  <div style={{ maxWidth: '567px', marginTop: 'var(--spacing-s)' }}>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      heading="Linkbox title"
+      text="Linkbox text"
+      size="large"
+      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 567, height: 363 }}
+    />
+  </div>
+</div>
+```
 
 </Playground>
 

--- a/site/src/docs/components/linkbox/code.mdx
+++ b/site/src/docs/components/linkbox/code.mdx
@@ -4,6 +4,7 @@ title: 'Linkbox - Code'
 ---
 
 import { Linkbox } from 'hds-react';
+import { withPrefix } from "gatsby"
 import ExternalLink from '../../../components/ExternalLink';
 import TabsLayout from './tabs.mdx';
 
@@ -139,7 +140,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      imgProps={{ src: "/images/foundation/visual-assets/placeholders/image-m@3x.png", width: 384, height: 245 }}
+      imgProps={{ src: withPrefix("/images/foundation/visual-assets/placeholders/image-m@3x.png"), width: 384, height: 245 }}
     />
   </div>
 </div>
@@ -160,7 +161,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
       heading="Linkbox title"
       text="Linkbox text"
       size="small"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 284, height: 181 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 284, height: 181 }}
     />
   </div>
   <div style={{ maxWidth: '384px', marginTop: 'var(--spacing-s)' }}>
@@ -171,7 +172,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
       heading="Linkbox title"
       text="Linkbox text"
       size="medium"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 384, height: 245 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 384, height: 245 }}
     />
   </div>
   <div style={{ maxWidth: '567px', marginTop: 'var(--spacing-s)' }}>
@@ -182,7 +183,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
       heading="Linkbox title"
       text="Linkbox text"
       size="large"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 567, height: 363 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 567, height: 363 }}
     />
   </div>
 </div>

--- a/site/src/docs/components/linkbox/index.mdx
+++ b/site/src/docs/components/linkbox/index.mdx
@@ -5,6 +5,7 @@ navTitle: 'Linkbox'
 ---
 
 import { Link, Linkbox } from 'hds-react';
+import { withPrefix } from "gatsby"
 import PlaygroundPreview from '../../../components/Playground';
 import TabsLayout from './tabs.mdx';
 
@@ -162,7 +163,7 @@ HDS offers styling for a Linkbox with an image as its content.
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 384, height: 245 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 384, height: 245 }}
     />
   </div>
 </PlaygroundPreview>
@@ -183,7 +184,7 @@ Size variants differ in (default) heading size and inner spacing. Use the size p
       heading="Linkbox title"
       text="Linkbox text"
       size="small"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 284, height: 181 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 284, height: 181 }}
     />
   </div>
   <div style={{ maxWidth: '384px', marginTop: 'var(--spacing-s)' }}>
@@ -194,7 +195,7 @@ Size variants differ in (default) heading size and inner spacing. Use the size p
       heading="Linkbox title"
       text="Linkbox text"
       size="medium"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 384, height: 245 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 384, height: 245 }}
     />
   </div>
   <div style={{ maxWidth: '567px', marginTop: 'var(--spacing-s)' }}>
@@ -205,7 +206,7 @@ Size variants differ in (default) heading size and inner spacing. Use the size p
       heading="Linkbox title"
       text="Linkbox text"
       size="large"
-      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 567, height: 363 }}
+      imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 567, height: 363 }}
     />
   </div>
 </PlaygroundPreview>

--- a/site/src/docs/components/linkbox/index.mdx
+++ b/site/src/docs/components/linkbox/index.mdx
@@ -166,3 +166,46 @@ HDS offers styling for a Linkbox with an image as its content.
     />
   </div>
 </PlaygroundPreview>
+
+
+#### Linkbox size variants
+
+HDS Linkbox includes three (3) size variants; small, default, and large.
+You can use different sizes depending on the screen size or use case.
+Size variants differ in (default) heading size and inner spacing. Use the size property to alter the size.
+
+<PlaygroundPreview style={{ backgroundColor: 'var(--color-black-5)' }}>
+  <div style={{ maxWidth: '284px' }}>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      heading="Linkbox title"
+      text="Linkbox text"
+      size="small"
+      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 284, height: 181 }}
+    />
+  </div>
+  <div style={{ maxWidth: '384px', marginTop: 'var(--spacing-s)' }}>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      heading="Linkbox title"
+      text="Linkbox text"
+      size="medium"
+      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 384, height: 245 }}
+    />
+  </div>
+  <div style={{ maxWidth: '567px', marginTop: 'var(--spacing-s)' }}>
+    <Linkbox
+      linkboxAriaLabel="Linkbox: Helsinki Design System"
+      linkAriaLabel="HDS"
+      href="https://hds.hel.fi"
+      heading="Linkbox title"
+      text="Linkbox text"
+      size="large"
+      imgProps={{ src: '/images/foundation/visual-assets/placeholders/image-m@3x.png', width: 567, height: 363 }}
+    />
+  </div>
+</PlaygroundPreview>


### PR DESCRIPTION
## Description

Add Linkbox size variants to documentation site

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1347

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-linkbox-size-variants/components/linkbox#linkbox-size-variants)

## Screenshots (if appropriate):

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/2777633/181476979-90e7f0ca-ee99-4b23-9b92-99101237e583.png">

