### PR TITLE
HDS-1377: number input accessibility fix

### DIFF
--- a/packages/react/.loki/reference/chrome_iphone7_Components_NumberInput_With_a_custom_step_value.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_NumberInput_With_a_custom_step_value.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:294f771334524b99f9d187df58e5484e316ffa7112e9d3cc6fcfc0d621b08a3e
-size 10238
+oid sha256:91322c5cbb0f0998e329e17f024e02cb38de256bfd7416ec4d4e8ad9c6662924
+size 13054

--- a/packages/react/.loki/reference/chrome_laptop_Components_NumberInput_With_a_custom_step_value.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_NumberInput_With_a_custom_step_value.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc5d6add80869d389862e6b1ac518965c78910dfca161e9d1f50df653e8d879c
-size 4478
+oid sha256:1fada5d4fdc400495bf524008be69487a8f4d9ed1b9cb107e69224295bbae96f
+size 5750

--- a/packages/react/src/components/numberInput/NumberInput.stories.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.stories.tsx
@@ -26,8 +26,8 @@ CustomStep.storyName = 'With a custom step value';
 CustomStep.args = {
   id: 'CustomStep',
   step: 10,
-  helperText: 'Assistive text',
-  label: 'Label for step 10',
+  helperText: 'Assistive text for input with steps of 10',
+  label: 'Label for step test',
   minusStepButtonAriaLabel: 'Decrease by ten',
   plusStepButtonAriaLabel: 'Increase by ten',
   unit: '€',

--- a/packages/react/src/components/numberInput/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react/src/components/numberInput/__snapshots__/NumberInput.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`<NumberInput /> spec renders the component with steppers 1`] = `
     <label
       class="label "
       for="numberInputTestId"
+      id="numberInputTestId-label"
     >
       Test label number input
     </label>
@@ -44,7 +45,9 @@ exports[`<NumberInput /> spec renders the component with steppers 1`] = `
       class="inputWrapper"
     >
       <div
+        aria-labelledby="numberInputTestId-label"
         class="numberInputContainer"
+        role="group"
       >
         <input
           class="input numberInputWithSteps"


### PR DESCRIPTION
## Description

When screen reader user clicks stepper buttons, the user receives no information about the new value.
Also, an input and its control buttons should be grouped. 

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1377


## How Has This Been Tested?

Added new tests for new features.

## Demo

https://city-of-helsinki.github.io/hds-demo/numberinput-accessibility/iframe.html?id=components-numberinput--custom-step&args=&viewMode=story
