### PR TITLE
HDS-1385 Doc site: New visuals on component overview page

### DIFF
--- a/site/src/components/ComponentsList.js
+++ b/site/src/components/ComponentsList.js
@@ -12,7 +12,9 @@ const ComponentsList = () => {
       href: '/components/accordion',
       imgProps: { 
         src: '/images/components/overview/accordion@2x.png', 
-        alt: 'An illustration of the Accordion component.'
+        alt: 'An illustration of the Accordion component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -23,7 +25,9 @@ const ComponentsList = () => {
       href: '/components/buttons',
       imgProps: { 
         src: '/images/components/overview/button@2x.png', 
-        alt: 'An illustration of the Button component.'
+        alt: 'An illustration of the Button component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -34,7 +38,9 @@ const ComponentsList = () => {
       href: '/components/card',
       imgProps: { 
         src: '/images/components/overview/card@2x.png', 
-        alt: 'An illustration of the Card component.'
+        alt: 'An illustration of the Card component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -45,7 +51,9 @@ const ComponentsList = () => {
       href: '/components/checkbox',
       imgProps: { 
         src: '/images/components/overview/checkbox@2x.png', 
-        alt: 'An illustration of the Checkbox component.'
+        alt: 'An illustration of the Checkbox component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -56,7 +64,9 @@ const ComponentsList = () => {
       href: '/components/cookie-consent',
       imgProps: { 
         src: '/images/components/overview/cookieconsent@2x.png', 
-        alt: 'An illustration of the CookieConsent component.'
+        alt: 'An illustration of the CookieConsent component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -67,7 +77,9 @@ const ComponentsList = () => {
       href: '/components/date-input',
       imgProps: { 
         src: '/images/components/overview/dateinput@2x.png', 
-        alt: 'An illustration of the DateInput component.'
+        alt: 'An illustration of the DateInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -78,7 +90,9 @@ const ComponentsList = () => {
       href: '/components/dialog',
       imgProps: { 
         src: '/images/components/overview/dialog@2x.png', 
-        alt: 'An illustration of the Dialog component.'
+        alt: 'An illustration of the Dialog component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -89,7 +103,9 @@ const ComponentsList = () => {
       href: '/components/dropdown',
       imgProps: { 
         src: '/images/components/overview/dropdown@2x.png', 
-        alt: 'An illustration of the Dropdown component.'
+        alt: 'An illustration of the Dropdown component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -100,7 +116,9 @@ const ComponentsList = () => {
       href: '/components/fieldset',
       imgProps: { 
         src: '/images/components/overview/fieldset@2x.png', 
-        alt: 'An illustration of the Fieldset component.'
+        alt: 'An illustration of the Fieldset component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -111,7 +129,9 @@ const ComponentsList = () => {
       href: '/components/file-input',
       imgProps: { 
         src: '/images/components/overview/fileinput@2x.png', 
-        alt: 'An illustration of the FileInput component.'
+        alt: 'An illustration of the FileInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -122,7 +142,9 @@ const ComponentsList = () => {
       href: '/components/footer',
       imgProps: { 
         src: '/images/components/overview/footer@2x.png', 
-        alt: 'An illustration of the Footer component.'
+        alt: 'An illustration of the Footer component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -133,7 +155,9 @@ const ComponentsList = () => {
       href: '/components/icon',
       imgProps: { 
         src: '/images/components/overview/icon@2x.png', 
-        alt: 'An illustration of the Icon component.'
+        alt: 'An illustration of the Icon component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -144,7 +168,9 @@ const ComponentsList = () => {
       href: '/components/koros',
       imgProps: { 
         src: '/images/components/overview/koros@2x.png', 
-        alt: 'An illustration of the Koros component.'
+        alt: 'An illustration of the Koros component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -155,7 +181,9 @@ const ComponentsList = () => {
       href: '/components/link',
       imgProps: { 
         src: '/images/components/overview/link@2x.png', 
-        alt: 'An illustration of the Link component.'
+        alt: 'An illustration of the Link component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -166,7 +194,9 @@ const ComponentsList = () => {
       href: '/components/linkbox',
       imgProps: { 
         src: '/images/components/overview/linkbox@2x.png', 
-        alt: 'An illustration of the Linkbox component.'
+        alt: 'An illustration of the Linkbox component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -177,7 +207,9 @@ const ComponentsList = () => {
       href: '/components/loading-spinner',
       imgProps: { 
         src: '/images/components/overview/loadingspinner@2x.png', 
-        alt: 'An illustration of the LoadingSpinner component.'
+        alt: 'An illustration of the LoadingSpinner component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -188,7 +220,9 @@ const ComponentsList = () => {
       href: '/components/logo',
       imgProps: { 
         src: '/images/components/overview/logo@2x.png', 
-        alt: 'An illustration of the Logo component.'
+        alt: 'An illustration of the Logo component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -199,7 +233,9 @@ const ComponentsList = () => {
       href: '/components/navigation',
       imgProps: { 
         src: '/images/components/overview/navigation@2x.png', 
-        alt: 'An illustration of the Navigation component.'
+        alt: 'An illustration of the Navigation component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -210,7 +246,9 @@ const ComponentsList = () => {
       href: '/components/notification',
       imgProps: { 
         src: '/images/components/overview/notification@2x.png', 
-        alt: 'An illustration of the Notification component.'
+        alt: 'An illustration of the Notification component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -221,7 +259,9 @@ const ComponentsList = () => {
       href: '/components/number-input',
       imgProps: { 
         src: '/images/components/overview/numberinput@2x.png', 
-        alt: 'An illustration of the NumberInput component.'
+        alt: 'An illustration of the NumberInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -232,7 +272,9 @@ const ComponentsList = () => {
       href: '/components/pagination',
       imgProps: { 
         src: '/images/components/overview/pagination@2x.png', 
-        alt: 'An illustration of the Pagination component.'
+        alt: 'An illustration of the Pagination component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -243,7 +285,9 @@ const ComponentsList = () => {
       href: '/components/password-input',
       imgProps: { 
         src: '/images/components/overview/passwordinput@2x.png', 
-        alt: 'An illustration of the PasswordInput component.'
+        alt: 'An illustration of the PasswordInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -254,7 +298,9 @@ const ComponentsList = () => {
       href: '/components/phone-input',
       imgProps: { 
         src: '/images/components/overview/phoneinput@2x.png', 
-        alt: 'An illustration of the PhoneInput component.'
+        alt: 'An illustration of the PhoneInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -265,7 +311,9 @@ const ComponentsList = () => {
       href: '/components/radio-button',
       imgProps: { 
         src: '/images/components/overview/radiobutton@2x.png', 
-        alt: 'An illustration of the RadioButton component.'
+        alt: 'An illustration of the RadioButton component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -276,7 +324,9 @@ const ComponentsList = () => {
       href: '/components/search-input',
       imgProps: { 
         src: '/images/components/overview/searchinput@2x.png', 
-        alt: 'An illustration of the SearchInput component.'
+        alt: 'An illustration of the SearchInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -287,7 +337,9 @@ const ComponentsList = () => {
       href: '/components/selection-group',
       imgProps: { 
         src: '/images/components/overview/selectiongroup@2x.png', 
-        alt: 'An illustration of the SelectionGroup component.'
+        alt: 'An illustration of the SelectionGroup component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -298,7 +350,9 @@ const ComponentsList = () => {
       href: '/components/side-navigation',
       imgProps: { 
         src: '/images/components/overview/sidenavigation@2x.png', 
-        alt: 'An illustration of the SideNavigation component.'
+        alt: 'An illustration of the SideNavigation component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -309,7 +363,9 @@ const ComponentsList = () => {
       href: '/components/status-label',
       imgProps: { 
         src: '/images/components/overview/statuslabel@2x.png', 
-        alt: 'An illustration of the StatusLabel component.'
+        alt: 'An illustration of the StatusLabel component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -320,7 +376,9 @@ const ComponentsList = () => {
       href: '/components/stepper',
       imgProps: { 
         src: '/images/components/overview/stepper@2x.png', 
-        alt: 'An illustration of the Stepper component.'
+        alt: 'An illustration of the Stepper component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -331,7 +389,9 @@ const ComponentsList = () => {
       href: '/components/table',
       imgProps: { 
         src: '/images/components/overview/table@2x.png', 
-        alt: 'An illustration of the Table component.'
+        alt: 'An illustration of the Table component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -342,7 +402,9 @@ const ComponentsList = () => {
       href: '/components/tabs',
       imgProps: { 
         src: '/images/components/overview/tabs@2x.png', 
-        alt: 'An illustration of the Tabs component.'
+        alt: 'An illustration of the Tabs component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -353,7 +415,9 @@ const ComponentsList = () => {
       href: '/components/tag',
       imgProps: { 
         src: '/images/components/overview/tag@2x.png', 
-        alt: 'An illustration of the Tag component.'
+        alt: 'An illustration of the Tag component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -364,7 +428,9 @@ const ComponentsList = () => {
       href: '/components/text-area',
       imgProps: { 
         src: '/images/components/overview/textarea@2x.png', 
-        alt: 'An illustration of the TextArea component.'
+        alt: 'An illustration of the TextArea component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -375,7 +441,9 @@ const ComponentsList = () => {
       href: '/components/text-input',
       imgProps: { 
         src: '/images/components/overview/textinput@2x.png', 
-        alt: 'An illustration of the TextInput component.'
+        alt: 'An illustration of the TextInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -386,7 +454,9 @@ const ComponentsList = () => {
       href: '/components/time-input',
       imgProps: { 
         src: '/images/components/overview/timeinput@2x.png', 
-        alt: 'An illustration of the TimeInput component.'
+        alt: 'An illustration of the TimeInput component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -397,7 +467,9 @@ const ComponentsList = () => {
       href: '/components/toggle-button',
       imgProps: { 
         src: '/images/components/overview/togglebutton@2x.png', 
-        alt: 'An illustration of the ToggleButton component.'
+        alt: 'An illustration of the ToggleButton component.',
+        height: 180,
+        width: 280,
       },
     },
     {
@@ -408,7 +480,9 @@ const ComponentsList = () => {
       href: '/components/tooltip',
       imgProps: { 
         src: '/images/components/overview/tooltip@2x.png', 
-        alt: 'An illustration of the Tooltip component.'
+        alt: 'An illustration of the Tooltip component.',
+        height: 180,
+        width: 280,
       },
     },
   ];

--- a/site/src/components/ComponentsList.js
+++ b/site/src/components/ComponentsList.js
@@ -10,6 +10,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Accordion component',
       linkAriaLabel: 'Go to the Accordion component page',
       href: '/components/accordion',
+      imgProps: { 
+        src: '/images/components/overview/accordion@2x.png', 
+        alt: 'An illustration of the Accordion component.'
+      },
     },
     {
       name: 'Button',
@@ -17,6 +21,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Button component',
       linkAriaLabel: 'Go to the Button component page',
       href: '/components/buttons',
+      imgProps: { 
+        src: '/images/components/overview/button@2x.png', 
+        alt: 'An illustration of the Button component.'
+      },
     },
     {
       name: 'Card',
@@ -24,6 +32,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Card component',
       linkAriaLabel: 'Go to the Card component page',
       href: '/components/card',
+      imgProps: { 
+        src: '/images/components/overview/card@2x.png', 
+        alt: 'An illustration of the Card component.'
+      },
     },
     {
       name: 'Checkbox',
@@ -31,6 +43,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Checkbox component',
       linkAriaLabel: 'Go to the Checkbox component page',
       href: '/components/checkbox',
+      imgProps: { 
+        src: '/images/components/overview/checkbox@2x.png', 
+        alt: 'An illustration of the Checkbox component.'
+      },
     },
     {
       name: 'CookieConsent',
@@ -38,6 +54,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'CookieConsent components',
       linkAriaLabel: 'Go to the CookieConsent components page',
       href: '/components/cookie-consent',
+      imgProps: { 
+        src: '/images/components/overview/cookieconsent@2x.png', 
+        alt: 'An illustration of the CookieConsent component.'
+      },
     },
     {
       name: 'DateInput',
@@ -45,6 +65,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'DateInput component',
       linkAriaLabel: 'Go to the DateInput component page',
       href: '/components/date-input',
+      imgProps: { 
+        src: '/images/components/overview/dateinput@2x.png', 
+        alt: 'An illustration of the DateInput component.'
+      },
     },
     {
       name: 'Dialog',
@@ -52,6 +76,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Dialog component',
       linkAriaLabel: 'Go to the Dialog component page',
       href: '/components/dialog',
+      imgProps: { 
+        src: '/images/components/overview/dialog@2x.png', 
+        alt: 'An illustration of the Dialog component.'
+      },
     },
     {
       name: 'Dropdown',
@@ -59,6 +87,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Dropdown component',
       linkAriaLabel: 'Go to the Dropdown component page',
       href: '/components/dropdown',
+      imgProps: { 
+        src: '/images/components/overview/dropdown@2x.png', 
+        alt: 'An illustration of the Dropdown component.'
+      },
     },
     {
       name: 'Fieldset',
@@ -66,6 +98,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Fieldset component',
       linkAriaLabel: 'Go to the Fieldset component page',
       href: '/components/fieldset',
+      imgProps: { 
+        src: '/images/components/overview/fieldset@2x.png', 
+        alt: 'An illustration of the Fieldset component.'
+      },
     },
     {
       name: 'FileInput',
@@ -73,6 +109,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'FileInput component',
       linkAriaLabel: 'Go to the FileInput component page',
       href: '/components/file-input',
+      imgProps: { 
+        src: '/images/components/overview/fileinput@2x.png', 
+        alt: 'An illustration of the FileInput component.'
+      },
     },
     {
       name: 'Footer',
@@ -80,6 +120,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Footer component',
       linkAriaLabel: 'Go to the Footer component page',
       href: '/components/footer',
+      imgProps: { 
+        src: '/images/components/overview/footer@2x.png', 
+        alt: 'An illustration of the Footer component.'
+      },
     },
     {
       name: 'Icon',
@@ -87,6 +131,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Icon component',
       linkAriaLabel: 'Go to the Icon component page',
       href: '/components/icon',
+      imgProps: { 
+        src: '/images/components/overview/icon@2x.png', 
+        alt: 'An illustration of the Icon component.'
+      },
     },
     {
       name: 'Koros',
@@ -94,6 +142,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Koros component',
       linkAriaLabel: 'Go to the Koros component page',
       href: '/components/koros',
+      imgProps: { 
+        src: '/images/components/overview/koros@2x.png', 
+        alt: 'An illustration of the Koros component.'
+      },
     },
     {
       name: 'Link',
@@ -101,6 +153,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Link component',
       linkAriaLabel: 'Go to the Link component page',
       href: '/components/link',
+      imgProps: { 
+        src: '/images/components/overview/link@2x.png', 
+        alt: 'An illustration of the Link component.'
+      },
     },
     {
       name: 'Linkbox',
@@ -108,6 +164,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Linkbox component',
       linkAriaLabel: 'Go to the Linkbox component page',
       href: '/components/linkbox',
+      imgProps: { 
+        src: '/images/components/overview/linkbox@2x.png', 
+        alt: 'An illustration of the Linkbox component.'
+      },
     },
     {
       name: 'LoadingSpinner',
@@ -115,6 +175,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'LoadingSpinner component',
       linkAriaLabel: 'Go to the LoadingSpinner component page',
       href: '/components/loading-spinner',
+      imgProps: { 
+        src: '/images/components/overview/loadingspinner@2x.png', 
+        alt: 'An illustration of the LoadingSpinner component.'
+      },
     },
     {
       name: 'Logo',
@@ -122,6 +186,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Logo component',
       linkAriaLabel: 'Go to the Logo component page',
       href: '/components/logo',
+      imgProps: { 
+        src: '/images/components/overview/logo@2x.png', 
+        alt: 'An illustration of the Logo component.'
+      },
     },
     {
       name: 'Navigation',
@@ -129,6 +197,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Navigation component',
       linkAriaLabel: 'Go to the Navigation component page',
       href: '/components/navigation',
+      imgProps: { 
+        src: '/images/components/overview/navigation@2x.png', 
+        alt: 'An illustration of the Navigation component.'
+      },
     },
     {
       name: 'Notification',
@@ -136,6 +208,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Notification component',
       linkAriaLabel: 'Go to the Notification component page',
       href: '/components/notification',
+      imgProps: { 
+        src: '/images/components/overview/notification@2x.png', 
+        alt: 'An illustration of the Notification component.'
+      },
     },
     {
       name: 'NumberInput',
@@ -143,6 +219,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'NumberInput component',
       linkAriaLabel: 'Go to the NumberInput component page',
       href: '/components/number-input',
+      imgProps: { 
+        src: '/images/components/overview/numberinput@2x.png', 
+        alt: 'An illustration of the NumberInput component.'
+      },
     },
     {
       name: 'Pagination',
@@ -150,6 +230,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Pagination component',
       linkAriaLabel: 'Go to the Pagination component page',
       href: '/components/pagination',
+      imgProps: { 
+        src: '/images/components/overview/pagination@2x.png', 
+        alt: 'An illustration of the Pagination component.'
+      },
     },
     {
       name: 'PasswordInput',
@@ -157,6 +241,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'PasswordInput component',
       linkAriaLabel: 'Go to the PasswordInput component page',
       href: '/components/password-input',
+      imgProps: { 
+        src: '/images/components/overview/passwordinput@2x.png', 
+        alt: 'An illustration of the PasswordInput component.'
+      },
     },
     {
       name: 'PhoneInput',
@@ -164,6 +252,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'PhoneInput component',
       linkAriaLabel: 'Go to the PhoneInput component page',
       href: '/components/phone-input',
+      imgProps: { 
+        src: '/images/components/overview/phoneinput@2x.png', 
+        alt: 'An illustration of the PhoneInput component.'
+      },
     },
     {
       name: 'RadioButton',
@@ -171,6 +263,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'RadioButton component',
       linkAriaLabel: 'Go to the RadioButton component page',
       href: '/components/radio-button',
+      imgProps: { 
+        src: '/images/components/overview/radiobutton@2x.png', 
+        alt: 'An illustration of the RadioButton component.'
+      },
     },
     {
       name: 'SearchInput',
@@ -178,6 +274,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'SearchInput component',
       linkAriaLabel: 'Go to the SearchInput component page',
       href: '/components/search-input',
+      imgProps: { 
+        src: '/images/components/overview/searchinput@2x.png', 
+        alt: 'An illustration of the SearchInput component.'
+      },
     },
     {
       name: 'SelectionGroup',
@@ -185,6 +285,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'SelectionGroup component',
       linkAriaLabel: 'Go to the SelectionGroup component page',
       href: '/components/selection-group',
+      imgProps: { 
+        src: '/images/components/overview/selectiongroup@2x.png', 
+        alt: 'An illustration of the SelectionGroup component.'
+      },
     },
     {
       name: 'SideNavigation',
@@ -192,6 +296,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'SideNavigation component',
       linkAriaLabel: 'Go to the SideNavigation component page',
       href: '/components/side-navigation',
+      imgProps: { 
+        src: '/images/components/overview/sidenavigation@2x.png', 
+        alt: 'An illustration of the SideNavigation component.'
+      },
     },
     {
       name: 'StatusLabel',
@@ -199,6 +307,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'StatusLabel component',
       linkAriaLabel: 'Go to the StatusLabel component page',
       href: '/components/status-label',
+      imgProps: { 
+        src: '/images/components/overview/statuslabel@2x.png', 
+        alt: 'An illustration of the StatusLabel component.'
+      },
     },
     {
       name: 'Stepper',
@@ -206,6 +318,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Stepper component',
       linkAriaLabel: 'Go to the Stepper component page',
       href: '/components/stepper',
+      imgProps: { 
+        src: '/images/components/overview/stepper@2x.png', 
+        alt: 'An illustration of the Stepper component.'
+      },
     },
     {
       name: 'Table',
@@ -213,6 +329,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Table component',
       linkAriaLabel: 'Go to the Table component page',
       href: '/components/table',
+      imgProps: { 
+        src: '/images/components/overview/table@2x.png', 
+        alt: 'An illustration of the Table component.'
+      },
     },
     {
       name: 'Tabs',
@@ -220,6 +340,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Tabs component',
       linkAriaLabel: 'Go to the Tabs component page',
       href: '/components/tabs',
+      imgProps: { 
+        src: '/images/components/overview/tabs@2x.png', 
+        alt: 'An illustration of the Tabs component.'
+      },
     },
     {
       name: 'Tag',
@@ -227,6 +351,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Tag component',
       linkAriaLabel: 'Go to the Tag component page',
       href: '/components/tag',
+      imgProps: { 
+        src: '/images/components/overview/tag@2x.png', 
+        alt: 'An illustration of the Tag component.'
+      },
     },
     {
       name: 'TextArea',
@@ -234,6 +362,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'TextArea component',
       linkAriaLabel: 'Go to the TextArea component page',
       href: '/components/text-area',
+      imgProps: { 
+        src: '/images/components/overview/textarea@2x.png', 
+        alt: 'An illustration of the TextArea component.'
+      },
     },
     {
       name: 'TextInput',
@@ -241,6 +373,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'TextInput component',
       linkAriaLabel: 'Go to the TextInput component page',
       href: '/components/text-input',
+      imgProps: { 
+        src: '/images/components/overview/textinput@2x.png', 
+        alt: 'An illustration of the TextInput component.'
+      },
     },
     {
       name: 'TimeInput',
@@ -248,6 +384,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'TimeInput component',
       linkAriaLabel: 'Go to the TimeInput component page',
       href: '/components/time-input',
+      imgProps: { 
+        src: '/images/components/overview/timeinput@2x.png', 
+        alt: 'An illustration of the TimeInput component.'
+      },
     },
     {
       name: 'ToggleButton',
@@ -255,6 +395,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'ToggleButton component',
       linkAriaLabel: 'Go to the ToggleButton component page',
       href: '/components/toggle-button',
+      imgProps: { 
+        src: '/images/components/overview/togglebutton@2x.png', 
+        alt: 'An illustration of the ToggleButton component.'
+      },
     },
     {
       name: 'Tooltip',
@@ -262,6 +406,10 @@ const ComponentsList = () => {
       linkboxAriaLabel: 'Tooltip component',
       linkAriaLabel: 'Go to the Tooltip component page',
       href: '/components/tooltip',
+      imgProps: { 
+        src: '/images/components/overview/tooltip@2x.png', 
+        alt: 'An illustration of the Tooltip component.'
+      },
     },
   ];
 

--- a/site/src/components/LinkboxList.js
+++ b/site/src/components/LinkboxList.js
@@ -21,7 +21,7 @@ const LinkboxList = ({ data, className }) => (
             external={item.external}
             heading={item.name}
             text={item.text}
-            imgProps={item.imgProps ? { ...item.imgProps, src: withPrefix(item.imgProps.src) } : undefined}
+            imgProps={{ src: withPrefix("/images/components/overview/" + item.name + "@2x.png"), width: 280, height: 180}}
             onClick={(event) => {
               if (!item.external) {
                 event.preventDefault();

--- a/site/src/components/LinkboxList.js
+++ b/site/src/components/LinkboxList.js
@@ -21,7 +21,7 @@ const LinkboxList = ({ data, className }) => (
             external={item.external}
             heading={item.name}
             text={item.text}
-            imgProps={{ src: withPrefix("/images/components/overview/" + item.name + "@2x.png"), width: 280, height: 180}}
+            imgProps={item.imgProps ? { ...item.imgProps, src: withPrefix(item.imgProps.src) } : undefined}
             onClick={(event) => {
               if (!item.external) {
                 event.preventDefault();

--- a/site/src/components/LinkboxList.scss
+++ b/site/src/components/LinkboxList.scss
@@ -1,7 +1,7 @@
 @import "~hds-design-tokens/lib/all.scss";
 
 .linkbox-list {
-  grid-template-columns: repeat(auto-fit, minmax(204px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   display: grid;
   column-gap: var(--spacing-layout-xs);
   row-gap: var(--spacing-layout-xs);

--- a/site/src/components/LinkboxList.scss
+++ b/site/src/components/LinkboxList.scss
@@ -1,7 +1,7 @@
 @import "~hds-design-tokens/lib/all.scss";
 
 .linkbox-list {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(216px, 1fr));
   display: grid;
   column-gap: var(--spacing-layout-xs);
   row-gap: var(--spacing-layout-xs);

--- a/site/src/docs/patterns/index.mdx
+++ b/site/src/docs/patterns/index.mdx
@@ -9,7 +9,7 @@ import Image from '../../components/Image';
 # Patterns overview
 
 <LeadParagraph>
-  Patterns a collection of design principles and solutions. They consist of guidelines and component examples of how to to build pages for specific user flows.
+  Patterns are a collection of design principles and solutions. They consist of guidelines and component examples of how to to build pages for specific user flows.
 </LeadParagraph>
 
 Patterns describe how [HDS components](/components/) are used together to build solutions that are coherent across the whole city.

--- a/site/static/images/components/overview/accordion@2x.png
+++ b/site/static/images/components/overview/accordion@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe9e99712f65bd15c7851eb5f03dc4bc5ccce740cb96942986544d4cd9630023
+size 4425

--- a/site/static/images/components/overview/button@2x.png
+++ b/site/static/images/components/overview/button@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59dc1dc14b0adee844fec842657493cf6574b32a0855974c5ceaf0f8f9dce8b9
+size 6570

--- a/site/static/images/components/overview/card@2x.png
+++ b/site/static/images/components/overview/card@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ccea826cd4027385a1a9e45e95e0a22be605484de8ba03d84e0d443caf44510
+size 6472

--- a/site/static/images/components/overview/checkbox@2x.png
+++ b/site/static/images/components/overview/checkbox@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4642b125d6b75ef1d9afa6a38f86f69266c46b2abb98fdea78acb24bb8a9b229
+size 4809

--- a/site/static/images/components/overview/cookieconsent@2x.png
+++ b/site/static/images/components/overview/cookieconsent@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ee95bbf0600367919a8529336251693c7f3c40efbb26637943693ce204d36c4
+size 8746

--- a/site/static/images/components/overview/dateinput@2x.png
+++ b/site/static/images/components/overview/dateinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e06394a19ff67f3ddeabd859193c9b8b165c833d576b55cd62d524d6ed9bb264
+size 4572

--- a/site/static/images/components/overview/dialog@2x.png
+++ b/site/static/images/components/overview/dialog@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50c98061169591d853247a66c795c04a588ef873f0c6a4e6606517c1f3bc3ea1
+size 6832

--- a/site/static/images/components/overview/dropdown@2x.png
+++ b/site/static/images/components/overview/dropdown@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9702a19abc33c09eadb16fd0417182b5893da61c53b8f4809b2d994d36bf2125
+size 4526

--- a/site/static/images/components/overview/fieldset@2x.png
+++ b/site/static/images/components/overview/fieldset@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc187fdcee57a4051e5637ad7dd5728c3d4bfeacbc18f8e003401d1be362db7a
+size 4920

--- a/site/static/images/components/overview/fileinput@2x.png
+++ b/site/static/images/components/overview/fileinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8da9ff396b354d713e8672b63af555850bce8d31245a0b8f9034696f9f9d38e5
+size 7525

--- a/site/static/images/components/overview/footer@2x.png
+++ b/site/static/images/components/overview/footer@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbce77d98862d2c8bc8057a321b35766622dedb24988718c469cf25ece2c98fe
+size 8143

--- a/site/static/images/components/overview/icon@2x.png
+++ b/site/static/images/components/overview/icon@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f126e8076147ae0d11f0f8dda7a51aee5dcc53038e5e963893ed99961853774
+size 7968

--- a/site/static/images/components/overview/koros@2x.png
+++ b/site/static/images/components/overview/koros@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f7214b3289474154b34cfc8dd0a5b511ed56767594caeb050ae97bfc14793b
+size 6829

--- a/site/static/images/components/overview/link@2x.png
+++ b/site/static/images/components/overview/link@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4dbbf60f69332d7a5ed75130dadde5ff4435269814d2e5e3a0a8f02699ea556
+size 6737

--- a/site/static/images/components/overview/linkbox@2x.png
+++ b/site/static/images/components/overview/linkbox@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2361d1121ee6317ced9b0016fd53e72acab38f1f0fa91586733b31ee1f1d3d5
+size 6545

--- a/site/static/images/components/overview/loadingspinner@2x.png
+++ b/site/static/images/components/overview/loadingspinner@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfec685a525365a126641ebc40eaa74de6d5b033aacd15fd3cd48f0589e7c7d0
+size 7028

--- a/site/static/images/components/overview/logo@2x.png
+++ b/site/static/images/components/overview/logo@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0622fe14ff378a8312155e3d2b1a5767d626bb6d064ee22d922bf0569faae06d
+size 10066

--- a/site/static/images/components/overview/navigation@2x.png
+++ b/site/static/images/components/overview/navigation@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c3f2afc47c65d8ee4001acd98e4b8e8056f961b43fdd0cf23f3166b6a1528d6
+size 7218

--- a/site/static/images/components/overview/notification@2x.png
+++ b/site/static/images/components/overview/notification@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1ba3ca8770941f2d0cf84670fb9a96f7e66da243d5248e7b224d0dc6230fcfb
+size 7643

--- a/site/static/images/components/overview/numberinput@2x.png
+++ b/site/static/images/components/overview/numberinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06d1b727f3f4d7c197430f64d6135c6eccf5722e6c1d90c609d972e3e566e98e
+size 5997

--- a/site/static/images/components/overview/pagination@2x.png
+++ b/site/static/images/components/overview/pagination@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0715c19520531c9c143d3192a4fc393863d7f4137570059d16f3c95852600499
+size 12429

--- a/site/static/images/components/overview/passwordinput@2x.png
+++ b/site/static/images/components/overview/passwordinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72a90f500259bf1058de48efe8453de8bf644344a6ebf58011393cb8e5ac878a
+size 6952

--- a/site/static/images/components/overview/phoneinput@2x.png
+++ b/site/static/images/components/overview/phoneinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8d31063e2608a7c9c24d8831e1b737ce36bf41a504bd7efd784d6f1cc83d55b
+size 7047

--- a/site/static/images/components/overview/radiobutton@2x.png
+++ b/site/static/images/components/overview/radiobutton@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e014946d90d433ed5512a55d86ab0b8c5b67c5dfda65ef76e9e3bb76324d1f7d
+size 8252

--- a/site/static/images/components/overview/searchinput@2x.png
+++ b/site/static/images/components/overview/searchinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb6dad33e7c5de131bceb75ffe3bb15a861462a51b2591c5a6f23f2b6b277583
+size 5686

--- a/site/static/images/components/overview/selectiongroup@2x.png
+++ b/site/static/images/components/overview/selectiongroup@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8700bcab9cdcb1987587bb3ad7f588c04524143cd365f704b1d0574b2e896c52
+size 5296

--- a/site/static/images/components/overview/sidenavigation@2x.png
+++ b/site/static/images/components/overview/sidenavigation@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f4700393ffafb895b15ddf39039535bd78ab8428cc1ecd8ef4e4695aaafe8e6
+size 5005

--- a/site/static/images/components/overview/statuslabel@2x.png
+++ b/site/static/images/components/overview/statuslabel@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a39e9ce739f35364ca84c002e3c7a42e8a268d96bfe9632cb77c3b7d7c1f462b
+size 8206

--- a/site/static/images/components/overview/stepper@2x.png
+++ b/site/static/images/components/overview/stepper@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:581b2e3359eba903b1dce337c61a0947752141c036ff232aece1de7428fe2047
+size 12227

--- a/site/static/images/components/overview/table@2x.png
+++ b/site/static/images/components/overview/table@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1f8dcc6e6a18bb32538d3c3c823bbc7b78f47db3a68f28f9812cc9d8df87f2b
+size 4831

--- a/site/static/images/components/overview/tabs@2x.png
+++ b/site/static/images/components/overview/tabs@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8168a847b505b277545f4a9826d9a45dcd622c6a6c94207432a09349ce12239
+size 5365

--- a/site/static/images/components/overview/tag@2x.png
+++ b/site/static/images/components/overview/tag@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12d093c4fcc04aadde2ecdd3e5e59ee5f653808f4a91f3acb27e027388645aa6
+size 7538

--- a/site/static/images/components/overview/textarea@2x.png
+++ b/site/static/images/components/overview/textarea@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:098e02ff52362ccef953ce9a849a74c98f7648abf7ca83a25dd5f6052b06870a
+size 4663

--- a/site/static/images/components/overview/textinput@2x.png
+++ b/site/static/images/components/overview/textinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc7f30eb9c8806ebd2c9e27f6cacf0577b110ac8fd085762ac65829fbe77fead
+size 4169

--- a/site/static/images/components/overview/timeinput@2x.png
+++ b/site/static/images/components/overview/timeinput@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf68ebbeba6ce0751aac6e3280f15276833fd5ec7861dc8d646f37ecbced3676
+size 5946

--- a/site/static/images/components/overview/togglebutton@2x.png
+++ b/site/static/images/components/overview/togglebutton@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae1fd71f63bf24c69a85f7ee9872c6393c8ef90c112eea2bafdc58a7e7dcdd8b
+size 6708

--- a/site/static/images/components/overview/tooltip@2x.png
+++ b/site/static/images/components/overview/tooltip@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:398a793e7161d3338eb52d0cca974cb3bf70b6cce241830a846467dddac76c2d
+size 5290


### PR DESCRIPTION
## Description

- Added component overview images as pngs --> /site/static/images/components/overview/.
- Changed text-only linkboxes to linkboxes with images.
- Made the linkboxes a bit wider than the previous ones (from 204px to 280 px). The added width gives the visuals a bit more breathing room.

## Motivation and Context

Make the doc site's component overview page visually more appealing.

## How Has This Been Tested?

Locally on the designer's workstation.

## Screenshots (if appropriate):
<img width="859" alt="updated-component-overview" src="https://user-images.githubusercontent.com/110812500/192276858-4f045e1e-f733-48fc-b8e6-3c479e2ce234.png">
