### PR TITLE
Update year, 2022 -> 2023, in Footer lokitest images

### DIFF
--- a/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Custom_theme.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Custom_theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbee2c3e9787158c19d779d7e920c1fea37d70ceb9d301b449933851104b5a58
-size 72883
+oid sha256:ab158e7c8efd18e6e031fbc7045111db592427b5a70e97a92e366cf7b5c06bc5
+size 73306

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Default.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d3afe12cf869f7bad97c1f0fa7c2f857b9bf1dbc28e2dcd3245ff6c5aa24ecc
-size 69346
+oid sha256:242220447390ada6481444a55715fa7b2b3c773453809b55feb4a0d43c3bb2d9
+size 69768

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Example.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Example.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b44f01f87aa22d9ca238126172463b8a8b587ca56904bf91c4cbff0d7d5ead1
-size 83550
+oid sha256:388f9a175649a722946fb329a12839959ced1cf8cdf9018c5bbdfae9d62c0506
+size 83966

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Minimal.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Minimal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7d51611f01d59286aed95e42b1482f164f3b84eb1c63cc6004678f854e7ba11
-size 57152
+oid sha256:cfa11cb7fb1b0812b6fdcb550bb6da6047edcabd33ca2a057722d2a0ff339cd2
+size 57532

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Footer_No_navigation.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Footer_No_navigation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e7c14efba6263856e70384c0ddb2211fb64829bba298ddae5acbd9c0aff2c47
-size 45264
+oid sha256:ef1b5ebf331b1bd571ed15d69564e490795d6a2084f1f780bf19c5ba9f9f43e0
+size 45688

--- a/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Sitemap.png
+++ b/packages/react/.loki/reference/chrome_iphone7_Components_Footer_Sitemap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97803e2a084685904ab9768e3c451116b44fb30702fd7a88d1e6ab8fd4f292ed
-size 142146
+oid sha256:ea36c959e71c97e664b81ba56900fec499428f8c1eaad14c9bf2d96a35543c51
+size 142669

--- a/packages/react/.loki/reference/chrome_laptop_Components_Footer_Custom_theme.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Footer_Custom_theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a19cfa4d680c6d1476255bc57f32ad413a367a7752361f4360bb9a5313bbc19e
-size 18952
+oid sha256:f4878c938a09d538782029d3246feeef1981d182e0d4fb376636975a23ebab2a
+size 19159

--- a/packages/react/.loki/reference/chrome_laptop_Components_Footer_Default.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Footer_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c1507ad78f7f5171c37e5a3afa032ce80d300d3b9a96fc777fb28c9c3432ea4
-size 18092
+oid sha256:dd281cd44d3eeaf870e47e62dad7384a06e99345a792fc1bdb55d88ce814d22c
+size 18303

--- a/packages/react/.loki/reference/chrome_laptop_Components_Footer_Example.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Footer_Example.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4f6c05c3cce8c9ba0e030eb269891876fdf789106bba4341ed63c1d57c444a3
-size 25357
+oid sha256:c79755e6efb6f6b52bce36cffe6a5c5107011af2075caee97f376abc1865acc3
+size 25563

--- a/packages/react/.loki/reference/chrome_laptop_Components_Footer_Minimal.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Footer_Minimal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5942faef46d098cbc5d887bc14f18253b728dfc64210703cae45252a48cf5728
-size 17412
+oid sha256:169d1eac046a61d01d13395f4c89b0c4c532b791256da9d5395a9d556eae4305
+size 17651

--- a/packages/react/.loki/reference/chrome_laptop_Components_Footer_No_navigation.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Footer_No_navigation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd09086a1143141d40e17fb7ffd94452b5ea3c85ea00c987b613314b1ac9d4ae
-size 16219
+oid sha256:1e5f7132905e173f625a086aad86d271c86bbe1135466ebe5de3eda77c9d5343
+size 16442

--- a/packages/react/.loki/reference/chrome_laptop_Components_Footer_Sitemap.png
+++ b/packages/react/.loki/reference/chrome_laptop_Components_Footer_Sitemap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e28deab0e1d70a53c2d94699d59bbb735287e5f445f8d87183b43f81412f8596
-size 28235
+oid sha256:67f6d549bada1f1c5e287b146e47fea6d3c7b8a5d26664b731af0dc7c3b9fced
+size 28448


### PR DESCRIPTION
## Description
- Update year, 2022 -> 2023, in Footer lokitest images

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1524

## Motivation and Context
- Update lokitests year now so we can continue without broken lokitests
