### PR TITLE
HDS-1360 Storybook React component extended properties

### DIFF
--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 module.exports = {
   core: {
     builder: 'webpack5',

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -31,4 +31,12 @@ module.exports = {
       plugins: config.resolve.plugins.filter((plugin) => plugin.constructor.name !== 'ModuleScopePlugin'),
     },
   }),
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      compilerOptions: {
+        allowSyntheticDefaultImports: true,
+      },
+    }
+  }
 };

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -36,6 +36,7 @@ module.exports = {
     reactDocgenTypescriptOptions: {
       compilerOptions: {
         allowSyntheticDefaultImports: true,
+        esModuleInterop: false
       },
     }
   }

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   core: {
     builder: 'webpack5',
@@ -31,13 +33,4 @@ module.exports = {
       plugins: config.resolve.plugins.filter((plugin) => plugin.constructor.name !== 'ModuleScopePlugin'),
     },
   }),
-  typescript: {
-    reactDocgen: 'react-docgen-typescript',
-    reactDocgenTypescriptOptions: {
-      compilerOptions: {
-        allowSyntheticDefaultImports: true,
-        esModuleInterop: false
-      },
-    }
-  }
 };

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -39,5 +39,5 @@ export const parameters = {
       { name: 'Black', value: '#111' },
     ],
   },
-  controls: { expanded: true },
+  controls: { expanded: true, sort: 'alpha' },
 };

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -39,5 +39,5 @@ export const parameters = {
       { name: 'Black', value: '#111' },
     ],
   },
-  controls: { expanded: true, sort: 'alpha' },
+  controls: { expanded: true },
 };

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -10,7 +10,7 @@ export type ButtonSize = 'default' | 'small';
 export type ButtonTheme = 'default' | 'coat' | 'black';
 export type ButtonVariant = 'primary' | 'secondary' | 'supplementary' | 'success' | 'danger';
 
-export type CommonButtonProps = React.ComponentPropsWithoutRef<'button'> & {
+export type CommonButtonProps = {
   /**
    * The content of the button
    */
@@ -55,7 +55,7 @@ export type CommonButtonProps = React.ComponentPropsWithoutRef<'button'> & {
    * Loading text to show alongside loading spinner
    */
   loadingText?: string;
-};
+} & React.ComponentPropsWithoutRef<'button'>;
 
 // Supplementary variant requires iconLeft or iconRight
 export type SupplementaryButtonProps = Omit<CommonButtonProps, 'variant'> & {

--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import styles from './Checkbox.module.css';
 import classNames from '../../utils/classNames';
 import mergeRefWithInternalRef from '../../utils/mergeRefWithInternalRef';
 
-export type CheckboxProps = React.ComponentPropsWithoutRef<'input'> & {
+export type CheckboxProps = {
   /**
    * If `true`, the component is checked
    */
@@ -47,7 +47,7 @@ export type CheckboxProps = React.ComponentPropsWithoutRef<'input'> & {
    * The value of the component
    */
   value?: string;
-};
+} & React.ComponentPropsWithoutRef<'input'>;
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (

--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -7,10 +7,7 @@ import { IconLinkExternal } from '../../icons';
 import classNames from '../../utils/classNames';
 import { getTextFromReactChildren } from '../../utils/getTextFromReactChildren';
 
-export type LinkProps = Omit<
-  React.ComponentPropsWithoutRef<'a'>,
-  'target' | 'href' | 'onPointerEnterCapture' | 'onPointerLeaveCapture' | 'aria-label'
-> & {
+export type LinkProps = {
   /**
    * aria-label for providing detailed information for screen readers about a link text.
    */
@@ -55,7 +52,10 @@ export type LinkProps = Omit<
    * Additional styles
    */
   style?: React.CSSProperties;
-};
+} & Omit<
+  React.ComponentPropsWithoutRef<'a'>,
+  'target' | 'href' | 'onPointerEnterCapture' | 'onPointerLeaveCapture' | 'aria-label'
+>;
 
 type LinkToIconSizeMappingType = {
   L: 'l';

--- a/packages/react/src/components/linkbox/Linkbox.tsx
+++ b/packages/react/src/components/linkbox/Linkbox.tsx
@@ -6,7 +6,7 @@ import styles from './Linkbox.module.scss';
 import { IconArrowRight, IconLinkExternal } from '../../icons';
 import classNames from '../../utils/classNames';
 
-export type LinkboxProps = Omit<React.ComponentPropsWithoutRef<'a'>, 'tabIndex'> & {
+export type LinkboxProps = {
   /**
    * Boolean indicating for external link that takes user to an entirely new web site. Defaults to false.
    */
@@ -60,7 +60,7 @@ export type LinkboxProps = Omit<React.ComponentPropsWithoutRef<'a'>, 'tabIndex'>
    * Size variant for the linkbox. Affects texts and paddings.
    */
   size?: 'small' | 'medium' | 'large';
-};
+} & Omit<React.ComponentPropsWithoutRef<'a'>, 'tabIndex'>;
 
 export const Linkbox = ({
   children,

--- a/packages/react/src/components/logo/Logo.tsx
+++ b/packages/react/src/components/logo/Logo.tsx
@@ -6,7 +6,7 @@ import classNames from '../../utils/classNames';
 export type LogoLanguage = 'fi' | 'sv' | 'ru';
 export type LogoSize = 'full' | 'small' | 'medium' | 'large';
 
-export type LogoProps = React.ComponentPropsWithoutRef<'svg'> & {
+export type LogoProps = {
   /**
    * Additional class names to apply to the logo
    */
@@ -29,7 +29,7 @@ export type LogoProps = React.ComponentPropsWithoutRef<'svg'> & {
    * Override or extend the styles applied to the component
    */
   style?: React.CSSProperties;
-};
+} & React.ComponentPropsWithoutRef<'svg'>;
 
 const LogoFI = (props): React.ReactElement => (
   <svg viewBox="0 0 78 36" title="Helsingin kaupunki" role="img" xmlns="http://www.w3.org/2000/svg" {...props}>

--- a/packages/react/src/components/radioButton/RadioButton.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.tsx
@@ -5,7 +5,7 @@ import 'hds-core';
 import styles from './RadioButton.module.css';
 import classNames from '../../utils/classNames';
 
-export type RadioButtonProps = React.ComponentPropsWithoutRef<'input'> & {
+export type RadioButtonProps = {
   /**
    * If `true`, the component is checked
    */
@@ -38,7 +38,7 @@ export type RadioButtonProps = React.ComponentPropsWithoutRef<'input'> & {
    * The value of the component
    */
   value?: string;
-};
+} & React.ComponentPropsWithoutRef<'input'>;
 
 export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
   (

--- a/packages/react/src/components/sideNavigation/subLevel/SubLevel.tsx
+++ b/packages/react/src/components/sideNavigation/subLevel/SubLevel.tsx
@@ -4,7 +4,7 @@ import styles from './SubLevel.module.scss';
 import SideNavigationContext from '../SideNavigationContext';
 import classNames from '../../../utils/classNames';
 
-export type SubLevelProps = React.ComponentPropsWithoutRef<'a'> & {
+export type SubLevelProps = {
   /**
    * If `true`, the item will be marked as active
    */
@@ -33,7 +33,7 @@ export type SubLevelProps = React.ComponentPropsWithoutRef<'a'> & {
    * Override or extend the styles applied to the component
    */
   style?: React.CSSProperties;
-};
+} & React.ComponentPropsWithoutRef<'a'>;
 
 export const SubLevel = ({ active, className, href, id, label, mainLevelIndex, onClick, style }: SubLevelProps) => {
   const { setActiveParentLevel, setMobileMenuOpen } = useContext(SideNavigationContext);

--- a/packages/react/src/components/stepper/Step.tsx
+++ b/packages/react/src/components/stepper/Step.tsx
@@ -14,7 +14,7 @@ export enum StepState {
   paused,
 }
 
-export type StepProps = React.ComponentPropsWithoutRef<'button'> & {
+export type StepProps = {
   /**
    * Data test id of step
    */
@@ -59,7 +59,7 @@ export type StepProps = React.ComponentPropsWithoutRef<'button'> & {
    * The total number of steps
    */
   stepsTotal: number;
-};
+} & React.ComponentPropsWithoutRef<'button'>;
 
 type Language = 'en' | 'fi' | 'sv' | string;
 

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -51,7 +51,7 @@ export interface TableCustomTheme {
 
 type SelectedRow = string | number;
 
-export type TableProps = React.ComponentPropsWithoutRef<'table'> & {
+export type TableProps = {
   /**
    * Aria-label for checkbox selection.
    * @default 'Rivin valinta'
@@ -193,7 +193,7 @@ export type TableProps = React.ComponentPropsWithoutRef<'table'> & {
    * Boolean indicating whether the table has alternating row colors zebra style.
    */
   zebra?: boolean;
-};
+} & React.ComponentPropsWithoutRef<'table'>;
 
 const processRows = (rows, order, sorting, cols) => {
   const sortingEnabled = cols.some((column) => {

--- a/packages/react/src/components/table/components/SortingHeaderCell/SortingHeaderCell.tsx
+++ b/packages/react/src/components/table/components/SortingHeaderCell/SortingHeaderCell.tsx
@@ -11,7 +11,7 @@ import {
   IconSortDescending,
 } from '../../../../icons';
 
-export type SortingHeaderCellProps = React.ComponentPropsWithoutRef<'th'> & {
+export type SortingHeaderCellProps = {
   ariaLabelSortButtonUnset: string;
   ariaLabelSortButtonAscending: string;
   ariaLabelSortButtonDescending: string;
@@ -21,7 +21,7 @@ export type SortingHeaderCellProps = React.ComponentPropsWithoutRef<'th'> & {
   title: string;
   setSortingAndOrder: (colKey: string) => void;
   sortIconType: 'string' | 'other';
-};
+} & React.ComponentPropsWithoutRef<'th'>;
 
 type SortingIconProps = {
   ariaLabelSortButtonUnset: string;

--- a/packages/react/src/components/table/components/TableContainer/TableContainer.tsx
+++ b/packages/react/src/components/table/components/TableContainer/TableContainer.tsx
@@ -5,7 +5,7 @@ import 'hds-core';
 import classNames from '../../../../utils/classNames';
 import styles from '../../Table.module.scss';
 
-export type TableContainerProps = React.ComponentPropsWithoutRef<'table'> & {
+export type TableContainerProps = {
   children: React.ReactNode;
   dataTestId?: string;
   variant?: 'dark' | 'light';
@@ -15,7 +15,7 @@ export type TableContainerProps = React.ComponentPropsWithoutRef<'table'> & {
   verticalLines?: boolean;
   customThemeClass?: string;
   headingId?: string;
-};
+} & React.ComponentPropsWithoutRef<'table'>;
 
 export const TableContainer = ({
   children,

--- a/packages/react/src/components/textInput/TextInput.tsx
+++ b/packages/react/src/components/textInput/TextInput.tsx
@@ -7,7 +7,7 @@ import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
 import classNames from '../../utils/classNames';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 
-export type TextInputProps = React.ComponentPropsWithoutRef<'input'> & {
+export type TextInputProps = {
   /**
    * Additional class names to apply to the text input
    */
@@ -112,7 +112,7 @@ export type TextInputProps = React.ComponentPropsWithoutRef<'input'> & {
    * Button click callback
    */
   onButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
-};
+} & React.ComponentPropsWithoutRef<'input'>;
 
 export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   (

--- a/packages/react/src/components/textarea/TextArea.tsx
+++ b/packages/react/src/components/textarea/TextArea.tsx
@@ -6,7 +6,7 @@ import styles from '../textInput/TextInput.module.css';
 import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 
-export type TextAreaProps = React.ComponentPropsWithoutRef<'textarea'> & {
+export type TextAreaProps = {
   /**
    * Additional class names to apply to the textarea
    */
@@ -87,7 +87,7 @@ export type TextAreaProps = React.ComponentPropsWithoutRef<'textarea'> & {
    * The `ref` is forwarded to the native textarea element.
    */
   ref?: React.Ref<HTMLTextAreaElement>;
-};
+} & React.ComponentPropsWithoutRef<'textarea'>;
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (

--- a/packages/react/src/internal/menuButton/menu/Menu.tsx
+++ b/packages/react/src/internal/menuButton/menu/Menu.tsx
@@ -9,12 +9,12 @@ type MenuStyles = {
   minWidth?: number;
 };
 
-type MenuProps = React.ComponentPropsWithoutRef<'div'> & {
+type MenuProps = {
   menuContainerSize: RectReadOnly;
   menuOffset?: number;
   menuOpen: boolean;
   onItemClick?: (event: MouseEvent<HTMLElement>) => void;
-};
+} & React.ComponentPropsWithoutRef<'div'>;
 
 const MENU_MIN_WIDTH = 190;
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Fix missing components properties

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1360

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

As a default `react-docgen-typescript` parser filters out extended properties for `node_modules`. Some HDS components have properties named identical to native HTML attributes e.g. `className`. Changing component types in such a way that normal properties are treated as a first priority and won't then get filtered out with extended properties.

## How Has This Been Tested?
- Tested on local machine
- Unit tests

## Screenshots (if appropriate):
