### PR TITLE
Remove unnecessary TimeInput logging

### DIFF
--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -52,8 +52,6 @@ const getHourAndMinuteValues = (value?: string): string[] | null => {
     if (valueString.match(/^\d{2}:\d{2}$/)) {
       return valueString.split(':');
     }
-    // eslint-disable-next-line no-console
-    console.warn('Invalid default value for TimeInput. The default value must be in hh:mm format');
   }
   return null;
 };


### PR DESCRIPTION
## Description
- Remove console.warn log when user types into TimeInput (does not bring user value)

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1480

## Motivation and Context
- At the moment TimeInput component warns on every value change even tough user was not ready typing the value. Validation warnings in the console are not very useful for end user.

## How Has This Been Tested?
- Locally on dev machine