### PR TITLE
HDS-1516: fix search input cursor jumping

### DIFF
--- a/packages/react/src/components/searchInput/SearchInput.test.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.test.tsx
@@ -69,6 +69,7 @@ describe('<SearchInput /> spec', () => {
       userEvent.click(options[0]);
     });
     expect(onSubmit.mock.calls[0][0]).toBe('Apple');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it('Controlled component submits the input value on enter press or icon click', async () => {
@@ -98,6 +99,7 @@ describe('<SearchInput /> spec', () => {
     await waitFor(() => {
       expect(input.getAttribute('value')).toBe('abc');
       expect(onSubmit.mock.calls[0][0]).toBe('abc');
+      expect(onSubmit).toHaveBeenCalledTimes(1);
     });
 
     userEvent.click(getByLabelText('Clear', { selector: 'button' }));
@@ -109,6 +111,7 @@ describe('<SearchInput /> spec', () => {
     await waitFor(() => {
       expect(input.getAttribute('value')).toBe('1234');
       expect(onSubmit.mock.calls[1][0]).toBe('1234');
+      expect(onSubmit).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -145,6 +148,7 @@ describe('<SearchInput /> spec', () => {
 
     userEvent.type(input, '{arrowdown}{arrowdown}{enter}');
     await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
       expect(onSubmit.mock.calls[0][0]).toBe(targetValue);
       expect(input.getAttribute('value')).toBe(targetValue);
     });

--- a/packages/react/src/components/searchInput/SearchInput.test.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.test.tsx
@@ -71,6 +71,35 @@ describe('<SearchInput /> spec', () => {
     expect(onSubmit.mock.calls[0][0]).toBe('Apple');
   });
 
+  it('submits the selected value on enter press or icon click', async () => {
+    const onSubmit = jest.fn();
+    const { getByLabelText } = render(
+      <SearchInput<SuggestionItemType>
+        label="search"
+        suggestionLabelField="value"
+        getSuggestions={getSuggestions}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const input = getByLabelText('search', { selector: 'input' });
+    userEvent.type(input, 'abc{enter}');
+    await waitFor(() => {
+      expect(onSubmit.mock.calls[0][0]).toBe('abc');
+    });
+    const clearButton = getByLabelText('Clear', { selector: 'button' });
+    const submitButton = getByLabelText('Search', { selector: 'button' });
+    userEvent.click(clearButton);
+    await waitFor(() => {
+      expect(input.getAttribute('value')).toBe('');
+    });
+    userEvent.type(input, '1234');
+    userEvent.click(submitButton);
+    await waitFor(() => {
+      expect(onSubmit.mock.calls[1][0]).toBe('1234');
+    });
+  });
+
   it('renders the input with default value', async () => {
     const onSubmit = jest.fn();
     const onChange = jest.fn();

--- a/packages/react/src/components/searchInput/SearchInput.test.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.test.tsx
@@ -41,6 +41,18 @@ describe('<SearchInput /> spec', () => {
     userEvent.click(renderResult.getByLabelText('Clear', { selector: 'button' }));
   };
 
+  const getMockFunctionArgument = (fn: jest.Mock, index: number) => {
+    return fn.mock.calls[index][0];
+  };
+
+  const getOnChangeArgumentByIndex = (index: number) => {
+    return getMockFunctionArgument(onChange, index);
+  };
+
+  const getOnSubmitArgumentByIndex = (index: number) => {
+    return getMockFunctionArgument(onSubmit, index);
+  };
+
   const initTests = (props: Partial<SearchInputProps<SuggestionItemType>>, defaultValue?: string): RenderResult => {
     const mergedProps = {
       ...defaultProps,
@@ -81,13 +93,13 @@ describe('<SearchInput /> spec', () => {
     initTests({ onSubmit, onChange });
     const input = getInputByDefaultLabel();
     userEvent.type(input, 't');
-    expect(onChange.mock.calls[0][0]).toBe('t');
+    expect(getOnChangeArgumentByIndex(0)).toBe('t');
     userEvent.type(input, 'e');
-    expect(onChange.mock.calls[1][0]).toBe('te');
+    expect(getOnChangeArgumentByIndex(1)).toBe('te');
     userEvent.type(input, 's');
-    expect(onChange.mock.calls[2][0]).toBe('tes');
+    expect(getOnChangeArgumentByIndex(2)).toBe('tes');
     userEvent.type(input, 't');
-    expect(onChange.mock.calls[3][0]).toBe('test');
+    expect(getOnChangeArgumentByIndex(3)).toBe('test');
   });
 
   it('submits the selected item on mouse click', async () => {
@@ -98,7 +110,7 @@ describe('<SearchInput /> spec', () => {
       const options = getAllByRole('option');
       userEvent.click(options[0]);
     });
-    expect(onSubmit.mock.calls[0][0]).toBe('Apple');
+    expect(getOnSubmitArgumentByIndex(0)).toBe('Apple');
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
@@ -109,7 +121,7 @@ describe('<SearchInput /> spec', () => {
     userEvent.type(input, 'c{enter}');
     await waitFor(() => {
       expect(input.getAttribute('value')).toBe('abc');
-      expect(onSubmit.mock.calls[0][0]).toBe('abc');
+      expect(getOnSubmitArgumentByIndex(0)).toBe('abc');
       expect(onSubmit).toHaveBeenCalledTimes(1);
     });
     clickResetButton();
@@ -120,7 +132,7 @@ describe('<SearchInput /> spec', () => {
     userEvent.click(getByLabelText('Search', { selector: 'button' }));
     await waitFor(() => {
       expect(input.getAttribute('value')).toBe('1234');
-      expect(onSubmit.mock.calls[1][0]).toBe('1234');
+      expect(getOnSubmitArgumentByIndex(1)).toBe('1234');
       expect(onSubmit).toHaveBeenCalledTimes(2);
     });
   });
@@ -141,7 +153,7 @@ describe('<SearchInput /> spec', () => {
     userEvent.type(input, '{arrowdown}{arrowdown}{enter}');
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
-      expect(onSubmit.mock.calls[0][0]).toBe(targetValue);
+      expect(getOnSubmitArgumentByIndex(0)).toBe(targetValue);
       expect(input.getAttribute('value')).toBe(targetValue);
     });
   });
@@ -161,7 +173,7 @@ describe('<SearchInput /> spec', () => {
     });
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
-      expect(onSubmit.mock.calls[0][0]).toBe(targetValue);
+      expect(getOnSubmitArgumentByIndex(0)).toBe(targetValue);
       expect(onChange).toHaveBeenLastCalledWith(targetValue);
     });
 
@@ -179,7 +191,7 @@ describe('<SearchInput /> spec', () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(2);
-      expect(onSubmit.mock.calls[1][0]).toBe(secondTargetValue);
+      expect(getOnSubmitArgumentByIndex(1)).toBe(secondTargetValue);
     });
   });
 

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -124,10 +124,18 @@ export const SearchInput = <SuggestionItem,>({
   };
 
   const wasSubmitted = () => {
-    return lastAction === userEnterKeyAction || wasLastActionStateChangeEnterKey();
+    return (
+      lastAction === useCombobox.stateChangeTypes.ItemClick ||
+      lastAction === userEnterKeyAction ||
+      wasLastActionStateChangeEnterKey()
+    );
   };
 
-  const { suggestions, isLoading } = useSuggestions<SuggestionItem>(inputValue, getSuggestions, wasSubmitted());
+  const { suggestions, isLoading, clearSuggestions } = useSuggestions<SuggestionItem>(
+    inputValue,
+    getSuggestions,
+    wasSubmitted(),
+  );
   const showLoadingSpinner = useShowLoadingSpinner(isLoading, 1500 - SUGGESTIONS_DEBOUNCE_VALUE);
   const isControlledComponent = value !== undefined && onChange;
 
@@ -151,6 +159,7 @@ export const SearchInput = <SuggestionItem,>({
     const inputElementValue = inputRef.current?.value;
     const valueToSubmit = val !== undefined ? val : inputElementValue;
     onSubmit(valueToSubmit);
+    clearSuggestions();
   };
 
   const {
@@ -193,12 +202,11 @@ export const SearchInput = <SuggestionItem,>({
 
   const onInputKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
     const key = event.key || event.keyCode;
-    if (!wasLastActionStateChangeEnterKey() && (key === 'Enter' || key === 13)) {
+    const wasEnterKey = key === 'Enter' || key === 13;
+    if (!wasLastActionStateChangeEnterKey() && wasEnterKey) {
       submitValue();
-      updateLastAction(userEnterKeyAction);
-    } else {
-      updateLastAction(undefined);
     }
+    updateLastAction(wasEnterKey ? userEnterKeyAction : undefined);
   };
 
   const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -218,6 +226,7 @@ export const SearchInput = <SuggestionItem,>({
   const clear = () => {
     reset();
     inputRef.current.focus();
+    clearSuggestions();
   };
 
   /**

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -177,6 +177,20 @@ export const SearchInput = <SuggestionItem,>({
     }
   };
 
+  const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // isOpen is sometimes true for no reason
+    if (isOpen && suggestions.length) {
+      return;
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      // When preventDownshiftDefault = true, downshift does not alter native behavior
+      // eslint-disable-next-line no-param-reassign
+      (event.nativeEvent as typeof event.nativeEvent & {
+        preventDownshiftDefault: boolean;
+      }).preventDownshiftDefault = true;
+    }
+  };
+
   const clear = () => {
     reset();
     inputRef.current.focus();
@@ -202,6 +216,7 @@ export const SearchInput = <SuggestionItem,>({
         <input
           {...getInputProps({
             onKeyUp: onInputKeyUp,
+            onKeyDown: onInputKeyDown,
             onChange: onInputValueChange,
             ref: inputRef,
             role: getComboboxProps().role,

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -1,5 +1,5 @@
 import React, { KeyboardEvent, useState, useRef, useEffect } from 'react';
-import { useCombobox } from 'downshift';
+import { useCombobox, UseComboboxStateChangeTypes } from 'downshift';
 
 // import core base styles
 import 'hds-core';
@@ -114,7 +114,6 @@ export const SearchInput = <SuggestionItem,>({
 }: SearchInputProps<SuggestionItem>) => {
   const didMount = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const isItemClicked = useRef<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
   const [internalValue, setInternalValue] = useState<string>('');
   const inputValue = value || internalValue;
@@ -157,11 +156,13 @@ export const SearchInput = <SuggestionItem,>({
   } = useCombobox<SuggestionItem>({
     items: suggestions,
     onStateChange(props) {
-      const { ItemClick } = useCombobox.stateChangeTypes;
-      if (props.type === ItemClick) {
-        isItemClicked.current = true;
+      const { ItemClick, FunctionReset, InputKeyDownEnter } = useCombobox.stateChangeTypes;
+      const handledChanges = [ItemClick, FunctionReset, InputKeyDownEnter] as UseComboboxStateChangeTypes[];
+      if (handledChanges.includes(props.type)) {
         dispatchValueChange(props.inputValue);
-        submitValue(props.inputValue);
+        if (props.type !== FunctionReset) {
+          submitValue(props.inputValue);
+        }
       }
     },
     itemToString: (item) => (item ? `${item[suggestionLabelField]}` : ''),

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useState, useRef, useEffect, useCallback } from 'react';
+import React, { KeyboardEvent, useState, useRef, useEffect } from 'react';
 import { useCombobox } from 'downshift';
 
 // import core base styles
@@ -138,6 +138,13 @@ export const SearchInput = <SuggestionItem,>({
     dispatchValueChange(e.target.value);
   };
 
+  const submitValue = (val?: string) => {
+    const inputElementValue = inputRef.current?.value;
+    const valueToSubmit = val !== undefined ? val : inputElementValue;
+    onSubmit(valueToSubmit);
+    setIsSubmitted(true);
+  };
+
   const {
     isOpen,
     getLabelProps,
@@ -154,32 +161,21 @@ export const SearchInput = <SuggestionItem,>({
       if (props.type === ItemClick) {
         isItemClicked.current = true;
         dispatchValueChange(props.inputValue);
+        submitValue(props.inputValue);
       }
     },
     itemToString: (item) => (item ? `${item[suggestionLabelField]}` : ''),
     ...(isControlledComponent && { inputValue }),
   });
 
-  const submit = useCallback(() => {
-    setIsSubmitted(true);
-    onSubmit(inputValue);
-  }, [setIsSubmitted, onSubmit, inputValue]);
-
   const onInputKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
     const key = event.key || event.keyCode;
     if (key === 'Enter' || key === 13) {
-      submit();
+      submitValue();
     } else {
       setIsSubmitted(false);
     }
   };
-
-  useEffect(() => {
-    if (isItemClicked.current) {
-      isItemClicked.current = false;
-      submit();
-    }
-  }, [isItemClicked, submit]);
 
   const clear = () => {
     reset();
@@ -233,7 +229,7 @@ export const SearchInput = <SuggestionItem,>({
               type="button"
               aria-label={searchButtonAriaLabel}
               className={classNames(styles.button)}
-              onClick={submit}
+              onClick={() => submitValue()}
             >
               <IconSearch className={styles.searchIcon} aria-hidden />
             </button>

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -168,9 +168,19 @@ export const SearchInput = <SuggestionItem,>({
       const { ItemClick, FunctionReset, InputKeyDownEnter } = useCombobox.stateChangeTypes;
       const handledChanges = [ItemClick, FunctionReset, InputKeyDownEnter] as UseComboboxStateChangeTypes[];
       if (handledChanges.includes(props.type)) {
-        dispatchValueChange(props.inputValue);
+        // if props.type === ItemClick and the value of the clicked item matches
+        // the value in the input element then props.inputValue does not exist.
+        const clickedValueMatchesCurrentValue = props.type === ItemClick && props.inputValue === undefined;
+        const newValue = clickedValueMatchesCurrentValue ? inputRef.current?.value : props.inputValue;
+        // additional check to make sure the value is never set to undefined
+        if (newValue === undefined) {
+          return;
+        }
+        if (!clickedValueMatchesCurrentValue) {
+          dispatchValueChange(newValue);
+        }
         if (props.type !== FunctionReset) {
-          submitValue(props.inputValue);
+          submitValue(newValue);
         }
         updateLastAction(props.type);
       } else {

--- a/packages/react/src/components/searchInput/useSuggestions.ts
+++ b/packages/react/src/components/searchInput/useSuggestions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { cancellablePromise } from '../../utils/cancellablePromise';
 import { useDebouncedEffect } from '../../hooks/useDebouncedEffect';
@@ -20,6 +20,19 @@ export const useSuggestions = <SuggestionItemType>(
   const cancelSuggestionsFunction = useRef<() => void>(() => null);
   // Currently visible suggestion items
   const [suggestions, setSuggestions] = useState<SuggestionItemType[]>([]);
+
+  const clearSuggestions = useCallback(() => {
+    setSuggestions([]);
+    setIsLoading(false);
+    cancelSuggestionsFunction.current();
+  }, [setSuggestions, cancelSuggestionsFunction]);
+
+  // cancel possible suggestion promise on unload
+  useEffect(() => {
+    return () => {
+      cancelSuggestionsFunction.current();
+    };
+  }, [cancelSuggestionsFunction]);
 
   // If form is submitted, cancel all suggestions
   useEffect(() => {
@@ -60,5 +73,5 @@ export const useSuggestions = <SuggestionItemType>(
     [searchString, getSuggestions, setSuggestions],
   );
 
-  return { suggestions, isLoading: cancelAll.current ? false : isLoading };
+  return { suggestions, isLoading: cancelAll.current ? false : isLoading, clearSuggestions };
 };


### PR DESCRIPTION
## Description

When SearchInput had text and the text was edited somewhere else than end of the string, the cursor jumped to the end.

Downshift rendered the input multiple times when input was changed: once with new value, once with old value and then new again. React could not track the cursor position.

Changed how changes are tracked with DownShift. Link to suggested fixes are in the ticket.

Also fixed how home/end keys work inside the input as commented in the ticket

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1516

## How Has This Been Tested?

Added new tests
