### PR TITLE
HDS-831: Check components with UniqueId

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -124,7 +124,6 @@
     "lodash.isundefined": "3.0.1",
     "lodash.pick": "^4.4.0",
     "lodash.pickby": "^4.6.0",
-    "lodash.uniqueid": "4.0.1",
     "lodash.xor": "^4.5.0",
     "memoize-one": "5.2.1",
     "postcss": "7.0.36",

--- a/packages/react/src/components/accordion/Accordion.tsx
+++ b/packages/react/src/components/accordion/Accordion.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import uniqueId from 'lodash.uniqueid';
 import pickBy from 'lodash.pickby';
 
 // import core base styles
@@ -7,6 +6,7 @@ import 'hds-core';
 
 import styles from './Accordion.module.scss';
 import classNames from '../../utils/classNames';
+import uniqueId from '../../utils/getUniqueId';
 import { IconAngleDown, IconAngleUp } from '../../icons';
 import { useAccordion } from './useAccordion';
 import { useTheme } from '../../hooks/useTheme';

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import uniqueId from 'lodash.uniqueid';
 
 import { Button } from '../../button';
 import { Combobox } from './Combobox';
 import { IconFaceSmile, IconLocation } from '../../../icons';
+import uniqueId from '../../../utils/getUniqueId';
 
 type Option = { label: string };
 

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -3,7 +3,6 @@
 import React, { useRef, useState, KeyboardEvent, FocusEvent, FocusEventHandler, useMemo, useCallback } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
 import isEqual from 'lodash.isequal';
-import uniqueId from 'lodash.uniqueid';
 import { useVirtual } from 'react-virtual';
 
 import 'hds-core';
@@ -11,6 +10,7 @@ import 'hds-core';
 import styles from './Combobox.module.scss';
 import { FieldLabel } from '../../../internal/field-label/FieldLabel';
 import classNames from '../../../utils/classNames';
+import uniqueId from '../../../utils/getUniqueId';
 import { IconAlertCircleFill, IconAngleDown } from '../../../icons';
 import { ClearButton, SelectedItems } from '../../../internal/selectedItems/SelectedItems';
 import { multiSelectReducer, onMultiSelectStateChange, SelectCustomTheme, SelectProps } from '../select';
@@ -90,7 +90,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
     getA11ySelectionMessage = () => '',
     getA11yStatusMessage = () => '',
     helper,
-    id = uniqueId('hds-combobox-') as string,
+    id = uniqueId('hds-combobox-'),
     invalid = false,
     isOptionDisabled,
     label,

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import uniqueId from 'lodash.uniqueid';
 
 import { Button } from '../../button';
 import { Select } from './Select';
 import { IconFaceSmile, IconLocation } from '../../../icons';
+import uniqueId from '../../../utils/getUniqueId';
 
 type Option = { label: string };
 

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -10,7 +10,6 @@ import {
   UseMultipleSelectionState,
 } from 'downshift';
 import isEqual from 'lodash.isequal';
-import uniqueId from 'lodash.uniqueid';
 import { useVirtual } from 'react-virtual';
 
 import 'hds-core';
@@ -18,6 +17,7 @@ import 'hds-core';
 import styles from './Select.module.scss';
 import { FieldLabel } from '../../../internal/field-label/FieldLabel';
 import classNames from '../../../utils/classNames';
+import uniqueId from '../../../utils/getUniqueId';
 import { IconAlertCircleFill, IconAngleDown } from '../../../icons';
 import { ClearButton, SelectedItems } from '../../../internal/selectedItems/SelectedItems';
 import { DROPDOWN_MENU_ITEM_HEIGHT, getIsInSelectedOptions } from '../dropdownUtils';
@@ -322,7 +322,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
     getA11ySelectionMessage = () => '',
     getA11yStatusMessage = () => '',
     helper,
-    id = uniqueId('hds-select-') as string,
+    id = uniqueId('hds-select-'),
     invalid,
     isOptionDisabled,
     label,

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -1,10 +1,10 @@
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
-import uniqueId from 'lodash.uniqueid';
 
 // import core base styles
 import 'hds-core';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 import classNames from '../../utils/classNames';
+import uniqueId from '../../utils/getUniqueId';
 import { Button } from '../button';
 import { IconPlus, IconPhoto, IconCross, IconDocument, IconUpload } from '../../icons';
 import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';

--- a/packages/react/src/components/koros/Koros.tsx
+++ b/packages/react/src/components/koros/Koros.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import uniqueId from 'lodash.uniqueid';
 
 // import core base styles
 import 'hds-core';
 import classNames from '../../utils/classNames';
+import uniqueId from '../../utils/getUniqueId';
 import styles from './Koros.module.css';
 
 export type KorosType = 'basic' | 'beat' | 'pulse' | 'storm' | 'wave' | 'calm';

--- a/packages/react/src/components/loadingSpinner/useNotificationArea.ts
+++ b/packages/react/src/components/loadingSpinner/useNotificationArea.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import uniqueId from 'lodash.uniqueid';
 
 import styles from './LoadingSpinner.module.scss';
+import uniqueId from '../../utils/getUniqueId';
 
 const notificationAreaId = 'hds-loading-spinner-notification-area';
 const activeSpinnersAttrKey = 'data-active-spinners';

--- a/packages/react/src/components/navigation/navigationDropdownLink/NavigationDropdownLink.tsx
+++ b/packages/react/src/components/navigation/navigationDropdownLink/NavigationDropdownLink.tsx
@@ -1,8 +1,8 @@
 import React, { MouseEventHandler, useState } from 'react';
-import uniqueId from 'lodash.uniqueid';
 
 import { MenuButton, MenuButtonProps } from '../../../internal/menuButton/MenuButton';
 import { NavigationItem } from '../navigationItem/NavigationItem';
+import uniqueId from '../../../utils/getUniqueId';
 
 export type NavigationDropdownLinkProps = MenuButtonProps & {
   /**

--- a/packages/react/src/hooks/useTheme.tsx
+++ b/packages/react/src/hooks/useTheme.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
-import uniqueId from 'lodash.uniqueid';
 
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
+import uniqueId from '../utils/getUniqueId';
 
 /**
  * Sets the given custom theme for the component

--- a/packages/react/src/internal/menuButton/MenuButton.tsx
+++ b/packages/react/src/internal/menuButton/MenuButton.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 // import core base styles
 import 'hds-core';
-import uniqueId from 'lodash.uniqueid';
 import mergeRefs from 'react-merge-refs';
 import useMeasure from 'react-use-measure';
 import { ResizeObserver } from '@juggle/resize-observer';
@@ -10,6 +9,7 @@ import styles from './MenuButton.module.scss';
 import { Menu } from './menu/Menu';
 import { IconAngleDown, IconAngleUp } from '../../icons';
 import classNames from '../../utils/classNames';
+import uniqueId from '../../utils/getUniqueId';
 import { useMobile } from '../../hooks/useMobile';
 
 export type MenuButtonProps = React.PropsWithChildren<{

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import mergeRefs from 'react-merge-refs';
 import useMeasure from 'react-use-measure';
-import uniqueId from 'lodash.uniqueid';
 import { ResizeObserver } from '@juggle/resize-observer';
 
 import styles from './SelectedItems.module.scss';
 import { Tag } from '../../components/tag';
 import classNames from '../../utils/classNames';
 import { IconCrossCircle } from '../../icons';
+import uniqueId from '../../utils/getUniqueId';
 
 type SelectedItemsProps<OptionType> = {
   /**

--- a/packages/react/src/utils/getUniqueId.ts
+++ b/packages/react/src/utils/getUniqueId.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns unique id
+ */
+
+let uniqueIdCounter = 0;
+export default (prefix = ''): string => {
+  uniqueIdCounter += 1;
+  return `${prefix}${uniqueIdCounter}`;
+};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Replaced not working `lodash.uniqueid` with local util function. `utils/getUniqueId()` gives running unique id numbers for ui components. This approach works also with server side rendered mode (which was the problem with `lodash.uniqueid`

<!-- Add [Feature] or [BreakingChange] to the title -->
This isn't a breaking change as it is replacement bug fix

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->
https://helsinkisolutionoffice.atlassian.net/browse/HDS-831

Closes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
`lodash.uniqueid` didn't work with SSR, but it could be replaced with this simple function

## How Has This Been Tested?
All HDS tests pass and this can be tested also with [https://github.com/City-of-Helsinki/hds-next](https://github.com/City-of-Helsinki/hds-next) 

## Screenshots (if appropriate):
