### PR TITLE
Hds 1571 fix a couple broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Start setting up your local development by going through the steps in [the devel
 
 ## Roadmap
 
-Helsinki Design System has a public roadmap. For the long-term Roadmap, please refer to [HDS About - Roadmap page](https://hds.hel.fi/about/roadmap). If you are interested what the team is currently working on, refer to the [Design System Roadmap in Github](https://github.com/City-of-Helsinki/helsinki-design-system/projects/1).
+If you are interested what the team is currently working on, refer to the [Design System Roadmap in Github](https://github.com/City-of-Helsinki/helsinki-design-system/projects/1).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ See the package specific instructions on how to get started using the packages.
 
 Start setting up your local development by going through the steps in [the development guide](./DEVELOPMENT.md).
 
-## Roadmap
-
-If you are interested what the team is currently working on, refer to the [Design System Roadmap in Github](https://github.com/City-of-Helsinki/helsinki-design-system/projects/1).
-
 ## Contributing
 
 **Before contributing, it is recommended to read [HDS Contribution - Before contributing page](https://hds.hel.fi/getting-started/contributing/how-to-contribute.**

--- a/site/src/docs/components/cookie-consent/api.mdx
+++ b/site/src/docs/components/cookie-consent/api.mdx
@@ -14,7 +14,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 ### Component properties
 
-Common texts, groups and cookie data can be found in <ExternalLink openInExternalDomainAriaLabel="Opens in a new domain" openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/cookieConsent/content.json">HDS-provided content file</ExternalLink>. The file contains all user interface strings, language options, descriptions for common cookie groups, and details about common Helsinki cookies. By default, this content file is used. You can also override parts of it and add your project-specific groups and cookies.
+Common texts, groups and cookie data can be found in <ExternalLink openInExternalDomainAriaLabel="Opens in a new domain" openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/cookieConsent/getContent.ts">HDS-provided content file</ExternalLink>. The file contains all user interface strings, language options, descriptions for common cookie groups, and details about common Helsinki cookies. By default, this content file is used. You can also override parts of it and add your project-specific groups and cookies.
 
 #### ContentSource
 

--- a/site/src/docs/getting-started/contributing/how-to-contribute.mdx
+++ b/site/src/docs/getting-started/contributing/how-to-contribute.mdx
@@ -22,15 +22,15 @@ Ways to contribute to HDS:
 * <InternalLink href="/about/#contact">Contact</InternalLink> HDS team to see how we can help and collaborate
 * Propose a new component, pattern, or update to the documentation
 * Give feedback and report bugs
-* Send a <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/CONTRIBUTING.md">pull request</ExternalLink>
+* Send a <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/CONTRIBUTING.md">pull request</ExternalLink>
 
 ## Update documentation
 
-<InternalLink href="/about/#contact">Contact</InternalLink> HDS team or send in a <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/CONTRIBUTING.md">pull request</ExternalLink>.
+<InternalLink href="/about/#contact">Contact</InternalLink> HDS team or send in a <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/CONTRIBUTING.md">pull request</ExternalLink>.
 
 ## Propose a new pattern
 
-Take a look at existing <InternalLink href="/patterns">patterns</InternalLink> and <InternalLink href="/about/#contact">contact</InternalLink> HDS team. You can also send in a <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/CONTRIBUTING.md">pull request</ExternalLink>.
+Take a look at existing <InternalLink href="/patterns">patterns</InternalLink> and <InternalLink href="/about/#contact">contact</InternalLink> HDS team. You can also send in a <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/CONTRIBUTING.md">pull request</ExternalLink>.
 
 ## New components
 
@@ -39,7 +39,7 @@ Note that every component added to HDS requires these three parts:
 2. Documentation
 3. Code
 
-You may contribute in any part of these but all three parts have to be implemented and validated by HDS team before a component can be released. More detailed guide for developers can be found in the <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/CONTRIBUTING.md">HDS Github repository</ExternalLink>.
+You may contribute in any part of these but all three parts have to be implemented and validated by HDS team before a component can be released. More detailed guide for developers can be found in the <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/CONTRIBUTING.md">HDS Github repository</ExternalLink>.
 
 <Notification size="small" label="HDS team response time" type="alert" className="siteNotification" style={{marginBottom: 'var(--spacing-m)'}}>
 The process of adding component to HDS can take a while. New feature request and proposed designs are first evaluated and prioritised on HDS roadmap. If the need for a feature is urgent, discuss this with HDS team.

--- a/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
+++ b/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
@@ -28,7 +28,7 @@ import ExternalLink from '../../../components/ExternalLink';
 
 ## Common cookies between \*.hel.fi sites
 
-The following is a list of approved common cookies between services using \*.hel.fi domain. You can find this list as a JSON object in the <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/cookieConsent/content.json" openInNewTab openInNewTabAriaLabel="Opens in a new tab" openInExternalDomainAriaLabel="Opens a different website">Helsinki Design System GitHub repository</ExternalLink>.
+The following is a list of approved common cookies between services using \*.hel.fi domain. You can find this list as a JSON object in the <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/cookieConsent/getContent.ts" openInNewTab openInNewTabAriaLabel="Opens in a new tab" openInExternalDomainAriaLabel="Opens a different website">Helsinki Design System GitHub repository</ExternalLink>.
 
 ### General
 

--- a/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
+++ b/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
@@ -28,7 +28,7 @@ import ExternalLink from '../../../components/ExternalLink';
 
 ## Common cookies between \*.hel.fi sites
 
-The following is a list of approved common cookies between services using \*.hel.fi domain. You can find this list as a JSON object in the <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/cookieConsent/getContent.ts" openInNewTab openInNewTabAriaLabel="Opens in a new tab" openInExternalDomainAriaLabel="Opens a different website">Helsinki Design System GitHub repository</ExternalLink>.
+The following is a list of approved common cookies between services using \*.hel.fi domain. You can find this list as a JSON object in the <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/cookieConsent/content.json" openInNewTab openInNewTabAriaLabel="Opens in a new tab" openInExternalDomainAriaLabel="Opens a different website">Helsinki Design System GitHub repository</ExternalLink>.
 
 ### General
 


### PR DESCRIPTION
## Description

deadlinkchecker found a couple of broken links. Removed the whole Roadmap section from README because neither links are supported anymore and Laura said the section is not needed anymore.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1571

## How Has This Been Tested?
Locally

