### PR TITLE
Combobox scroll bug fix

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -447,6 +447,10 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
         onFocus={ignoreFocusHandlerWhenClickingItem(handleWrapperFocus)}
         onBlur={ignoreFocusHandlerWhenClickingItem(handleWrapperBlur)}
         onClick={handleWrapperClick}
+        onMouseUp={() => {
+          setIsClicking(false);
+          focusInput();
+        }}
         className={classNames(styles.wrapper, props.multiselect && props.icon && styles.wrapperWithMultiSelectAndIcon)}
         ref={getComboboxProps().ref}
       >

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -148,7 +148,6 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
       inputRef.current.focus();
     }
   };
-  var timer;
   // init multi-select
   const {
     activeIndex,

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -148,7 +148,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
       inputRef.current.focus();
     }
   };
-
+  var timer;
   // init multi-select
   const {
     activeIndex,
@@ -204,7 +204,9 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     getA11ySelectionMessage,
     getA11yStatusMessage,
     itemToString: (item): string => (item ? item[optionLabelField] ?? '' : ''),
-    onHighlightedIndexChange: ({ highlightedIndex: _highlightedIndex }) => virtualizer.scrollToIndex(_highlightedIndex),
+    onHighlightedIndexChange: ({ highlightedIndex: _highlightedIndex }) => {
+      if (virtualized) virtualizer.scrollToIndex(_highlightedIndex);
+    },
     onSelectedItemChange: ({ selectedItem: _selectedItem }) =>
       props.multiselect === false && typeof props.onChange === 'function' && props.onChange(_selectedItem),
     onStateChange({ type, selectedItem: _selectedItem }) {

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -203,9 +203,6 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     getA11ySelectionMessage,
     getA11yStatusMessage,
     itemToString: (item): string => (item ? item[optionLabelField] ?? '' : ''),
-    onHighlightedIndexChange: ({ highlightedIndex: _highlightedIndex }) => {
-      if (virtualized) virtualizer.scrollToIndex(_highlightedIndex);
-    },
     onSelectedItemChange: ({ selectedItem: _selectedItem }) =>
       props.multiselect === false && typeof props.onChange === 'function' && props.onChange(_selectedItem),
     onStateChange({ type, selectedItem: _selectedItem }) {


### PR DESCRIPTION
## Description

Combobox automatically scrolls to hovered menu items. This creates a confusing user experience when user scrolls down the list and (accidentally or not) moves the mouse up and the Combobox keeps scrolling even if user didn't mean to. I think this functionality is more trouble than it's worth. 

I checked if this serves any purpose accessibility-wise with Emmi Nyqvist and she thought no, if anything it may confuse people with problems perceiving things or using the magnifying glass functionality.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1210

## Motivation and Context

People in the Jira ticket's comments and Slack are waiting for us to fix the behaviour.

## How Has This Been Tested?
Locally on dev machine.
[Demo](https://city-of-helsinki.github.io/hds-demo/combobox-scroll-fix/?path=/story/components-dropdowns-combobox--multi-select-example)
