### PR TITLE
Navigation documentation language selector focus

### DIFF
--- a/site/src/docs/components/navigation/code.mdx
+++ b/site/src/docs/components/navigation/code.mdx
@@ -73,9 +73,9 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
     <Navigation.Search searchLabel="Search" searchPlaceholder="Search page" />
     <Navigation.User label="Sign in" />
     <Navigation.LanguageSelector label="FI">
-      <Navigation.Item lang="fi" label="Suomeksi" />
-      <Navigation.Item lang="sv" label="På svenska" />
-      <Navigation.Item lang="en" label="In English" />
+      <Navigation.Item href="#navigation-actions" lang="fi" label="Suomeksi" />
+      <Navigation.Item href="#navigation-actions" lang="sv" label="På svenska" />
+      <Navigation.Item href="#navigation-actions" lang="en" label="In English" />
     </Navigation.LanguageSelector>
   </Navigation.Actions>
 </Navigation>

--- a/site/src/docs/components/navigation/customisation.mdx
+++ b/site/src/docs/components/navigation/customisation.mdx
@@ -53,9 +53,9 @@ You can use the `theme` property to customise the component. See all available t
       <Navigation.Search searchLabel="Search" searchPlaceholder="Search page" />
       <Navigation.User label="Sign in" />
       <Navigation.LanguageSelector label="FI">
-        <Navigation.Item lang="fi" label="Suomeksi" />
-        <Navigation.Item lang="sv" label="På svenska" />
-        <Navigation.Item lang="en" label="In English" />
+        <Navigation.Item href="#customisation-example" lang="fi" label="Suomeksi" />
+        <Navigation.Item href="#customisation-example" lang="sv" label="På svenska" />
+        <Navigation.Item href="#customisation-example" lang="en" label="In English" />
       </Navigation.LanguageSelector>
     </Navigation.Actions>
     <Navigation.Row>

--- a/site/src/docs/components/navigation/index.mdx
+++ b/site/src/docs/components/navigation/index.mdx
@@ -100,9 +100,9 @@ HDS Navigation component supports many commonly used features out of the box. Th
       <Navigation.Search searchLabel="Search" searchPlaceholder="Search page" />
       <Navigation.User label="Sign in" />
       <Navigation.LanguageSelector label="FI">
-        <Navigation.Item lang="fi" label="Suomeksi" />
-        <Navigation.Item lang="sv" label="På svenska" />
-        <Navigation.Item lang="en" label="In English" />
+        <Navigation.Item href="#navigation-actions" lang="fi" label="Suomeksi" />
+        <Navigation.Item href="#navigation-actions" lang="sv" label="På svenska" />
+        <Navigation.Item href="#navigation-actions" lang="en" label="In English" />
       </Navigation.LanguageSelector>
     </Navigation.Actions>
   </Navigation>


### PR DESCRIPTION
## Description

In the documentation page of Navigation component, the language selector's items are not focusable by keyboard. This is fixed simply by adding a href attribute. This was noticed by Unicus-Emmi.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1508

Closes #

## Motivation and Context

https://helsinkicity.slack.com/archives/C0319GUE3RC/p1670839431894059

## How Has This Been Tested?
Localhost
[Demo](https://city-of-helsinki.github.io/hds-demo/docsite-nav-lang-focus)
