### PR TITLE
HDS-1541-input asterisk position fix

### DIFF
--- a/packages/react/src/internal/field-label/__snapshots__/FieldLabel.test.tsx.snap
+++ b/packages/react/src/internal/field-label/__snapshots__/FieldLabel.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<FieldLabel /> spec renders the component 1`] = `
     <span
       class="indicator"
     >
-       *
+      *
     </span>
   </label>
 </DocumentFragment>

--- a/packages/react/src/internal/required-indicator/RequiredIndicator.tsx
+++ b/packages/react/src/internal/required-indicator/RequiredIndicator.tsx
@@ -10,7 +10,6 @@ type RequiredIndicatorProps = {
 
 export const RequiredIndicator = ({ className, style }: RequiredIndicatorProps) => (
   <span className={classNames(styles.indicator, className)} style={style}>
-    {' '}
     *
   </span>
 );

--- a/packages/react/src/internal/required-indicator/__snapshots__/RequiredIndicator.test.tsx.snap
+++ b/packages/react/src/internal/required-indicator/__snapshots__/RequiredIndicator.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<RequiredIndicator /> spec renders the component 1`] = `
   <span
     class="indicator"
   >
-     *
+    *
   </span>
 </DocumentFragment>
 `;

--- a/site/src/docs/components/fieldset/code.mdx
+++ b/site/src/docs/components/fieldset/code.mdx
@@ -53,28 +53,19 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   <fieldset class="hds-fieldset" style="max-width: 400px">
     <legend class="hds-fieldset-legend">Child information</legend>
     <div class="hds-text-input">
-      <label for="first-name-child-1" class="hds-text-input__label">
-        First name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="first-name-child-1" class="hds-text-input__label">First name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="first-name-child-1" name="first-name-child-1" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="last-name-child-1" class="hds-text-input__label">
-        Last name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="last-name-child-1" class="hds-text-input__label">Last name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="last-name-child-1" name="last-name-child-1" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="social-security-number-child-1" class="hds-text-input__label">
-        Social security number
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="social-security-number-child-1" class="hds-text-input__label">Social security number<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input
           id="social-security-number-child-1"
@@ -89,28 +80,19 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   <fieldset class="hds-fieldset" style="max-width: 400px;margin-top: var(--spacing-s);">
     <legend class="hds-fieldset-legend">Guardian information</legend>
     <div class="hds-text-input">
-      <label for="first-name-guardian-1" class="hds-text-input__label">
-        First name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="first-name-guardian-1" class="hds-text-input__label">First name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="first-name-guardian-1" name="first-name-guardian-1" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="last-name-guardian-1" class="hds-text-input__label">
-        Last name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="last-name-guardian-1" class="hds-text-input__label">Last name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="last-name-guardian-1" name="last-name-guardian-1" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="social-security-number-guardian-1" class="hds-text-input__label">
-        Social security number
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="social-security-number-guardian-1" class="hds-text-input__label">Social security number<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input
           id="social-security-number-guardian-1"
@@ -167,28 +149,19 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   <fieldset class="hds-fieldset hds-fieldset--border" style="max-width: 400px;">
     <legend class="hds-fieldset-legend">Child information</legend>
     <div class="hds-text-input">
-      <label for="first-name-child-3" class="hds-text-input__label">
-        First name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="first-name-child-3" class="hds-text-input__label">First name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="first-name-child-3" name="first-name-child-3" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="last-name-child-3" class="hds-text-input__label">
-        Last name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="last-name-child-3" class="hds-text-input__label">Last name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="last-name-child-3" name="last-name-child-3" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="social-security-number-child-3" class="hds-text-input__label">
-        Social security number
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="social-security-number-child-3" class="hds-text-input__label">Social security number<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input
           id="social-security-number-child-3"
@@ -203,28 +176,19 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   <fieldset class="hds-fieldset hds-fieldset--border" style="max-width: 400px;margin-top: var(--spacing-s);">
     <legend class="hds-fieldset-legend">Guardian information</legend>
     <div class="hds-text-input">
-      <label for="first-name-guardian-3" class="hds-text-input__label">
-        First name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="first-name-guardian-3" class="hds-text-input__label">First name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="first-name-guardian-3" name="first-name-guardian-3" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="last-name-guardian-3" class="hds-text-input__label">
-        Last name
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="last-name-guardian-3" class="hds-text-input__label">Last name<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input id="last-name-guardian-3" name="last-name-guardian-3" class="hds-text-input__input" type="text" />
       </div>
     </div>
     <div class="hds-text-input" style="margin-top: 12px">
-      <label for="social-security-number-guardian-3" class="hds-text-input__label">
-        Social security number
-        <span class="hds-text-input__required">*</span>
-      </label>
+      <label for="social-security-number-guardian-3" class="hds-text-input__label">Social security number<span class="hds-text-input__required">*</span></label>
       <div class="hds-text-input__input-wrapper">
         <input
           id="social-security-number-guardian-3"

--- a/site/src/docs/components/password-input/code.mdx
+++ b/site/src/docs/components/password-input/code.mdx
@@ -38,10 +38,7 @@ style={{
 
 ```html
 <div class="hds-text-input" style="max-width:320px;">
-  <label for="password-input-2" class="hds-text-input__label">
-    Password
-    <span class="hds-text-input__required">*</span>
-  </label>
+  <label for="password-input-2" class="hds-text-input__label">Password<span class="hds-text-input__required">*</span></label>
   <div class="hds-text-input__input-wrapper">
     <input
       id="password-input-2"

--- a/site/src/docs/components/text-area/code.mdx
+++ b/site/src/docs/components/text-area/code.mdx
@@ -49,10 +49,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```html
 <div style="max-width:320px;">
   <div class="hds-text-input">
-    <label for="textarea-core" class="hds-text-input__label">
-      Label
-      <span class="hds-text-input__required">*</span>
-    </label>
+    <label for="textarea-core" class="hds-text-input__label">Label<span class="hds-text-input__required">*</span></label>
     <div class="hds-text-input__input-wrapper">
       <textarea id="textarea-core" class="hds-text-input__input" placeholder="Placeholder" required></textarea>
     </div>

--- a/site/src/docs/components/text-input/code.mdx
+++ b/site/src/docs/components/text-input/code.mdx
@@ -49,10 +49,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ```html
 <div style="max-width:320px;">
   <div class="hds-text-input">
-    <label for="textinput-core" class="hds-text-input__label">
-      Label
-      <span class="hds-text-input__required">*</span>
-    </label>
+    <label for="textinput-core" class="hds-text-input__label">Label<span class="hds-text-input__required">*</span></label>
     <div class="hds-text-input__input-wrapper">
       <input id="textinput-core" class="hds-text-input__input" type="text" placeholder="Placeholder" required />
     </div>


### PR DESCRIPTION
## Description
Fixes the empty space in the site on the core-component between the "Label" and the *-asterisk. This is caused somehow by the `.mdx` -format which adds excessive spaces to `"Label"` sitting on it's own line in the code which becomes `" Label "`. This is fixed by just putting the Label and the asterisk on the same line in the mdx-file.

## Related Issue
[HDS-1209](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1209)

## How Has This Been Tested?
- own machine


[HDS-1209]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ