### PR TITLE
Unify error messages implementation, examples and documentation

### DIFF
--- a/packages/core/src/components/error-summary/error-summary.stories.js
+++ b/packages/core/src/components/error-summary/error-summary.stories.js
@@ -12,7 +12,7 @@ export const Default = () => `
     <section aria-label="Error summary" class="hds-notification hds-notification--error">
       <div class="hds-notification__content">
         <div class="hds-notification__label" role="heading" aria-level="2" tabindex="-1">
-          <span class="hds-icon hds-icon--alert-circle" aria-hidden="true"></span>
+          <span class="hds-icon hds-icon--alert-circle-fill" aria-hidden="true"></span>
           <span>Form contains following errors</span>
         </div>
         <div class="hds-notification__body hds-error-summary__body">
@@ -36,7 +36,7 @@ export const Large = () => `
     <section aria-label="Error summary" class="hds-notification hds-notification--error hds-notification--large">
       <div class="hds-notification__content">
         <div class="hds-notification__label" role="heading" aria-level="2" tabindex="-1">
-          <span class="hds-icon hds-icon--alert-circle" aria-hidden="true"></span>
+          <span class="hds-icon hds-icon--alert-circle-fill" aria-hidden="true"></span>
           <span>Form contains following errors</span>
         </div>
         <div class="hds-notification__body hds-error-summary__body">

--- a/site/src/docs/patterns/forms/form-building.mdx
+++ b/site/src/docs/patterns/forms/form-building.mdx
@@ -1330,12 +1330,8 @@ Filling a long form can be daunting task for the user. One way to make a long fo
 
 This approach also makes fixing validation errors easier, when the inputted data can be validated and fixed step by step, and thus fever errors are shown at a same time.
 
-<p>
-  <StatusLabel type="error" style={{ marginRight: 'var(--spacing-3-xs)' }}>
-    Coming soon
-  </StatusLabel>
-  <strong>The navigation component for multi-page forms has not yet been designed or implemented in HDS.</strong>
-</p>
+To create multi-page forms, use <InternalLink href="h/components/stepper/">Stepper</InternalLink> for navigating between the pages.
+See guidelines for <InternalLink href="/patterns/forms/form-multi-page/">Multi-page forms</InternalLink>.
 
 <Image
   src="/images/patterns/form/building/form-steps@2x.png"

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -4,10 +4,11 @@ title: 'Form validation'
 navTitle: 'Form validation'
 ---
 
-import { Link, IconCheck, IconError, Notification, StatusLabel } from 'hds-react';
+import { Button, ErrorSummary, IconCheck, IconError, Notification, TextInput, Link, StatusLabel } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import InternalLink from '../../../components/InternalLink';
+import Playground from '../../../components/Playground';
 
 # Form validation
 
@@ -241,12 +242,79 @@ The usage of the error summary component is triggered when the form is submitted
 4. The user can use the error description anchor link to quickly jump and focus each of the erroneous inputs.
 5. When the user submits the form again and errors are still found, the contents of the error summary are updated and the focus is moved back to the summary heading again.
 
-<Image
-  src="/images/patterns/form/validation/validation-pattern-example@2x.png"
-  alt="Validation summary example"
-  style={{ maxWidth: 432 }}
-  viewable
-/>
+<Playground scope={{ Button, ErrorSummary, TextInput }} >
+
+```jsx
+import { Button, ErrorSummary, TextInput } from 'hds-react';
+
+{
+  () => {
+    const [formValues, setFormValues] = React.useState({});
+    const [formErrors, setFormErrors] = React.useState({});
+    const [isSubmitted, setIsSubmitted] = React.useState(false);
+    const errorList = Object.entries(formErrors);
+
+    const validate = (values) => {
+      const errors = {
+        ...(values['firstName'] ? {} : { firstName: 'Please enter your first name' }),
+        ...(values['lastName'] ? {} : { lastName: 'Please enter your last name' }),
+      };
+      setFormErrors(errors);
+    };
+
+    const onSubmit = (e) => {
+      e.preventDefault();
+      setIsSubmitted(true);
+    };
+
+    React.useEffect(() => {
+      validate(formValues);
+    }, [formValues]);
+
+    return (
+      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+        {isSubmitted && errorList.length > 0 && (
+          <ErrorSummary autofocus label="Form contains following errors">
+            {errorList.map(([key, value], index) => (
+              <li key={key}>
+                {`Error ${index + 1}: `}
+                <a href={`#validationExample-${key}`}>{value}</a>
+              </li>
+            ))}
+          </ErrorSummary>
+        )}
+        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+          <TextInput
+            id="validationExample-firstName"
+            name="firstName"
+            label="First name"
+            onBlur={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
+            invalid={!!formErrors['firstName']}
+            errorText={formErrors['firstName']}
+            required
+          />
+          <TextInput
+            id="validationExample-lastName"
+            name="lastName"
+            label="Last name"
+            onBlur={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
+            invalid={!!formErrors['lastName']}
+            errorText={formErrors['lastName']}
+            required
+          />
+        </div>
+        <div style={{ marginTop: 'var(--spacing-m)' }}>
+          <Button onClick={onSubmit} type="button">
+            Submit
+          </Button>
+        </div>
+      </form>
+    );
+  }
+}
+```
+
+</Playground>
 
 You can see the validation summary pattern in action in HDS Storybook <Link href="/storybook/react/iframe.html?id=patterns-form-validation--static&viewMode=story" external openInNewTab openInNewTabAriaLabel="Opens in new tab">static validation example</Link> and <Link href="/storybook/react/iframe.html?id=patterns-form-validation--hybrid&viewMode=story" external openInNewTab openInNewTabAriaLabel="Opens in new tab">hybrid validation example</Link>.
 

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -280,43 +280,48 @@ import { Button, ErrorSummary, TextInput } from 'hds-react';
     }, [formValues]);
     console.log(formErrors);
     return (
-      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
-        {isSubmitted && errorList.length > 0 && (
-          <ErrorSummary autofocus label="Form contains following errors">
-            {errorList.map(([key, value], index) => (
-              <li key={key}>
-                {`Error ${index + 1}: `}
-                <a href={`#validationExample-${key}`}>{value}</a>
-              </li>
-            ))}
-          </ErrorSummary>
-        )}
-        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
-          <TextInput
-            id="validationExample-firstName"
-            name="firstName"
-            label="First name"
-            onChange={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
-            invalid={!!formErrors['firstName']}
-            errorText={formErrors['firstName']}
-            required
-          />
-          <TextInput
-            id="validationExample-lastName"
-            name="lastName"
-            label="Last name"
-            onChange={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
-            invalid={!!formErrors['lastName']}
-            errorText={formErrors['lastName']}
-            required
-          />
-        </div>
-        <div style={{ marginTop: 'var(--spacing-m)' }}>
-          <Button onClick={onSubmit} type="button">
-            Submit
-          </Button>
-        </div>
-      </form>
+      <>
+        <h4>Live example</h4>
+        <p>Test how the hybrid validation works by pressing Submit which causes validation errors to show about missing inputs. The validation errors disappear immediately after input has changed.</p>
+        
+        <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+          {isSubmitted && errorList.length > 0 && (
+            <ErrorSummary autofocus label="Form contains following errors">
+              {errorList.map(([key, value], index) => (
+                <li key={key}>
+                  {`Error ${index + 1}: `}
+                  <a href={`#validationExample-${key}`}>{value}</a>
+                </li>
+              ))}
+            </ErrorSummary>
+          )}
+          <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+            <TextInput
+              id="validationExample-firstName"
+              name="firstName"
+              label="First name"
+              onChange={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
+              invalid={!!formErrors['firstName']}
+              errorText={formErrors['firstName']}
+              required
+            />
+            <TextInput
+              id="validationExample-lastName"
+              name="lastName"
+              label="Last name"
+              onChange={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
+              invalid={!!formErrors['lastName']}
+              errorText={formErrors['lastName']}
+              required
+            />
+          </div>
+          <div style={{ marginTop: 'var(--spacing-m)' }}>
+            <Button onClick={onSubmit} type="button">
+              Submit
+            </Button>
+          </div>
+        </form>
+      </>
     );
   }
 ```
@@ -347,6 +352,7 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
   const validate = (values) => {
     const startDate = values['startDate'];
     const endDate = values['endDate'];
+    if (startDate == null & endDate == null) return null;
     const errors = {
       ...(!startDate || isSameOrAfter(startDate, endDate) ? { startDate: 'Start date must be before end date' } : {}),
       ...(!endDate || isSameOrAfter(startDate, endDate) ? { endDate: 'End date must be after start date' } : {}),
@@ -363,46 +369,50 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
     validate(formValues);
   }, [formValues]);
 
-  return (
-    <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
-      {isSubmitted && errorList.length > 0 && (
-        <ErrorSummary autofocus label="Form contains following errors">
-          {errorList.map(([key, value], index) => (
-            <li key={key}>
-              {`Error ${index + 1}: `}
-              <a href={`#dateValidationExample-${key}`}>{value}</a>
-            </li>
-          ))}
-        </ErrorSummary>
-      )}
-      <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
-        <DateInput
-          id="dateValidationExample-startDate"
-          name="startDate"
-          label="Start date"
-          onChange={(date) => setFormValues({ ...formValues, startDate: date })}
-          invalid={!!formErrors['startDate']}
-          errorText={formErrors['startDate']}
-          required
-          disableConfirmation
-        />
-        <DateInput
-          id="dateValidationExample-endDate"
-          name="endDate"
-          label="End date"
-          onChange={(date) => setFormValues({ ...formValues, endDate: date })}
-          invalid={!!formErrors['endDate']}
-          errorText={formErrors['endDate']}
-          required
-          disableConfirmation
-        />
-      </div>
-      <div style={{ marginTop: 'var(--spacing-m)' }}>
-        <Button onClick={onSubmit} type="button">
-          Submit
-        </Button>
-      </div>
-    </form>
+  return ( 
+    <>
+      <h4>Live example</h4>
+      <p>Check the how the validation behaves by selecting end date before the start date or vice versa.</p>   
+      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+        {isSubmitted && errorList.length > 0 && (
+          <ErrorSummary autofocus label="Form contains following errors">
+            {errorList.map(([key, value], index) => (
+              <li key={key}>
+                {`Error ${index + 1}: `}
+                <a href={`#dateValidationExample-${key}`}>{value}</a>
+              </li>
+            ))}
+          </ErrorSummary>
+        )}
+        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+          <DateInput
+            id="dateValidationExample-startDate"
+            name="startDate"
+            label="Start date"
+            onChange={(date) => setFormValues({ ...formValues, startDate: date })}
+            invalid={!!formErrors['startDate']}
+            errorText={formErrors['startDate']}
+            required
+            disableConfirmation
+          />
+          <DateInput
+            id="dateValidationExample-endDate"
+            name="endDate"
+            label="End date"
+            onChange={(date) => setFormValues({ ...formValues, endDate: date })}
+            invalid={!!formErrors['endDate']}
+            errorText={formErrors['endDate']}
+            required
+            disableConfirmation
+          />
+        </div>
+        <div style={{ marginTop: 'var(--spacing-m)' }}>
+          <Button onClick={onSubmit} type="button">
+            Submit
+          </Button>
+        </div>
+      </form>
+    </>
   )
 }
 ```

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -261,13 +261,20 @@ import { Button, ErrorSummary, TextInput } from 'hds-react';
     const [isSubmitted, setIsSubmitted] = React.useState(false);
     const errorList = Object.entries(formErrors);
 
-    const validate = (values, onlyValidationErrors) => {
+    const getFieldError = (fieldName, formData, errorData) => {
+      return errorData ? !formData[fieldName] && errorData[fieldName] : !formData[fieldName];
+    }
+
+    const validate = (values, currentErrors) => {
+      const hasFirstNameError = getFieldError('firstName', values, currentErrors);
+      const hasLastNameError = getFieldError('lastName', values, currentErrors);
+
       const errors = {
-        ...((!values['firstName'] && !onlyValidationErrors) || (!values['firstName'] && onlyValidationErrors && 'firstName' in formErrors) ? { firstName: 'Please enter your first name' } : {}),
-       ...((!values['lastName'] && !onlyValidationErrors) || (!values['lastName'] && onlyValidationErrors && 'lastName' in formErrors) ? { lastName: 'Please enter your last name' } : {}),
+        ...(hasFirstNameError ? { firstName: 'Please enter your first name' } : {}),
+        ...(hasLastNameError ? { lastName: 'Please enter your last name' } : {}),
       };
       setFormErrors(errors);
-    };
+    }
 
     const onSubmit = (e) => {
       e.preventDefault();
@@ -278,7 +285,7 @@ import { Button, ErrorSummary, TextInput } from 'hds-react';
     React.useEffect(() => {
       if (Object.keys(formErrors).length > 0) validate(formValues, true);
     }, [formValues]);
-    console.log(formErrors);
+    
     return (
       <>
         <h4>Live example</h4>
@@ -347,12 +354,13 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
   const [isSubmitted, setIsSubmitted] = React.useState(false);
   const errorList = Object.entries(formErrors);
 
-  const isSameOrAfter = (dateA, dateB) => dateA && dateB && dateA.valueOf() >= dateB.valueOf();
+  const isSameOrAfter = (dateA, dateB) => dateA && dateB && dateA >= dateB;
 
   const validate = (values) => {
     const startDate = values['startDate'];
     const endDate = values['endDate'];
     if (startDate == null & endDate == null) return null;
+
     const errors = {
       ...(!startDate || isSameOrAfter(startDate, endDate) ? { startDate: 'Start date must be before end date' } : {}),
       ...(!endDate || isSameOrAfter(startDate, endDate) ? { endDate: 'End date must be after start date' } : {}),
@@ -389,7 +397,7 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
             id="dateValidationExample-startDate"
             name="startDate"
             label="Start date"
-            onChange={(date) => setFormValues({ ...formValues, startDate: date })}
+            onChange={(dateString, date) => setFormValues({ ...formValues, startDate: date })}
             invalid={!!formErrors['startDate']}
             errorText={formErrors['startDate']}
             required
@@ -399,7 +407,7 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
             id="dateValidationExample-endDate"
             name="endDate"
             label="End date"
-            onChange={(date) => setFormValues({ ...formValues, endDate: date })}
+            onChange={(dateString, date) => setFormValues({ ...formValues, endDate: date })}
             invalid={!!formErrors['endDate']}
             errorText={formErrors['endDate']}
             required

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -4,7 +4,17 @@ title: 'Form validation'
 navTitle: 'Form validation'
 ---
 
-import { Button, ErrorSummary, IconCheck, IconError, Notification, TextInput, Link, StatusLabel } from 'hds-react';
+import {
+  Button,
+  DateInput,
+  ErrorSummary,
+  IconCheck,
+  IconError,
+  Notification,
+  TextInput,
+  Link,
+  StatusLabel,
+} from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import InternalLink from '../../../components/InternalLink';
@@ -324,12 +334,85 @@ In some cases, multiple input fields can be related to each other in a way that 
 
 An example of this could be having two date inputs for setting a start and an end time. If the end time is set to be earlier than the start time, both date inputs become erroneous. Since assistive technologies only see one input at a time, all related inputs should be set to an error state and given an appropriate error message. The error message can be the same for all inputs or more input specific if the situation allows so. All error messages are also added to the error summary list. This method has been illustrated in the image below.
 
-<Image
-  src="/images/patterns/form/validation/multiple-fields-validation@2x.png"
-  alt="Showing error messages of multiple input fields"
-  style={{ maxWidth: 482 }}
-  viewable
-/>
+<Playground scope={{ Button, ErrorSummary, DateInput }} >
+
+```jsx
+import { Button, ErrorSummary, DateInput } from 'hds-react';
+
+{
+  () => {
+    const [formValues, setFormValues] = React.useState({});
+    const [formErrors, setFormErrors] = React.useState({});
+    const [isSubmitted, setIsSubmitted] = React.useState(false);
+    const errorList = Object.entries(formErrors);
+
+    const isSameOrAfter = (dateA, dateB) => dateA && dateB && dateA.valueOf() >= dateB.valueOf();
+
+    const validate = (values) => {
+      const startDate = values['startDate'];
+      const endDate = values['endDate'];
+      const errors = {
+        ...(!startDate || isSameOrAfter(startDate, endDate) ? { startDate: 'Start date must be before end date' } : {}),
+        ...(!endDate || isSameOrAfter(startDate, endDate) ? { endDate: 'End date must be after start date' } : {}),
+      };
+      setFormErrors(errors);
+    };
+
+    const onSubmit = (e) => {
+      e.preventDefault();
+      setIsSubmitted(true);
+    };
+
+    React.useEffect(() => {
+      validate(formValues);
+    }, [formValues]);
+
+    return (
+      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+        {isSubmitted && errorList.length > 0 && (
+          <ErrorSummary autofocus label="Form contains following errors">
+            {errorList.map(([key, value], index) => (
+              <li key={key}>
+                {`Error ${index + 1}: `}
+                <a href={`#dateValidationExample-${key}`}>{value}</a>
+              </li>
+            ))}
+          </ErrorSummary>
+        )}
+        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+          <DateInput
+            id="dateValidationExample-startDate"
+            name="startDate"
+            label="Start date"
+            onChange={(date) => setFormValues({ ...formValues, startDate: date })}
+            invalid={!!formErrors['startDate']}
+            errorText={formErrors['startDate']}
+            required
+            disableConfirmation
+          />
+          <DateInput
+            id="dateValidationExample-endDate"
+            name="endDate"
+            label="End date"
+            onChange={(date) => setFormValues({ ...formValues, endDate: date })}
+            invalid={!!formErrors['endDate']}
+            errorText={formErrors['endDate']}
+            required
+            disableConfirmation
+          />
+        </div>
+        <div style={{ marginTop: 'var(--spacing-m)' }}>
+          <Button onClick={onSubmit} type="button">
+            Submit
+          </Button>
+        </div>
+      </form>
+    );
+  };
+}
+```
+
+</Playground>
 
 When there are multiple related fields, a later field in the form can make an earlier field erroneous. In this case, it is important to note that the state change of the earlier field can go unnoticed for assistive technologies. It is recommended to notify assistive technologies of other inputs' state change by using the <InternalLink href="/components/notification#invisible">HDS invisible notification.</InternalLink>
 

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -247,7 +247,8 @@ The usage of the error summary component is triggered when the form is submitted
 2. The focus is moved from the form submit button to the error summary heading.
 3. The error summary is populated with a list of errors found in the form. Errors are in the same order as they appear in the form. For each error, a running number and an error description are provided. The error description also acts as an anchor link.
 4. The user can use the error description anchor link to quickly jump and focus each of the erroneous inputs.
-5. When the user submits the form again and errors are still found, the contents of the error summary are updated and the focus is moved back to the summary heading again.
+5. The error validation check happens immediately after the input value changes.
+6. When the user submits the form again and errors are still found, the contents of the error summary are updated and the focus is moved back to the summary heading again.
 
 <Playground scope={{ Button, ErrorSummary, TextInput }} >
 
@@ -255,68 +256,69 @@ The usage of the error summary component is triggered when the form is submitted
 import { Button, ErrorSummary, TextInput } from 'hds-react';
 
 () => {
-  const [formValues, setFormValues] = React.useState({});
-  const [formErrors, setFormErrors] = React.useState({});
-  const [isSubmitted, setIsSubmitted] = React.useState(false);
-  const errorList = Object.entries(formErrors);
+    const [formValues, setFormValues] = React.useState({});
+    const [formErrors, setFormErrors] = React.useState({});
+    const [isSubmitted, setIsSubmitted] = React.useState(false);
+    const errorList = Object.entries(formErrors);
 
-  const validate = (values) => {
-    const errors = {
-      ...(values['firstName'] ? {} : { firstName: 'Please enter your first name' }),
-      ...(values['lastName'] ? {} : { lastName: 'Please enter your last name' }),
+    const validate = (values, onlyValidationErrors) => {
+      const errors = {
+        ...((!values['firstName'] && !onlyValidationErrors) || (!values['firstName'] && onlyValidationErrors && 'firstName' in formErrors) ? { firstName: 'Please enter your first name' } : {}),
+       ...((!values['lastName'] && !onlyValidationErrors) || (!values['lastName'] && onlyValidationErrors && 'lastName' in formErrors) ? { lastName: 'Please enter your last name' } : {}),
+      };
+      setFormErrors(errors);
     };
-    setFormErrors(errors);
-  };
 
-  const onSubmit = (e) => {
-    e.preventDefault();
-    setIsSubmitted(true);
-  };
+    const onSubmit = (e) => {
+      e.preventDefault();
+      validate(formValues);
+      setIsSubmitted(true);
+    };
 
-  React.useEffect(() => {
-    validate(formValues);
-  }, [formValues]);
-
-  return (
-    <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
-      {isSubmitted && errorList.length > 0 && (
-        <ErrorSummary autofocus label="Form contains following errors">
-          {errorList.map(([key, value], index) => (
-            <li key={key}>
-              {`Error ${index + 1}: `}
-              <a href={`#validationExample-${key}`}>{value}</a>
-            </li>
-          ))}
-        </ErrorSummary>
-      )}
-      <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
-        <TextInput
-          id="validationExample-firstName"
-          name="firstName"
-          label="First name"
-          onBlur={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
-          invalid={!!formErrors['firstName']}
-          errorText={formErrors['firstName']}
-          required
-        />
-        <TextInput
-          id="validationExample-lastName"
-          name="lastName"
-          label="Last name"
-          onBlur={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
-          invalid={!!formErrors['lastName']}
-          errorText={formErrors['lastName']}
-          required
-        />
-      </div>
-      <div style={{ marginTop: 'var(--spacing-m)' }}>
-        <Button onClick={onSubmit} type="button">
-          Submit
-        </Button>
-      </div>
-    </form>
-  )
-}
+    React.useEffect(() => {
+      if (Object.keys(formErrors).length > 0) validate(formValues, true);
+    }, [formValues]);
+    console.log(formErrors);
+    return (
+      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+        {isSubmitted && errorList.length > 0 && (
+          <ErrorSummary autofocus label="Form contains following errors">
+            {errorList.map(([key, value], index) => (
+              <li key={key}>
+                {`Error ${index + 1}: `}
+                <a href={`#validationExample-${key}`}>{value}</a>
+              </li>
+            ))}
+          </ErrorSummary>
+        )}
+        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+          <TextInput
+            id="validationExample-firstName"
+            name="firstName"
+            label="First name"
+            onChange={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
+            invalid={!!formErrors['firstName']}
+            errorText={formErrors['firstName']}
+            required
+          />
+          <TextInput
+            id="validationExample-lastName"
+            name="lastName"
+            label="Last name"
+            onChange={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
+            invalid={!!formErrors['lastName']}
+            errorText={formErrors['lastName']}
+            required
+          />
+        </div>
+        <div style={{ marginTop: 'var(--spacing-m)' }}>
+          <Button onClick={onSubmit} type="button">
+            Submit
+          </Button>
+        </div>
+      </form>
+    );
+  }
 ```
 
 </Playground>

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -12,13 +12,10 @@ import {
   IconError,
   Notification,
   TextInput,
-  Link,
   StatusLabel,
 } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
-import InternalLink from '../../../components/InternalLink';
-import Playground from '../../../components/Playground';
 
 # Form validation
 
@@ -257,70 +254,68 @@ The usage of the error summary component is triggered when the form is submitted
 ```jsx
 import { Button, ErrorSummary, TextInput } from 'hds-react';
 
-{
-  () => {
-    const [formValues, setFormValues] = React.useState({});
-    const [formErrors, setFormErrors] = React.useState({});
-    const [isSubmitted, setIsSubmitted] = React.useState(false);
-    const errorList = Object.entries(formErrors);
+() => {
+  const [formValues, setFormValues] = React.useState({});
+  const [formErrors, setFormErrors] = React.useState({});
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+  const errorList = Object.entries(formErrors);
 
-    const validate = (values) => {
-      const errors = {
-        ...(values['firstName'] ? {} : { firstName: 'Please enter your first name' }),
-        ...(values['lastName'] ? {} : { lastName: 'Please enter your last name' }),
-      };
-      setFormErrors(errors);
+  const validate = (values) => {
+    const errors = {
+      ...(values['firstName'] ? {} : { firstName: 'Please enter your first name' }),
+      ...(values['lastName'] ? {} : { lastName: 'Please enter your last name' }),
     };
+    setFormErrors(errors);
+  };
 
-    const onSubmit = (e) => {
-      e.preventDefault();
-      setIsSubmitted(true);
-    };
+  const onSubmit = (e) => {
+    e.preventDefault();
+    setIsSubmitted(true);
+  };
 
-    React.useEffect(() => {
-      validate(formValues);
-    }, [formValues]);
+  React.useEffect(() => {
+    validate(formValues);
+  }, [formValues]);
 
-    return (
-      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
-        {isSubmitted && errorList.length > 0 && (
-          <ErrorSummary autofocus label="Form contains following errors">
-            {errorList.map(([key, value], index) => (
-              <li key={key}>
-                {`Error ${index + 1}: `}
-                <a href={`#validationExample-${key}`}>{value}</a>
-              </li>
-            ))}
-          </ErrorSummary>
-        )}
-        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
-          <TextInput
-            id="validationExample-firstName"
-            name="firstName"
-            label="First name"
-            onBlur={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
-            invalid={!!formErrors['firstName']}
-            errorText={formErrors['firstName']}
-            required
-          />
-          <TextInput
-            id="validationExample-lastName"
-            name="lastName"
-            label="Last name"
-            onBlur={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
-            invalid={!!formErrors['lastName']}
-            errorText={formErrors['lastName']}
-            required
-          />
-        </div>
-        <div style={{ marginTop: 'var(--spacing-m)' }}>
-          <Button onClick={onSubmit} type="button">
-            Submit
-          </Button>
-        </div>
-      </form>
-    );
-  }
+  return (
+    <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+      {isSubmitted && errorList.length > 0 && (
+        <ErrorSummary autofocus label="Form contains following errors">
+          {errorList.map(([key, value], index) => (
+            <li key={key}>
+              {`Error ${index + 1}: `}
+              <a href={`#validationExample-${key}`}>{value}</a>
+            </li>
+          ))}
+        </ErrorSummary>
+      )}
+      <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+        <TextInput
+          id="validationExample-firstName"
+          name="firstName"
+          label="First name"
+          onBlur={(e) => setFormValues({ ...formValues, firstName: e.target.value })}
+          invalid={!!formErrors['firstName']}
+          errorText={formErrors['firstName']}
+          required
+        />
+        <TextInput
+          id="validationExample-lastName"
+          name="lastName"
+          label="Last name"
+          onBlur={(e) => setFormValues({ ...formValues, lastName: e.target.value })}
+          invalid={!!formErrors['lastName']}
+          errorText={formErrors['lastName']}
+          required
+        />
+      </div>
+      <div style={{ marginTop: 'var(--spacing-m)' }}>
+        <Button onClick={onSubmit} type="button">
+          Submit
+        </Button>
+      </div>
+    </form>
+  )
 }
 ```
 
@@ -339,76 +334,74 @@ An example of this could be having two date inputs for setting a start and an en
 ```jsx
 import { Button, ErrorSummary, DateInput } from 'hds-react';
 
-{
-  () => {
-    const [formValues, setFormValues] = React.useState({});
-    const [formErrors, setFormErrors] = React.useState({});
-    const [isSubmitted, setIsSubmitted] = React.useState(false);
-    const errorList = Object.entries(formErrors);
+() => {
+  const [formValues, setFormValues] = React.useState({});
+  const [formErrors, setFormErrors] = React.useState({});
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+  const errorList = Object.entries(formErrors);
 
-    const isSameOrAfter = (dateA, dateB) => dateA && dateB && dateA.valueOf() >= dateB.valueOf();
+  const isSameOrAfter = (dateA, dateB) => dateA && dateB && dateA.valueOf() >= dateB.valueOf();
 
-    const validate = (values) => {
-      const startDate = values['startDate'];
-      const endDate = values['endDate'];
-      const errors = {
-        ...(!startDate || isSameOrAfter(startDate, endDate) ? { startDate: 'Start date must be before end date' } : {}),
-        ...(!endDate || isSameOrAfter(startDate, endDate) ? { endDate: 'End date must be after start date' } : {}),
-      };
-      setFormErrors(errors);
+  const validate = (values) => {
+    const startDate = values['startDate'];
+    const endDate = values['endDate'];
+    const errors = {
+      ...(!startDate || isSameOrAfter(startDate, endDate) ? { startDate: 'Start date must be before end date' } : {}),
+      ...(!endDate || isSameOrAfter(startDate, endDate) ? { endDate: 'End date must be after start date' } : {}),
     };
-
-    const onSubmit = (e) => {
-      e.preventDefault();
-      setIsSubmitted(true);
-    };
-
-    React.useEffect(() => {
-      validate(formValues);
-    }, [formValues]);
-
-    return (
-      <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
-        {isSubmitted && errorList.length > 0 && (
-          <ErrorSummary autofocus label="Form contains following errors">
-            {errorList.map(([key, value], index) => (
-              <li key={key}>
-                {`Error ${index + 1}: `}
-                <a href={`#dateValidationExample-${key}`}>{value}</a>
-              </li>
-            ))}
-          </ErrorSummary>
-        )}
-        <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
-          <DateInput
-            id="dateValidationExample-startDate"
-            name="startDate"
-            label="Start date"
-            onChange={(date) => setFormValues({ ...formValues, startDate: date })}
-            invalid={!!formErrors['startDate']}
-            errorText={formErrors['startDate']}
-            required
-            disableConfirmation
-          />
-          <DateInput
-            id="dateValidationExample-endDate"
-            name="endDate"
-            label="End date"
-            onChange={(date) => setFormValues({ ...formValues, endDate: date })}
-            invalid={!!formErrors['endDate']}
-            errorText={formErrors['endDate']}
-            required
-            disableConfirmation
-          />
-        </div>
-        <div style={{ marginTop: 'var(--spacing-m)' }}>
-          <Button onClick={onSubmit} type="button">
-            Submit
-          </Button>
-        </div>
-      </form>
-    );
+    setFormErrors(errors);
   };
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    setIsSubmitted(true);
+  };
+
+  React.useEffect(() => {
+    validate(formValues);
+  }, [formValues]);
+
+  return (
+    <form onSubmit={onSubmit} style={{ maxWidth: '450px', margin: 'var(--spacing-xl) var(--spacing-m)' }}>
+      {isSubmitted && errorList.length > 0 && (
+        <ErrorSummary autofocus label="Form contains following errors">
+          {errorList.map(([key, value], index) => (
+            <li key={key}>
+              {`Error ${index + 1}: `}
+              <a href={`#dateValidationExample-${key}`}>{value}</a>
+            </li>
+          ))}
+        </ErrorSummary>
+      )}
+      <div style={{ display: 'flex', gap: 'var(--spacing-m)', marginTop: 'var(--spacing-m)' }}>
+        <DateInput
+          id="dateValidationExample-startDate"
+          name="startDate"
+          label="Start date"
+          onChange={(date) => setFormValues({ ...formValues, startDate: date })}
+          invalid={!!formErrors['startDate']}
+          errorText={formErrors['startDate']}
+          required
+          disableConfirmation
+        />
+        <DateInput
+          id="dateValidationExample-endDate"
+          name="endDate"
+          label="End date"
+          onChange={(date) => setFormValues({ ...formValues, endDate: date })}
+          invalid={!!formErrors['endDate']}
+          errorText={formErrors['endDate']}
+          required
+          disableConfirmation
+        />
+      </div>
+      <div style={{ marginTop: 'var(--spacing-m)' }}>
+        <Button onClick={onSubmit} type="button">
+          Submit
+        </Button>
+      </div>
+    </form>
+  )
 }
 ```
 

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -370,11 +370,12 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
 
   const onSubmit = (e) => {
     e.preventDefault();
+    validate(formValues);
     setIsSubmitted(true);
   };
 
   React.useEffect(() => {
-    validate(formValues);
+    if (Object.keys(formErrors).length > 0) validate(formValues);
   }, [formValues]);
 
   return ( 

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -429,15 +429,11 @@ import { Button, ErrorSummary, DateInput } from 'hds-react';
 
 When there are multiple related fields, a later field in the form can make an earlier field erroneous. In this case, it is important to note that the state change of the earlier field can go unnoticed for assistive technologies. It is recommended to notify assistive technologies of other inputs' state change by using the <InternalLink href="/components/notification#invisible">HDS invisible notification.</InternalLink>
 
-### Validation in multi-page forms
+### Validation in multi-page forms 
 
-<p>
-  <StatusLabel type="error" style={{ marginRight: 'var(--spacing-3-xs)' }}>
-    Coming soon
-  </StatusLabel>
-  <strong> The navigation component for multi-page forms has not yet been designed or implemented in HDS.</strong>
-</p>
+HDS Form pattern suggests dividing longer forms into separate steps. You can read more about this in the <InternalLink href="/patterns/forms/form-building#4-dividing-long-forms-into-separate-steps">HDS Form pattern documentation</InternalLink>.
+See guidelines for <InternalLink href="/patterns/forms/form-multi-page/">Multi-page forms</InternalLink>.
 
-HDS Form pattern suggests dividing longer forms into separate steps. You can read more about this in the <InternalLink href="/patterns/forms/form-building#4-dividing-long-forms-into-separate-steps">HDS Form pattern documentation.</InternalLink>
+To create multi-page forms, use <InternalLink href="h/components/stepper/">Stepper</InternalLink> for navigating between the pages. 
 
 **Validation is strongly recommended to be done separately for each page of the form.** This means that the user should not be able to proceed to the next form step before all the input fields have been validated on the current step. If some selection can make a selection in a previous step invalid, this should be clearly indicated to the user.


### PR DESCRIPTION
## Description
- Use fill-icons in Core ErrorSummary examples
- Replace obsolete images with live Playground examples

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1506

## Motivation and Context
- Consistent examples prevent confusion of designers and developers using HDS.

## How Has This Been Tested?
- Locally on dev machine

[Site example validation pattern](https://city-of-helsinki.github.io/hds-demo/hds-1506-unify-error-messages-site/patterns/forms/form-validation#validation-summary-pattern)
[Site example validation multi-field pattern](https://city-of-helsinki.github.io/hds-demo/hds-1506-unify-error-messages-site/patterns/forms/form-validation#validation-of-multiple-input-fields)
[Core](https://city-of-helsinki.github.io/hds-demo/hds-1506-unify-error-messages-core/?path=/story/components-error-summary--default)

Todo:

- [x] set examples so, that they are not by default on error state
- [x] write as text that the examples show the error state when there is an user error (e.g. mandatory fields are not filled or end date is before start date)
- [x] Fix mdx p-tag problem on the page
- [x] With multiple fields, the error should come up after submit, not immediately after one field is input