### PR TITLE
Content/Add Accordion size variants to documentation site

### DIFF
--- a/site/src/docs/components/accordion/code.mdx
+++ b/site/src/docs/components/accordion/code.mdx
@@ -56,6 +56,26 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 </Playground>
 
+#### Accordion size variants
+
+<Playground>
+
+```jsx
+<>
+  <Accordion size="s" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+  <Accordion size="m" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px', marginTop: 'var(--spacing-s)' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+  <Accordion size="l" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px', marginTop: 'var(--spacing-s)' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+</>
+```
+
+</Playground>
+
 
 #### Custom accordion
 

--- a/site/src/docs/components/accordion/index.mdx
+++ b/site/src/docs/components/accordion/index.mdx
@@ -71,6 +71,22 @@ In accordions that have very little content the close button does not offer much
   </Accordion>  
 </PlaygroundPreview>
 
+#### Accordion size variants
+
+HDS Accordion includes three (3) size variants; small, default, and large. You can use different sizes depending on the screen size or use case. Use the `size` property to alter the size.
+
+<PlaygroundPreview>
+  <Accordion size="s" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+  <Accordion size="m" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px', marginTop: 'var(--spacing-s)' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+  <Accordion size="l" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px', marginTop: 'var(--spacing-s)' }}>
+    To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+</PlaygroundPreview>
+
 #### Custom accordion
 
 If the basic accordion components do not fit your needs, you can build a custom accordion by using HDS provided accordion elements.


### PR DESCRIPTION
## Description

Add Accordion size variants to documentation site.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1347

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-accordion-size-variants/components/accordion)

## Screenshots (if appropriate):

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/2777633/181510909-a224d8e0-6d9d-4003-aab1-d07615c2da97.png">
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/2777633/181511029-352b7f7e-69ee-447f-893d-acdbfc0d9607.png">

