### PR TITLE
Core components' style importing made easier

### DIFF
--- a/packages/core/src/components/link/link.css
+++ b/packages/core/src/components/link/link.css
@@ -1,3 +1,6 @@
+@import "../../icons/icon.css";
+@import "../../icons/ui/icon-link-external.css";
+
 .hds-link {
   --link-visited-color: #551a8b;
   --link-color: var(--color-bus);

--- a/packages/core/src/components/link/link.stories.js
+++ b/packages/core/src/components/link/link.stories.js
@@ -1,5 +1,4 @@
 import './link.css';
-import '../../icons/icon.css';
 
 export default {
   title: 'Components/Link',

--- a/packages/core/src/components/notification/notification.css
+++ b/packages/core/src/components/notification/notification.css
@@ -1,3 +1,9 @@
+@import "../../icons/icon.css";
+@import "../../icons/ui/icon-alert-circle-fill.css";
+@import "../../icons/ui/icon-check-circle-fill.css";
+@import "../../icons/ui/icon-error-fill.css";
+@import "../../icons/ui/icon-info-circle-fill.css";
+
 .hds-notification {
   --notification-background-color: var(--color-info-light);
   --notification-border-color: var(--color-info);

--- a/packages/core/src/components/notification/notification.stories.js
+++ b/packages/core/src/components/notification/notification.stories.js
@@ -1,5 +1,4 @@
 import './notification.css';
-import '../../icons/icon.css';
 
 const iconMapping = {
   info: 'info-circle-fill',

--- a/packages/core/src/components/notification/notification.stories.js
+++ b/packages/core/src/components/notification/notification.stories.js
@@ -1,10 +1,5 @@
 import './notification.css';
 import '../../icons/icon.css';
-import '../../icons/ui/icon-info-circle.css';
-import '../../icons/ui/icon-cross.css';
-import '../../icons/ui/icon-alert-circle.css';
-import '../../icons/ui/icon-error.css';
-import '../../icons/ui/icon-check.css';
 
 const iconMapping = {
   info: 'info-circle-fill',

--- a/packages/core/src/components/pagination/pagination.css
+++ b/packages/core/src/components/pagination/pagination.css
@@ -1,3 +1,8 @@
+@import "../button//button.css";
+@import "../../icons/icon.css";
+@import "../../icons/ui/icon-angle-right.css";
+@import "../../icons/ui/icon-angle-left.css";
+
 .hds-pagination-container {
   text-align: center;
 }

--- a/packages/core/src/components/search-input/search-input.css
+++ b/packages/core/src/components/search-input/search-input.css
@@ -1,3 +1,5 @@
+@import "../../icons/icon.css";
+@import "../../icons/ui/icon-search.css";
 
 .hds-search-input {
   --border-width: 2px;

--- a/packages/core/src/components/search-input/search-input.stories.js
+++ b/packages/core/src/components/search-input/search-input.stories.js
@@ -1,5 +1,4 @@
 import './search-input.css';
-import '../../icons/icon.css';
 
 export default {
   title: 'Components/Search input',

--- a/packages/core/src/components/tag/tag.css
+++ b/packages/core/src/components/tag/tag.css
@@ -1,3 +1,6 @@
+@import "../../icons/icon.css";
+@import "../../icons/ui/icon-cross.css";
+
 .hds-tag {
   --tag-background: var(--color-black-10);
   --tag-color: var(--color-black-90);

--- a/packages/core/src/components/tag/tag.stories.js
+++ b/packages/core/src/components/tag/tag.stories.js
@@ -1,6 +1,4 @@
 import './tag.css';
-import '../../icons/icon.css';
-import '../../icons/ui/icon-cross.css';
 
 export default {
   title: 'Components/Tag',

--- a/packages/react/src/components/notification/Notification.module.css
+++ b/packages/react/src/components/notification/Notification.module.css
@@ -27,6 +27,7 @@
 
 .icon {
   composes: hds-icon from 'hds-core/lib/components/notification/notification.css';
+  background-color: transparent;
 }
 
 .label {


### PR DESCRIPTION
## Description

Instead of importing several CSS files when using core components, the user needs to import only one file which takes care of importing the rest of the needed styles. Only a small handful of components was affected (Link, Notification, Pagination, SearchInput and Tag.)

Are you worried about double style definitions? Don't be! `cssnano` takes care of removing double styles during building.

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-1263

## Motivation and Context

Using core components should be simple and therefore importing the component's styles should be relatively straightforward.

## How Has This Been Tested?
Locally with `hds-cra` project and storybook
[Demo](https://city-of-helsinki.github.io/hds-demo/core-css-imports/?path=/story/components-link--external-links)