### PR TITLE
Fix/Broken link in docsite button accessibility page

### DIFF
--- a/site/src/docs/components/buttons/accessibility.mdx
+++ b/site/src/docs/components/buttons/accessibility.mdx
@@ -11,7 +11,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ## Accessibility
 
 ### Pay attention to
-- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to <Link size="M" href="/design-tokens/colour">colour guidelines</Link> to ensure accessibility.
+- **It is advisable to use colour combinations provided by the implementation.** These combinations are ensured to comply with WCAG AA requirements. When customising colours, refer to <Link size="M" href="/foundation/design-tokens/colour">colour guidelines</Link> to ensure accessibility.
 - In most cases, prefer using normal size buttons over small buttons. Default sized buttons are easier for users to notice and press.
 - Pay attention to the button role. If you use the button as a link instead of an action (i.e. the button press causes a page load), you must specify a `role="link"` attribute to the button.
 - HDS Buttons (even the Small variant) comply with <ExternalLink href="https://www.w3.org/TR/WCAG21/#target-size">WCAG 2.5.5 Target Size (AAA) guideline</ExternalLink>. Customizing button sizes is not recommended.


### PR DESCRIPTION
## Description

Fix broken link in docsite button accessibility page

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1346

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-fix-broken-link/components/buttons/accessibility#pay-attention-to)

## Screenshots (if appropriate):

<img width="978" alt="image" src="https://user-images.githubusercontent.com/2777633/181519646-4e946814-8db9-42a1-a8bb-ac54f3133165.png">

