### PR TITLE
Add info about browser support into README

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -37,3 +37,14 @@ Read more [here](DEVELOPMENT.md).
 - [Prettier](https://github.com/prettier/prettier) for code formatting
 - [Jest](https://github.com/facebook/jest) with [React Testing Library](https://github.com/testing-library/react-testing-library) for testing
 - [Loki](https://loki.js.org/) for visual regression testing
+
+## Supported browsers
+Helsinki Design System uses the react-scripts library's default browserslist config to target a broad range of browsers.
+This means that the following browsers are supported:
+- Chrome
+- Firefox
+- Safari
+The supported browser versions are listed in [browserslists test page](https://browsersl.ist/#q=%3E+0.2%25%2C+not+dead%2C+not+op_mini+all&region=FI)
+
+More info about browser support:
+- [HDS documentation general FAQ](https://hds.hel.fi/getting-started/faq#general)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -57,4 +57,4 @@ The supported browser versions are listed in [browserslists test page](https://b
 
 More info about browser support:
 - [Create React App - Configuring Supported Browsers](https://create-react-app.dev/docs/supported-browsers-features/#configuring-supported-browsers)
-- [HDS documentation general FAQ](https://hds.hel.fi/getting-started/faq#general)
+- [HDS documentation general FAQ - What browser and browser versions are supported?](https://hds.hel.fi/getting-started/faq#general)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,8 +43,16 @@ Helsinki Design System uses the react-scripts library's default browserslist con
 This means that the following browsers are supported:
 - Chrome
 - Firefox
+- Edge
 - Safari
+- Chrome for Android
+- Edge for Android ([uses same engine as Chrome for Android](https://github.com/browserslist/browserslist#browsers))
+- Safari iOS
+- Chrome for iOS ([uses same engine as Safari iOS](https://github.com/browserslist/browserslist#browsers))
+- Edge for iOS ([uses same engine as Safari iOS](https://github.com/browserslist/browserslist#browsers))
+
 The supported browser versions are listed in [browserslists test page](https://browsersl.ist/#q=%3E+0.2%25%2C+not+dead%2C+not+op_mini+all&region=FI)
 
 More info about browser support:
+- [Create React App - Configuring Supported Browsers](https://create-react-app.dev/docs/supported-browsers-features/#configuring-supported-browsers)
 - [HDS documentation general FAQ](https://hds.hel.fi/getting-started/faq#general)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -42,14 +42,14 @@ Read more [here](DEVELOPMENT.md).
 Helsinki Design System uses the react-scripts library's default browserslist config to target a broad range of browsers.
 This means that the following browsers are supported:
 - Chrome
-- Firefox
-- Edge
-- Safari
 - Chrome for Android
-- Edge for Android ([uses same engine as Chrome for Android](https://github.com/browserslist/browserslist#browsers))
-- Safari iOS
 - Chrome for iOS ([uses same engine as Safari iOS](https://github.com/browserslist/browserslist#browsers))
+- Edge
+- Edge for Android ([uses same engine as Chrome for Android](https://github.com/browserslist/browserslist#browsers))
 - Edge for iOS ([uses same engine as Safari iOS](https://github.com/browserslist/browserslist#browsers))
+- Firefox
+- Safari
+- Safari iOS
 
 The supported browser versions are listed in [browserslists test page](https://browsersl.ist/#q=%3E+0.2%25%2C+not+dead%2C+not+op_mini+all&region=FI)
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -48,6 +48,8 @@ This means that the following browsers are supported:
 - Edge for Android ([uses same engine as Chrome for Android](https://github.com/browserslist/browserslist#browsers))
 - Edge for iOS ([uses same engine as Safari iOS](https://github.com/browserslist/browserslist#browsers))
 - Firefox
+- Firefox for Android
+- Firefox for iOS ([uses same engine as Safari iOS](https://github.com/browserslist/browserslist#browsers))
 - Safari
 - Safari iOS
 


### PR DESCRIPTION
## Description
- Add info about browser support into README

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1177

## Motivation and Context
- The knowledge is for the library users to inform about the support  

## How Has This Been Tested?
- Locally on dev machine

