### PR TITLE
Fix input wrapper reference id

### DIFF
--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -269,7 +269,7 @@ export const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(
     const minuteInputId = `${id}-minutes`;
 
     return (
-      <InputWrapper {...wrapperProps} id={`${id}-hours`}>
+      <InputWrapper {...wrapperProps} id={id}>
         <div {...frameProps}>
           <input
             aria-hidden


### PR DESCRIPTION
## Description
- Use given id as InputWrapper id property

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1379 

## Motivation and Context
- At the moment, there is no linkage between the time inputs and the helper text element for screen readers.
The helper text element had the wrong id because the id property had "hours" postfix.

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1379-fix-time-input-aria-describedby/iframe.html?id=components-timeinput--default&args=&viewMode=story)
