### PR TITLE
DateInput breaks if minDate is over ten years in the future

### DIFF
--- a/packages/react/src/components/dateInput/DateInput.stories.tsx
+++ b/packages/react/src/components/dateInput/DateInput.stories.tsx
@@ -12,6 +12,15 @@ import { IconCrossCircle } from '../../icons';
 
 const formatHelperTextEnglish = 'Use format D.M.YYYY';
 
+const argTypes = {
+  minDate: {
+    control: 'date',
+  },
+  maxDate: {
+    control: 'date',
+  },
+};
+
 export default {
   component: DateInput,
   title: 'Components/DateInput',
@@ -19,6 +28,7 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
   },
+  argTypes,
   args: {
     id: 'date',
     label: 'Choose a date',

--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -1,4 +1,4 @@
-import { format, parse, isValid, subYears, addYears, startOfMonth, endOfMonth } from 'date-fns';
+import { format, parse, isValid, subYears, addYears, startOfMonth, endOfMonth, max } from 'date-fns';
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 
 import { IconCalendar } from '../../icons';
@@ -183,6 +183,10 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     // Get the current value as Date object
     const inputValueAsDate = stringToDate(inputValue);
     const toggleButton = getToggleButton();
+    const minDateToUse = minDate && isValid(minDate) ? minDate : startOfMonth(subYears(new Date(), 10));
+    const maxDateToUse =
+      maxDate && isValid(maxDate) ? maxDate : endOfMonth(addYears(max([minDateToUse, new Date()]), 10));
+
     return (
       <div lang={language} className={styles.wrapper}>
         <TextInput
@@ -210,8 +214,8 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
               onCloseButtonClick={(focusToggleButton) => closeDatePicker(focusToggleButton)}
               selectButtonLabel={getSelectButtonLabel()}
               closeButtonLabel={getCloseButtonLabel()}
-              minDate={minDate && isValid(minDate) ? minDate : startOfMonth(subYears(new Date(), 10))}
-              maxDate={maxDate && isValid(maxDate) ? maxDate : endOfMonth(addYears(new Date(), 10))}
+              minDate={minDateToUse}
+              maxDate={maxDateToUse}
               isDateDisabledBy={isDateDisabledBy}
               open={showPicker}
               inputRef={inputRef}


### PR DESCRIPTION
## Description
- Use minDate as base for default maxDate if minDate is later than today
- Add support for testing min and max dates in Storybook 

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1437

## Motivation and Context
- There might be a case where the minDate is in the future, for example

## How Has This Been Tested?
- locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1437-dateinput-error-ten-year-fix/?path=/story/components-dateinput--default)
