### PR TITLE
HDS-1387: refocus cookie consent title on language change

### DIFF
--- a/packages/react/src/components/cookieConsent/content/Content.tsx
+++ b/packages/react/src/components/cookieConsent/content/Content.tsx
@@ -32,10 +32,10 @@ export function Content(): React.ReactElement {
       );
 
   const setFocusToTitle = useCallback(() => {
-    if (titleRef.current) {
+    if (title && titleRef.current) {
       titleRef.current.focus();
     }
-  }, [titleRef]);
+  }, [titleRef, title]);
 
   useEffect(() => {
     setFocusToTitle();

--- a/packages/react/src/components/cookieConsent/contexts/ConsentContext.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/ConsentContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 import createConsentController, { ConsentController, ConsentList } from '../cookieConsentController';
-import { CookieData, CookieGroup, useCookieContentContext } from './ContentContext';
+import { CookieData, CookieGroup, forceFocusToElement, useCookieContentContext } from './ContentContext';
 
 export type Consents = {
   requiredCookies?: string[];
@@ -44,17 +44,6 @@ export const getConsentsFromCookieGroup = (groups: CookieGroup[]): ConsentList =
     });
     return ids;
   }, [] as string[]);
-};
-
-export const forceFocusToElement = (elementSelector: string): void => {
-  const focusTarget = document.querySelector(elementSelector) as HTMLElement;
-  if (focusTarget && focusTarget.focus) {
-    focusTarget.focus();
-    if (document.activeElement !== focusTarget) {
-      focusTarget.setAttribute('tabindex', '-1');
-      focusTarget.focus();
-    }
-  }
 };
 
 export const Provider = ({ cookieDomain, children }: ConsentContextProps): React.ReactElement => {

--- a/packages/react/src/components/cookieConsent/cookieModal/__snapshots__/CookieModal.test.tsx.snap
+++ b/packages/react/src/components/cookieConsent/cookieModal/__snapshots__/CookieModal.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                   <a
                     aria-current="page"
                     class="item "
+                    data-testid="cookie-consent-language-option-fi"
                     href="#"
                     lang="fi"
                   >
@@ -93,6 +94,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                   </a>
                   <a
                     class="item "
+                    data-testid="cookie-consent-language-option-sv"
                     href="#"
                     lang="sv"
                   >
@@ -104,6 +106,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                   </a>
                   <a
                     class="item "
+                    data-testid="cookie-consent-language-option-en"
                     href="#"
                     lang="en"
                   >

--- a/packages/react/src/components/cookieConsent/languageSwitcher/LanguageSwitcher.tsx
+++ b/packages/react/src/components/cookieConsent/languageSwitcher/LanguageSwitcher.tsx
@@ -5,9 +5,17 @@ import { Navigation } from '../../navigation/Navigation';
 import styles from '../CookieConsent.module.scss';
 
 export function LanguageSwitcher(): React.ReactElement {
+  const languageSelectorId = 'cookie-consent-language-selector';
   const { current, languageOptions, languageSelectorAriaLabel, onLanguageChange } = useContentLanguage();
   const setLanguage = (code: string, e: React.MouseEvent) => {
     e.preventDefault();
+    if (code === current) {
+      const languageMenuButton = document.getElementById(`${languageSelectorId}-button`);
+      if (languageMenuButton) {
+        languageMenuButton.focus();
+      }
+      return;
+    }
     onLanguageChange(code);
   };
   const currentOption = languageOptions.find((option) => option.code === current);
@@ -16,7 +24,7 @@ export function LanguageSwitcher(): React.ReactElement {
       label={currentOption.label}
       buttonAriaLabel={languageSelectorAriaLabel}
       className={styles.languageSelectorOverride}
-      id="cookie-consent-language-selector"
+      id={languageSelectorId}
     >
       {languageOptions.map((option) => (
         <Navigation.Item
@@ -26,6 +34,7 @@ export function LanguageSwitcher(): React.ReactElement {
           active={current === option.code}
           key={option.code}
           lang={option.code}
+          data-testid={`cookie-consent-language-option-${option.code}`}
         />
       ))}
     </Navigation.LanguageSelector>

--- a/packages/react/src/components/cookieConsent/test.util.ts
+++ b/packages/react/src/components/cookieConsent/test.util.ts
@@ -107,6 +107,10 @@ export function clickElement(result: RenderResult, testId: string) {
   result.getByTestId(testId).click();
 }
 
+export function getElementById(result: RenderResult, id: string) {
+  return result.container.querySelector(`#${id}`);
+}
+
 export function isAccordionOpen(result: RenderResult, testId: string): boolean {
   const toggler = result.getByTestId(testId) as HTMLElement;
   return toggler.getAttribute('aria-expanded') === 'true';


### PR DESCRIPTION
## Description

When user changes the language, focus is lost and the modal shrinks.

Fixed by adding the modal title as a dependency to the useEffect which handles the initial focusing.

If user selects the same language again, the focus is moved back to the language selector button for better accessibility.

## How Has This Been Tested?

Added tests for both scenarios: language is changed and same language is reselected.

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/cookie-consent/?path=/story/components-cookieconsent--english-modal-version)
