### PR TITLE
Prevent DateInput calendar value reset on scroll

### DIFF
--- a/packages/react/src/components/dateInput/DateInput.module.scss
+++ b/packages/react/src/components/dateInput/DateInput.module.scss
@@ -1,27 +1,3 @@
 .wrapper {
   position: relative;
 }
-
-.pickerWrapper {
-  transition: opacity 150ms;
-  display: flex;
-  justify-content: flex-end;
-  pointer-events: none;
-  opacity: 0;
-  visibility: hidden;
-  will-change: opacity, visibility;
-  z-index: 900;
-  overflow: hidden;
-  height: 0;
-
-  &.isVisible {
-    opacity: 1;
-    visibility: visible;
-    height: auto;
-    overflow: visible;
-
-    > * {
-      pointer-events: auto;
-    }
-  }
-}

--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -1,11 +1,8 @@
 import { format, parse, isValid, subYears, addYears, startOfMonth, endOfMonth } from 'date-fns';
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { usePopper } from 'react-popper';
 
 import { IconCalendar } from '../../icons';
-import classNames from '../../utils/classNames';
 import mergeRefWithInternalRef from '../../utils/mergeRefWithInternalRef';
-import { scrollIntoViewIfNeeded } from '../../utils/scrollIntoViewIfNeeded';
 import { TextInput, TextInputProps } from '../textInput';
 import { DatePicker } from './components/datePicker';
 import styles from './DateInput.module.scss';
@@ -83,7 +80,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     ref?: React.Ref<HTMLInputElement>,
   ) => {
     const dateFormat = 'd.M.yyyy';
-    const pickerWrapperRef = useRef<HTMLDivElement>();
     const inputRef = useRef<HTMLInputElement>();
     const didMount = useRef(false);
     const [inputValue, setInputValue] = useState<string>(providedValue || defaultValue || '');
@@ -115,92 +111,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         }
       }
     };
-
-    /**
-     * Close datepicker when clicked outside
-     */
-    useEffect(() => {
-      const handleClickOutsideWrapper = (event: MouseEvent) => {
-        if (showPicker === true) {
-          const isOutside = pickerWrapperRef.current && !pickerWrapperRef.current.contains(event.target as Node);
-          const toggleButton = getToggleButton();
-          const isToggleButton =
-            toggleButton && (toggleButton === event.target || toggleButton.contains(event.target as Node));
-          if (isOutside && !isToggleButton) {
-            const focusToggleButton = document.activeElement === null || document.activeElement.tagName === 'BODY';
-            closeDatePicker(focusToggleButton);
-          }
-        }
-      };
-      window.addEventListener('click', handleClickOutsideWrapper);
-      return () => {
-        window.removeEventListener('click', handleClickOutsideWrapper);
-      };
-    });
-
-    /**
-     * Handle tab inside date picker
-     */
-    useEffect(() => {
-      const pickerModalElement = pickerWrapperRef.current;
-      const tabbleEventHandler = (event: KeyboardEvent) => {
-        // Skip if pressed key was not tab
-        const isTab = event.key === 'Tab' || event.keyCode === 9;
-        if (!isTab) {
-          return;
-        }
-        // Get all focusable elements inside the modal
-        const focusableElements = pickerModalElement.querySelectorAll(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        );
-        const firstFocusableElement = focusableElements[0];
-        const lastFocusableElement = focusableElements[focusableElements.length - 1];
-
-        // Check if shift key is pressed
-        if (event.shiftKey) {
-          // If currently focused element is the first element, move focus the last one
-          if (document.activeElement === firstFocusableElement) {
-            (lastFocusableElement as HTMLElement).focus();
-            event.preventDefault();
-          }
-        }
-        // If shift is not pressed and currently focused element is the last element,
-        // move focust the first one
-        else if (document.activeElement === lastFocusableElement) {
-          (firstFocusableElement as HTMLElement).focus();
-          event.preventDefault();
-        }
-      };
-      if (pickerModalElement) {
-        pickerModalElement.addEventListener('keydown', tabbleEventHandler);
-      }
-      return () => {
-        if (pickerModalElement) {
-          pickerModalElement.removeEventListener('keydown', tabbleEventHandler);
-        }
-      };
-    }, []);
-
-    /**
-     * Focus the first focusable element inside the datepicker
-     * when opened.
-     */
-    useEffect(() => {
-      let scrollTimeout;
-      if (showPicker === true && pickerWrapperRef.current) {
-        const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-        const firstFocusableElement = pickerWrapperRef.current.querySelector(focusableElements);
-        if (firstFocusableElement) {
-          (firstFocusableElement as HTMLElement).focus();
-        }
-        scrollTimeout = setTimeout(() => {
-          scrollIntoViewIfNeeded(pickerWrapperRef.current);
-        }, 30);
-      }
-      return () => {
-        clearTimeout(scrollTimeout);
-      };
-    }, [showPicker]);
 
     /**
      * Handle the date picker open button
@@ -272,38 +182,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
     // Get the current value as Date object
     const inputValueAsDate = stringToDate(inputValue);
-
-    // Initialize Popper.js
-    const { styles: datePickerPopperStyles, attributes: datePickerPopperAttributes } = usePopper(
-      inputRef.current,
-      pickerWrapperRef.current,
-      {
-        placement: 'bottom-end',
-        modifiers: [
-          {
-            name: 'offset',
-            options: {
-              offset: [0, 5],
-            },
-          },
-          {
-            name: 'flip',
-            options: {
-              rootBoundary: 'document',
-              fallbackPlacements: ['bottom-start', 'top-end'],
-            },
-          },
-          {
-            name: 'eventListeners',
-            options: {
-              scroll: false,
-              resize: true,
-            },
-          },
-        ],
-      },
-    );
-
+    const toggleButton = getToggleButton();
     return (
       <div lang={language} className={styles.wrapper}>
         <TextInput
@@ -319,32 +198,25 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           inputMode="numeric"
         >
           {disableDatePicker === false && (
-            <div
-              ref={pickerWrapperRef}
-              className={classNames(styles.pickerWrapper, showPicker && styles.isVisible)}
-              role="dialog"
-              aria-modal="true"
-              aria-hidden={showPicker ? undefined : true}
-              style={datePickerPopperStyles.popper}
-              {...datePickerPopperAttributes.popper}
-            >
-              <DatePicker
-                language={language}
-                disableConfirmation={disableConfirmation}
-                selected={isValid(inputValueAsDate) ? inputValueAsDate : undefined}
-                initialMonth={initialMonth}
-                onDaySelect={(day) => {
-                  closeDatePicker();
-                  handleInputChange(format(day, dateFormat));
-                }}
-                onCloseButtonClick={() => closeDatePicker()}
-                selectButtonLabel={getSelectButtonLabel()}
-                closeButtonLabel={getCloseButtonLabel()}
-                minDate={minDate && isValid(minDate) ? minDate : startOfMonth(subYears(new Date(), 10))}
-                maxDate={maxDate && isValid(maxDate) ? maxDate : endOfMonth(addYears(new Date(), 10))}
-                isDateDisabledBy={isDateDisabledBy}
-              />
-            </div>
+            <DatePicker
+              language={language}
+              disableConfirmation={disableConfirmation}
+              selected={isValid(inputValueAsDate) ? inputValueAsDate : undefined}
+              initialMonth={initialMonth}
+              onDaySelect={(day) => {
+                closeDatePicker();
+                handleInputChange(format(day, dateFormat));
+              }}
+              onCloseButtonClick={(focusToggleButton) => closeDatePicker(focusToggleButton)}
+              selectButtonLabel={getSelectButtonLabel()}
+              closeButtonLabel={getCloseButtonLabel()}
+              minDate={minDate && isValid(minDate) ? minDate : startOfMonth(subYears(new Date(), 10))}
+              maxDate={maxDate && isValid(maxDate) ? maxDate : endOfMonth(addYears(new Date(), 10))}
+              isDateDisabledBy={isDateDisabledBy}
+              open={showPicker}
+              inputRef={inputRef}
+              toggleButton={toggleButton}
+            />
           )}
         </TextInput>
       </div>

--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -293,6 +293,13 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
               fallbackPlacements: ['bottom-start', 'top-end'],
             },
           },
+          {
+            name: 'eventListeners',
+            options: {
+              scroll: false,
+              resize: true,
+            },
+          },
         ],
       },
     );

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.module.scss
@@ -21,6 +21,30 @@
   }
 }
 
+.pickerWrapper {
+  transition: opacity 150ms;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  will-change: opacity, visibility;
+  z-index: 900;
+  overflow: hidden;
+  height: 0;
+
+  &.isVisible {
+    opacity: 1;
+    visibility: visible;
+    height: auto;
+    overflow: visible;
+
+    > * {
+      pointer-events: auto;
+    }
+  }
+}
+
 .hds-datepicker {
   background: #fff;
   position: relative;

--- a/packages/react/src/components/dateInput/components/datePicker/types/DayPickerProps.ts
+++ b/packages/react/src/components/dateInput/components/datePicker/types/DayPickerProps.ts
@@ -79,9 +79,21 @@ export interface DayPickerProps {
   /**
    * Event handler for the close button
    */
-  onCloseButtonClick: React.MouseEventHandler;
+  onCloseButtonClick: (focus?: boolean | undefined) => void;
   /**
    * Disables date(s) in datepicker calendar based on conditional function
    */
   isDateDisabledBy?: (Date) => boolean;
+  /**
+   * Boolean value for showing the DatePicker
+   */
+  open?: boolean;
+  /**
+   * Reference object to DateInput
+   */
+  inputRef?: React.MutableRefObject<HTMLDivElement>;
+  /**
+   * Calendar toggle button
+   */
+  toggleButton?: HTMLButtonElement | null;
 }


### PR DESCRIPTION
Prevent value from resetting by disabling scroll event listener in react-popper. At least I didn't find how this could break functionality but **test with creativity please!** 

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1421

## Motivation and Context

hel.fi notified us about this in Slack. The need for a fix is great.

## How Has This Been Tested?
Locally on dev machine
[Demo](https://city-of-helsinki.github.io/hds-demo/dateinput-scroll-fix/?path=/story/components-dateinput--default)
