### PR TITLE
HDS-1458: Matomo cookie domain changed to *.hel.fi

### DIFF
--- a/packages/react/src/components/cookieConsent/getContent.ts
+++ b/packages/react/src/components/cookieConsent/getContent.ts
@@ -676,7 +676,7 @@ export function getCookieContent() {
       },
       matomo: {
         id: 'matomo',
-        hostName: 'digia.fi',
+        hostName: '*.hel.fi',
         fi: {
           name: '_pk_id.*',
           description: 'Eväste kerää tietoa kävijän liikkeistä sivustolla.',


### PR DESCRIPTION
Note: base branch for this PR is not master, because this branch requires changes from HDS-1509

## Description

Matomo stores only cookies for current domain - unless manually configured to store something else.

So the default domain should be *.hel.fi

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1458



[HDS-1509]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-1458]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ