### PR TITLE
Hds 1495 exportable mediaquery hooks

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,6 +58,7 @@
     "@storybook/react": "6.4.22",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.8.1",
     "@types/cleave.js": "1.4.4",
     "@types/jest": "^26.0.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -100,6 +100,7 @@
     "rollup-plugin-includepaths": "0.2.4",
     "rollup-plugin-postcss": "3.1.8",
     "rollup-plugin-terser": "7.0.2",
+    "rollup-plugin-ts": "2.0.4",
     "sass": "1.39.2",
     "stylelint": "^15.1.0",
     "stylelint-config-css-modules": "^4.2.0",

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 import includePaths from 'rollup-plugin-includepaths';
 import resolve from '@rollup/plugin-node-resolve';
-import ts from '@wessberg/rollup-plugin-ts';
+import ts from 'rollup-plugin-ts';
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';

--- a/packages/react/src/hooks/__tests__/useMediaQuery.test.tsx
+++ b/packages/react/src/hooks/__tests__/useMediaQuery.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useMediaQueryLessThan, useMediaQueryGreaterThan } from '../useMediaQuery';
+
+describe('useMediaQuery', () => {
+  beforeEach(cleanup);
+  it('useMediaQueryLessThan returns correct value', () => {
+    // By default the window.innerWidth is 1024px
+    const isSmallView = renderHook(() => useMediaQueryLessThan('s'));
+    const isLargeView = renderHook(() => useMediaQueryLessThan('xl'));
+
+    expect(isSmallView.result.current).toBe(false);
+    expect(isLargeView.result.current).toBe(true);
+  });
+  it('useMediaQueryGreaterThan returns correct value', () => {
+    // By default the window.innerWidth is 1024px
+    const isLargeView = renderHook(() => useMediaQueryGreaterThan('s'));
+    const isXLargeView = renderHook(() => useMediaQueryGreaterThan('xl'));
+
+    expect(isLargeView.result.current).toBe(true);
+    expect(isXLargeView.result.current).toBe(false);
+  });
+});

--- a/packages/react/src/hooks/__tests__/useMediaQuery.test.tsx
+++ b/packages/react/src/hooks/__tests__/useMediaQuery.test.tsx
@@ -1,17 +1,23 @@
-import { cleanup } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { cleanup, fireEvent } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react-hooks';
 
 import { useMediaQueryLessThan, useMediaQueryGreaterThan } from '../useMediaQuery';
 
 /* This test suite changes window width but it's set to default 1024 after this is done. */
 describe('useMediaQuery', () => {
-  afterAll(cleanup);
+  const defaultInnerWidth = global.innerWidth;
+  afterAll(() => {
+    cleanup();
+    global.innerWidth = defaultInnerWidth;
+  });
 
   it('useMediaQueryLessThan returns correct value', () => {
-    // Change the viewport to 500px
-    global.innerWidth = 500;
     // Trigger the window resize event
-    global.dispatchEvent(new Event('resize'));
+    act(() => {
+      // Change the viewport to 500px
+      global.innerWidth = 500;
+      fireEvent(window, new Event('resize'));
+    });
 
     const isSmallView = renderHook(() => useMediaQueryLessThan('m'));
     const isMobileView = renderHook(() => useMediaQueryLessThan('xs'));
@@ -21,27 +27,33 @@ describe('useMediaQuery', () => {
   });
 
   it('useMediaQueryLessThan reacts to window resize', () => {
-    // Set the viewport width again just to be safe
-    global.innerWidth = 600;
     // Trigger the window resize event
-    global.dispatchEvent(new Event('resize'));
+    act(() => {
+      // Set the viewport width to be under medium breakpoint
+      global.innerWidth = 600;
+      fireEvent(window, new Event('resize'));
+    });
 
     const isMediumView = renderHook(() => useMediaQueryLessThan('m'));
     expect(isMediumView.result.current).toBe(true);
 
-    // Set the viewport width again just to be safe
-    global.innerWidth = 1000;
     // Trigger the window resize event
-    global.dispatchEvent(new Event('resize'));
+    act(() => {
+      // Set the viewport width to over medium breakpoint
+      global.innerWidth = 1000;
+      fireEvent(window, new Event('resize'));
+    });
 
     expect(isMediumView.result.current).toBe(false);
   });
 
   it('useMediaQueryGreaterThan returns correct value', () => {
-    // Set the viewport width again just to be safe
-    global.innerWidth = 500;
     // Trigger the window resize event
-    global.dispatchEvent(new Event('resize'));
+    act(() => {
+      // Set the viewport width to small
+      global.innerWidth = 500;
+      fireEvent(window, new Event('resize'));
+    });
     const isSmallView = renderHook(() => useMediaQueryGreaterThan('xs'));
     const isLargeView = renderHook(() => useMediaQueryGreaterThan('l'));
 
@@ -50,18 +62,22 @@ describe('useMediaQuery', () => {
   });
 
   it('useMediaQueryGreaterThan reacts to window resize', () => {
-    // Set the viewport width again just to be safe
-    global.innerWidth = 800;
     // Trigger the window resize event
-    global.dispatchEvent(new Event('resize'));
+    act(() => {
+      // Set the viewport width to over medium
+      global.innerWidth = 800;
+      fireEvent(window, new Event('resize'));
+    });
 
     const isMediumView = renderHook(() => useMediaQueryGreaterThan('m'));
     expect(isMediumView.result.current).toBe(true);
 
-    // Set the viewport width again just to be safe
-    global.innerWidth = 500;
     // Trigger the window resize event
-    global.dispatchEvent(new Event('resize'));
+    act(() => {
+      // Set the viewport width to small
+      global.innerWidth = 500;
+      fireEvent(window, new Event('resize'));
+    });
 
     expect(isMediumView.result.current).toBe(false);
   });

--- a/packages/react/src/hooks/__tests__/useMediaQuery.test.tsx
+++ b/packages/react/src/hooks/__tests__/useMediaQuery.test.tsx
@@ -3,22 +3,66 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { useMediaQueryLessThan, useMediaQueryGreaterThan } from '../useMediaQuery';
 
+/* This test suite changes window width but it's set to default 1024 after this is done. */
 describe('useMediaQuery', () => {
-  beforeEach(cleanup);
+  afterAll(cleanup);
+
   it('useMediaQueryLessThan returns correct value', () => {
-    // By default the window.innerWidth is 1024px
-    const isSmallView = renderHook(() => useMediaQueryLessThan('s'));
-    const isLargeView = renderHook(() => useMediaQueryLessThan('xl'));
+    // Change the viewport to 500px
+    global.innerWidth = 500;
+    // Trigger the window resize event
+    global.dispatchEvent(new Event('resize'));
 
-    expect(isSmallView.result.current).toBe(false);
-    expect(isLargeView.result.current).toBe(true);
+    const isSmallView = renderHook(() => useMediaQueryLessThan('m'));
+    const isMobileView = renderHook(() => useMediaQueryLessThan('xs'));
+
+    expect(isSmallView.result.current).toBe(true);
+    expect(isMobileView.result.current).toBe(false);
   });
-  it('useMediaQueryGreaterThan returns correct value', () => {
-    // By default the window.innerWidth is 1024px
-    const isLargeView = renderHook(() => useMediaQueryGreaterThan('s'));
-    const isXLargeView = renderHook(() => useMediaQueryGreaterThan('xl'));
 
-    expect(isLargeView.result.current).toBe(true);
-    expect(isXLargeView.result.current).toBe(false);
+  it('useMediaQueryLessThan reacts to window resize', () => {
+    // Set the viewport width again just to be safe
+    global.innerWidth = 600;
+    // Trigger the window resize event
+    global.dispatchEvent(new Event('resize'));
+
+    const isMediumView = renderHook(() => useMediaQueryLessThan('m'));
+    expect(isMediumView.result.current).toBe(true);
+
+    // Set the viewport width again just to be safe
+    global.innerWidth = 1000;
+    // Trigger the window resize event
+    global.dispatchEvent(new Event('resize'));
+
+    expect(isMediumView.result.current).toBe(false);
+  });
+
+  it('useMediaQueryGreaterThan returns correct value', () => {
+    // Set the viewport width again just to be safe
+    global.innerWidth = 500;
+    // Trigger the window resize event
+    global.dispatchEvent(new Event('resize'));
+    const isSmallView = renderHook(() => useMediaQueryGreaterThan('xs'));
+    const isLargeView = renderHook(() => useMediaQueryGreaterThan('l'));
+
+    expect(isSmallView.result.current).toBe(true);
+    expect(isLargeView.result.current).toBe(false);
+  });
+
+  it('useMediaQueryGreaterThan reacts to window resize', () => {
+    // Set the viewport width again just to be safe
+    global.innerWidth = 800;
+    // Trigger the window resize event
+    global.dispatchEvent(new Event('resize'));
+
+    const isMediumView = renderHook(() => useMediaQueryGreaterThan('m'));
+    expect(isMediumView.result.current).toBe(true);
+
+    // Set the viewport width again just to be safe
+    global.innerWidth = 500;
+    // Trigger the window resize event
+    global.dispatchEvent(new Event('resize'));
+
+    expect(isMediumView.result.current).toBe(false);
   });
 });

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './useMediaQuery';
+export * from './useMobile';
+export * from './useTheme';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,1 @@
 export * from './useMediaQuery';
-export * from './useMobile';
-export * from './useTheme';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
 export * from './icons';
 export * from './components';
 export * from './ssr';
+export * from './hooks';

--- a/site/src/docs/foundation/design-tokens/breakpoints/index.mdx
+++ b/site/src/docs/foundation/design-tokens/breakpoints/index.mdx
@@ -15,7 +15,9 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 HDS includes tokenized values for both breakpoints and a maximum container width. Breakpoint tokens can be also used alongside <InternalLink size="M" href="/foundation/guidelines/grid">HDS grid guidelines</InternalLink> in order to create consistent designs and implementations.
 
-**HDS offers a Container component which follows breakpoint and container width tokens automatically.** It is recommended to use it if possible. For more info and examples, see <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-container--example">Container - React documentation</Link> and <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/core/?path=/story/components-container--default">Container - Core documentation</Link>.
+HDS offers helpful utilities for breakpoint handling:
+- **Container component** which follows breakpoint and container width tokens automatically. It is recommended to use it if possible. For more info and examples, see <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-container--example">Container - React documentation</Link> and <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/core/?path=/story/components-container--default">Container - Core documentation</Link>.
+- **Hooks for React components**; `useMediaQueryLessThan` and `useMediaQueryGreaterThan` hooks listen to browser window resize events and return a boolean value when the window size is over or under the given breakpoint parameter. For more information see <ExternalLink openInNewTab href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/development/packages/react/src/hooks/useMediaQuery.ts">the hooks' code</ExternalLink>, and for examples, see <ExternalLink openInNewTab href="https://github.com/City-of-Helsinki/helsinki-design-system/blob/development/packages/react/src/components/header/Header.tsx">the Header component's source code</ExternalLink>. 
 
 ### Principles
 
@@ -28,7 +30,7 @@ HDS includes tokenized values for both breakpoints and a maximum container width
 ### Accessibility
 
 - Carefully test your implementation at different breakpoints - especially at the edge values of a breakpoint.
-- Pay extra attention how your service behaves if browser zoom functionality is used. Read more about the <ExternalLink href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html">WCAG requirements considering reflow</ExternalLink>.
+- Pay extra attention how your service behaves if browser zoom functionality is used. Read more about the <ExternalLink openInNewTab href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html">WCAG requirements considering reflow</ExternalLink>.
 
 ### Using breakpoint tokens
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,22 +7919,6 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wessberg/rollup-plugin-ts@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@wessberg/rollup-plugin-ts/-/rollup-plugin-ts-2.0.4.tgz#ccedcc738114f2a640bf10f41ebb0455f017fa13"
-  integrity sha512-+p5eRldRODlsCZs0vpBgl64jChzoxad0RxutvFGhhJyiXrN8lwewTo1MAwae/dsanK+L2WUCGZsMyxIYY8JGfA==
-  dependencies:
-    "@rollup/pluginutils" "^4.1.1"
-    "@wessberg/stringutil" "^1.0.19"
-    browserslist "^4.18.1"
-    browserslist-generator "^1.0.65"
-    chalk "^4.1.2"
-    compatfactory "^0.0.12"
-    crosspath "1.0.0"
-    magic-string "^0.25.7"
-    ts-clone-node "^0.3.29"
-    tslib "^2.3.1"
-
 "@wessberg/stringutil@^1.0.19":
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/@wessberg/stringutil/-/stringutil-1.0.19.tgz#baadcb6f4471fe2d46462a7d7a8294e4b45b29ad"
@@ -24281,6 +24265,22 @@ rollup-plugin-terser@7.0.2, rollup-plugin-terser@^7.0.0:
     jest-worker "^26.2.1"
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
+
+rollup-plugin-ts@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-ts/-/rollup-plugin-ts-2.0.4.tgz#d5557ae355315dc202e660d5e68a6f2103d8bb39"
+  integrity sha512-VXx1qg+8ySrMxThIoBzy73qRg4q8SD0H8Kd8XquVMm4nrH8bj80DBEJ2baZekQWa5TxHyVOHHNloZ+oqCLhLTQ==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.1"
+    "@wessberg/stringutil" "^1.0.19"
+    browserslist "^4.18.1"
+    browserslist-generator "^1.0.65"
+    chalk "^4.1.2"
+    compatfactory "^0.0.12"
+    crosspath "1.0.0"
+    magic-string "^0.25.7"
+    ts-clone-node "^0.3.29"
+    tslib "^2.3.1"
 
 rollup-pluginutils@^2.8.2:
   version "2.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6658,6 +6658,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@11.2.0":
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.0.tgz#ce977a76b6342ea95c71ccd6de3012b1635fb559"
@@ -7918,6 +7926,22 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@wessberg/rollup-plugin-ts@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@wessberg/rollup-plugin-ts/-/rollup-plugin-ts-2.0.4.tgz#ccedcc738114f2a640bf10f41ebb0455f017fa13"
+  integrity sha512-+p5eRldRODlsCZs0vpBgl64jChzoxad0RxutvFGhhJyiXrN8lwewTo1MAwae/dsanK+L2WUCGZsMyxIYY8JGfA==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.1"
+    "@wessberg/stringutil" "^1.0.19"
+    browserslist "^4.18.1"
+    browserslist-generator "^1.0.65"
+    chalk "^4.1.2"
+    compatfactory "^0.0.12"
+    crosspath "1.0.0"
+    magic-string "^0.25.7"
+    ts-clone-node "^0.3.29"
+    tslib "^2.3.1"
 
 "@wessberg/stringutil@^1.0.19":
   version "1.0.19"
@@ -23096,6 +23120,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.11:
   version "6.0.11"


### PR DESCRIPTION
## Description

- useMediaQueryLessThan and useMediaQueryGreaterThan hooks are exported and tested
- Removed console build warning about changed package name: @wessberg/rollup-plugin-ts => rollup-plugin-ts

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1495

## Motivation and Context

useMediaQueryLessThan and useMediaQueryGreaterThan hooks can be used by users as well as they support the hds breakpoints by default.

## How Has This Been Tested?
Locally checking the lib-folder's content and with hds-cra app to check that the hooks can be used

[Documentation page](https://city-of-helsinki.github.io/hds-demo/breakpoint-hooks/foundation/design-tokens/breakpoints)

To do:
- [x] Mention hooks in documentation
