### PR TITLE
HDS-824-dateInput-input-mode

### DIFF
--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -186,6 +186,8 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const minDateToUse = minDate && isValid(minDate) ? minDate : startOfMonth(subYears(new Date(), 10));
     const maxDateToUse =
       maxDate && isValid(maxDate) ? maxDate : endOfMonth(addYears(max([minDateToUse, new Date()]), 10));
+    // set inputmode to "text" on all Mac* devices to avoid decimal "," -problem
+    const inputMode = navigator.userAgent.toLowerCase().includes('mac') ? 'text' : 'decimal';
 
     return (
       <div lang={language} className={styles.wrapper}>
@@ -199,7 +201,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           }}
           value={inputValue}
           ref={inputRef}
-          inputMode="numeric"
+          inputMode={inputMode}
         >
           {disableDatePicker === false && showPicker && (
             <DatePicker

--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -186,8 +186,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const minDateToUse = minDate && isValid(minDate) ? minDate : startOfMonth(subYears(new Date(), 10));
     const maxDateToUse =
       maxDate && isValid(maxDate) ? maxDate : endOfMonth(addYears(max([minDateToUse, new Date()]), 10));
-    // set inputmode to "text" on all Mac* devices to avoid decimal "," -problem
-    const inputMode = navigator.userAgent.toLowerCase().includes('mac') ? 'text' : 'decimal';
 
     return (
       <div lang={language} className={styles.wrapper}>
@@ -201,7 +199,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           }}
           value={inputValue}
           ref={inputRef}
-          inputMode={inputMode}
         >
           {disableDatePicker === false && showPicker && (
             <DatePicker

--- a/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
         <input
           class="input hasButton"
           id="date"
-          inputmode="numeric"
           type="text"
           value=""
         />
@@ -1542,7 +1541,6 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
         <input
           class="input hasButton"
           id="date"
-          inputmode="numeric"
           type="text"
           value=""
         />
@@ -3075,7 +3073,6 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
         <input
           class="input hasButton"
           id="date"
-          inputmode="numeric"
           type="text"
           value=""
         />
@@ -4563,7 +4560,6 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
         <input
           class="input hasButton"
           id="date"
-          inputmode="numeric"
           type="text"
           value=""
         />


### PR DESCRIPTION
Set all to use text instead of numeric or decimal.

## Description

## Related Issue
[HDS-824](https://helsinkisolutionoffice.atlassian.net/browse/HDS-824)

## How Has This Been Tested?
- local machine, emulators, iOS devices


[HDS-824]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ