### PR TITLE
Feature/docsite matomo without consent

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -216,6 +216,7 @@ module.exports = {
         siteUrl: 'https://hds.hel.fi',
         matomoJsScript: 'piwik.min.js',
         matomoPhpScript: 'tracker.php',
+        requireCookieConsent: true,
       }
     }
   ],

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
     title: `Helsinki Design System`,
     description: `Documentation for the Helsinki Design System`,
     siteUrl: process.env.SITE_URL,
-    menuLinks: [  
+    menuLinks: [
       {
         name: 'Getting started',
         link: '/getting-started',
@@ -206,6 +206,16 @@ module.exports = {
       options: {
         sitemap: null,
         policy: [{userAgent: '*', disallow: '/v1'}]
+      }
+    },
+    {
+      resolve: 'gatsby-plugin-matomo',
+      options: {
+        siteId: '831',
+        matomoUrl: 'https://webanalytics.digiaiiris.com/js',
+        siteUrl: 'https://hds.hel.fi',
+        matomoJsScript: 'piwik.min.js',
+        matomoPhpScript: 'tracker.php',
       }
     }
   ],

--- a/site/package.json
+++ b/site/package.json
@@ -17,6 +17,7 @@
     "gatsby": "^4.17.0",
     "gatsby-plugin-image": "^2.17.0",
     "gatsby-plugin-manifest": "^4.17.0",
+    "gatsby-plugin-matomo": "^0.13.0",
     "gatsby-plugin-mdx": "^3.17.0",
     "gatsby-plugin-offline": "^5.17.0",
     "gatsby-plugin-react-helmet": "^5.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15031,6 +15031,11 @@ gatsby-plugin-manifest@^4.17.0:
     semver "^7.3.7"
     sharp "^0.30.3"
 
+gatsby-plugin-matomo@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.13.0.tgz#abf1bd561f3ca35c57b8bbbd5d8e87579ba17886"
+  integrity sha512-zwmxcwOoDi3hjNQoUJehoC5XwQKgR+bArAAvArGJWHlJqv7G688tlmKgbIGqEUj3aFSdyWAzAM7QhEt68buMNw==
+
 gatsby-plugin-mdx@^3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-3.17.0.tgz#6df646cae67662fceb92ff5016c12347786ba10a"


### PR DESCRIPTION
## Description

- Add matomo configurations for the new doc site

Built based on https://github.com/City-of-Helsinki/helsinki-design-system/pull/751

## Related Issues
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1023

## Motivation and Context
Adds an analytics

## How Has This Been Tested?
- Locally on developers machine. Verified entry logs from matomo site (digiaiiris.com)

[Demo](https://city-of-helsinki.github.io/hds-demo/docs-cookie-settings-analytics/)
