### PR TITLE
HDS-1416 Fix docsite Table customisation page theme variables

### DIFF
--- a/site/src/docs/components/table/customisation.mdx
+++ b/site/src/docs/components/table/customisation.mdx
@@ -17,11 +17,10 @@ In React version, you can use the `theme` property to customise the component.
 
 See all available theme variables in the table below.
 
-| Theme variable                        | Description                                 |
-| ------------------------------------- | ------------------------------------------- |
-| `--hds-not-selected-step-label-color` | Colour of a non-selected step label.        |
-
-TODO
+| Theme variable               | Description                                    |
+| ---------------------------- | ---------------------------------------------- |
+| `--content-background-color` | Custom background color for the table content. |
+| `--header-background-color`  | Custom background color for table headers.     |
 
 ### Customisation example
 <Playground>


### PR DESCRIPTION
## Description

Fixes docsite Table component's customisation theme variables table content.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1416

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-table-customisation-fix/components/table/customisation#customisation-properties)

## Screenshots (if appropriate):

Old:

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/2777633/192811239-4071abc1-ee79-47f0-9136-d4f413e503b7.png">

Fixed:

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/2777633/192811642-348ca1e5-7d0b-4f2e-ac75-d33ea8e52606.png">
