### PR TITLE
Add missing enterkeyhint-attribute to search input

### DIFF
--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -192,6 +192,7 @@ export const SearchInput = <SuggestionItem,>({
           })}
           className={classNames(styles.input)}
           placeholder={placeholder}
+          enterKeyHint="search"
         />
         <div className={styles.buttons}>
           {inputValue.length > 0 && (

--- a/packages/react/src/components/searchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react/src/components/searchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`<SearchInput /> spec renders the component 1`] = `
         aria-owns="downshift-1-menu"
         autocomplete="off"
         class="input"
+        enterkeyhint="search"
         id="downshift-0-input"
         role="combobox"
         value=""


### PR DESCRIPTION
## Description
- Add missing enterhintKey to search input

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1429

## Motivation and Context
- The enterhint key enumeration tells the mobile browsers what kind of label enter key needs. The browser will resolve the text with the help of the enterhintkey-attribute.

## How Has This Been Tested?
- locally on the dev machine
- snapshot test


[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1429-search-input-mobile-enter-fix/iframe.html?args=&id=components-searchinput--default&viewMode=story)

### Old in Mobile Chrome:
![FF8F8982-518C-4BF2-874D-71B2C0F376A2](https://user-images.githubusercontent.com/1610860/200346448-3b6313fb-3914-451f-8100-6532bff159b7.png)

### With this fix in Mobile Chrome:
![A4E33B6A-5097-40AF-ACED-E2755EB9AA2A](https://user-images.githubusercontent.com/1610860/200346611-2707d631-f465-4bf6-95c0-a5fe869e36d0.png)