### PR TITLE
Element ids for NumberInputs in site documentation

### DIFF
--- a/site/src/docs/components/number-input/code.mdx
+++ b/site/src/docs/components/number-input/code.mdx
@@ -11,39 +11,39 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ## Code
 
-### Code examples 
+### Code examples
 
 #### Default
-<Playground>
 
+<Playground>
 
 ```jsx
 <>
-<NumberInput
-  helperText="Assistive text"
-  label="Total compensation"
-  unit="€"
-  defaultValue={1000}
-  style={{ maxWidth: '320px' }}
-/>
+  <NumberInput
+    id="input"
+    helperText="Assistive text"
+    label="Total compensation"
+    unit="€"
+    defaultValue={1000}
+    style={{ maxWidth: '320px' }}
+  />
 
-<NumberInput
-  disabled
-  helperText="Assistive text"
-  label="Total compensation"
-  unit="€"
-  defaultValue={1000}
-  style={{ maxWidth: '320px', marginTop: 'var(--spacing-s)' }}
-/>
+  <NumberInput
+    disabled
+    id="input"
+    helperText="Assistive text"
+    label="Total compensation"
+    unit="€"
+    defaultValue={1000}
+    style={{ maxWidth: '320px', marginTop: 'var(--spacing-s)' }}
+  />
 </>
 ```
 
 ```html
 <div style="max-width:320px;">
   <div class="hds-text-input">
-    <label for="input" class="hds-text-input__label">
-      Total compensation (€)
-    </label>
+    <label for="input" class="hds-text-input__label"> Total compensation (€) </label>
     <div class="hds-text-input__input-wrapper">
       <input id="input" value="1000" class="hds-text-input__input" type="number" placeholder="Placeholder" />
     </div>
@@ -51,11 +51,16 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   </div>
 
   <div class="hds-text-input" style="margin-top:var(--spacing-s);">
-    <label for="input-disabled" class="hds-text-input__label">
-      Total compensation (€)
-    </label>
+    <label for="input-disabled" class="hds-text-input__label"> Total compensation (€) </label>
     <div class="hds-text-input__input-wrapper">
-      <input id="input-disabled" value="1000" class="hds-text-input__input" type="number" placeholder="Placeholder" disabled />
+      <input
+        id="input-disabled"
+        value="1000"
+        class="hds-text-input__input"
+        type="number"
+        placeholder="Placeholder"
+        disabled
+      />
     </div>
     <span class="hds-text-input__helper-text">Assistive text</span>
   </div>
@@ -65,11 +70,12 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 </Playground>
 
 #### With steppers
-<Playground>
 
+<Playground>
 
 ```jsx
 <NumberInput
+  id="stepper"
   helperText="Assistive text"
   label="Number of attendees"
   minusStepButtonAriaLabel="Decrease by one"
@@ -82,9 +88,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ```html
 <div class="hds-text-input" style="max-width:320px;">
-  <label for="input" class="hds-text-input__label">
-    Number of attendees
-  </label>
+  <label for="input" class="hds-text-input__label"> Number of attendees </label>
   <div class="hds-text-input__input-wrapper">
     <input id="input" value="5" class="hds-text-input__input" type="number" step="1" placeholder="Placeholder" />
   </div>
@@ -95,11 +99,12 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 </Playground>
 
 #### With min and max values
-<Playground>
 
+<Playground>
 
 ```jsx
 <NumberInput
+  id="stepper"
   helperText="At least 3 attendees are required"
   label="Number of attendees"
   min={3}
@@ -114,11 +119,19 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ```html
 <div class="hds-text-input" style="max-width:320px;">
-  <label for="input" class="hds-text-input__label">
-    Number of attendees
-  </label>
+  <label for="input" class="hds-text-input__label"> Number of attendees </label>
   <div class="hds-text-input__input-wrapper">
-    <input id="input" value="3" class="hds-text-input__input" type="number" step="1" min="3" max="99" placeholder="Placeholder" required />
+    <input
+      id="input"
+      value="3"
+      class="hds-text-input__input"
+      type="number"
+      step="1"
+      min="3"
+      max="99"
+      placeholder="Placeholder"
+      required
+    />
   </div>
   <span class="hds-text-input__helper-text">At least 3 attendees are required</span>
 </div>
@@ -126,25 +139,26 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 </Playground>
 
-
 ### Packages
-| Package           | Included                                                                                        | Storybook link                                                                                                      | Source link                                                                                                                                                      |
-| ----------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **HDS React**     | <div style={{ display: 'flex', gap: 'var(--spacing-3-xs)' }}><IconCheckCircleFill /> Yes </div> | <ExternalLink href="/storybook/react/?path=/story/components-numberinput--default">View in Storybook</ExternalLink> | <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/components/numberInput">View source</ExternalLink> |
-| **HDS Core**      | <div style={{ display: 'flex', gap: 'var(--spacing-3-xs)' }}><IconCheckCircleFill /> Yes </div> | <ExternalLink href="/storybook/react/?path=/story/components-numberinput--default">View in Storybook</ExternalLink> | <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/number-input">View source</ExternalLink> |
+
+| Package       | Included                                                                                        | Storybook link                                                                                                      | Source link                                                                                                                                                      |
+| ------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **HDS React** | <div style={{ display: 'flex', gap: 'var(--spacing-3-xs)' }}><IconCheckCircleFill /> Yes </div> | <ExternalLink href="/storybook/react/?path=/story/components-numberinput--default">View in Storybook</ExternalLink> | <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/react/src/components/numberInput">View source</ExternalLink> |
+| **HDS Core**  | <div style={{ display: 'flex', gap: 'var(--spacing-3-xs)' }}><IconCheckCircleFill /> Yes </div> | <ExternalLink href="/storybook/react/?path=/story/components-numberinput--default">View in Storybook</ExternalLink> | <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/components/number-input">View source</ExternalLink> |
 
 ### Properties
+
 Note! You can find the full list of properties in the <ExternalLink href="/storybook/react/?path=/story/components-numberinput--default">React Storybook.</ExternalLink>
 
 Also, note that this component is an input. All features supported by the HDS TextInput are also supported by this component. See [TextInput documentation page](/components/text-input) for more information.
 
-| Property                   | Description                                                                | Values   | Default value |
-| -------------------------- | -------------------------------------------------------------------------- | -------- | ------------- |
-| `label`                    | The label for the input.                                                   | `string` | -             |
-| `value`                    | The value of the input element, required for a controlled component.       | `number` | -             |
-| `defaultValue`             | The default input element value. Use when the component is not controlled. | `number` | -             |
-| `minusStepButtonAriaLabel` | The aria label for minus step button.                                      | `string` | -             |
-| `plusStepButtonAriaLabel`  | The aria label for plus step button.                                       | `string` | -             |
-| `unit`                     | Unit characters of the input. Example: €                                   | `string` | -             |
-[Table 1:NumberInput properties]|
-
+| Property                         | Description                                                                | Values   | Default value |
+| -------------------------------- | -------------------------------------------------------------------------- | -------- | ------------- |
+| `id`                             | The id for the input.                                                      | `string` | -             |
+| `label`                          | The label for the input.                                                   | `string` | -             |
+| `value`                          | The value of the input element, required for a controlled component.       | `number` | -             |
+| `defaultValue`                   | The default input element value. Use when the component is not controlled. | `number` | -             |
+| `minusStepButtonAriaLabel`       | The aria label for minus step button.                                      | `string` | -             |
+| `plusStepButtonAriaLabel`        | The aria label for plus step button.                                       | `string` | -             |
+| `unit`                           | Unit characters of the input. Example: €                                   | `string` | -             |
+| [Table 1:NumberInput properties] |

--- a/site/src/docs/components/number-input/code.mdx
+++ b/site/src/docs/components/number-input/code.mdx
@@ -20,7 +20,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```jsx
 <>
   <NumberInput
-    id="input"
+    id="default"
     helperText="Assistive text"
     label="Total compensation"
     unit="€"
@@ -30,7 +30,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
   <NumberInput
     disabled
-    id="input"
+    id="disabled"
     helperText="Assistive text"
     label="Total compensation"
     unit="€"
@@ -43,18 +43,18 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```html
 <div style="max-width:320px;">
   <div class="hds-text-input">
-    <label for="input" class="hds-text-input__label"> Total compensation (€) </label>
+    <label for="core-default" class="hds-text-input__label"> Total compensation (€) </label>
     <div class="hds-text-input__input-wrapper">
-      <input id="input" value="1000" class="hds-text-input__input" type="number" placeholder="Placeholder" />
+      <input id="core-default" value="1000" class="hds-text-input__input" type="number" placeholder="Placeholder" />
     </div>
     <span class="hds-text-input__helper-text">Assistive text</span>
   </div>
 
   <div class="hds-text-input" style="margin-top:var(--spacing-s);">
-    <label for="input-disabled" class="hds-text-input__label"> Total compensation (€) </label>
+    <label for="core-disabled" class="hds-text-input__label"> Total compensation (€) </label>
     <div class="hds-text-input__input-wrapper">
       <input
-        id="input-disabled"
+        id="core-disabled"
         value="1000"
         class="hds-text-input__input"
         type="number"
@@ -88,9 +88,9 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ```html
 <div class="hds-text-input" style="max-width:320px;">
-  <label for="input" class="hds-text-input__label"> Number of attendees </label>
+  <label for="core-stepper" class="hds-text-input__label"> Number of attendees </label>
   <div class="hds-text-input__input-wrapper">
-    <input id="input" value="5" class="hds-text-input__input" type="number" step="1" placeholder="Placeholder" />
+    <input id="core-stepper" value="5" class="hds-text-input__input" type="number" step="1" placeholder="Placeholder" />
   </div>
   <span class="hds-text-input__helper-text">Assistive text</span>
 </div>
@@ -104,7 +104,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ```jsx
 <NumberInput
-  id="stepper"
+  id="stepper-minmax"
   helperText="At least 3 attendees are required"
   label="Number of attendees"
   min={3}
@@ -119,10 +119,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ```html
 <div class="hds-text-input" style="max-width:320px;">
-  <label for="input" class="hds-text-input__label"> Number of attendees </label>
+  <label for="core-stepper-minmax" class="hds-text-input__label"> Number of attendees </label>
   <div class="hds-text-input__input-wrapper">
     <input
-      id="input"
+      id="core-stepper-minmax"
       value="3"
       class="hds-text-input__input"
       type="number"

--- a/site/src/docs/components/number-input/index.mdx
+++ b/site/src/docs/components/number-input/index.mdx
@@ -17,7 +17,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 <PlaygroundPreview>
   <NumberInput
-    id="input"
+    id="example"
     helperText="Assistive text"
     label="Total compensation"
     unit="€"
@@ -48,7 +48,7 @@ When applicable, a unit can be set for the input by using the `unit` prop.
 
 <PlaygroundPreview>
   <NumberInput
-    id="input"
+    id="default"
     helperText="Assistive text"
     label="Total compensation"
     unit="€"
@@ -82,7 +82,7 @@ If your input has special requirements, it is a good practice to describe them i
 
 <PlaygroundPreview>
   <NumberInput
-    id="stepper"
+    id="stepper-minmax"
     helperText="At least 3 attendees are required"
     label="Number of attendees"
     min={3}

--- a/site/src/docs/components/number-input/index.mdx
+++ b/site/src/docs/components/number-input/index.mdx
@@ -14,8 +14,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ## Usage
 
 ### Example
+
 <PlaygroundPreview>
   <NumberInput
+    id="input"
     helperText="Assistive text"
     label="Total compensation"
     unit="€"
@@ -25,25 +27,28 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 </PlaygroundPreview>
 
 ### Principles
+
 - **A label should always be provided with a number input.**
   - Make sure that the label is clear and concise. The user should immediately understand what number they are supposed to input.
 - HDS Number input also supports displaying an unit for the number. Displaying the unit is not mandatory. Only use it when you think it will help the user.
-    - Display the unit for <ExternalLink href="https://en.wikipedia.org/wiki/International_System_of_Units">SI units</ExternalLink> (such as meters) and currencies.
-    - The unit does not need to be displayed when it is self-evident for the user, such as in "Number of people"
+  - Display the unit for <ExternalLink href="https://en.wikipedia.org/wiki/International_System_of_Units">SI units</ExternalLink> (such as meters) and currencies.
+  - The unit does not need to be displayed when it is self-evident for the user, such as in "Number of people"
 - It is recommended to give the number input a default value. Placeholders should be avoided in number inputs.
 - HDS Number input supports visual steppers that can be set to increase and decrease the number value by a set amount.
-    - Steppers can be used when changes to the value are small or when they are intuitive to the user (e.g. from 0 to 100 with steps of 10).
-    - You should not use steppers when large value changes are expected.
+  - Steppers can be used when changes to the value are small or when they are intuitive to the user (e.g. from 0 to 100 with steps of 10).
+  - You should not use steppers when large value changes are expected.
 
 ### Variations
 
 #### Default
+
 Default HDS Number input comes without stepper. The number is always inputted manually. Using this over a text input is still helpful since it has a `type=number` to aid screen readers and mobile keyboards.
 
 When applicable, a unit can be set for the input by using the `unit` prop.
 
 <PlaygroundPreview>
   <NumberInput
+    id="input"
     helperText="Assistive text"
     label="Total compensation"
     unit="€"
@@ -53,10 +58,12 @@ When applicable, a unit can be set for the input by using the `unit` prop.
 </PlaygroundPreview>
 
 #### With steppers
+
 Steppers can be enabled via providing a `step` property. Use this variant when value changes are small and you can determine logical amounts for an increase and a decrease step.
 
 <PlaygroundPreview>
   <NumberInput
+    id="stepper"
     helperText="Assistive text"
     label="Number of attendees"
     minusStepButtonAriaLabel="Decrease by one"
@@ -68,12 +75,14 @@ Steppers can be enabled via providing a `step` property. Use this variant when v
 </PlaygroundPreview>
 
 #### With min and max values
+
 Steppers can be enabled by providing a `step` property. Use this variant when value changes are small and you can determine logical amounts for an increase and a decrease step.
 
 If your input has special requirements, it is a good practice to describe them in the assistive text.
 
 <PlaygroundPreview>
   <NumberInput
+    id="stepper"
     helperText="At least 3 attendees are required"
     label="Number of attendees"
     min={3}


### PR DESCRIPTION
## Description

Add element ids for NumberInputs in site documentation in component Usage and Code pages for accessibility.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1376

## How Has This Been Tested?

Locally on developer's machine
