### PR TITLE
HDS-1637: Add new troubleshooting item into site README

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -74,3 +74,8 @@ PATH_PREFIX='/hds-demo/docsite-fixes' yarn build -- --prefix-paths
 ## Troubleshooting
 - **Site build fails with error #11903 COMPILATION or something similar**. Gatsby's cache might not be in sync with the source files due to a checkout (chancing branches, etc.)  
   **Solution:** Run `$(npm bin)/gatsby clean` or manually remove .cache folder to clean up cache files. Then try to run the build again.
+
+- **Development: A new local component is not available when trying to import from the hds-react in the site**:
+  - Review that all component exports exist in hds-react package
+  - Remove old build folders from package-folders
+  - Run ```bash yarn build``` in the root folder of the repository. This will build the local libraries into root node_modules as installed libraries.

--- a/site/README.md
+++ b/site/README.md
@@ -76,6 +76,6 @@ PATH_PREFIX='/hds-demo/docsite-fixes' yarn build -- --prefix-paths
   **Solution:** Run `$(npm bin)/gatsby clean` or manually remove .cache folder to clean up cache files. Then try to run the build again.
 
 - **Development: A new local component is not available when trying to import from the hds-react in the site**:
-  1. Review that all component exports exist in hds-react package
+  1. Review that all component exports exist in hds-react package. Check the hds-react [DEVELOPMENT.md](../packages/react/DEVELOPMENT.md) for more information.
   2. Remove old build folders from package-folders
   3. Run ```bash yarn build``` in the root folder of the repository. This will build the local libraries into root node_modules as installed libraries.

--- a/site/README.md
+++ b/site/README.md
@@ -76,6 +76,6 @@ PATH_PREFIX='/hds-demo/docsite-fixes' yarn build -- --prefix-paths
   **Solution:** Run `$(npm bin)/gatsby clean` or manually remove .cache folder to clean up cache files. Then try to run the build again.
 
 - **Development: A new local component is not available when trying to import from the hds-react in the site**:
-  - Review that all component exports exist in hds-react package
-  - Remove old build folders from package-folders
-  - Run ```bash yarn build``` in the root folder of the repository. This will build the local libraries into root node_modules as installed libraries.
+  1. Review that all component exports exist in hds-react package
+  2. Remove old build folders from package-folders
+  3. Run ```bash yarn build``` in the root folder of the repository. This will build the local libraries into root node_modules as installed libraries.


### PR DESCRIPTION
## Description
- Add new troubleshooting item into the documentation site README

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1637

## Motivation and Context
- Better repository documentation makes it easier to develop HDS which saves time and therefore 💰 
