### PR TITLE
HDS-1431 Add possibility to use external label for Select and Combobox components

### DIFF
--- a/packages/react/.loki/reference/chrome_iphone7_Components_Dropdowns_Combobox_With_external_label.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Dropdowns_Combobox_With_external_label.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5ad262b26d71d17a15372ad9932349945977ff8af325011b2a64d0c6c4922bd
+size 16303

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Dropdowns_Select_With_external_label.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Dropdowns_Select_With_external_label.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b346afdc28ec2fddff9b106e887354b9ebf7b2f7b03b076023d588f8a9a9fae0
+size 14859

--- a/packages/react/.loki/reference/chrome_laptop_Components_Dropdowns_Combobox_With_external_label.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Dropdowns_Combobox_With_external_label.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71669a541ba6acd2e58e4d132566d259fb5a6d3ef19793a61ee8daedd181db30
+size 6339

--- a/packages/react/.loki/reference/chrome_laptop_Components_Dropdowns_Select_With_external_label.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Dropdowns_Select_With_external_label.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3b2aa9039b7b2b4d0fd4832bdf75dd8c7984167ccbc44f8c85bbad6ee1aace1
+size 6252

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -42,7 +42,11 @@ function getRegionOptions() {
 export default {
   component: Combobox,
   title: 'Components/Dropdowns/Combobox',
-  decorators: [(storyFn) => <div style={{ maxWidth: '420px' }}>{storyFn()}</div>],
+  decorators: [
+    (storyFn, context) => {
+      return <div style={{ maxWidth: `${context.name === 'With external label' ? 820 : 420}px` }}>{storyFn()}</div>;
+    },
+  ],
   parameters: {
     controls: { expanded: true },
   },
@@ -247,3 +251,26 @@ export const MultiSelectExample = (args) => {
   );
 };
 MultiSelectExample.storyName = 'Multi-select combobox example';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const WithExternalLabel = (args) => {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr' }}>
+      <p id="externalLabelId">External label for the combobox</p>
+      <Combobox
+        aria-labelledby="externalLabelId"
+        id={getId()}
+        helper="Choose an element"
+        placeholder="Placeholder"
+        clearButtonAriaLabel="Clear selection"
+        options={options}
+        onBlur={action('onBlur')}
+        onChange={(change) => action('onChange')(change)}
+        onFocus={action('onFocus')}
+        toggleButtonAriaLabel="Open the combobox"
+      />
+    </div>
+  );
+};
+
+WithExternalLabel.storyName = 'With external label';

--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -41,6 +41,18 @@ describe('<Combobox />', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('renders the component without label when aria-labelledby is given', () => {
+    const { asFragment } = render(
+      <Combobox
+        aria-labelledby="some-external-label-id"
+        options={options}
+        clearButtonAriaLabel={defaultProps.clearButtonAriaLabel}
+        toggleButtonAriaLabel={defaultProps.toggleButtonAriaLabel}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('should not have basic accessibility issues', async () => {
     const { container } = getWrapper();
     const results = await axe(container);

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -79,6 +79,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   // we can't destructure all the props. after destructuring, the link
   // between the multiselect prop and the value, onChange etc. props would vanish
   const {
+    'aria-labelledby': ariaLabelledBy,
     'aria-describedby': customAriaDescribedBy,
     catchEscapeKey,
     circularNavigation = false,
@@ -334,11 +335,11 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   const isInputVisible = !props.multiselect || isOpen || (!isOpen && selectedItems.length === 0);
 
   // screen readers should read the labels in the following order:
-  // field label > helper text > error text > toggle button label
+  // field label > ariaLabelledBy > helper text > error text > toggle button label
   // helper and error texts should only be read if they have been defined
   // prettier-ignore
   const inputAriaLabel =
-    `${getLabelProps().id}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getInputProps().id}`;
+    `${getLabelProps().id}${ariaLabelledBy ? ` ${ariaLabelledBy}` : ''}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getInputProps().id}`;
 
   const renderInput = () => (
     <input

--- a/packages/react/src/components/dropdown/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/components/dropdown/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -70,3 +70,67 @@ exports[`<Combobox /> renders the component 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`<Combobox /> renders the component without label when aria-labelledby is given 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <div
+      class="wrapper"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="hds-combobox-4-menu"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="hds-combobox-4-label some-external-label-id hds-combobox-4-input"
+        aria-owns="hds-combobox-4-menu"
+        autocomplete="off"
+        autocorrect="off"
+        class="input"
+        id="hds-combobox-4-input"
+        role="combobox"
+        type="text"
+        value=""
+      />
+      <button
+        aria-expanded="false"
+        aria-label="undefined: Open the combobox"
+        class="button"
+        id="hds-combobox-4-toggle-button"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon s angleIcon"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M0 0h24v24H0z"
+            />
+            <path
+              d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+              fill="currentColor"
+            />
+          </g>
+        </svg>
+      </button>
+      <ul
+        aria-labelledby="hds-combobox-4-label"
+        class="menu"
+        id="hds-combobox-4-menu"
+        role="listbox"
+        style="max-height: 260px;"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -31,7 +31,11 @@ const options = getOptions();
 export default {
   component: Select,
   title: 'Components/Dropdowns/Select',
-  decorators: [(storyFn) => <div style={{ maxWidth: '420px' }}>{storyFn()}</div>],
+  decorators: [
+    (storyFn, context) => {
+      return <div style={{ maxWidth: `${context.name === 'With external label' ? 820 : 420}px` }}>{storyFn()}</div>;
+    },
+  ],
   parameters: {
     controls: { expanded: true },
   },
@@ -235,3 +239,25 @@ export const MultiSelectExample = ({ options: itemOptions, ...args }) => {
   );
 };
 MultiSelectExample.storyName = 'Multi-select example';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const WithExternalLabel = (args) => {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr' }}>
+      <p id="externalLabelId">External label for the select</p>
+      <Select
+        aria-labelledby="externalLabelId"
+        id={getId()}
+        helper="Choose an element"
+        placeholder="Placeholder"
+        clearButtonAriaLabel="Clear selection"
+        options={options}
+        onBlur={action('onBlur')}
+        onChange={(change) => action('onChange')(change)}
+        onFocus={action('onFocus')}
+      />
+    </div>
+  );
+};
+
+WithExternalLabel.storyName = 'With external label';

--- a/packages/react/src/components/dropdown/select/Select.test.tsx
+++ b/packages/react/src/components/dropdown/select/Select.test.tsx
@@ -27,6 +27,16 @@ describe('<Select /> spec', () => {
     const { asFragment } = getWrapper();
     expect(asFragment()).toMatchSnapshot();
   });
+  it('renders the component without label when aria-labelledby is given', () => {
+    const { asFragment } = render(
+      <Select
+        aria-labelledby="some-external-label-id"
+        options={options}
+        clearButtonAriaLabel={defaultProps.clearButtonAriaLabel}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
   it('should not have basic accessibility issues', async () => {
     const { container } = getWrapper();
     const results = await axe(container);

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -65,6 +65,7 @@ export interface SelectCustomTheme {
 }
 
 export type CommonSelectProps<OptionType> = {
+  'aria-labelledby'?: string;
   /**
    * When `true`, allows moving from the first item to the last item with Arrow Up, and vice versa using Arrow Down.
    */
@@ -116,7 +117,7 @@ export type CommonSelectProps<OptionType> = {
   /**
    * The label for the dropdown
    */
-  label: React.ReactNode;
+  label?: React.ReactNode;
   /**
    * Callback function fired when the state is changed
    */
@@ -299,6 +300,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   // we can't destructure all the props. after destructuring, the link
   // between the multiselect prop and the value, onChange etc. props would vanish
   const {
+    'aria-labelledby': ariaLabelledBy,
     circularNavigation = false,
     className,
     clearable = props.multiselect,
@@ -469,11 +471,11 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
   };
 
   // screen readers should read the labels in the following order:
-  // field label > helper text > error text > toggle button label
+  // field label > ariaLabelledBy > helper text > error text > toggle button label
   // helper and error texts should only be read if they have been defined
   // prettier-ignore
   const buttonAriaLabel =
-    `${getLabelProps().id}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getToggleButtonProps().id}`;
+    `${getLabelProps().id}${ariaLabelledBy ? ` ${ariaLabelledBy}`: ''}${error ? ` ${id}-error` : ''}${helper ? ` ${id}-helper` : ''} ${getToggleButtonProps().id}`;
 
   // show placeholder if no value is selected
   const showPlaceholder = (props.multiselect && selectedItems.length === 0) || (!props.multiselect && !selectedItem);

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -66,9 +66,10 @@ export interface SelectCustomTheme {
 
 interface Label {
   /**
-   * The label for the dropdown
+   * The label for the dropdown.
    */
   label: React.ReactNode;
+  'aria-labelledby'?: undefined;
 }
 
 interface LabelledBy {
@@ -76,6 +77,7 @@ interface LabelledBy {
    * The id of the external label element. Use this if you use external label instead of label.
    */
   'aria-labelledby': string;
+  label?: undefined;
 }
 
 type LabelType = Label | LabelledBy;

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -65,6 +65,9 @@ export interface SelectCustomTheme {
 }
 
 export type CommonSelectProps<OptionType> = {
+  /**
+   * The id of the external label element. Use this if you use external label instead of label.
+   */
   'aria-labelledby'?: string;
   /**
    * When `true`, allows moving from the first item to the last item with Arrow Up, and vice versa using Arrow Down.

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -64,11 +64,23 @@ export interface SelectCustomTheme {
   '--placeholder-color'?: string;
 }
 
-export type CommonSelectProps<OptionType> = {
+interface Label {
+  /**
+   * The label for the dropdown
+   */
+  label: React.ReactNode;
+}
+
+interface LabelledBy {
   /**
    * The id of the external label element. Use this if you use external label instead of label.
    */
-  'aria-labelledby'?: string;
+  'aria-labelledby': string;
+}
+
+type LabelType = Label | LabelledBy;
+
+export type CommonSelectProps<OptionType> = LabelType & {
   /**
    * When `true`, allows moving from the first item to the last item with Arrow Up, and vice versa using Arrow Down.
    */
@@ -117,10 +129,6 @@ export type CommonSelectProps<OptionType> = {
    * A function used to detect whether an option is disabled
    */
   isOptionDisabled?: (option: OptionType, index: number) => boolean;
-  /**
-   * The label for the dropdown
-   */
-  label?: React.ReactNode;
   /**
    * Callback function fired when the state is changed
    */

--- a/packages/react/src/components/dropdown/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react/src/components/dropdown/select/__snapshots__/Select.test.tsx.snap
@@ -57,3 +57,54 @@ exports[`<Select /> spec renders the component 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`<Select /> spec renders the component without label when aria-labelledby is given 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <div
+      class="wrapper"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="hds-select-4-label some-external-label-id hds-select-4-toggle-button"
+        aria-owns="hds-select-4-menu"
+        class="button placeholder"
+        id="hds-select-4-toggle-button"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon s angleIcon"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M0 0h24v24H0z"
+            />
+            <path
+              d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+              fill="currentColor"
+            />
+          </g>
+        </svg>
+      </button>
+      <ul
+        aria-labelledby="hds-select-4-label"
+        class="menu"
+        id="hds-select-4-menu"
+        role="listbox"
+        style="max-height: 260px;"
+        tabindex="-1"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Description

Add possibility to use external label for Select and Combobox components. This enables custom labels that are placed and styled differently than the components own label.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1431

## How Has This Been Tested?

- Locally in dev machine
- Automated visual regression tests

👉 [Combobox demo](https://city-of-helsinki.github.io/hds-demo/external-label-for-dropdowns/?path=/story/components-dropdowns-combobox--with-external-label)
👉 [Select demo](https://city-of-helsinki.github.io/hds-demo/external-label-for-dropdowns/?path=/story/components-dropdowns-select--with-external-label)

## Screenshots (if appropriate):

<img width="903" alt="image" src="https://user-images.githubusercontent.com/2777633/195926779-c07f91a0-6049-4cd6-ba33-f7328f422c30.png">

