### PR TITLE
HDS-1011: Prevent clearing multi-item ComboBox on selection

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.test.tsx
@@ -121,7 +121,7 @@ describe('<Combobox />', () => {
         multiselect: true,
       });
 
-      const input = getAllByLabelText(label)[0];
+      const input = getAllByLabelText(label)[0] as HTMLInputElement;
 
       // Search an option
       userEvent.type(input, 'Fi');
@@ -131,6 +131,8 @@ describe('<Combobox />', () => {
       // Choose one option
       userEvent.click(visibleOptions[0]);
       await waitFor(() => {
+        // input value is not cleared on selection
+        expect(input.value).toBe('Fi');
         // Ensure that it's visible in selected items
         expect(queryAllByText(options[0].label).length).toEqual(2);
         // Ensure that it has been passed upwards with onChange
@@ -138,10 +140,24 @@ describe('<Combobox />', () => {
         expect(onChange).toHaveBeenCalledWith([options[0]]);
       });
 
+      // clear input text
+      userEvent.clear(input);
       // Search another option
       userEvent.type(input, 'bo');
-      expect(getAllByRole('option').length).toBe(2);
-      userEvent.click(getAllByRole('option')[1]);
+      const newVisibleOptions = getAllByRole('option');
+      // Ensure that options are filtered correctly
+      expect(newVisibleOptions.length).toBe(2);
+      userEvent.click(newVisibleOptions[1]);
+      await waitFor(() => {
+        // input value is not cleared on selection
+        expect(input.value).toBe('bo');
+        // Ensure that it's visible in selected items
+        expect(queryAllByText(options[4].label).length).toEqual(2);
+        // Ensure that it has been passed upwards with onChange
+      });
+
+      // clear input text so all options will be visible again
+      userEvent.clear(input);
       await waitFor(() => {
         // Ensure that previous and current selection are visible in
         // selected items


### PR DESCRIPTION
The input was cleared on selection, which is annoying when wanting to select multiple items and items need to be filtered first.

The input value is now kept until blurred or menu is closed.

## Description

When item is selected with pointer / spacebar, the input value is not reset like before.
If item is selected with enter key, then the menu closes and input is cleared. This behaviour has not changed in this PR.
Input is cleared on blur, if it is a multi-select combobox

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1011

## How Has This Been Tested?

Added tests.


[HDS-1011]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ