### PR TITLE
Fix useTheme compatibility with Jest

### DIFF
--- a/packages/react/src/hooks/__tests__/useTheme.test.tsx
+++ b/packages/react/src/hooks/__tests__/useTheme.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { useTheme } from '../useTheme';
+
+const baseSelector = 'baseClass';
+const themeProperty = '--accent-line-color';
+const themeValue = 'red';
+const targetTestId = 'target-element';
+
+const ThemeElement = () => {
+  const customThemeClass = useTheme(baseSelector, {
+    [themeProperty]: themeValue,
+  });
+  return (
+    <div>
+      <div data-testid={targetTestId} className={customThemeClass} />
+      TEST ELEMENT
+    </div>
+  );
+};
+
+const renderElement = () => render(<ThemeElement />);
+
+describe('useTheme', () => {
+  beforeEach(cleanup);
+  it('appends a new style to the document.styleSheets. Added className matches the returned class and style has given content', () => {
+    renderElement();
+    const targetElement = screen.queryByTestId(targetTestId) as HTMLElement;
+    const classNames = targetElement.getAttribute('class') as string;
+    const appendedStyleRule = document.styleSheets[0].cssRules[0] as CSSStyleRule;
+    const appendedThemeValue = appendedStyleRule.style[themeProperty];
+    expect(classNames?.length).toBeGreaterThan(0);
+    expect(appendedStyleRule.selectorText.includes(baseSelector)).toBeTruthy();
+    expect(appendedStyleRule.selectorText.includes(classNames)).toBeTruthy();
+    expect(appendedThemeValue).toBe(themeValue);
+  });
+});

--- a/packages/react/src/hooks/useTheme.tsx
+++ b/packages/react/src/hooks/useTheme.tsx
@@ -43,7 +43,7 @@ const setComponentTheme = <T,>(selector: string, theme: T, customClass: string):
       customRuleIndex = [...parentCssRules].findIndex(hasCustomRule);
     }
     // the rule that should be updated
-    const rule = parentCssRules.item(customRuleIndex) as CSSStyleRule;
+    const rule = parentCssRules[customRuleIndex] as CSSStyleRule;
     // set the theme
     Object.entries(theme).forEach(([property, value]) => rule.style.setProperty(property, value));
   } catch (e) {


### PR DESCRIPTION
## Description

useTheme - hook throws a warning in jest/testing-library tests when an HDS component is using a theme property.

Dom used in Jest testing does not have `CSSRules.item` -function. `rules.item(index)` gets a rule at given index. `rules[index]` does the same thing and works with Jest.

## How Has This Been Tested?
Old tests pass. Added a test file for useTheme. Those tests fails without this change.

