### PR TITLE
Include missing subComponents in analytics results

### DIFF
--- a/analytics/scanner.config.js
+++ b/analytics/scanner.config.js
@@ -3,4 +3,5 @@ module.exports = {
   importedFrom: 'hds-react',
   exclude: (dirname) => dirname === 'node_modules',
   processors: ['count-components', 'count-components-and-props'],
+  includeSubComponents: true,
 };


### PR DESCRIPTION
## Description
- Add includeSubComponents config into scanner.config

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1469

## Motivation and Context
- Add missing subComponents in analytics results. For example, Navigation sub components were missing from React Library analytics.

Updated analytics:
- [React library usage](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HDS/pages/7922781697/HDS+React+package+usage)
- [React version usage](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HDS/pages/8028225540/HDS+React+version+usage)
