### PR TITLE
Analytics script for finding usage of hds-react versions

### DIFF
--- a/analytics/.gitignore
+++ b/analytics/.gitignore
@@ -1,3 +1,4 @@
 tmp
 results
+hds-react-version-usage.json
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -29,9 +29,24 @@ To collect analytics from all found repositories, run:
 The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL and hds-react version and puts them in a JSON file. This could possibly be merged into the analytics scripts to provide even more refined analytics data.
 
 ### How to use it
-You need bash and a Github account.
 
+Requirements for running the script:
+- Github account
+- Personal Access Token (PAT for short) for Github
+- [brew](https://brew.sh/)
+- [jq](https://stedolan.github.io/jq/) - for JSON handling
+- sponge library - for file management
+
+#### Github Personal Access Token
 The script uses an environment variable called `GITHUB_TOKEN` which is Personal Access Token (PAT for short) which you can obtain from your [Github settings](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). If you can't be bothered, you can replace the `GITHUB_TOKEN` in the script with your PAT.
+The PAT token requires the following permissions: repo, admin:public_key and project.
+
+#### Brew, jq and sponge
+Install brew for MacOS and Linux with this command: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"``
+
+jq: `brew install jq`
+
+sponge: `brew install sponge`
 
 Run the script in the terminal with `bash find-hds-react-version-usage.sh`
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -28,7 +28,7 @@ To collect analytics from a subset of found repositories (for testing purposes),
 To collect analytics from all found repositories, run:
 ```TOKEN=$GITHUB_TOKEN node run-analytics.js```
 
-## Bonus content: Search which City of Helsinki Github repositories use hds-react and what version
+## HDS version usage analytics: collect data of HDS versions in repos
 The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL, path to the package.json file and hds-react version and puts them in a JSON file.
 
 ### How to use it
@@ -52,6 +52,6 @@ jq: `brew install jq`
 sponge: `brew install sponge`
 
 ### Running the script
-Run the script in the terminal with `bash find-hds-react-version-usage.sh`
+Run the script in the terminal with `TOKEN=$GITHUB_TOKEN bash find-hds-react-version-usage.sh`
 
 The script produces a `hds-react-version-usage.json` file which contains an array of objects with the name and Github URL of the repository, which hds-react version it uses and the path to the package.json file where hds-react was mentioned. The path is useful information to determine if subfolders of a repository use the same hds-react version.

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -15,6 +15,7 @@ It will strain the network and might exceed some Github rate limits. Running scr
 
 ### Prerequisites
 - [Node](https://nodejs.org/en/)
+- [Github cli](https://cli.github.com/)
 - Github account
 - [Github PAT for authentication](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 - [React-scanner](https://github.com/moroshko/react-scanner) as globally or locally installed

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -26,7 +26,7 @@ To collect analytics from all found repositories, run:
 ```node run-analytics.js```
 
 ## Bonus content
-The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organization and gets the corresponding repository name, Github URL and hds-react version and puts them in a JSON file. This could possibly be merged into the analytics scripts to provide even more refined analytics data.
+The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL and hds-react version and puts them in a JSON file. This could possibly be merged into the analytics scripts to provide even more refined analytics data.
 
 ### How to use it
 You need bash and a Github account.

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -24,3 +24,15 @@ To collect analytics from a subset of found repositories (for testing purposes),
 
 To collect analytics from all found repositories, run:
 ```node run-analytics.js```
+
+## Bonus content
+The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organization and gets the corresponding repository name, Github URL and hds-react version and puts them in a JSON file. This could possibly be merged into the analytics scripts to provide even more refined analytics data.
+
+### How to use it
+You need bash and a Github account.
+
+The script uses an environment variable called `GITHUB_TOKEN` which is Personal Access Token (PAT for short) which you can obtain from your [Github settings](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). If you can't be bothered, you can replace the `GITHUB_TOKEN` in the script with your PAT.
+
+Run the script in the terminal with `bash find-hds-react-version-usage.sh`
+
+The script produces a `hds-react-version-usage.json` file which contains an array of objects with the name and Github URL of the repository and which hds-react version it uses.

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -3,7 +3,7 @@
 A node script to collect the HDS-React package's usage statistics from City of Helsinki Github repositories.
 
 The script does the next steps:
-1. Searches all City of Helsinki TypeScript Github repositories. It filters out the Helsinki Design System repository
+1. Searches all City of Helsinki Github repositories that use hds-react package. It filters out the Helsinki Design System repository
 2. Clones all the found repositories into the local folder
 3. Runs React-scanner for repositories to generate reports of HDS-React usage
 4. Removes the local temporary repository folder
@@ -27,8 +27,8 @@ To collect analytics from a subset of found repositories (for testing purposes),
 To collect analytics from all found repositories, run:
 ```TOKEN=$GITHUB_TOKEN node run-analytics.js```
 
-## Bonus content
-The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL and hds-react version and puts them in a JSON file. This could possibly be merged into the analytics scripts to provide even more refined analytics data.
+## Bonus content: Search which City of Helsinki Github repositories use hds-react and what version
+The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL, path to the package.json file and hds-react version and puts them in a JSON file.
 
 ### How to use it
 
@@ -50,6 +50,7 @@ jq: `brew install jq`
 
 sponge: `brew install sponge`
 
+### Running the script
 Run the script in the terminal with `bash find-hds-react-version-usage.sh`
 
-The script produces a `hds-react-version-usage.json` file which contains an array of objects with the name and Github URL of the repository and which hds-react version it uses.
+The script produces a `hds-react-version-usage.json` file which contains an array of objects with the name and Github URL of the repository, which hds-react version it uses and the path to the package.json file where hds-react was mentioned. The path is useful information to determine if subfolders of a repository use the same hds-react version.

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -29,7 +29,7 @@ To collect analytics from all found repositories, run:
 ```TOKEN=$GITHUB_TOKEN node run-analytics.js```
 
 ## HDS version usage analytics: collect data of HDS versions in repos
-The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL, path to the package.json file and hds-react version and puts them in a JSON file.
+The bash script file `find-hds-react-version-usage.sh` under helpers folder calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL, path to the package.json file and hds-react version and puts them in a JSON file.
 
 ### How to use it
 
@@ -52,6 +52,6 @@ jq: `brew install jq`
 sponge: `brew install sponge`
 
 ### Running the script
-Run the script in the terminal with `TOKEN=$GITHUB_TOKEN bash find-hds-react-version-usage.sh`
+Run the script in the terminal with `TOKEN=$GITHUB_TOKEN bash find-hds-react-version-usage.sh` while in the helpers folder.
 
-The script produces a `hds-react-version-usage.json` file which contains an array of objects with the name and Github URL of the repository, which hds-react version it uses and the path to the package.json file where hds-react was mentioned. The path is useful information to determine if subfolders of a repository use the same hds-react version.
+The script produces a JSON file under results folder that contains an array of objects with the name and Github URL of the repository, which hds-react version it uses and the path to the package.json file where hds-react was mentioned. The path is useful information to determine if subfolders of a repository use the same hds-react version.

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -15,15 +15,17 @@ It will strain the network and might exceed some Github rate limits. Running scr
 
 ### Prerequisites
 - [Node](https://nodejs.org/en/)
-- [Github cli](https://cli.github.com/)
+- Github account
+- [Github PAT for authentication](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 - [React-scanner](https://github.com/moroshko/react-scanner) as globally or locally installed
 
 ### Running the script
+Set your Github PAT to environment variable called `GITHUB_TOKEN` or inject it into the command below.
 To collect analytics from a subset of found repositories (for testing purposes), run:
-```OFFSET=0 LIMIT=1 node run-analytics.js```
+```OFFSET=0 LIMIT=1 TOKEN=$GITHUB_TOKEN node run-analytics.js```
 
 To collect analytics from all found repositories, run:
-```node run-analytics.js```
+```TOKEN=$GITHUB_TOKEN node run-analytics.js```
 
 ## Bonus content
 The bash script file `find-hds-react-version-usage.sh` calls Github API and finds all `hds-react` occurrences in code under the City of Helsinki organisation and gets the corresponding repository name, Github URL and hds-react version and puts them in a JSON file. This could possibly be merged into the analytics scripts to provide even more refined analytics data.

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
+curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki" | jq '[.items[] | {name: .repository.name, html_url: .repository.html_url, package_url: .git_url}]' > hds-react-version-usage.json
+
+# count variable is used to access the correct object inside hds-react-version-usage.json array
+count=0;
+# Iterate through hds-react-version-usage.json file
+jq -c '.[]' hds-react-version-usage.json | while read i; do
+
+    # Read the git url for package json
+    url=$(echo $i | jq -r '.package_url');
+    # Get the contents of package.json through the URL
+    content=$(curl -H "Authorization: token $GITHUB_TOKEN" ${url} | jq -r '.content' | base64 --decode)
+    # Read the version for hds-react
+    version=$(jq '.dependencies."hds-react"' <<< "${content}")
+    # If version is null, read it from devDependencies instead
+    [[ "$version" = "null" ]] && properVersion=$(jq '.devDependencies."hds-react"' <<< "${content}") || properVersion=$(jq '.dependencies."hds-react"' <<< "${content}");
+    # Insert the key value pair "version": "xx.xx" into the hds-react-version-usage.json with sponge
+    jq --argjson properVersion "$properVersion" --argjson count "$count" '.[$count] += { version: $properVersion }' hds-react-version-usage.json | sponge hds-react-version-usage.json;
+    
+    ((count++))
+done
+# Remove package helsinki-design-system from the list
+jq 'del(.[] | select(.name == "helsinki-design-system"))' hds-react-version-usage.json | sponge hds-react-version-usage.json

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -2,12 +2,13 @@
 # Set environment variable to local variable
 TOKEN=$GITHUB_TOKEN
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
-curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki" | jq '[.items[] | {name: .repository.name, html_url: .repository.html_url, package_url: .git_url}]' > hds-react-version-usage.json
+curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, html_url: .repository.html_url, package_url: .git_url}]}' > hds-react-version-usage.json
+
 
 # count variable is used to access the correct object inside hds-react-version-usage.json array
 count=0;
 # Iterate through hds-react-version-usage.json file
-jq -c '.[]' hds-react-version-usage.json | while read i; do
+jq -c '.repositories[]' hds-react-version-usage.json | while read i; do
 
     # Read the git url for package json
     url=$(echo $i | jq -r '.package_url');
@@ -18,9 +19,9 @@ jq -c '.[]' hds-react-version-usage.json | while read i; do
     # If version is null, read it from devDependencies instead
     [[ "$version" = "null" ]] && properVersion=$(jq '.devDependencies."hds-react"' <<< "${content}") || properVersion=$(jq '.dependencies."hds-react"' <<< "${content}");
     # Insert the key value pair "version": "xx.xx" into the hds-react-version-usage.json with sponge
-    jq --argjson properVersion "$properVersion" --argjson count "$count" '.[$count] += { version: $properVersion }' hds-react-version-usage.json | sponge hds-react-version-usage.json;
+    jq --argjson properVersion "$properVersion" --argjson count "$count" '.repositories[$count] += { version: $properVersion }' hds-react-version-usage.json | sponge hds-react-version-usage.json;
     
     ((count++))
 done
 # Remove package helsinki-design-system from the list
-jq 'del(.[] | select(.name == "helsinki-design-system"))' hds-react-version-usage.json | sponge hds-react-version-usage.json
+jq 'del(.repositories[] | select(.name == "helsinki-design-system"))' hds-react-version-usage.json | sponge hds-react-version-usage.json

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+# Set environment variable to local variable
+TOKEN=$GITHUB_TOKEN
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
-curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki" | jq '[.items[] | {name: .repository.name, html_url: .repository.html_url, package_url: .git_url}]' > hds-react-version-usage.json
+curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki" | jq '[.items[] | {name: .repository.name, html_url: .repository.html_url, package_url: .git_url}]' > hds-react-version-usage.json
 
 # count variable is used to access the correct object inside hds-react-version-usage.json array
 count=0;
@@ -10,7 +12,7 @@ jq -c '.[]' hds-react-version-usage.json | while read i; do
     # Read the git url for package json
     url=$(echo $i | jq -r '.package_url');
     # Get the contents of package.json through the URL
-    content=$(curl -H "Authorization: token $GITHUB_TOKEN" ${url} | jq -r '.content' | base64 --decode)
+    content=$(curl -H "Authorization: token $TOKEN" ${url} | jq -r '.content' | base64 --decode)
     # Read the version for hds-react
     version=$(jq '.dependencies."hds-react"' <<< "${content}")
     # If version is null, read it from devDependencies instead

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -2,7 +2,7 @@
 # Set environment variable to local variable
 TOKEN=$GITHUB_TOKEN
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
-curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, html_url: .repository.html_url, package_url: .git_url}]}' > hds-react-version-usage.json
+curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > hds-react-version-usage.json
 
 
 # count variable is used to access the correct object inside hds-react-version-usage.json array

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
+
+# Path to file
+
+# jos toimii, nii kokeile suoraan stringissä $()
+date=$(date -u +"%Y-%m-%dT%H-%M-%SZ");
+echo $date;
+FILE_NAME="./results/${date}_HDS_react_versions_in_use.json";
+
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
-curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > hds-react-version-usage.json
+curl -H  --retry 5 --retry-connrefused --retry-max-time 60 -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > $FILE_NAME
 
-
-# count variable is used to access the correct object inside hds-react-version-usage.json array
+# count variable is used to access the correct object inside the file array
 count=0;
-# Iterate through hds-react-version-usage.json file
-jq -c '.repositories[]' hds-react-version-usage.json | while read i; do
+# Iterate through the generated file
+jq -c '.repositories[]' $FILE_NAME | while read i; do
 
     # Read the git url for package json
     url=$(echo $i | jq -r '.package_url');
@@ -16,10 +23,10 @@ jq -c '.repositories[]' hds-react-version-usage.json | while read i; do
     version=$(jq '.dependencies."hds-react"' <<< "${content}")
     # If version is null, read it from devDependencies instead
     [[ "$version" = "null" ]] && properVersion=$(jq '.devDependencies."hds-react"' <<< "${content}") || properVersion=$(jq '.dependencies."hds-react"' <<< "${content}");
-    # Insert the key value pair "version": "xx.xx" into the hds-react-version-usage.json with sponge
-    jq --argjson properVersion "$properVersion" --argjson count "$count" '.repositories[$count] += { version: $properVersion }' hds-react-version-usage.json | sponge hds-react-version-usage.json;
+    # Insert the key value pair "version": "xx.xx" into the json file with sponge
+    jq --argjson properVersion "$properVersion" --argjson count "$count" '.repositories[$count] += { version: $properVersion }' $FILE_NAME | sponge $FILE_NAME;
     
     ((count++))
 done
 # Remove package helsinki-design-system from the list
-jq 'del(.repositories[] | select(.name == "helsinki-design-system"))' hds-react-version-usage.json | sponge hds-react-version-usage.json
+jq 'del(.repositories[] | select(.name == "helsinki-design-system"))' $FILE_NAME | sponge $FILE_NAME

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-# Path to file
-
-# jos toimii, nii kokeile suoraan stringissä $()
 date=$(date -u +"%Y-%m-%dT%H-%M-%SZ");
-echo $date;
+# Path to file
 FILE_NAME="./results/${date}_HDS_react_versions_in_use.json";
 
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Set environment variable to local variable
-TOKEN=$GITHUB_TOKEN
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
 curl -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > hds-react-version-usage.json
 

--- a/analytics/find-hds-react-version-usage.sh
+++ b/analytics/find-hds-react-version-usage.sh
@@ -2,11 +2,11 @@
 
 date=$(date -u +"%Y-%m-%dT%H-%M-%SZ");
 # Path to file that will be generated
-FILE_NAME="../results/${date}_HDS_react_versions_in_use.json";
+FILE_NAME="./results/${date}_HDS_react_versions_in_use.json";
 
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
-node search-repos.js $TOKEN | jq '. | .totalCount as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > $FILE_NAME
-
+cd helpers && node search-repos.js $TOKEN | jq '. | .totalCount as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > ".${FILE_NAME}"
+cd ..;
 # count variable is used to access the correct object inside the file array
 count=0;
 # Iterate through the generated file

--- a/analytics/helpers/clone-repos.js
+++ b/analytics/helpers/clone-repos.js
@@ -33,8 +33,8 @@ async function cloneRepos(repos, reposDir) {
     fs.mkdirSync(reposDir);
   }
 
-  const clonePromiseFunctions = repos.map(({ name, url }) => () =>
-    exec(`gh repo clone ${url} ${reposDir}/${name}`)
+  const clonePromiseFunctions = repos.map(({ name, html_url }) => () =>
+    exec(`gh repo clone ${html_url} ${reposDir}/${name}`)
       .then(() => {
         console.log(`Repo cloned, name: ${name}`);
         return name;

--- a/analytics/helpers/find-hds-react-version-usage.sh
+++ b/analytics/helpers/find-hds-react-version-usage.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 date=$(date -u +"%Y-%m-%dT%H-%M-%SZ");
-# Path to file
-FILE_NAME="./results/${date}_HDS_react_versions_in_use.json";
+# Path to file that will be generated
+FILE_NAME="../results/${date}_HDS_react_versions_in_use.json";
 
 # Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
-curl -H  --retry 5 --retry-connrefused --retry-max-time 60 -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100" | jq '. | .total_count as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > $FILE_NAME
+node search-repos.js $TOKEN | jq '. | .totalCount as $total_count | { total_count: $total_count, repositories: [.items[] | {name: .repository.name, url: .repository.html_url, package_url: .git_url, path: .path}]}' > $FILE_NAME
 
 # count variable is used to access the correct object inside the file array
 count=0;
 # Iterate through the generated file
+
 jq -c '.repositories[]' $FILE_NAME | while read i; do
 
     # Read the git url for package json
@@ -27,3 +28,4 @@ jq -c '.repositories[]' $FILE_NAME | while read i; do
 done
 # Remove package helsinki-design-system from the list
 jq 'del(.repositories[] | select(.name == "helsinki-design-system"))' $FILE_NAME | sponge $FILE_NAME
+

--- a/analytics/helpers/github-api-call.sh
+++ b/analytics/helpers/github-api-call.sh
@@ -1,0 +1,2 @@
+# Call to Github API to find all occurrences of "hds-react" under City-of-Helsinki org.
+curl -H  --retry 5 --retry-connrefused --retry-max-time 60 -H "Accept: application/vnd.github+json"  -H "Authorization: token $TOKEN" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100&page=$PAGE"

--- a/analytics/helpers/search-repos.js
+++ b/analytics/helpers/search-repos.js
@@ -1,11 +1,38 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-async function searchRepos() {
+/**
+ * Function for searching Github repositories that use hds-react under City-of-Helsinki organization.
+ * Github API returns a maximum of 100 results per request but this function will fetch everything as long
+ * as there is items left to fetch.
+ * @param {string} githubToken
+ * @param {object | null} cumulativeValue
+ * @param {number | null} page
+ * @returns
+ */
+async function searchRepos(githubToken, cumulativeValue, page = 1) {
   try {
-    return exec('gh search repos --owner=City-of-Helsinki --language=typescript --limit=100 --json name,url').then(
-      ({ stdout }) => JSON.parse(stdout),
+    const response = await exec(
+      'curl -H "Accept: application/vnd.github+json"  -H "Authorization: token ' +
+        githubToken +
+        '" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100&page=' +
+        page +
+        '"',
     );
+    const data = JSON.parse(response.stdout);
+    const totalCount = data.total_count;
+    const returnObject = { totalCount, items: cumulativeValue ? cumulativeValue.items.concat(data.items) : data.items };
+    console.log(`Total amount of repos: ${totalCount}`);
+
+    /* As long as total count of results is higher than the amount we have gathered so far,
+    call this function again recursively until all the data has been gathered. */
+    if (totalCount > returnObject.items.length) {
+      console.log('Call this function again');
+      return await searchRepos(githubToken, returnObject, ++page);
+    } else {
+      console.log('Search is done.');
+      return returnObject;
+    }
   } catch (e) {
     console.error(e);
   }

--- a/analytics/helpers/search-repos.js
+++ b/analytics/helpers/search-repos.js
@@ -22,12 +22,11 @@ async function searchRepos(githubToken, cumulativeValue, page = 1) {
     const data = JSON.parse(response.stdout);
     const totalCount = data.total_count;
     const returnObject = { totalCount, items: cumulativeValue ? cumulativeValue.items.concat(data.items) : data.items };
-    console.log(`Total amount of repos: ${totalCount}`);
 
     /* As long as total count of results is higher than the amount we have gathered so far,
     call this function again recursively until all the data has been gathered. */
     if (totalCount > returnObject.items.length) {
-      console.log('Call this function again');
+      console.log('Still more repositories left for fetching, please wait...');
       return await searchRepos(githubToken, returnObject, ++page);
     } else {
       console.log('Search is done.');

--- a/analytics/helpers/search-repos.js
+++ b/analytics/helpers/search-repos.js
@@ -14,7 +14,7 @@ async function searchRepos(githubToken, cumulativeValue, page = 1) {
   try {
     
     /* Call to Github API. Retry max 5 times with 1 min timeout on transient errors and connection refusals. */
-    const response = await exec(`TOKEN=${githubToken} PAGE=${page} bash github-api-call.sh`);
+    const response = await exec(`(cd helpers; TOKEN=${githubToken} PAGE=${page} bash github-api-call.sh)`);
     const data = JSON.parse(response.stdout);
     const totalCount = data.total_count;
     const returnObject = { totalCount, items: cumulativeValue ? cumulativeValue.items.concat(data.items) : data.items };

--- a/analytics/helpers/search-repos.js
+++ b/analytics/helpers/search-repos.js
@@ -12,8 +12,9 @@ const exec = util.promisify(require('child_process').exec);
  */
 async function searchRepos(githubToken, cumulativeValue, page = 1) {
   try {
+    /* Call to Github API. Retry max 5 times with 1 min timeout on transient errors and connection refusals. */
     const response = await exec(
-      'curl -H "Accept: application/vnd.github+json"  -H "Authorization: token ' +
+      'curl --retry 5 --retry-connrefused --retry-max-time 60 -H "Accept: application/vnd.github+json"  -H "Authorization: token ' +
         githubToken +
         '" "https://api.github.com/search/code?q=hds-react+in:file+filename:package.json+org:City-of-Helsinki&per_page=100&page=' +
         page +

--- a/analytics/run-analytics.js
+++ b/analytics/run-analytics.js
@@ -21,7 +21,8 @@ const runAnalytics = async () => {
   const codeRepos = await searchRepos(githubToken);
 
   /* Remove duplicate repositories and helsinki-design-system from the results. Also make a new array with just the repo information.
-  Duplicate repos happen because the search items are package.jsons where hds-react was mentioned. So a repo might have many package.jsons. */
+  Duplicate repos happen because the search items are package.jsons where hds-react was mentioned. 
+  So a repo might have many package.jsons in subfolders.*/
   const validRepos = codeRepos.items
     .filter((value, index, self) => index === self.findIndex((t) => t.repository.id === value.repository.id))
     .filter(({ repository: { name } }) => name !== 'helsinki-design-system')


### PR DESCRIPTION
## Description

Bash script for calling Github API and fetching information about repositories under City of Helsinki organisation that use hds-react package. Saves a JSON file in the same directory as the script was run.

Updated Confluence as well: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HDS/pages/8028225540/HDS+React+version+usage

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1369

## How Has This Been Tested?
Running the script locally. You need a Github account and Personal Access Token to run it. The script uses an environment variable called `GITHUB_TOKEN`. You can add that to your environment variable or just add your PAT into the script code.

## Screenshots (if appropriate):
Screenshot of result file: 
<img width="904" alt="Screenshot 2022-09-19 at 12 34 45" src="https://user-images.githubusercontent.com/108321134/190989809-d900dee9-a010-4822-b91c-c3e1bc2b8e53.png">
