### PR TITLE
Hds 530 search history

### DIFF
--- a/packages/react/src/components/dropdown/_dropdown.common.scss
+++ b/packages/react/src/components/dropdown/_dropdown.common.scss
@@ -152,6 +152,29 @@
 }
 
 /**
+ * MENU GROUP
+ */
+
+%dropdownMenuGroupLabel {
+  align-items: center;
+  background-color: var(--color-black-20);
+  display: flex;
+  font-weight: bold;
+  min-height: 2rem;
+  padding: 2px var(--spacing-s);
+}
+
+%dropdownMenuGroupLabelIcon {
+  display: flex;
+  margin-right: 3px;
+}
+
+%dropdownMenuGroupOptions {
+  margin: 0;
+  padding: 0;
+}
+
+/**
  * MENU ITEM
  */
 

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -627,6 +627,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
           selectedItem={selectedItem}
           selectedItems={selectedItems}
           virtualizer={virtualized && virtualizer}
+          highlightedIndex={highlightedIndex}
         />
       </div>
       {/* INVALID TEXT */}

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -613,6 +613,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
           selectedItem={selectedItem}
           selectedItems={selectedItems}
           virtualizer={virtualized && virtualizer}
+          highlightedIndex={highlightedIndex}
         />
       </div>
       {/* INVALID TEXT */}

--- a/packages/react/src/components/searchInput/SearchInput.module.scss
+++ b/packages/react/src/components/searchInput/SearchInput.module.scss
@@ -90,6 +90,21 @@
 }
 
 /**
+ * MENU GROUP
+ */
+.menuGroupOptions {
+  @extend %dropdownMenuGroupOptions;
+}
+
+.menuGroupLabel {
+  @extend %dropdownMenuGroupLabel;
+}
+
+.menuGroupLabelIcon {
+  @extend %dropdownMenuGroupLabelIcon;
+}
+
+/**
  * MENU ITEM
  */
 .menuItem {

--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -247,9 +247,10 @@ WithHistoryAndSuggestions.args = {
   helperText: 'Assistive text',
   highlightSuggestions: true,
   placeholder: 'Placeholder',
-  parameters: {
-    loki: { skip: true },
-  },
+};
+
+WithHistoryAndSuggestions.parameters = {
+  loki: { skip: true },
 };
 
 export const WithSuggestionsSpinner = (args) => {

--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -249,7 +249,7 @@ WithHistoryAndSuggestions.args = {
   placeholder: 'Placeholder',
   parameters: {
     loki: { skip: true },
-  }
+  },
 };
 
 export const WithSuggestionsSpinner = (args) => {

--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -183,8 +183,66 @@ export const WithSuggestionsAndHighlighting = (args) => {
     />
   );
 };
+
 WithSuggestionsAndHighlighting.storyName = 'With suggestions and highlighting';
 WithSuggestionsAndHighlighting.args = {
+  label: 'Search for a fruit',
+  helperText: 'Assistive text',
+  highlightSuggestions: true,
+  placeholder: 'Placeholder',
+};
+
+export const WithHistoryAndSuggestions = (args) => {
+  type SuggestionItemType = {
+    value: string;
+  };
+
+  const getSuggestions = async (inputValue: string): Promise<SuggestionItemType[]> => {
+    const suggestions = await asynchronousSearchOperation(inputValue);
+    return suggestions;
+  };
+
+  const searchHistoryKey = 'search-history';
+
+  const getStorageHistoryItems = (): string[] => {
+    const historyString = sessionStorage.getItem(searchHistoryKey);
+    if (!historyString) {
+      return [];
+    }
+
+    return historyString.split(',');
+  };
+
+  const getSearchHistory = (): SuggestionItemType[] => {
+    const historyItems = getStorageHistoryItems();
+    return historyItems.map((value) => ({ value }));
+  };
+
+  const setHistoryItem = (value): void => {
+    const historyStringItems = getStorageHistoryItems();
+    const uniqueHistoryWithNew = Array.from(new Set([value, ...historyStringItems]));
+    return sessionStorage.setItem(searchHistoryKey, uniqueHistoryWithNew.join());
+  };
+
+  const onSubmit = (value: string) => {
+    console.log('Submitted value:', value);
+    setHistoryItem(value);
+  };
+
+  return (
+    <SearchInput<SuggestionItemType>
+      {...args}
+      onSubmit={onSubmit}
+      searchHistoryGroupLabel="Search history"
+      getSearchHistory={getSearchHistory}
+      suggestionLabelField="value"
+      suggestionGroupLabel="All suggestions"
+      getSuggestions={getSuggestions}
+    />
+  );
+};
+
+WithHistoryAndSuggestions.args = {
   label: 'Search for a fruit',
   helperText: 'Assistive text',
   highlightSuggestions: true,

--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -247,6 +247,9 @@ WithHistoryAndSuggestions.args = {
   helperText: 'Assistive text',
   highlightSuggestions: true,
   placeholder: 'Placeholder',
+  parameters: {
+    loki: { skip: true },
+  }
 };
 
 export const WithSuggestionsSpinner = (args) => {

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -301,11 +301,11 @@ export const SearchInput = <SuggestionItem,>({
    * Show also the first optionGroup label when the user navigates with arrow keys to the first option.
    */
   useEffect(() => {
-    if (scrollMenuTop && menuRef.current) {
+    if (hasOptionGroups && scrollMenuTop && menuRef.current) {
       menuRef.current.scrollTo(0, 0);
       setScrollMenuTop(false);
     }
-  }, [scrollMenuTop, menuRef]);
+  }, [hasOptionGroups, scrollMenuTop, menuRef]);
 
   return (
     <div className={classNames(styles.root, isOpen && styles.open, className)} style={style}>

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -33,7 +33,7 @@ export type SearchInputProps<SuggestionItem> = {
    */
   getSearchHistory?: () => SuggestionItem[];
   /**
-   * A label for search history items group
+   * A label for suggestions items group
    */
   suggestionGroupLabel?: string;
   /**

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -140,7 +140,6 @@ export const SearchInput = <SuggestionItem,>({
   const [lastAction, updateLastAction] = useState<UseComboboxStateChangeTypes | typeof userEnterKeyAction>(undefined);
   const [internalValue, setInternalValue] = useState<string>('');
   const inputValue = value || internalValue;
-  const [scrollMenuTop, setScrollMenuTop] = useState<boolean>(false);
 
   const wasLastActionStateChangeEnterKey = () => {
     return lastAction === useCombobox.stateChangeTypes.InputKeyDownEnter;
@@ -217,20 +216,8 @@ export const SearchInput = <SuggestionItem,>({
     // @ts-ignore
     items: hasOptionGroups ? menuOptionProps.optionGroups.flatMap((group) => group.options) : suggestions,
     onStateChange(props) {
-      const {
-        ItemClick,
-        FunctionReset,
-        InputKeyDownEnter,
-        InputKeyDownArrowUp,
-        InputKeyDownArrowDown,
-      } = useCombobox.stateChangeTypes;
+      const { ItemClick, FunctionReset, InputKeyDownEnter } = useCombobox.stateChangeTypes;
       const handledChanges = [ItemClick, FunctionReset, InputKeyDownEnter] as UseComboboxStateChangeTypes[];
-      if (
-        (hasOptionGroups && props.type === InputKeyDownArrowUp && props.highlightedIndex === 0) ||
-        (props.type === InputKeyDownArrowDown && props.highlightedIndex === 0)
-      ) {
-        setScrollMenuTop(true);
-      }
       if (handledChanges.includes(props.type)) {
         // if props.type === ItemClick and the value of the clicked item matches
         // the value in the input element then props.inputValue does not exist.
@@ -296,16 +283,6 @@ export const SearchInput = <SuggestionItem,>({
       didMount.current = true;
     }
   }, [onChange, inputValue]);
-
-  /**
-   * Show also the first optionGroup label when the user navigates with arrow keys to the first option.
-   */
-  useEffect(() => {
-    if (hasOptionGroups && scrollMenuTop && menuRef.current) {
-      menuRef.current.scrollTo(0, 0);
-      setScrollMenuTop(false);
-    }
-  }, [hasOptionGroups, scrollMenuTop, menuRef]);
 
   return (
     <div className={classNames(styles.root, isOpen && styles.open, className)} style={style}>
@@ -385,6 +362,7 @@ export const SearchInput = <SuggestionItem,>({
               ),
             })
           }
+          highlightedIndex={highlightedIndex}
         />
       </div>
       {helperText && <div className={styles.helperText}>{helperText}</div>}

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -198,9 +198,11 @@ export const SearchInput = <SuggestionItem,>({
 
   const submitValue = (val?: string) => {
     const inputElementValue = inputRef.current?.value;
-    const valueToSubmit = val !== undefined ? val : inputElementValue;
-    onSubmit(valueToSubmit);
-    clearSuggestions();
+    const valueToSubmit = (val !== undefined ? val : inputElementValue).trim();
+    if (valueToSubmit.length > 0) {
+      onSubmit(valueToSubmit);
+      clearSuggestions();
+    }
   };
 
   const {
@@ -283,6 +285,15 @@ export const SearchInput = <SuggestionItem,>({
       didMount.current = true;
     }
   }, [onChange, inputValue]);
+
+  /**
+   * Reset the ComboBox if input value is empty and dropdown is open
+   */
+  useEffect(() => {
+    if (internalValue.length === 0 && isOpen) {
+      reset();
+    }
+  }, [internalValue, isOpen]);
 
   return (
     <div className={classNames(styles.root, isOpen && styles.open, className)} style={style}>

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -290,10 +290,10 @@ export const SearchInput = <SuggestionItem,>({
    * Reset the ComboBox if input value is empty and dropdown is open
    */
   useEffect(() => {
-    if (internalValue.length === 0 && isOpen) {
+    if (!isControlledComponent && internalValue.length === 0 && isOpen) {
       reset();
     }
-  }, [internalValue, isOpen]);
+  }, [isControlledComponent, internalValue, isOpen]);
 
   return (
     <div className={classNames(styles.root, isOpen && styles.open, className)} style={style}>

--- a/packages/react/src/internal/dropdownMenu/DropdownMenu.tsx
+++ b/packages/react/src/internal/dropdownMenu/DropdownMenu.tsx
@@ -215,63 +215,65 @@ export const DropdownMenu = <T,>({
 
   return (
     <ul {...menuProps} className={classNames(menuStyles.menu)}>
-      {open && sanitizedOptionGroups.length > 0 ? (
+      {open && (
         <>
-          {sanitizedOptionGroups.map((optionGroup, groupIndex) => {
-            return (
-              <li key={optionGroup.label} className={menuStyles.menuGroup}>
-                <div className={menuStyles.menuGroupLabel}>
-                  {optionGroup.icon && (
-                    <span className={menuStyles.menuGroupLabelIcon} aria-hidden="true">
-                      {optionGroup.icon}
-                    </span>
-                  )}
-                  {optionGroup.label}
-                </div>
-                <ul className={menuStyles.menuGroupOptions}>
-                  {optionGroup.options.length &&
-                    optionGroup.options.map((data, _index) => {
-                      groupIndexRef.current = groupIndex === 0 && _index === 0 ? 0 : groupIndexRef.current + 1;
-                      const elementIndex = groupIndexRef.current;
-                      const optionLabel = data[optionLabelField];
+          {sanitizedOptionGroups.length > 0 ? (
+            sanitizedOptionGroups.map((optionGroup, groupIndex) => {
+              return (
+                <li key={optionGroup.label} className={menuStyles.menuGroup}>
+                  <div className={menuStyles.menuGroupLabel}>
+                    {optionGroup.icon && (
+                      <span className={menuStyles.menuGroupLabelIcon} aria-hidden="true">
+                        {optionGroup.icon}
+                      </span>
+                    )}
+                    {optionGroup.label}
+                  </div>
+                  <ul className={menuStyles.menuGroupOptions}>
+                    {optionGroup.options.length &&
+                      optionGroup.options.map((data, _index) => {
+                        groupIndexRef.current = groupIndex === 0 && _index === 0 ? 0 : groupIndexRef.current + 1;
+                        const elementIndex = groupIndexRef.current;
+                        const optionLabel = data[optionLabelField];
 
-                      return (
-                        <ItemWrapper
-                          key={optionLabel}
-                          {...{
-                            elementIndex,
-                            optionLabel,
-                            // @ts-ignore
-                            options: optionGroups.flatMap((group) => group.options),
-                            data,
-                            ...commonItemProps,
-                          }}
-                        />
-                      );
-                    })}
-                </ul>
-              </li>
-            );
-          })}
-        </>
-      ) : (
-        <>
-          {isVirtualized && <li key="total-size" aria-hidden style={{ height: virtualizer.totalSize }} />}
-          {listOptions.map((data, _index) => {
-            const optionLabel = data[optionLabelField];
-            return (
-              <ItemWrapper
-                key={optionLabel}
-                {...{
-                  elementIndex: _index,
-                  optionLabel,
-                  data,
-                  options,
-                  ...commonItemProps,
-                }}
-              />
-            );
-          })}
+                        return (
+                          <ItemWrapper
+                            key={optionLabel}
+                            {...{
+                              elementIndex,
+                              optionLabel,
+                              // @ts-ignore
+                              options: optionGroups.flatMap((group) => group.options),
+                              data,
+                              ...commonItemProps,
+                            }}
+                          />
+                        );
+                      })}
+                  </ul>
+                </li>
+              );
+            })
+          ) : (
+            <>
+              {isVirtualized && <li key="total-size" aria-hidden style={{ height: virtualizer.totalSize }} />}
+              {listOptions.map((data, _index) => {
+                const optionLabel = data[optionLabelField];
+                return (
+                  <ItemWrapper
+                    key={optionLabel}
+                    {...{
+                      elementIndex: _index,
+                      optionLabel,
+                      data,
+                      options,
+                      ...commonItemProps,
+                    }}
+                  />
+                );
+              })}
+            </>
+          )}
         </>
       )}
     </ul>

--- a/packages/react/src/internal/dropdownMenu/DropdownMenu.tsx
+++ b/packages/react/src/internal/dropdownMenu/DropdownMenu.tsx
@@ -128,6 +128,10 @@ type DropdownMenuProps<T> = {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   getItemProps(item: T, index: number, selected: boolean, disabled: boolean, virtualItem: VirtualItem | null): any;
   /**
+   * Index of the highlighted item
+   */
+  highlightedIndex: number;
+  /**
    * String to be highlighted in a item
    */
   highlightValue?: string;
@@ -153,6 +157,10 @@ type DropdownMenuProps<T> = {
    */
   open: boolean;
   /**
+   * Array of optionGroups with label String and Options. Used instead of options. Prints label before each group in list.
+   */
+  optionGroups?: OptionGroup<T>[];
+  /**
    * Data item field that represents the item label
    */
   optionLabelField: string;
@@ -160,10 +168,6 @@ type DropdownMenuProps<T> = {
    * Array of options that should be shown in the menu
    */
   options: T[];
-  /**
-   * Array of optionGroups with label String and Options. Used instead of options. Prints label before each group in list.
-   */
-  optionGroups?: OptionGroup<T>[];
   /**
    * Currently selected item
    */
@@ -183,15 +187,16 @@ type DropdownMenuProps<T> = {
 
 export const DropdownMenu = <T,>({
   getItemProps,
+  highlightedIndex,
   highlightValue,
   isOptionDisabled,
   menuProps,
   menuStyles,
   multiselect,
   open,
+  optionGroups,
   optionLabelField,
   options,
-  optionGroups,
   selectedItem,
   selectedItems,
   virtualizer,
@@ -200,18 +205,26 @@ export const DropdownMenu = <T,>({
   const listOptions: (VirtualItem | T)[] = isVirtualized ? virtualizer.virtualItems : options;
   const groupIndexRef = useRef<number>(0);
   const sanitizedOptionGroups = optionGroups ? optionGroups.filter((group) => group.options.length > 0) : [];
+  const firstOptionGroupContainerRef = useRef(null);
 
   const commonItemProps = {
-    isVirtualized,
-    optionLabelField,
-    multiselect,
-    selectedItems,
-    selectedItem,
-    isOptionDisabled,
     getItemProps,
+    highlightedIndex,
     highlightValue,
+    isOptionDisabled,
+    isVirtualized,
     menuStyles,
+    multiselect,
+    optionLabelField,
+    selectedItem,
+    selectedItems,
   };
+
+  React.useEffect(() => {
+    if (open && highlightedIndex === 0 && firstOptionGroupContainerRef.current) {
+      firstOptionGroupContainerRef.current.scrollIntoView();
+    }
+  }, [open, highlightedIndex]);
 
   return (
     <ul {...menuProps} className={classNames(menuStyles.menu)}>
@@ -220,7 +233,11 @@ export const DropdownMenu = <T,>({
           {sanitizedOptionGroups.length > 0 ? (
             sanitizedOptionGroups.map((optionGroup, groupIndex) => {
               return (
-                <li key={optionGroup.label} className={menuStyles.menuGroup}>
+                <li
+                  key={optionGroup.label}
+                  className={menuStyles.menuGroup}
+                  ref={groupIndex === 0 ? firstOptionGroupContainerRef : null}
+                >
                   <div className={menuStyles.menuGroupLabel}>
                     {optionGroup.icon && (
                       <span className={menuStyles.menuGroupLabelIcon} aria-hidden="true">


### PR DESCRIPTION
## Description
- Add support for option groups in internal DropdownMenu component
- Add search history support for Search Component

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-530

## Motivation and Context
- The lib users can provide better and faster searching for end users when search history can be added among suggestions

## How Has This Been Tested?
- Locally on dev machine 

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-530-search-history/?path=/story/components-searchinput--with-history-and-suggestions)