### PR TITLE
Hds 1405 add time format for timers

### DIFF
--- a/site/src/docs/foundation/guidelines/data-formats.mdx
+++ b/site/src/docs/foundation/guidelines/data-formats.mdx
@@ -21,6 +21,7 @@ Type                            | Format                        | Notes
 --------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Time (forms, schedules, etc.)   | 15:00, 02:00                  | When presenting times in forms and schedules, use leading zeros and a colon separator. A 24-hour clock is always used.
 Time (in text)                  | 15.00, 2.00                   | When presenting times in the written text, use a single dot instead of a colon separator. Leading zeros can be opted out as well. A 24-hour clock is always used.
+Timer (forms)                   | 05:00                         | When presenting timer in forms that counts down expiration. The time format is mm:ss.
 Day, month, and year            | 24.6.2020                     | Date format is D.M.YYYY even if the user's locale is something else than Finnish. Leading zeros are not used for dates.
 Day, month, and year (longer)   | 24. June 2020, 24 June 2020   | Using the written format of the month makes the date easier to understand for different locales. Note that technically English translation omits the dot after day number.
 Today, tomorrow, yesterday      | Today, 12:30                  | If talking about today, tomorrow, or yesterday, the written format is used instead of date.
@@ -31,7 +32,7 @@ When presenting time or date ranges, consider making information simpler by leav
 
 Type                                  | Format                                 | Notes
 --------------------------------------|----------------------------------------|---------------------------------------------------------------------------------------
-Time range (forms, schedules, etc.)   | 12:30–16:30                            | When presenting times in forms and schedules, use leading zeros and a colon separator. 
+Time range (forms, schedules, etc.)   | 12:30–16:30                            | When presenting times in forms and schedules, use leading zeros and a colon separator.
 Time range (in text)                  | 12.30–16.30                            | When presenting times in the written text, use a single dot instead of a colon separator.
 Date range                            | 2.–15. January 2020 / 2.1.–5.2.2020    | Year and/or month can be only written once if both dates share the same year/month.
 [Table 2:Recommended range formats]|


### PR DESCRIPTION
## Description

Added time format mm:ss on documentation site page Foundation/Guidelines/Data formats.

## Motivation and Context

Forms are increasingly using timers for displaying to the user when the allocation will expire. The allocation can be related to events or products with limited availability and payment user flows.