### PR TITLE
HDS-1518: clear SearchInput suggestions on submit.

### DIFF
--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -124,10 +124,18 @@ export const SearchInput = <SuggestionItem,>({
   };
 
   const wasSubmitted = () => {
-    return lastAction === userEnterKeyAction || wasLastActionStateChangeEnterKey();
+    return (
+      lastAction === useCombobox.stateChangeTypes.ItemClick ||
+      lastAction === userEnterKeyAction ||
+      wasLastActionStateChangeEnterKey()
+    );
   };
 
-  const { suggestions, isLoading } = useSuggestions<SuggestionItem>(inputValue, getSuggestions, wasSubmitted());
+  const { suggestions, isLoading, clearSuggestions } = useSuggestions<SuggestionItem>(
+    inputValue,
+    getSuggestions,
+    wasSubmitted(),
+  );
   const showLoadingSpinner = useShowLoadingSpinner(isLoading, 1500 - SUGGESTIONS_DEBOUNCE_VALUE);
   const isControlledComponent = value !== undefined && onChange;
 
@@ -151,6 +159,7 @@ export const SearchInput = <SuggestionItem,>({
     const inputElementValue = inputRef.current?.value;
     const valueToSubmit = val !== undefined ? val : inputElementValue;
     onSubmit(valueToSubmit);
+    clearSuggestions();
   };
 
   const {
@@ -218,6 +227,7 @@ export const SearchInput = <SuggestionItem,>({
   const clear = () => {
     reset();
     inputRef.current.focus();
+    clearSuggestions();
   };
 
   /**

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -202,12 +202,11 @@ export const SearchInput = <SuggestionItem,>({
 
   const onInputKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
     const key = event.key || event.keyCode;
-    if (!wasLastActionStateChangeEnterKey() && (key === 'Enter' || key === 13)) {
+    const wasEnterKey = key === 'Enter' || key === 13;
+    if (!wasLastActionStateChangeEnterKey() && wasEnterKey) {
       submitValue();
-      updateLastAction(userEnterKeyAction);
-    } else {
-      updateLastAction(undefined);
     }
+    updateLastAction(wasEnterKey ? userEnterKeyAction : undefined);
   };
 
   const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {

--- a/packages/react/src/components/searchInput/useSuggestions.ts
+++ b/packages/react/src/components/searchInput/useSuggestions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { cancellablePromise } from '../../utils/cancellablePromise';
 import { useDebouncedEffect } from '../../hooks/useDebouncedEffect';
@@ -20,6 +20,19 @@ export const useSuggestions = <SuggestionItemType>(
   const cancelSuggestionsFunction = useRef<() => void>(() => null);
   // Currently visible suggestion items
   const [suggestions, setSuggestions] = useState<SuggestionItemType[]>([]);
+
+  const clearSuggestions = useCallback(() => {
+    setSuggestions([]);
+    setIsLoading(false);
+    cancelSuggestionsFunction.current();
+  }, [setSuggestions, cancelSuggestionsFunction]);
+
+  // cancel possible suggestion promise on unload
+  useEffect(() => {
+    return () => {
+      cancelSuggestionsFunction.current();
+    };
+  }, [cancelSuggestionsFunction]);
 
   // If form is submitted, cancel all suggestions
   useEffect(() => {
@@ -60,5 +73,5 @@ export const useSuggestions = <SuggestionItemType>(
     [searchString, getSuggestions, setSuggestions],
   );
 
-  return { suggestions, isLoading: cancelAll.current ? false : isLoading };
+  return { suggestions, isLoading: cancelAll.current ? false : isLoading, clearSuggestions };
 };


### PR DESCRIPTION
## Description

From Slack: 

I'm using <SearchInput> and facing an issue with search suggestions. Those suggestions won't disappear when running the search by Enter key nor clicking the magnifier icon in search input field.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1518

## How Has This Been Tested?

Added tests that fail without these changes.



[HDS-1518]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ