### PR TITLE
HDS-1274 Use span tag instead of i tag for icons.

### DIFF
--- a/packages/core/src/icons/icons.stories.js
+++ b/packages/core/src/icons/icons.stories.js
@@ -12,7 +12,7 @@ req.keys().forEach((fileName) => {
   const iconCapitalized = icon.charAt(0).toUpperCase() + icon.slice(1)
   const allSizes = () => {
     const all = ['xs', 's', 'm', 'l', 'xl'].reduce((acc, size) => {
-      acc += `\n<i class="hds-icon hds-icon--${icon} hds-icon--size-${size}" aria-hidden="true" style="vertical-align: middle"></i>`;
+      acc += `\n<span class="hds-icon hds-icon--${icon} hds-icon--size-${size}" aria-hidden="true" style="vertical-align: middle"></span>`;
       return acc;
     }, '');
 

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -161,7 +161,7 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              icon: `<i class="hds-anchor-icon hds-icon hds-icon--link hds-icon--size-xs" aria-hidden="true" style="vertical-align: middle"></i>`,
+              icon: `<span class="hds-anchor-icon hds-icon hds-icon--link hds-icon--size-xs" aria-hidden="true" style="vertical-align: middle"></span>`,
               isIconAfterHeader: true,
               className: `header-anchor`,
             },

--- a/site/src/docs/about/accessibility/statement.mdx
+++ b/site/src/docs/about/accessibility/statement.mdx
@@ -23,12 +23,11 @@ As regards the accessibility of digital services, Helsinki aims to reach at leas
 The accessibility compliance of this website was evaluated by a third-party auditor on 27. June 2022. Most of the issues noted in the audit were fixed. Three (3) issues were not fixed before the release of this site. The team will continue improving the site accessibility during 2022. The remaining issues will be fixed if it is technically feasible.
 
 Currently, known accessibility issues are:
-- `<i>` tag has been used in navigation link icons. (*1.3.1 Info and Relationships*)
 - On component pages, when clicking the "Copy code" button, the user does not get feedback on whether the copy was successful or not. (*4.1.3 Status Messages*)
 - The jump to content link does not always work correctly when using a screen reader. (*2.4.1 Bypass Blocks*)
 
 ## Preparing an accessibility statement
-This statement was originally prepared on 28. June 2022. The statement has been updated on 28. June 2022.
+This statement was originally prepared on 28. June 2022. The statement has been updated on 31. October 2022.
 
 ## Updating the accessibility statement
 The accessibility statement will be updated so that it corresponds with the most recent compliance status of the website.

--- a/site/src/docs/components/icon/code.mdx
+++ b/site/src/docs/components/icon/code.mdx
@@ -25,7 +25,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```
 
 ```html
-<i class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></i>
+<span class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></span>
 ```
 
 </Playground>
@@ -48,11 +48,11 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ```html
 <div>
-  <i class="hds-icon hds-icon--face-smile hds-icon--size-xs" aria-hidden="true"></i>
-  <i class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></i>
-  <i class="hds-icon hds-icon--face-smile hds-icon--size-m" aria-hidden="true"></i>
-  <i class="hds-icon hds-icon--face-smile hds-icon--size-l" aria-hidden="true"></i>
-  <i class="hds-icon hds-icon--face-smile hds-icon--size-xl" aria-hidden="true"></i>
+  <span class="hds-icon hds-icon--face-smile hds-icon--size-xs" aria-hidden="true"></span>
+  <span class="hds-icon hds-icon--face-smile hds-icon--size-s" aria-hidden="true"></span>
+  <span class="hds-icon hds-icon--face-smile hds-icon--size-m" aria-hidden="true"></span>
+  <span class="hds-icon hds-icon--face-smile hds-icon--size-l" aria-hidden="true"></span>
+  <span class="hds-icon hds-icon--face-smile hds-icon--size-xl" aria-hidden="true"></span>
 </div>
 ```
 
@@ -68,7 +68,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```
 
 ```html
-<i class="hds-icon hds-icon--plus-circle hds-icon--size-s" aria-label="Add an item"></i>
+<span class="hds-icon hds-icon--plus-circle hds-icon--size-s" aria-label="Add an item"></span>
 ```
 
 </Playground>

--- a/site/src/docs/components/icon/customisation.mdx
+++ b/site/src/docs/components/icon/customisation.mdx
@@ -29,11 +29,11 @@ Customising icons is rather simple. Use the `size` property to control size and 
 
 ```html
 <div>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-xs" style="color: var(--color-bus)" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-s" style="color: var(--color-brick)" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-m" style="color: var(--color-coat-of-arms)" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-l" style="color: var(--color-tram)" aria-hidden="true"></i>
-<i class="hds-icon hds-icon--face-smile hds-icon--size-xl" style="color: var(--color-metro)" aria-hidden="true"></i>
+<span class="hds-icon hds-icon--face-smile hds-icon--size-xs" style="color: var(--color-bus)" aria-hidden="true"></span>
+<span class="hds-icon hds-icon--face-smile hds-icon--size-s" style="color: var(--color-brick)" aria-hidden="true"></span>
+<span class="hds-icon hds-icon--face-smile hds-icon--size-m" style="color: var(--color-coat-of-arms)" aria-hidden="true"></span>
+<span class="hds-icon hds-icon--face-smile hds-icon--size-l" style="color: var(--color-tram)" aria-hidden="true"></span>
+<span class="hds-icon hds-icon--face-smile hds-icon--size-xl" style="color: var(--color-metro)" aria-hidden="true"></span>
 </div>
 ```
 

--- a/site/src/docs/components/link/code.mdx
+++ b/site/src/docs/components/link/code.mdx
@@ -40,7 +40,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
   <a href="https://github.com/City-of-Helsinki/helsinki-design-system" class="hds-link hds-link--small" aria-label="HDS Github. Opens in external domain">
-  HDS Github<i class="hds-icon icon hds-icon--link-external hds-icon--size-xs vertical-align-small-or-medium-icon" aria-hidden="true"></i></a>
+  HDS Github<span class="hds-icon icon hds-icon--link-external hds-icon--size-xs vertical-align-small-or-medium-icon" aria-hidden="true"></span></a>
   laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </p>
@@ -112,10 +112,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
     aria-label="Opens a different website."
   >
     External link
-    <i
+    <span
       class="hds-icon icon hds-icon--link-external hds-icon--size-s vertical-align-small-or-medium-icon"
       aria-hidden="true"
-    ></i>
+    ></span>
   </a>
 
   <a
@@ -126,10 +126,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
     aria-label="Opens a different website. Opens in a new tab."
   >
     Link that opens in a new tab
-    <i
+    <span
       class="hds-icon icon hds-icon--link-external hds-icon--size-xs vertical-align-small-or-medium-icon"
       aria-hidden="true"
-    ></i>
+    ></span>
   </a>
 </p>
 ```
@@ -182,22 +182,22 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```html
 <p>
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--document hds-icon--size-s" aria-hidden="true"></i></span>
+    <span class="hds-icon-left"><span class="hds-icon hds-icon--document hds-icon--size-s" aria-hidden="true"></span></span>
     Document link
   </a>
 
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--phone hds-icon--size-s" aria-hidden="true"></i></span>
+    <span class="hds-icon-left"><span class="hds-icon hds-icon--phone hds-icon--size-s" aria-hidden="true"></span></span>
     Phone link
   </a>
 
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--envelope hds-icon--size-s" aria-hidden="true"></i></span>
+    <span class="hds-icon-left"><spani class="hds-icon hds-icon--envelope hds-icon--size-s" aria-hidden="true"></span></span>
     Envelope link
   </a>
 
   <a href="/#" class="hds-link hds-link--medium">
-    <span class="hds-icon-left"><i class="hds-icon hds-icon--photo hds-icon--size-s" aria-hidden="true"></i></span>
+    <span class="hds-icon-left"><span class="hds-icon hds-icon--photo hds-icon--size-s" aria-hidden="true"></span></span>
     Photo link
   </a>
 </p>

--- a/site/src/docs/components/password-input/code.mdx
+++ b/site/src/docs/components/password-input/code.mdx
@@ -55,7 +55,7 @@ style={{
         aria-label="Show"
         class="hds-text-input__button"
       >
-        <i class="hds-icon hds-icon--eye hds-icon--size-s" aria-hidden="true"></i>
+        <span class="hds-icon hds-icon--eye hds-icon--size-s" aria-hidden="true"></span>
       </button>
     </div>
   </div>

--- a/site/src/docs/components/search-input/code.mdx
+++ b/site/src/docs/components/search-input/code.mdx
@@ -45,7 +45,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
         aria-label="Search"
         class="hds-search-input__button"
       >
-        <i class="hds-icon hds-icon--search hds-icon--size-s" aria-hidden="true"></i>
+        <span class="hds-icon hds-icon--search hds-icon--size-s" aria-hidden="true"></span>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Description

Fixes a11y problem in documentation site and hds-core icon examples by using span tag instead of i tag.

This can be merged without a release.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1274

## How Has This Been Tested?

- Locally on dev machine

👉 [Demo](https://city-of-helsinki.github.io/hds-demo/docsite-link-icon-a11y-fix/components#components-overview)
