### PR TITLE
Add missing focus-visible styles to button

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -33,7 +33,8 @@
 
 /* button transitions */
 .hds-button:hover,
-.hds-button:focus {
+.hds-button:focus,
+.hds-button:focus-visible {
   transition-property: background-color, border-color, color;
   transition-duration: 85ms;
   transition-timing-function: ease-out;
@@ -44,7 +45,8 @@
   color: var(--color-hover);
 }
 
-.hds-button:focus {
+.hds-button:focus,
+.hds-button:focus-visible {
   background-color: var(--background-color-focus, transparent);
   color: var(--color-focus);
   outline: none;
@@ -56,7 +58,8 @@
   outline: none;
 }
 
-.hds-button:focus:hover {
+.hds-button:focus:hover,
+.hds-button:focus-visible:hover {
   background-color: var(--background-color-hover-focus, transparent);
 }
 
@@ -79,7 +82,8 @@
   border-color: var(--border-color-hover, transparent);
 }
 
-.hds-button:not(:disabled):focus {
+.hds-button:not(:disabled):focus,
+.hds-button:not(:disabled):focus-visible {
   border-color: var(--border-color-focus, transparent);
 }
 
@@ -87,7 +91,8 @@
   border-color: var(--border-color-focus, transparent);
 }
 
-.hds-button:not(:disabled):focus:hover {
+.hds-button:not(:disabled):focus:hover,
+.hds-button:not(:disabled):focus-visible:hover {
   border-color: var(--border-color-hover-focus, transparent);
   color: var(--color-hover-focus);
 }
@@ -109,7 +114,8 @@
   width: var(--size);
 }
 
-.hds-button:focus::after {
+.hds-button:focus::after,
+.hds-button:focus-visible::after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
   border-color: var(--focus-outline-color);
 }
@@ -120,7 +126,8 @@
 }
 
 /* submit input */
-input[type="submit"].hds-button:focus {
+input[type="submit"].hds-button:focus,
+input[type="submit"].hds-button:focus-visible {
   box-shadow: 0 0 0 var(--outline-gutter) var(--submit-input-focus-gutter-color), 0 0 0 calc(var(--outline-gutter) + var(--outline-width)) var(--focus-outline-color);
 }
 

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -33,7 +33,6 @@
 
 /* button transitions */
 .hds-button:hover,
-.hds-button:focus,
 .hds-button:focus-visible {
   transition-property: background-color, border-color, color;
   transition-duration: 85ms;
@@ -45,7 +44,6 @@
   color: var(--color-hover);
 }
 
-.hds-button:focus,
 .hds-button:focus-visible {
   background-color: var(--background-color-focus, transparent);
   color: var(--color-focus);
@@ -58,7 +56,6 @@
   outline: none;
 }
 
-.hds-button:focus:hover,
 .hds-button:focus-visible:hover {
   background-color: var(--background-color-hover-focus, transparent);
 }
@@ -82,7 +79,6 @@
   border-color: var(--border-color-hover, transparent);
 }
 
-.hds-button:not(:disabled):focus,
 .hds-button:not(:disabled):focus-visible {
   border-color: var(--border-color-focus, transparent);
 }
@@ -91,7 +87,6 @@
   border-color: var(--border-color-focus, transparent);
 }
 
-.hds-button:not(:disabled):focus:hover,
 .hds-button:not(:disabled):focus-visible:hover {
   border-color: var(--border-color-hover-focus, transparent);
   color: var(--color-hover-focus);
@@ -114,7 +109,6 @@
   width: var(--size);
 }
 
-.hds-button:focus::after,
 .hds-button:focus-visible::after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
   border-color: var(--focus-outline-color);
@@ -126,7 +120,6 @@
 }
 
 /* submit input */
-input[type="submit"].hds-button:focus,
 input[type="submit"].hds-button:focus-visible {
   box-shadow: 0 0 0 var(--outline-gutter) var(--submit-input-focus-gutter-color), 0 0 0 calc(var(--outline-gutter) + var(--outline-width)) var(--focus-outline-color);
 }


### PR DESCRIPTION
## Description
- Use focus-visible instead of focus in Core button

## Other possible tasks
~~- [ ] replace focus with focus-visible in other form elements~~
- [ ] replace focus with focus-visible in links

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1311

## Motivation and Context
When focus-visible pseudoclass is used, browsers use a heuristic to determine if they should apply focus-visible styles or not. In general, the heuristic combines input device (mouse, touch, keyboard, etc.), element type (button, link, etc.) and the context (for example, how the focus was gained). 
Focus pseudoclass applies styles always, nevermind the device, element or context.

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1311-button-focus-visibility/?path=/story/components-button--primary)

[HDS-1311]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ