### PR TITLE
Show notification after successful or failing Playground code copy

### DIFF
--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -135,15 +135,14 @@ const Editor = ({ onChange, initialCode, code, language }) => {
     [getTextArea],
   );
 
-  const copy = () => {
+  const copy = async () => {
     if (viewPortRef.current && copyButtonRef.current) {
       const textArea = getTextArea(viewPortRef.current);
       textArea.focus();
       textArea.select();
       setCopyState('');
-
       try {
-        document.execCommand('copy');
+        await navigator.clipboard.writeText(textArea.value);
         if (copyButtonRef.current) {
           copyButtonRef.current.focus();
         }

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -244,13 +244,8 @@ const Editor = ({ onChange, initialCode, code, language }) => {
           Reset example
         </Button>
       </div>
-      {language === 'jsx' &&
-        <LiveError />
-      }
-      {language !== 'jsx' &&
-        <LiveErrorCore code={code} />
-      }
-
+      {language === 'jsx' && <LiveError />}
+      {language !== 'jsx' && <LiveErrorCore code={code} />}
     </>
   );
 };

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
 import sanitizeHtml from 'sanitize-html';
-import { Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
+import { Notification, Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
 import theme from 'prism-react-renderer/themes/github';
 
 import './Playground.scss';
@@ -117,6 +117,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
   const viewPortRef = useRef();
   const copyButtonRef = useRef();
   const [resetCount, setResetCount] = useState(0);
+  const [showCopyNotification, setShowCopyNotification] = useState(false);
   const textAreaId = `code-block-textarea-${language}-${resetCount}`;
   const helperTextId = `code-block-helper-${language}-${resetCount}`;
   const getTextArea = useCallback((el) => el.querySelector(`#${textAreaId}`), [textAreaId]);
@@ -143,6 +144,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
         if (copyButtonRef.current) {
           copyButtonRef.current.focus();
         }
+        setShowCopyNotification(true);
       } catch (err) {
         console.warn('Oops, unable to copy');
       }
@@ -207,6 +209,19 @@ const Editor = ({ onChange, initialCode, code, language }) => {
         <Button ref={copyButtonRef} variant="secondary" size="small" onClick={copy}>
           Copy code
         </Button>
+        {showCopyNotification && (
+          <Notification
+            type="success"
+            label="The example code is copied to clipboard."
+            position="bottom-right"
+            autoClose
+            displayAutoCloseProgress={false}
+            dismissible
+            closeButtonLabelText="Close toast"
+            onClose={() => setShowCopyNotification(false)}
+            style={{ zIndex: 100 }}
+          />
+        )}
         <Button
           variant="secondary"
           iconLeft={<IconArrowUndo aria-hidden />}

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -225,7 +225,12 @@ const Editor = ({ onChange, initialCode, code, language }) => {
             displayAutoCloseProgress={false}
             dismissible
             closeButtonLabelText="Close toast"
-            onClose={() => setCopyState('')}
+            onClose={() => {
+              setCopyState('');
+              if (copyButtonRef.current) {
+                copyButtonRef.current.focus();
+              }
+            }}
           />
         )}
         <Button

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -226,7 +226,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
         {copyState === copyErrorState && (
           <Notification
             type="error"
-            label="Code copy failed."
+            label="The code copy failed. Try again or copy the code using the clipboard."
             position="bottom-right"
             displayAutoCloseProgress={false}
             dismissible

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -220,8 +220,6 @@ const Editor = ({ onChange, initialCode, code, language }) => {
             position="bottom-right"
             autoClose
             displayAutoCloseProgress={false}
-            dismissible
-            closeButtonLabelText="Close toast"
             onClose={() => setCopyState('')}
           />
         )}
@@ -230,7 +228,6 @@ const Editor = ({ onChange, initialCode, code, language }) => {
             type="error"
             label="Code copy failed."
             position="bottom-right"
-            autoClose
             displayAutoCloseProgress={false}
             dismissible
             closeButtonLabelText="Close toast"

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -117,7 +117,9 @@ const Editor = ({ onChange, initialCode, code, language }) => {
   const viewPortRef = useRef();
   const copyButtonRef = useRef();
   const [resetCount, setResetCount] = useState(0);
-  const [showCopyNotification, setShowCopyNotification] = useState(false);
+  const copySuccessState = 'COPY_SUCCESS';
+  const copyErrorState = 'COPY_ERROR';
+  const [copyState, setCopyState] = useState('');
   const textAreaId = `code-block-textarea-${language}-${resetCount}`;
   const helperTextId = `code-block-helper-${language}-${resetCount}`;
   const getTextArea = useCallback((el) => el.querySelector(`#${textAreaId}`), [textAreaId]);
@@ -138,15 +140,17 @@ const Editor = ({ onChange, initialCode, code, language }) => {
       const textArea = getTextArea(viewPortRef.current);
       textArea.focus();
       textArea.select();
+      setCopyState('');
 
       try {
         document.execCommand('copy');
         if (copyButtonRef.current) {
           copyButtonRef.current.focus();
         }
-        setShowCopyNotification(true);
+        setCopyState(copySuccessState);
       } catch (err) {
-        console.warn('Oops, unable to copy');
+        setCopyState(copyErrorState);
+        console.warn(`Copy failed: ${err}`);
       }
       clearSelection();
     }
@@ -209,7 +213,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
         <Button ref={copyButtonRef} variant="secondary" size="small" onClick={copy}>
           Copy code
         </Button>
-        {showCopyNotification && (
+        {copyState === copySuccessState && (
           <Notification
             type="success"
             label="The example code is copied to clipboard."
@@ -218,8 +222,19 @@ const Editor = ({ onChange, initialCode, code, language }) => {
             displayAutoCloseProgress={false}
             dismissible
             closeButtonLabelText="Close toast"
-            onClose={() => setShowCopyNotification(false)}
-            style={{ zIndex: 100 }}
+            onClose={() => setCopyState('')}
+          />
+        )}
+        {copyState === copyErrorState && (
+          <Notification
+            type="error"
+            label="Code copy failed."
+            position="bottom-right"
+            autoClose
+            displayAutoCloseProgress={false}
+            dismissible
+            closeButtonLabelText="Close toast"
+            onClose={() => setCopyState('')}
           />
         )}
         <Button

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -210,17 +210,19 @@ const Editor = ({ onChange, initialCode, code, language }) => {
         {copyState === copySuccessState && (
           <Notification
             type="success"
-            label="The example code is copied to clipboard."
+            label="Code copied"
             position="bottom-right"
             autoClose
             displayAutoCloseProgress={false}
             onClose={() => setCopyState('')}
-          />
+          >
+            Example code was copied to clipboard.
+          </Notification>
         )}
         {copyState === copyErrorState && (
           <Notification
             type="error"
-            label="The code copy failed. Try again or copy the code using the clipboard."
+            label="Copy failed"
             position="bottom-right"
             displayAutoCloseProgress={false}
             dismissible
@@ -231,7 +233,9 @@ const Editor = ({ onChange, initialCode, code, language }) => {
                 copyButtonRef.current.focus();
               }
             }}
-          />
+          >
+            Try again or copy the code using the clipboard.
+          </Notification>
         )}
         <Button
           variant="secondary"

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -138,14 +138,9 @@ const Editor = ({ onChange, initialCode, code, language }) => {
   const copy = async () => {
     if (viewPortRef.current && copyButtonRef.current) {
       const textArea = getTextArea(viewPortRef.current);
-      textArea.focus();
-      textArea.select();
       setCopyState('');
       try {
         await navigator.clipboard.writeText(textArea.value);
-        if (copyButtonRef.current) {
-          copyButtonRef.current.focus();
-        }
         setCopyState(copySuccessState);
       } catch (err) {
         setCopyState(copyErrorState);

--- a/site/src/docs/about/accessibility/statement.mdx
+++ b/site/src/docs/about/accessibility/statement.mdx
@@ -24,11 +24,10 @@ The accessibility compliance of this website was evaluated by a third-party audi
 
 Currently, known accessibility issues are:
 - `<i>` tag has been used in navigation link icons. (*1.3.1 Info and Relationships*)
-- On component pages, when clicking the "Copy code" button, the user does not get feedback on whether the copy was successful or not. (*4.1.3 Status Messages*)
 - The jump to content link does not always work correctly when using a screen reader. (*2.4.1 Bypass Blocks*)
 
 ## Preparing an accessibility statement
-This statement was originally prepared on 28. June 2022. The statement has been updated on 28. June 2022.
+This statement was originally prepared on 28. June 2022. The statement has been updated on 17. October 2022.
 
 ## Updating the accessibility statement
 The accessibility statement will be updated so that it corresponds with the most recent compliance status of the website.


### PR DESCRIPTION
## Description
- Show notification when user copies code using Documentation Playground component's "copy code"-button
- This functionality requires that Notification accessibility screen reader issue is fixed, see related issue HDS-1375

Depends on #824 

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1281
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1375

## Motivation and Context
- This improves Documentation's accessibility when user gets feedback after a button click 

## How Has This Been Tested?
- locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/playground-copy-notification/components/buttons/code)