### PR TITLE
HDS-1521: Deleting tags in combobox has weird side-effects

### DIFF
--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -258,13 +258,13 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
               // reset input value
               inputValue: '',
             };
-          } else {
-            // clear the input value on blur
-            return {
-              ...changes,
-              inputValue: '',
-            };
           }
+
+          // otherwise clear the input value on blur
+          return {
+            ...changes,
+            inputValue: '',
+          };
         }
 
         // prevent the menu from being closed when the user selects an item by clicking

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -223,29 +223,50 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
       const { ItemClick, InputBlur, FunctionSelectItem, InputKeyDownEnter } = useCombobox.stateChangeTypes;
       const { selectedItem: _selectedItem, inputValue } = changes;
 
-      // clear the selected item if the input value doesn't match the selected item label
-      if (!props.multiselect && _selectedItem && _selectedItem[optionLabelField] !== inputValue) {
-        return {
-          ...changes,
-          selectedItem: null,
-        };
-      }
-
-      if (type === InputBlur) {
-        // clear the input value on blur if
-        // it is a single select and there's no selected item
-        // it is in a multiselect combobox
-        const singleSelectWithoutSelection = !props.multiselect && !_selectedItem;
-        if (singleSelectWithoutSelection || props.multiselect) {
+      // special cases with singleselect only
+      if (!props.multiselect) {
+        // clear the selected item if the input value doesn't match the selected item label
+        if (_selectedItem && _selectedItem[optionLabelField] !== inputValue) {
           return {
             ...changes,
-            inputValue: '',
+            selectedItem: null,
           };
+        }
+
+        if (type === InputBlur) {
+          // clear the input value on blur if
+          // it is a single select and there's no selected item
+          if (!_selectedItem) {
+            return {
+              ...changes,
+              inputValue: '',
+            };
+          }
         }
       }
 
       // special cases with multiselect only
       if (props.multiselect) {
+        // clear changes.selectedItem on blur, if state.selectedItem does not exist
+        // and therefore an item has not been selected. For some reason changes.selectedItem exists
+        // when deleting tag while suggestions are open.
+        if (type === InputBlur) {
+          if (!state.selectedItem) {
+            return {
+              ...changes,
+              selectedItem: null,
+              // reset input value
+              inputValue: '',
+            };
+          } else {
+            // clear the input value on blur
+            return {
+              ...changes,
+              inputValue: '',
+            };
+          }
+        }
+
         // prevent the menu from being closed when the user selects an item by clicking
         if (type === ItemClick) {
           return {
@@ -273,18 +294,6 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             inputValue: state.inputValue,
           };
         }
-      }
-
-      // clear changes.selectedItem on blur, if state.selectedItem does not exist
-      // and therefore an item has not been selected. For some reason changes.selectedItem exists
-      // when deleting tag while suggestions are open.
-      if (type === InputBlur && props.multiselect && !state.selectedItem) {
-        return {
-          ...changes,
-          selectedItem: null,
-          // reset input value
-          inputValue: '',
-        };
       }
 
       return changes;

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -274,6 +274,19 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
           };
         }
       }
+
+      // clear changes.selectedItem on blur, if state.selectedItem does not exist
+      // and therefore an item has not been selected. For some reason changes.selectedItem exists
+      // when deleting tag while suggestions are open.
+      if (type === InputBlur && props.multiselect && !state.selectedItem) {
+        return {
+          ...changes,
+          selectedItem: null,
+          // reset input value
+          inputValue: '',
+        };
+      }
+
       return changes;
     },
   });


### PR DESCRIPTION
## Description
If options are selected and then tags are deleted while options are open, items are deleted quite randomly and item can even be added. Depends on the indexes of the selected and deleted items.

Preventing selections onBlur fixes the problem.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1521

## How Has This Been Tested?

Added tests which fail without these changes.


[HDS-1011]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-1521]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ