### PR TITLE
HDS-1470 NOSCRIPT content

### DIFF
--- a/NOSCRIPT.md
+++ b/NOSCRIPT.md
@@ -1,6 +1,6 @@
 # noscript support
 
-Helsinki city web services require Javascript to function as intended. If the web browsers has disabled or doesn't support JavaScript it should fallback gracefully by notifying the user to enable JavaScript. This is implemented by adding the `<noscript>` tag content below at the end of contents inside the `<body>` tag. It will display the text to the user if JavaScript is disabled.
+Helsinki city web services require Javascript to function as intended. If the web browsers has disabled or doesn't support JavaScript it should fallback gracefully by notifying the user to enable JavaScript. This is implemented by adding the `<noscript>` tag content below at the end of contents inside the `<body>` tag. It will display the text to the user if JavaScript is disabled. Include [core styles](packages/core/README.md) to display the text as a [Notification component](https://hds.hel.fi/components/notification).
 
 <noscript>
     <section aria-label="Notification" class="hds-notification hds-notification--alert">

--- a/NOSCRIPT.md
+++ b/NOSCRIPT.md
@@ -1,0 +1,15 @@
+# noscript support
+
+Helsinki city web services require Javascript to function as intended. If the web browsers has disabled or doesn't support JavaScript it should fallback gracefully by notifying the user to enable JavaScript. This is implemented by adding the `<noscript>` tag content below at the end of contents inside the `<body>` tag. It will display the text to the user if JavaScript is disabled.
+
+<noscript>
+    <section aria-label="Notification" class="hds-notification hds-notification--alert">
+        <div class="hds-notification__content">
+            <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hds-icon hds-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Enable JavaScript in your browser</span>
+            </div>
+            <div class="hds-notification__body">Please enable JavaScript to guarantee full functionality and intended user experience.</div>
+        </div>
+    </section>
+</noscript>

--- a/NOSCRIPT.md
+++ b/NOSCRIPT.md
@@ -1,6 +1,6 @@
 # noscript support
 
-Helsinki city web services require Javascript to function as intended. If the web browsers has disabled or doesn't support JavaScript it should fallback gracefully by notifying the user to enable JavaScript. This is implemented by adding the `<noscript>` tag content below at the end of contents inside the `<body>` tag. It will display the text to the user if JavaScript is disabled. Include [core styles](packages/core/README.md) to display the text as a [Notification component](https://hds.hel.fi/components/notification).
+Helsinki city web services require Javascript to function as intended. If the web browser has disabled or doesn't support JavaScript it should fall back gracefully by notifying the user to enable JavaScript. This is implemented by adding the `<noscript>` tag content below at the end of contents inside the `<body>` tag. It will display the text to the user if JavaScript is disabled. Include [core styles](packages/core/README.md) to display the text as a [Notification component](https://hds.hel.fi/components/notification).
 
 <noscript>
     <section aria-label="Notification" class="hds-notification hds-notification--alert">

--- a/site/src/docs/getting-started/developer.mdx
+++ b/site/src/docs/getting-started/developer.mdx
@@ -75,6 +75,10 @@ export const SSRGuideline = () => {
 
 Using server-side rendering? Check our <SSRGuideline /> on how to use HDS React components with server-side rendering.
 
+## Supporting disabled JavaScript
+
+JavaScript is required to be enabled in the web browser to guarantee full functionality of Helsinki city's web services. Refer to the <ExternalLink openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/NOSCRIPT.md">Noscript guide</ExternalLink> on how to provide a fallback.
+
 ## WordPress and Drupal
 
 While HDS does not currently offer WordPress or Drupal implementations, HDS cooperates with multiple WordPress and Drupal projects in the City of Helsinki. Many of these projects have already implemented HDS components which can be reused in other projects.


### PR DESCRIPTION
## Description

* NOSCRIPT.md guide for handling situations when web browser JavaScript support is disabled
* Docsite updated with description and link to guide from developer section of Getting started

## Motivation and Context

The user experience is broken if user hasn't enabled JavaScript in the web browser. To solve this with a graceful fallback we need to have a consistent way of notifying to the user to enable JavaScript to guarantee full functionality and coherent user experience.
