### PR TITLE
HDS-1481: set notification heading level

### DIFF
--- a/packages/react/src/components/notification/Notification.stories.tsx
+++ b/packages/react/src/components/notification/Notification.stories.tsx
@@ -153,6 +153,18 @@ WithCustomAriaLabel.parameters = {
 
 WithCustomAriaLabel.storyName = 'With a custom aria-label';
 
+export const WithCustomHeadingLevel = () => (
+  <Notification {...props} headingLevel={3}>
+    {content}
+  </Notification>
+);
+
+WithCustomHeadingLevel.parameters = {
+  loki: { skip: true },
+};
+
+WithCustomHeadingLevel.storyName = 'With a custom aria-level';
+
 export const Playground = (args) => {
   const [open, setOpen] = useState(true);
 
@@ -191,6 +203,7 @@ export const Playground = (args) => {
           size={typedSize}
           dismissible={args.dismissible}
           closeButtonLabelText={args.closeButtonLabelText}
+          headingLevel={args.headingLevel}
         >
           {args.body}
         </Notification>
@@ -222,6 +235,7 @@ Playground.args = {
   autoClose: false,
   displayAutoCloseProgress: true,
   autoCloseDuration: 6000,
+  headingLevel: 2,
 };
 
 Playground.argTypes = {

--- a/packages/react/src/components/notification/Notification.stories.tsx
+++ b/packages/react/src/components/notification/Notification.stories.tsx
@@ -74,7 +74,7 @@ export const Invisible = () => {
 
 export const Dismissible = () => {
   const [open, setOpen] = useState(true);
-  const showButtonRef = useRef(null);
+  const showButtonRef = useRef<HTMLButtonElement | null>(null);
   const onClose = () => {
     setOpen(false);
     if (showButtonRef.current) {
@@ -100,7 +100,7 @@ export const Dismissible = () => {
 
 export const AutoClose = () => {
   const [open, setOpen] = useState(false);
-  const showButtonRef = useRef(null);
+  const showButtonRef = useRef<HTMLButtonElement | null>(null);
   const onClose = () => {
     setOpen(false);
     if (showButtonRef.current) {

--- a/packages/react/src/components/notification/Notification.test.tsx
+++ b/packages/react/src/components/notification/Notification.test.tsx
@@ -52,4 +52,18 @@ describe('<Notification /> spec', () => {
     );
     expect(getByRole('button')).toBeDefined();
   });
+
+  it('if headingLevel-property is not set, the aria-level of the heading element is 2 by default', () => {
+    const { getByRole } = render(<Notification label={label}>{body}</Notification>);
+    expect((getByRole('heading') as HTMLElement).getAttribute('aria-level')).toBe('2');
+  });
+
+  it('headingLevel-property sets the aria-level -attribute of the heading element', () => {
+    const { getByRole } = render(
+      <Notification label={label} headingLevel={3}>
+        {body}
+      </Notification>,
+    );
+    expect((getByRole('heading') as HTMLElement).getAttribute('aria-level')).toBe('3');
+  });
 });

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -82,6 +82,11 @@ type CommonProps = React.PropsWithChildren<{
    * @default 'info'
    */
   type?: NotificationType;
+  /**
+   * The aria-level of the heading element
+   * @default 2
+   */
+  headingLevel?: number;
 }>;
 
 type PositionAndSize =
@@ -197,6 +202,7 @@ export const Notification = React.forwardRef<HTMLDivElement, NotificationProps>(
       size = 'default',
       style,
       type = 'info',
+      headingLevel = 2,
     }: NotificationProps,
     ref,
   ) => {
@@ -268,7 +274,10 @@ export const Notification = React.forwardRef<HTMLDivElement, NotificationProps>(
           <div className={styles.content} ref={ref}>
             {label && (
               // Toast or invisible notifications do not always notice heading if role heading or aria-level is present.
-              <div className={styles.label} {...(isToast || invisible ? {} : { role: 'heading', 'aria-level': 2 })}>
+              <div
+                className={styles.label}
+                {...(isToast || invisible ? {} : { role: 'heading', 'aria-level': headingLevel })}
+              >
                 <Icon className={styles.icon} aria-hidden />
                 <ConditionalVisuallyHidden visuallyHidden={size === 'small'}>{label}</ConditionalVisuallyHidden>
               </div>


### PR DESCRIPTION
## Description

The arial-level is fixed to be "2", which may cause accessibility errors. The default is now "2", but can be overridden.

Closes HDS-1481

## How Has This Been Tested?

Tests included.
