### PR TITLE
release-2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - February, 21, 2023
+
+### React 
+
+#### Changed
+
+- [Checkbox] Support for tooltips
+- [Fieldset] Support for tooltips
+
+#### Fixed
+
+- [DateInput] Changed input type to textual so that even iOS users can write the date in addition of picking it from calendar
+- [Navigation] Fixed sizing 320px screens where title overlapped menu button
+
+### Documentation
+
+#### Added
+
+- Information about breaking changes and versioning in HDS
+
+#### Fixed
+
+- Date input default values for min and max
+- Required field asterisk position to match the components
+
 ## [2.11.0] - February, 9, 2023
 
 ### React 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-core",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Core styles for the Helsinki Design System",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "@storybook/html": "6.4.18",
     "copyfiles": "2.2.0",
     "cssnano": "4.1.10",
-    "hds-design-tokens": "2.11.0",
+    "hds-design-tokens": "2.12.0",
     "normalize.css": "8.0.1",
     "postcss": "8.2.15",
     "postcss-cli": "8.3.1",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-design-tokens",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Design tokens for the Helsinki Design System",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hds-react",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "React components for the Helsinki Design System",
   "homepage": "https://github.com/City-of-Helsinki/helsinki-design-system#readme",
   "license": "MIT",
@@ -115,7 +115,7 @@
     "crc-32": "1.2.0",
     "date-fns": "2.16.1",
     "downshift": "6.0.6",
-    "hds-core": "2.11.0",
+    "hds-core": "2.12.0",
     "kashe": "1.0.4",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "4.5.0",

--- a/site/package.json
+++ b/site/package.json
@@ -2,7 +2,7 @@
   "name": "site",
   "private": true,
   "description": "Documentation for Helsinki Design System",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "workspaces": {
     "nohoist": [
       "gatsby",
@@ -40,9 +40,9 @@
   "devDependencies": {
     "chalk": "4.0.0",
     "eslint-config-react-app": "^7.0.1",
-    "hds-core": "2.11.0",
-    "hds-design-tokens": "2.11.0",
-    "hds-react": "2.11.0",
+    "hds-core": "2.12.0",
+    "hds-design-tokens": "2.12.0",
+    "hds-react": "2.12.0",
     "inquirer": "7.1.0",
     "postcss": "8",
     "prettier": "2.5.1",


### PR DESCRIPTION
## [2.12.0] - February, 21, 2023

### React 

#### Changed

- [Checkbox] Support for tooltips
- [Fieldset] Support for tooltips

#### Fixed

- [DateInput] Changed input type to textual so that even iOS users can write the date in addition of picking it from calendar
- [Navigation] Fixed sizing 320px screens where title overlapped menu button

### Documentation

#### Added

- Information about breaking changes and versioning in HDS

#### Fixed

- Date input default values for min and max
- Required field asterisk position to match the components
