### PR TITLE
Feature/extra aria label for link

### DIFF
--- a/packages/react/src/components/link/Link.test.tsx
+++ b/packages/react/src/components/link/Link.test.tsx
@@ -6,7 +6,11 @@ import { Link } from './Link';
 
 describe('<Link /> spec', () => {
   it('renders the component', () => {
-    const { asFragment } = render(<Link href="https://hds.hel.fi">Test link</Link>);
+    const { asFragment } = render(
+      <Link href="https://hds.hel.fi" ariaLabel="Link to hds.hel">
+        Test link
+      </Link>,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
   it('should not have basic accessibility issues', async () => {

--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -12,7 +12,7 @@ export type LinkProps = Omit<
   'target' | 'href' | 'onPointerEnterCapture' | 'onPointerLeaveCapture' | 'aria-label'
 > & {
   /**
-   * aria-label for providing detailed information about a generic link text.
+   * aria-label for providing detailed information for screen readers about a link text.
    */
   ariaLabel?: string;
   /**

--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -83,7 +83,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     ref: React.Ref<HTMLAnchorElement>,
   ) => {
     const composeAriaLabel = () => {
-      let childrenText = getTextFromReactChildren(children);
+      let childrenText = ariaLabel || getTextFromReactChildren(children);
       const newTabText = openInNewTab ? openInNewTabAriaLabel || 'Avautuu uudessa välilehdessä.' : '';
       const externalText = external ? openInExternalDomainAriaLabel || 'Siirtyy toiseen sivustoon.' : '';
 
@@ -112,7 +112,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         href={href}
         style={style}
         {...(openInNewTab && { target: '_blank', rel: 'noopener' })}
-        {...((openInNewTab || external) && { 'aria-label': composeAriaLabel() })}
+        {...((openInNewTab || external || ariaLabel) && { 'aria-label': composeAriaLabel() })}
         ref={ref}
         {...rest}
       >

--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -12,6 +12,10 @@ export type LinkProps = Omit<
   'target' | 'href' | 'onPointerEnterCapture' | 'onPointerLeaveCapture' | 'aria-label'
 > & {
   /**
+   * aria-label for providing detailed information about a generic link text.
+   */
+  ariaLabel?: string;
+  /**
    * Link content
    */
   children: string;
@@ -62,6 +66,7 @@ type LinkToIconSizeMappingType = {
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   (
     {
+      ariaLabel,
       children,
       className,
       disableVisitedStyles = false,
@@ -97,6 +102,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     return (
       <a
+        aria-label={ariaLabel}
         className={classNames(
           styles.link,
           styles[`link${size}`],

--- a/packages/react/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`<Link /> spec external link that is opened in to a new tab should not h
 exports[`<Link /> spec renders the component 1`] = `
 <DocumentFragment>
   <a
+    aria-label="Link to hds.hel"
     class="link linkM"
     href="https://hds.hel.fi"
   >

--- a/packages/react/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`<Link /> spec external link that is opened in to a new tab should not h
 exports[`<Link /> spec renders the component 1`] = `
 <DocumentFragment>
   <a
-    aria-label="Link to hds.hel"
+    aria-label="Link to hds.hel."
     class="link linkM"
     href="https://hds.hel.fi"
   >

--- a/site/src/docs/components/link/accessibility.mdx
+++ b/site/src/docs/components/link/accessibility.mdx
@@ -10,17 +10,18 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ## Accessibility
 
 ### Pay attention to
+
 The HDS link component is primarily a native HTML hyperlink navigational element. The Enter key activates the link and causes the user agent to move focus to the link destination.
 
 - Remember to tell users if the link is going to open an entirely new site. In HDS React Link this feature is provided through external links (prop `external`). There is a default aria-label for screen readers. This can be overwritten by using the `openInExternalDomainAriaLabel` prop.
-In HDS Core, set a proper `aria-label` to the anchor tag as shown in the examples below.
+  In HDS Core, set a proper `aria-label` to the anchor tag as shown in the examples below.
 
 - Remember to tell users if the link is going to open in a new tab. In HDS React Link this feature is provided through prop `openInNewTab`. There is a default aria-label for screen readers. This can be overwritten by using the `openInNewTabAriaLabel` prop.
-In HDS Core, set a proper `aria-label` to the anchor tag as shown in the examples below.
+  In HDS Core, set a proper `aria-label` to the anchor tag as shown in the examples below.
 
 - Some assistive technologies provide a list of all links on the page to its user. If the text of the links does not clearly give the purpose, or if multiple links with the same name point to different targets (e.g., “read more”), users are forced to locate the link on the page and search surrounding information for context.
 
-- If you want to use a generic link text such as "Read more" but want to provide additional information for screen readers, you can use the `ariaLabel` property.
+- If you want to use a generic link text such as "Read more" but want to provide more detailed information for screen readers, you can use the `ariaLabel` property. However please note that as per the <ExternalLink href="https://www.w3.org/TR/accname/">Accessible Name and Description Computation</ExternalLink> and the <ExternalLink href="https://www.w3.org/TR/html-aapi/#accessible-name-and-description-calculation">HTML to Platform Accessibility APIs Implementation Guide</ExternalLink>, the aria-label text will override the text supplied within the link. As such the text supplied will be used instead of the link text by AT. Due to this it is recommended to start the text used in aria-label with the text used within the link. This will allow consistent communication between users.
 
 Make sure that:
 

--- a/site/src/docs/components/link/accessibility.mdx
+++ b/site/src/docs/components/link/accessibility.mdx
@@ -20,6 +20,8 @@ In HDS Core, set a proper `aria-label` to the anchor tag as shown in the example
 
 - Some assistive technologies provide a list of all links on the page to its user. If the text of the links does not clearly give the purpose, or if multiple links with the same name point to different targets (e.g., “read more”), users are forced to locate the link on the page and search surrounding information for context.
 
+- If you want to use a generic link text such as "Read more" but want to provide additional information for screen readers, you can use the `ariaLabel` property.
+
 Make sure that:
 
 - Link text is the visible label for the native HTML link and is used to provide the purpose of the link which is clear and easy to understand for all users.


### PR DESCRIPTION
## Description

KuVA expressed [a need](https://github.com/City-of-Helsinki/helsinki-design-system/issues/808) for extra aria label for links.

I thought that this particular link aria label usage could be added to the component's Accessibility page as it is something that accessibility standards recommend (https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA8). 
Link to documentation addition: https://city-of-helsinki.github.io/hds-demo/link-aria-label/components/link/accessibility

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1353

## Motivation and Context

Aria labels are useful for links especially when the link text is vague such as "Read more". Aria label can then be used to provide more context for screen reader users.

## How Has This Been Tested?
Locally on developers machine. I thought about doing a story for this but there doesn't appear to be other accessibility stories in Storybook so I didn't dare. 
