### PR TITLE
HDS-1367-dialog-page-jump

### DIFF
--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -24,7 +24,6 @@
 
   .dialogBackdrop {
     background: var(--overlay-color);
-    pointer-events: none;
   }
 
   .dialog {

--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -9,17 +9,18 @@
 .dialogContainer {
   --accent-line-color: var(--color-bus);
   --overlay-color: rgba(0, 0, 0, 0.3);
-  -webkit-overflow-scrolling: touch;
+  -webkit-overflow-scrolling: none;
   align-items: center;
   bottom: 0;
   display: flex;
   justify-content: center;
   left: 0;
   overflow: auto;
-  overscroll-behavior: contain;
+  overscroll-behavior: none;
   position: fixed;
   right: 0;
   top: 0;
+  touch-action: none;
   z-index: 800;
 
   .dialogBackdrop {

--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -3,7 +3,7 @@
 @value medium-up from "../../styles/breakpoints.css";
 
 .dialogVisibleBodyWithHiddenScrollbars {
-    overflow: hidden;
+    overflow: hidden !important;
 }
 
 .dialogContainer {

--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -3,26 +3,24 @@
 @value medium-up from "../../styles/breakpoints.css";
 
 .dialogVisibleBodyWithHiddenScrollbars {
-  touch-action: none;
-  -webkit-overflow-scrolling: none;
-  overflow: hidden !important;
-  overscroll-behavior: none;
+    overflow: hidden;
 }
 
 .dialogContainer {
   --accent-line-color: var(--color-bus);
   --overlay-color: rgba(0, 0, 0, 0.3);
-
+  -webkit-overflow-scrolling: touch;
   align-items: center;
+  bottom: 0;
   display: flex;
-  height: 100%;
   justify-content: center;
   left: 0;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 800;
   overflow: auto;
+  overscroll-behavior: contain;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 800;
 
   .dialogBackdrop {
     background: var(--overlay-color);
@@ -41,12 +39,10 @@
 
 .dialogBackdrop {
   bottom: 0;
-  height: 100%;
   left: 0;
   position: fixed;
   right: 0;
   top: 0;
-  width: 100%;
 }
 
 .dialog {

--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -9,7 +9,7 @@
 .dialogContainer {
   --accent-line-color: var(--color-bus);
   --overlay-color: rgba(0, 0, 0, 0.3);
-  -webkit-overflow-scrolling: none;
+  -webkit-overflow-scrolling: unset;
   align-items: center;
   bottom: 0;
   display: flex;

--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -3,8 +3,10 @@
 @value medium-up from "../../styles/breakpoints.css";
 
 .dialogVisibleBodyWithHiddenScrollbars {
-  height: 100vh !important;
+  touch-action: none;
+  -webkit-overflow-scrolling: none;
   overflow: hidden !important;
+  overscroll-behavior: none;
 }
 
 .dialogContainer {
@@ -24,6 +26,7 @@
 
   .dialogBackdrop {
     background: var(--overlay-color);
+    pointer-events: none;
   }
 
   .dialog {

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -156,14 +156,14 @@ export const Dialog = ({
   const [focusedElement, setFocusedElement] = useState(isBrowser ? document.activeElement : null);
 
   useEffect(() => {
-    if (isBrowser) {
+    if (isBrowser && isOpen) {
       document.addEventListener('focusin', () => setFocusedElement(document.activeElement));
       return () => {
         document.removeEventListener('focusin', () => setFocusedElement(document.activeElement));
       };
     }
     return null;
-  }, []);
+  }, [isOpen]);
 
   useEffect(() => {
     // if currently focused element is not inside the Dialog

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -156,16 +156,6 @@ export const Dialog = ({
   const [focusedElement, setFocusedElement] = useState(isBrowser ? document.activeElement : null);
 
   useEffect(() => {
-    if (isBrowser && isOpen) {
-      document.addEventListener('focusin', () => setFocusedElement(document.activeElement));
-      return () => {
-        document.removeEventListener('focusin', () => setFocusedElement(document.activeElement));
-      };
-    }
-    return null;
-  }, [isOpen]);
-
-  useEffect(() => {
     // if currently focused element is not inside the Dialog
     if (!dialogRef?.current?.contains(focusedElement)) {
       focusFirstDialogElement(dialogRef.current);
@@ -189,6 +179,9 @@ export const Dialog = ({
 
   useEffect(() => {
     if (isOpen) {
+      if (isBrowser) {
+        document.addEventListener('focusin', () => setFocusedElement(document.activeElement));
+      }
       document.body.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
       document.documentElement.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
       document.addEventListener('keydown', onKeyDown, false);
@@ -196,6 +189,9 @@ export const Dialog = ({
     }
     return (): void => {
       if (isOpen) {
+        if (isBrowser) {
+          document.removeEventListener('focusin', () => setFocusedElement(document.activeElement));
+        }
         setIsReadyToShowDialog(false);
         document.body.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
         document.documentElement.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
@@ -213,7 +209,6 @@ export const Dialog = ({
     <DialogContext.Provider value={dialogContextProps}>
       <div className={classNames(styles.dialogContainer, customThemeClass)}>
         <ContentTabBarrier onFocus={() => focusFirstDialogElement(dialogRef.current)} />
-        <ContentTabBarrier onFocus={() => focusLastDialogElement(dialogRef.current)} />
         <div tabIndex={-1} className={styles.dialogBackdrop} />
         <div
           ref={dialogRef}
@@ -232,9 +227,11 @@ export const Dialog = ({
           aria-labelledby={ariaLabelledby}
           aria-describedby={ariaDescribedby}
         >
+          <ContentTabBarrier onFocus={() => focusLastDialogElement(dialogRef.current)} />
           {children}
+          <ContentTabBarrier onFocus={() => focusFirstDialogElement(dialogRef.current)} />
         </div>
-        <ContentTabBarrier onFocus={() => focusFirstDialogElement(dialogRef.current)} />
+        <ContentTabBarrier onFocus={() => focusLastDialogElement(dialogRef.current)} />
       </div>
     </DialogContext.Provider>
   );

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -16,6 +16,11 @@ export interface DialogCustomTheme {
   '--overlay-color'?: string;
 }
 
+enum TabBarrierPosition {
+  top = 'top',
+  bottom = 'bottom',
+}
+
 type TabBarrierProps = {
   id: string;
   tabIndex: number;
@@ -32,11 +37,13 @@ const findFocusableDialogElements = (dialogElement: HTMLElement): NodeList =>
     'a, button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select',
   );
 
-const focusToDialogElement = (position: 'top' | 'bottom', dialogElement?: HTMLElement) => {
+const focusToDialogElement = (position: TabBarrierPosition, dialogElement?: HTMLElement) => {
   if (dialogElement) {
     const focusableElements = findFocusableDialogElements(dialogElement);
     if (focusableElements.length) {
-      (focusableElements[position === 'top' ? 0 : focusableElements.length - 1] as HTMLElement).focus();
+      (focusableElements[
+        position === TabBarrierPosition.top ? 0 : focusableElements.length - 1
+      ] as HTMLElement).focus();
     }
   }
 };
@@ -46,13 +53,13 @@ const ContentTabBarrier = ({ onFocus }: { onFocus: () => void }): JSX.Element =>
   return <div {...defaultBarrierProps} onFocus={onFocus} />;
 };
 
-const addDocumentTabBarrier = (position: 'top' | 'bottom', dialogElement?: HTMLElement): HTMLDivElement => {
+const addDocumentTabBarrier = (position: TabBarrierPosition, dialogElement?: HTMLElement): HTMLDivElement => {
   const element = document.createElement('div');
   element.className = 'hds-dialog-tab-barrier';
   element.tabIndex = defaultBarrierProps.tabIndex;
   element['aria-hidden'] = defaultBarrierProps.tabIndex['aria-hidden'];
   element.addEventListener('focus', () => focusToDialogElement(position, dialogElement));
-  if (position === 'top') {
+  if (position === TabBarrierPosition.top) {
     document.body.insertBefore(element, document.body.firstChild);
   } else {
     document.body.appendChild(element);
@@ -160,8 +167,8 @@ export const Dialog = ({
 
   useEffect(() => {
     if (isOpen && dialogRef !== undefined) {
-      addDocumentTabBarrier('top', dialogRef.current);
-      addDocumentTabBarrier('bottom', dialogRef.current);
+      addDocumentTabBarrier(TabBarrierPosition.top, dialogRef.current);
+      addDocumentTabBarrier(TabBarrierPosition.bottom, dialogRef.current);
 
       return () => {
         const barriers = document.querySelectorAll('.hds-dialog-tab-barrier');
@@ -220,7 +227,7 @@ export const Dialog = ({
   const renderDialogComponent = (): JSX.Element => (
     <DialogContext.Provider value={dialogContextProps}>
       <div className={classNames(styles.dialogContainer, customThemeClass)}>
-        <ContentTabBarrier onFocus={() => focusToDialogElement('bottom', dialogRef.current)} />
+        <ContentTabBarrier onFocus={() => focusToDialogElement(TabBarrierPosition.bottom, dialogRef.current)} />
         <div tabIndex={-1} className={styles.dialogBackdrop} />
         <div
           ref={dialogRef}
@@ -241,7 +248,7 @@ export const Dialog = ({
         >
           {children}
         </div>
-        <ContentTabBarrier onFocus={() => focusToDialogElement('top', dialogRef.current)} />
+        <ContentTabBarrier onFocus={() => focusToDialogElement(TabBarrierPosition.top, dialogRef.current)} />
       </div>
     </DialogContext.Provider>
   );

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, RefObject, useRef, useCallback, useState } from 'react';
+import React, { useEffect, RefObject, useCallback, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 // import core base styles
@@ -49,49 +49,6 @@ const focusLastDialogElement = (dialogElement?: HTMLElement) => {
       (focusableElements[focusableElements.length - 1] as HTMLElement).focus();
     }
   }
-};
-
-const addDocumentStartTabBarrier = (dialogElement?: HTMLElement): HTMLDivElement => {
-  const element = document.createElement('div');
-  element.className = 'hds-dialog-start-tab-barrier';
-  element.tabIndex = defaultBarrierProps.tabIndex;
-  element['aria-hidden'] = defaultBarrierProps.tabIndex['aria-hidden'];
-  element.addEventListener('focus', () => focusFirstDialogElement(dialogElement));
-  document.body.insertBefore(element, document.body.firstChild);
-  return element;
-};
-
-const addDocumentEndTabBarrier = (dialogElement?: HTMLElement): HTMLDivElement => {
-  const element = document.createElement('div');
-  element.className = 'hds-dialog-end-tab-barrier';
-  element.tabIndex = defaultBarrierProps.tabIndex;
-  element['aria-hidden'] = defaultBarrierProps.tabIndex['aria-hidden'];
-  element.addEventListener('focus', () => focusLastDialogElement(dialogElement));
-  document.body.appendChild(element);
-  return element;
-};
-
-const clearDocumentTabBarrier = (tabBarrier: HTMLDivElement): null => {
-  tabBarrier.parentElement.removeChild(tabBarrier);
-  return null;
-};
-
-export const useDocumentTabBarriers = (dialogRef: RefObject<HTMLDivElement>) => {
-  const firstBarrier = useRef<HTMLDivElement>(null);
-  const lastBarrier = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (dialogRef.current) {
-      firstBarrier.current = addDocumentStartTabBarrier(dialogRef.current);
-      lastBarrier.current = addDocumentEndTabBarrier(dialogRef.current);
-    }
-    return () => {
-      if (firstBarrier.current && lastBarrier.current) {
-        firstBarrier.current = clearDocumentTabBarrier(firstBarrier.current);
-        lastBarrier.current = clearDocumentTabBarrier(lastBarrier.current);
-      }
-    };
-  }, [dialogRef]);
 };
 
 const ContentTabBarrier = ({ onFocus }: { onFocus: () => void }): JSX.Element => {
@@ -195,7 +152,21 @@ export const Dialog = ({
   const dialogContextProps: DialogContextProps = { isReadyToShowDialog, scrollable, close, closeButtonLabelText };
   const customThemeClass = useTheme<DialogCustomTheme>(styles.dialogContainer, theme);
   const dialogRef: RefObject<HTMLInputElement> = React.createRef();
-  const bodyRightPaddingStyleRef = React.useRef<string>(null);
+  const [focusedElement, setFocusedElement] = useState(document.activeElement);
+
+  useEffect(() => {
+    document.addEventListener('focusin', () => setFocusedElement(document.activeElement));
+    return () => {
+      document.removeEventListener('focusin', () => setFocusedElement(document.activeElement));
+    };
+  }, []);
+
+  useEffect(() => {
+    // if currently focused element is not inside the Dialog
+    if (!dialogRef?.current?.contains(focusedElement)) {
+      focusFirstDialogElement(dialogRef.current);
+    }
+  }, [focusedElement]);
 
   const { 'aria-labelledby': ariaLabelledby, 'aria-describedby': ariaDescribedby } = props;
 
@@ -214,26 +185,15 @@ export const Dialog = ({
 
   useEffect(() => {
     if (isOpen) {
-      if (document.body.scrollHeight > document.documentElement.clientHeight) {
-        const documentScrollbarWidth: number = window.innerWidth - document.documentElement.clientWidth;
-        if (documentScrollbarWidth > 0) {
-          // Store body element's right padding declaration.
-          bodyRightPaddingStyleRef.current = document.body.style.paddingRight;
-          const bodyPaddingRightInPixels: number = parseInt(window.getComputedStyle(document.body).paddingRight, 10);
-          document.body.style.paddingRight = `${bodyPaddingRightInPixels + documentScrollbarWidth}px`;
-        }
-        document.body.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
-      }
+      document.body.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
       document.addEventListener('keydown', onKeyDown, false);
       setIsReadyToShowDialog(true);
     }
     return (): void => {
       if (isOpen) {
         setIsReadyToShowDialog(false);
-        document.removeEventListener('keydown', onKeyDown, false);
         document.body.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
-        // Reset body elements right padding.
-        document.body.style.paddingRight = bodyRightPaddingStyleRef.current || '';
+        document.removeEventListener('keydown', onKeyDown, false);
         const elementToFocus: HTMLElement | undefined = getElementToFocusAfterClose();
         if (elementToFocus) {
           elementToFocus.focus();
@@ -243,11 +203,10 @@ export const Dialog = ({
     // Omitting onKeyDown on purpose; adding it will break the Dialog with controlled child components
   }, [isOpen, getElementToFocusAfterClose]);
 
-  useDocumentTabBarriers(dialogRef);
-
   const renderDialogComponent = (): JSX.Element => (
     <DialogContext.Provider value={dialogContextProps}>
       <div className={classNames(styles.dialogContainer, customThemeClass)}>
+        <ContentTabBarrier onFocus={() => focusFirstDialogElement(dialogRef.current)} />
         <ContentTabBarrier onFocus={() => focusLastDialogElement(dialogRef.current)} />
         <div tabIndex={-1} className={styles.dialogBackdrop} />
         <div

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, RefObject, useCallback, useState } from 'react';
+import React, { useEffect, RefObject, useCallback, useState, useRef, createRef } from 'react';
 import ReactDOM from 'react-dom';
 
 // import core base styles
@@ -155,7 +155,8 @@ export const Dialog = ({
   const [isReadyToShowDialog, setIsReadyToShowDialog] = useState<boolean>(false);
   const dialogContextProps: DialogContextProps = { isReadyToShowDialog, scrollable, close, closeButtonLabelText };
   const customThemeClass = useTheme<DialogCustomTheme>(styles.dialogContainer, theme);
-  const dialogRef: RefObject<HTMLInputElement> = React.createRef();
+  const dialogRef: RefObject<HTMLInputElement> = createRef();
+  const bodyRightPaddingStyleRef = useRef<string>(null);
 
   useEffect(() => {
     if (isOpen && dialogRef !== undefined) {
@@ -189,6 +190,12 @@ export const Dialog = ({
 
   useEffect(() => {
     if (isOpen) {
+      const documentScrollbarWidth = window.innerWidth - document.body.offsetWidth;
+      if (documentScrollbarWidth > 0) {
+        bodyRightPaddingStyleRef.current = document.body.style.paddingRight;
+        const bodyPaddingRightInPixels: number = parseInt(window.getComputedStyle(document.body).paddingRight, 10);
+        document.body.style.paddingRight = `${bodyPaddingRightInPixels + documentScrollbarWidth}px`;
+      }
       document.body.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
       document.documentElement.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
       document.addEventListener('keydown', onKeyDown, false);
@@ -200,6 +207,7 @@ export const Dialog = ({
         document.body.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
         document.documentElement.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
         document.removeEventListener('keydown', onKeyDown, false);
+        document.body.style.paddingRight = bodyRightPaddingStyleRef.current || '';
         const elementToFocus: HTMLElement | undefined = getElementToFocusAfterClose();
         if (elementToFocus) {
           elementToFocus.focus();

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -148,17 +148,21 @@ export const Dialog = ({
   targetElement,
   ...props
 }: DialogProps) => {
+  const isBrowser = typeof window !== 'undefined';
   const [isReadyToShowDialog, setIsReadyToShowDialog] = useState<boolean>(false);
   const dialogContextProps: DialogContextProps = { isReadyToShowDialog, scrollable, close, closeButtonLabelText };
   const customThemeClass = useTheme<DialogCustomTheme>(styles.dialogContainer, theme);
   const dialogRef: RefObject<HTMLInputElement> = React.createRef();
-  const [focusedElement, setFocusedElement] = useState(document.activeElement);
+  const [focusedElement, setFocusedElement] = useState(isBrowser ? document.activeElement : null);
 
   useEffect(() => {
-    document.addEventListener('focusin', () => setFocusedElement(document.activeElement));
-    return () => {
-      document.removeEventListener('focusin', () => setFocusedElement(document.activeElement));
-    };
+    if (isBrowser) {
+      document.addEventListener('focusin', () => setFocusedElement(document.activeElement));
+      return () => {
+        document.removeEventListener('focusin', () => setFocusedElement(document.activeElement));
+      };
+    }
+    return null;
   }, []);
 
   useEffect(() => {
@@ -186,6 +190,7 @@ export const Dialog = ({
   useEffect(() => {
     if (isOpen) {
       document.body.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
+      document.documentElement.classList.add(styles.dialogVisibleBodyWithHiddenScrollbars);
       document.addEventListener('keydown', onKeyDown, false);
       setIsReadyToShowDialog(true);
     }
@@ -193,6 +198,7 @@ export const Dialog = ({
       if (isOpen) {
         setIsReadyToShowDialog(false);
         document.body.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
+        document.documentElement.classList.remove(styles.dialogVisibleBodyWithHiddenScrollbars);
         document.removeEventListener('keydown', onKeyDown, false);
         const elementToFocus: HTMLElement | undefined = getElementToFocusAfterClose();
         if (elementToFocus) {

--- a/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`<Dialog /> spec renders the component 1`] = `
 <body>
-  <div
-    class="hds-dialog-start-tab-barrier"
-    tabindex="0"
-  />
   <div />
   <div
     class="dialogContainer"
   >
+    <div
+      aria-hidden="true"
+      tabindex="0"
+    />
     <div
       aria-hidden="true"
       tabindex="0"
@@ -117,9 +117,5 @@ exports[`<Dialog /> spec renders the component 1`] = `
       tabindex="0"
     />
   </div>
-  <div
-    class="hds-dialog-end-tab-barrier"
-    tabindex="0"
-  />
 </body>
 `;

--- a/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Dialog /> spec renders the component 1`] = `
-<body>
+<body
+  class="dialogVisibleBodyWithHiddenScrollbars"
+>
   <div />
   <div
     class="dialogContainer"

--- a/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`<Dialog /> spec renders the component 1`] = `
 <body
   class="dialogVisibleBodyWithHiddenScrollbars"
 >
+  <div
+    class="hds-dialog-tab-barrier"
+    tabindex="0"
+  />
   <div />
   <div
     class="dialogContainer"
   >
-    <div
-      aria-hidden="true"
-      tabindex="0"
-    />
     <div
       aria-hidden="true"
       tabindex="0"
@@ -119,5 +119,9 @@ exports[`<Dialog /> spec renders the component 1`] = `
       tabindex="0"
     />
   </div>
+  <div
+    class="hds-dialog-tab-barrier"
+    tabindex="0"
+  />
 </body>
 `;


### PR DESCRIPTION
## Description
Fixes the nasty content and scroll position jumping due to Dialog-component rendering. Also did some rework on the accessibility-related containers controlling the focus. (~40 lines of code less now)

## Related Issue
[HDS-1367](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1367)

## How Has This Been Tested?
- tests
- on local machine
- on iOS simulator

[HDS-1367]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ