### PR TITLE
Hds 1420 accordions heading is not accessible

### DIFF
--- a/packages/react/src/components/accordion/Accordion.module.scss
+++ b/packages/react/src/components/accordion/Accordion.module.scss
@@ -76,6 +76,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  & > div {
+    flex: 1 1 auto;
+  }
 }
 
 .accordionContent {

--- a/packages/react/src/components/accordion/Accordion.test.tsx
+++ b/packages/react/src/components/accordion/Accordion.test.tsx
@@ -27,7 +27,7 @@ describe('<Accordion /> spec', () => {
         Bar
       </Accordion>,
     );
-    userEvent.click(container.querySelector('[id="accordion-heading"]'));
+    userEvent.click(container.querySelector('[id="accordion-heading"] .label'));
     expect(container.querySelector('[id="accordion-content"]')).toBeVisible();
   });
 

--- a/packages/react/src/components/accordion/Accordion.tsx
+++ b/packages/react/src/components/accordion/Accordion.tsx
@@ -222,24 +222,24 @@ export const Accordion = ({
       id={accordionId}
     >
       <div className={classNames(styles.accordionHeader)}>
-        <div
-          ref={headerRef}
-          role="button"
-          tabIndex={0}
-          onKeyPress={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              buttonProps.onClick();
-            }
-          }}
-          className={styles.headingContainer}
-          aria-labelledby={`${accordionId}-heading`}
-          {...buttonProps}
-          {...(beforeCloseButtonClick ? { 'aria-expanded': false } : {})}
-        >
-          <div role="heading" aria-level={headingLevel} id={`${accordionId}-heading`}>
-            {heading}
+        <div role="heading" aria-level={headingLevel} id={`${accordionId}-heading`}>
+          <div
+            ref={headerRef}
+            role="button"
+            tabIndex={0}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                buttonProps.onClick();
+              }
+            }}
+            className={styles.headingContainer}
+            aria-labelledby={`${accordionId}-heading`}
+            {...buttonProps}
+            {...(beforeCloseButtonClick ? { 'aria-expanded': false } : {})}
+          >
+            <span className="label">{heading}</span>
+            {icon}
           </div>
-          {icon}
         </div>
       </div>
       <div

--- a/packages/react/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -10,39 +10,43 @@ exports[`<Accordion /> spec renders the component 1`] = `
       class="accordionHeader"
     >
       <div
-        aria-expanded="false"
-        aria-labelledby="accordion-1-heading"
-        class="headingContainer"
-        role="button"
-        tabindex="0"
+        aria-level="2"
+        id="accordion-1-heading"
+        role="heading"
       >
         <div
-          aria-level="2"
-          id="accordion-1-heading"
-          role="heading"
+          aria-expanded="false"
+          aria-labelledby="accordion-1-heading"
+          class="headingContainer"
+          role="button"
+          tabindex="0"
         >
-          Foo
-        </div>
-        <svg
-          aria-hidden="true"
-          class="icon s accordionButtonIcon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fill-rule="evenodd"
+          <span
+            class="label"
           >
-            <path
-              d="M0 0h24v24H0z"
-            />
-            <path
-              d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
+            Foo
+          </span>
+          <svg
+            aria-hidden="true"
+            class="icon s accordionButtonIcon"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <path
+                d="M0 0h24v24H0z"
+              />
+              <path
+                d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
## Description

Fixes the issue with accordion component being not accessible by moving the button inside the heading in the title.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1420

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/accordion-header-a11y-fix/?path=/story/components-accordion--medium)
