### PR TITLE
Hds 1491 fix tag accessibility

### DIFF
--- a/packages/core/src/components/tag/tag.stories.js
+++ b/packages/core/src/components/tag/tag.stories.js
@@ -19,7 +19,7 @@ export const Clickable = () => `
 export const Deletable = () => `
   <div class="hds-tag">
     <span class="hds-tag__label">Label</span>
-    <button aria-label="Delete item" class="hds-tag__delete-button button-reset">
+    <button aria-label="Delete item: Label" class="hds-tag__delete-button button-reset">
         <span aria-hidden="true" class="hds-icon hds-icon--cross"></span>
     </button>
   </div>

--- a/packages/react/src/components/tag/Tag.stories.tsx
+++ b/packages/react/src/components/tag/Tag.stories.tsx
@@ -36,7 +36,7 @@ export const ClickableTag = (args) => (
 
 export const DeletableTag = (args) => {
   return (
-    <Tag {...args} deleteButtonAriaLabel="Delete item" onDelete={() => action(`Delete: ${args.children}`)()}>
+    <Tag {...args} deleteButtonAriaLabel="Delete item" onDelete={() => action(`Delete item: ${args.children}`)()}>
       {args.children}
     </Tag>
   );
@@ -63,7 +63,7 @@ export const RoundedDeletableTag = (args) => {
     <RoundedTagComponent
       {...args}
       deleteButtonAriaLabel="Delete item"
-      onDelete={() => action(`Delete: ${args.children}`)()}
+      onDelete={() => action(`Delete item: ${args.children}`)()}
     >
       {args.children}
     </RoundedTagComponent>
@@ -75,7 +75,7 @@ export const LargeRoundedDeletableTag = (args) => {
     <LargeRoundedTag
       {...args}
       deleteButtonAriaLabel="Delete item"
-      onDelete={() => action(`Delete: ${args.children}`)()}
+      onDelete={() => action(`Delete item: ${args.children}`)()}
     >
       {args.children}
     </LargeRoundedTag>

--- a/packages/react/src/components/tag/Tag.tsx
+++ b/packages/react/src/components/tag/Tag.tsx
@@ -104,7 +104,7 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>(
       >
         <span id={id && `${id}-label`} className={styles.label} {...labelProps}>
           {srOnlyLabel && <span className={styles.visuallyHidden}>{srOnlyLabel}</span>}
-          <span aria-hidden={!!srOnlyLabel}>{children}</span>
+          <span {...(srOnlyLabel ? { 'aria-hidden': true } : {})}>{children}</span>
         </span>
 
         {deletable && (

--- a/packages/react/src/components/tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/react/src/components/tag/__snapshots__/Tag.test.tsx.snap
@@ -10,9 +10,7 @@ exports[`<Tag /> spec renders the component 1`] = `
       class="label"
       id="hds-tag-label"
     >
-      <span
-        aria-hidden="false"
-      >
+      <span>
         Foo
       </span>
     </span>


### PR DESCRIPTION
## Description
- Omit arial-hidden attribute if the value is false. Confuses some screen readers.
- Fix Core and React Storybooks aria-labels in deletable Tag

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1491

## Motivation and Context
- This improves usability with screen readers when there is less noice and the labels in examples are more descriptive.

## How Has This Been Tested?
- locally on dev machine
- snapshot tests

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1491-fix-tag-accessibility/?path=/story/components-tag--deletable-tag)