### PR TITLE
HDS-1299: overly long dropdown tags

### DIFF
--- a/packages/react/.loki/reference/chrome_iphone7_Components_Dropdowns_Combobox_Multi_select_with_pre_selected_values.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Dropdowns_Combobox_Multi_select_with_pre_selected_values.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7f816d722b016e38035a1d3f7af18cd7e1d48e64c681039a8a02aa6acc96049
+size 12534

--- a/packages/react/.loki/reference/chrome_laptop_Components_Dropdowns_Combobox_Multi_select_with_pre_selected_values.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Dropdowns_Combobox_Multi_select_with_pre_selected_values.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:416cb7263ce8a104168bacdb29e72628d10c9aa8b980e19ed0f1ba527640d085
+size 5939

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -274,3 +274,31 @@ export const WithExternalLabel = (args) => {
 };
 
 WithExternalLabel.storyName = 'With external label';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const MultiSelectWithDefaultValue = (args) => {
+  // this story also tests very long labels are displayed correctly.
+  const optionsWithLongText = [
+    { label: 'This is a long text that is wider than the container, but should still be visible' },
+    ...options,
+  ];
+  return (
+    <Combobox
+      aria-labelledby="externalLabelId"
+      id={getId()}
+      helper="Choose an element"
+      placeholder="Placeholder"
+      clearButtonAriaLabel="Clear selection"
+      options={optionsWithLongText}
+      onBlur={action('onBlur')}
+      onChange={(change) => action('onChange')(change)}
+      onFocus={action('onFocus')}
+      toggleButtonAriaLabel="Open the combobox"
+      defaultValue={[optionsWithLongText[0], optionsWithLongText[1], optionsWithLongText[4]]}
+      selectedItemRemoveButtonAriaLabel="Remove element {value}"
+      multiselect
+    />
+  );
+};
+
+MultiSelectWithDefaultValue.storyName = 'Multi-select with pre-selected values';

--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -33,7 +33,7 @@ const defaultProps: ComboboxProps<{ label: string; value: string }> = {
   toggleButtonAriaLabel: 'Open the combobox',
 };
 
-const getWrapper = (props?: unknown) => render(<Combobox {...defaultProps} {...props} />);
+const getWrapper = (props?: Record<string, unknown>) => render(<Combobox {...defaultProps} {...props} />);
 
 describe('<Combobox />', () => {
   it('renders the component', () => {
@@ -61,7 +61,7 @@ describe('<Combobox />', () => {
 
   it('user should be able to search and choose an option ', async () => {
     const onChange = jest.fn();
-    const { getAllByLabelText, getAllByRole, queryByDisplayValue } = getWrapper({ onChange });
+    const { getAllByLabelText, getAllByRole, getByDisplayValue } = getWrapper({ onChange });
     const input = getAllByLabelText(label)[0];
     userEvent.type(input, 'Fi');
     const visibleOptions = getAllByRole('option');
@@ -72,7 +72,7 @@ describe('<Combobox />', () => {
     userEvent.click(visibleOptions[0]);
     await waitFor(() => {
       // Ensure that chosen option is shown as value of input
-      expect(queryByDisplayValue(options[0].label)).toBeDefined();
+      expect(getByDisplayValue(options[0].label)).toBeDefined();
       // Ensure that chosen option has been sent with the onChange event
       expect(onChange).toHaveBeenCalledWith(options[0]);
     });

--- a/packages/react/src/components/tag/Tag.test.tsx
+++ b/packages/react/src/components/tag/Tag.test.tsx
@@ -9,6 +9,23 @@ describe('<Tag /> spec', () => {
     const { asFragment } = render(<Tag>Foo</Tag>);
     expect(asFragment()).toMatchSnapshot();
   });
+  it('renders properties of the component', () => {
+    const { asFragment } = render(
+      <Tag
+        id="tag-id"
+        className="tag-class"
+        deleteButtonAriaLabel="delete me"
+        labelClassName="label-class"
+        labelProps={{ id: 'label-id' }}
+        onDelete={jest.fn()}
+        role="button"
+        srOnlyLabel="Tag label for screen readers"
+      >
+        Tag label
+      </Tag>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
   it('should not have basic accessibility issues', async () => {
     const { container } = render(<Tag>Foo</Tag>);
     const results = await axe(container);

--- a/packages/react/src/components/tag/Tag.tsx
+++ b/packages/react/src/components/tag/Tag.tsx
@@ -37,6 +37,10 @@ export type TagProps = {
    */
   id?: string;
   /**
+   * Additional class names to apply to the tag's label element
+   */
+  labelClassName?: string;
+  /**
    * Props that will be passed to the label `<span>` element.
    */
   labelProps?: React.ComponentPropsWithoutRef<'span'>;
@@ -73,6 +77,7 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>(
       deleteButtonAriaLabel,
       deleteButtonProps,
       id = 'hds-tag',
+      labelClassName,
       labelProps,
       onClick,
       onDelete,
@@ -94,6 +99,8 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>(
       if (event.key === 'Enter' || event.key === ' ') onClick(event);
     };
 
+    const labelContainerClassName = classNames(styles.label, labelClassName);
+
     return (
       <div
         id={id}
@@ -102,7 +109,7 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>(
         {...(clickable && { tabIndex: 0, role, onClick, onKeyDown })}
         {...rest}
       >
-        <span id={id && `${id}-label`} className={styles.label} {...labelProps}>
+        <span id={id && `${id}-label`} className={labelContainerClassName} {...labelProps}>
           {srOnlyLabel && <span className={styles.visuallyHidden}>{srOnlyLabel}</span>}
           <span aria-hidden={!!srOnlyLabel}>{children}</span>
         </span>

--- a/packages/react/src/components/tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/react/src/components/tag/__snapshots__/Tag.test.tsx.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Tag /> spec renders properties of the component 1`] = `
+<DocumentFragment>
+  <div
+    class="tag tag-class"
+    id="tag-id"
+  >
+    <span
+      class="label label-class"
+      id="label-id"
+    >
+      <span
+        class="visuallyHidden"
+      >
+        Tag label for screen readers
+      </span>
+      <span
+        aria-hidden="true"
+      >
+        Tag label
+      </span>
+    </span>
+    <button
+      aria-label="delete me"
+      class="deleteButton"
+      id="tag-id-delete-button"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon s icon"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <rect
+            height="24"
+            width="24"
+          />
+          <polygon
+            fill="currentColor"
+            points="18 7.5 13.5 12 18 16.5 16.5 18 12 13.5 7.5 18 6 16.5 10.5 12 6 7.5 7.5 6 12 10.5 16.5 6"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<Tag /> spec renders the component 1`] = `
 <DocumentFragment>
   <div

--- a/packages/react/src/internal/selectedItems/SelectedItems.module.scss
+++ b/packages/react/src/internal/selectedItems/SelectedItems.module.scss
@@ -34,10 +34,10 @@
 
   &.truncateFirstChild {
     flex-wrap: nowrap;
-    & > :first-child {
+    & > .tag:first-child {
       justify-content: flex-end;
       overflow: hidden;
-      > span {
+      .tagLabel {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/packages/react/src/internal/selectedItems/SelectedItems.module.scss
+++ b/packages/react/src/internal/selectedItems/SelectedItems.module.scss
@@ -5,12 +5,12 @@
   visibility: hidden;
 }
 
-
 .selectedItems {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  padding: var(--spacing-4-xs) calc((var(--spacing-s) - var(--border-width)) * 2 + (var(--icon-size) * 2)) calc(var(--spacing-2-xs) + var(--border-width)) var(--spacing-4-xs);
+  padding: var(--spacing-4-xs) calc((var(--spacing-s) - var(--border-width)) * 2 + (var(--icon-size) * 2))
+    calc(var(--spacing-2-xs) + var(--border-width)) var(--spacing-4-xs);
 
   &.itemsHidden {
     box-sizing: border-box;
@@ -29,6 +29,19 @@
 
     &.hidden {
       @extend %hidden;
+    }
+  }
+
+  &.truncateFirstChild {
+    flex-wrap: nowrap;
+    & > :first-child {
+      justify-content: flex-end;
+      overflow: hidden;
+      > span {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 
@@ -54,7 +67,6 @@
   cursor: pointer;
   font: inherit;
   padding: 0;
-
 
   display: flex;
   outline: none;

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -251,6 +251,7 @@ export const SelectedItems = <OptionType,>({
               className={styles.tag}
               id={tagId}
               labelProps={{ 'aria-labelledby': `${dropdownId}-label ${tagId}-label` }}
+              labelClassName={styles.tagLabel}
               role="button"
               deleteButtonAriaLabel={replaceTokenWithValue(removeButtonAriaLabel, selectedItemLabel)}
               // remove delete button from focus order

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -129,6 +129,7 @@ const handleItemHiding = (
     const childNodes = [...containerEl.childNodes].filter(
       (node: HTMLDivElement | HTMLSpanElement) => node.tagName === 'DIV',
     ) as HTMLDivElement[];
+    containerEl.classList.remove(styles.truncateFirstChild);
     // width of the hidden item count indicator
     const hiddenCountWidth = hiddenCountEl.offsetWidth + childSpacing;
     // available container width
@@ -143,6 +144,12 @@ const handleItemHiding = (
     }, 0);
 
     if (hideItems) {
+      // if first item is too wide to show, no items are shown.
+      // Fix is to show first item anyway, but add a css class to container, which will trucate first child's text
+      if (!visibleItems.length && hiddenItems.length) {
+        visibleItems.push(hiddenItems.shift());
+        containerEl.classList.add(styles.truncateFirstChild);
+      }
       // remove 'hidden' class from visible child nodes
       visibleItems.forEach((item) => item.classList.remove(styles.hidden));
       // add 'hidden' class to child nodes that should be hidden


### PR DESCRIPTION
## Description

If the element of the first selected item is wider that the container,  all items are hidden. The component hides all children that overflow the container.

After the fix, if there are selected items and all are hidden (indicating the first one is too wide), then a css class is added to the container which will truncate the label of the first item. 

## How Has This Been Tested?

Loki tests only. Jest tests cannot be used, because jsdom does not calculate element sizes.

