### PR TITLE
Fix dialog for react 18 users

### DIFF
--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -177,7 +177,7 @@ export const Dialog = ({
         });
       };
     }
-    return null;
+    return undefined;
   }, [dialogRef, isOpen]);
 
   const { 'aria-labelledby': ariaLabelledby, 'aria-describedby': ariaDescribedby } = props;


### PR DESCRIPTION
Dialog crashed when opened with react 18. I guess react 18 does not like that useEffect returns null, so changed it to undefined which fixes the issue.