### PR TITLE
HDS-1622 Clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
     "build:core": "lerna run --scope hds-core build",
     "build:react": "lerna run --scope hds-react build",
     "build:site": "lerna run --scope site build",
+    "clean": "rimraf node_modules/ packages/core/lib packages/core/node_modules packages/core/storybook-static packages/react/lib packages/react/node_modules packages/react/storybook-static packages/design-tokens/lib packages/design-tokens/node_modules site/.cache site/node_modules site/public",
     "start:core": "lerna run --scope hds-core start",
     "start:react": "lerna run --scope hds-react start",
     "release": "lerna publish from-package --yes",
     "update-versions": "lerna version --exact --no-git-tag-version --no-push --amend --yes"
   },
   "devDependencies": {
-    "lerna": "^3.16.4"
+    "lerna": "^3.16.4",
+    "rimraf": "^4.1.3"
   },
   "resolutions": {
     "multer": "1.4.4-lts.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "rimraf lib/ && yarn postcss-build",
+    "clean": "rimraf node_modules lib storybook-static",
     "start": "yarn storybook",
     "postcss-build": "postcss 'src/**/*.css' --base src -d lib && postcss 'src/**/*.css' --base src -d lib --ext 'min.css' --env 'minify'",
     "postcss-watch": "postcss 'src/**/*.css' --base src -d lib --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "rimraf lib/ && yarn run lint && yarn run tcm && rollup -c",
+    "clean": "rimraf node_modules lib storybook-static",
     "start": "tcm src internal --watch & yarn storybook",
     "scaffold": "node scripts/scaffold.js",
     "icon": "node scripts/icon.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24073,6 +24073,11 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.1.3.tgz#e8ace19d5f009b4fa6108deeaffe39ef68bba194"
+  integrity sha512-iyzalDLo3l5FZxxaIGUY7xI4Bf90Xt7pCipc1Mr7RsdU7H3538z+M0tlsUDrz0aHeGS9uNqiKHUJyTewwRP91Q==
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
## Description

Easy clean script to run that removes all node_modules folders and caches. 

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1622

## Motivation and Context

This is handy when switching between branches that have changed dependencies, builds or styles. Instead of manually removing these folders, developer can just run this script from the root.

## How Has This Been Tested?
Locally running the script, then `yarn && yarn build && yarn start` to check that the Storybooks and doc site works.
