### PR TITLE
Fix accessibility bug in TimeInput inputs' by grouping them

### DIFF
--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -267,10 +267,11 @@ export const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(
 
     const hourInputId = `${id}-hours`;
     const minuteInputId = `${id}-minutes`;
+    const labelId = `${id}-label`;
 
     return (
-      <InputWrapper {...wrapperProps} id={id}>
-        <div {...frameProps}>
+      <InputWrapper {...wrapperProps} id={id} labelId={labelId} isAriaLabelledBy>
+        <div {...frameProps} role="group" aria-labelledBy={labelId}>
           <input
             aria-hidden
             readOnly

--- a/packages/react/src/components/timeInput/__snapshots__/TimeInput.test.tsx.snap
+++ b/packages/react/src/components/timeInput/__snapshots__/TimeInput.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`<TimeInput /> spec renders the component 1`] = `
       class="inputWrapper"
     >
       <div
+        aria-labelledby="time-hours-label"
         class="input timeInputFrame"
+        role="group"
       >
         <input
           aria-hidden="true"

--- a/packages/react/src/components/timeInput/__snapshots__/TimeInput.test.tsx.snap
+++ b/packages/react/src/components/timeInput/__snapshots__/TimeInput.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<TimeInput /> spec renders the component 1`] = `
       class="inputWrapper"
     >
       <div
-        aria-labelledby="time-hours-label"
+        aria-labelledby="time-label"
         class="input timeInputFrame"
         role="group"
       >

--- a/packages/react/src/internal/field-label/FieldLabel.tsx
+++ b/packages/react/src/internal/field-label/FieldLabel.tsx
@@ -6,7 +6,9 @@ import { Tooltip } from '../../components/tooltip';
 
 type FieldLabelProps = {
   hidden?: boolean;
+  id?: string;
   inputId: string;
+  isAriaLabelledBy?: boolean;
   label: string | React.ReactNode;
   required?: boolean;
   tooltipLabel?: string;
@@ -16,7 +18,9 @@ type FieldLabelProps = {
 
 export const FieldLabel = ({
   hidden,
+  id,
   inputId,
+  isAriaLabelledBy,
   label,
   required,
   tooltipLabel,
@@ -25,7 +29,12 @@ export const FieldLabel = ({
   ...rest
 }: FieldLabelProps) => (
   <>
-    <label htmlFor={inputId} className={`${styles.label} ${hidden ? styles.hidden : ''}`} {...rest}>
+    <label
+      id={id}
+      {...((!isAriaLabelledBy || !id) && { htmlFor: inputId })}
+      className={`${styles.label} ${hidden ? styles.hidden : ''}`}
+      {...rest}
+    >
       {label}
       {required && <RequiredIndicator />}
     </label>

--- a/packages/react/src/internal/input-wrapper/InputWrapper.tsx
+++ b/packages/react/src/internal/input-wrapper/InputWrapper.tsx
@@ -12,7 +12,9 @@ type InputWrapperProps = {
   hideLabel?: boolean;
   id: string;
   invalid?: boolean;
+  isAriaLabelledBy?: boolean;
   label?: string | React.ReactNode;
+  labelId?: string;
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
   required?: boolean;
   style?: React.CSSProperties;
@@ -31,7 +33,9 @@ export const InputWrapper = ({
   hideLabel = false,
   id,
   invalid = false,
+  isAriaLabelledBy = false,
   label,
+  labelId,
   onBlur,
   required = false,
   style,
@@ -48,7 +52,9 @@ export const InputWrapper = ({
   >
     {label && (
       <FieldLabel
+        id={labelId}
         inputId={id}
+        isAriaLabelledBy={isAriaLabelledBy}
         hidden={hideLabel}
         label={label}
         required={required}


### PR DESCRIPTION
## Description
Add `group="role"` to the parent div of TimeInput's components hours and minutes inputs. Also add aria-labelledby to the parent div and reference the InputWrapper's FieldLabel's id.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1378

## Motivation and Context

Unicus accessibility experts found this while doing documentation site accessibility audit. As it stands the time input's hours and minutes inputs are not grouped under the same label.

## How Has This Been Tested?
Locally on dev machine.
Unicus expert reviewed the functionality on the demo site and gave thumbs up.

## Demo
https://city-of-helsinki.github.io/hds-demo/timeinput-accessibility/?path=/story/components-timeinput--default

## Screenshots (if appropriate):
<img width="608" alt="Screenshot 2022-10-05 at 10 28 57" src="https://user-images.githubusercontent.com/108321134/194004893-3652301d-8aab-45f7-9cb5-f6a25631b2f3.png">



