### PR TITLE
Hds 1576 rectangular tag and footer deprecation

### DIFF
--- a/packages/core/src/components/tag/tag.css
+++ b/packages/core/src/components/tag/tag.css
@@ -48,7 +48,7 @@
   padding-left:  var(--tag-padding);
 }
 
-.hds-tag--rounded-corners > button {
+.hds-tag--rounded-corners .hds-tag__delete-button {
   padding-right: calc(var(--tag-padding) / 2);
 }
 

--- a/packages/react/src/components/tag/Tag.module.scss
+++ b/packages/react/src/components/tag/Tag.module.scss
@@ -22,6 +22,8 @@
 .deleteButton {
   @extend %buttonReset;
   @extend %deleteButton;
+
+  composes: hds-tag__delete-button from 'hds-core/lib/components/tag/tag.css';
 }
 
 .visuallyHidden {

--- a/packages/react/src/components/tag/Tag.tsx
+++ b/packages/react/src/components/tag/Tag.tsx
@@ -69,6 +69,9 @@ export type TagProps = {
 const ROUNDED_CORNERS_CLASS_NAME = 'tag-rounded-corners';
 const ROUNDED_CORNERS_LARGE_CLASS_NAME = 'tag-rounded-corners-large';
 
+/**
+ * The RoundedTag component will replace Tag component in the next major release.
+ */
 export const Tag = forwardRef<HTMLDivElement, TagProps>(
   (
     {
@@ -132,10 +135,18 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>(
   },
 );
 
+/**
+ * RoundedTag will be removed in the next major release and replace Tag component. This means the Tag component will have rounded corners by default.
+ * @deprecated
+ */
 export const RoundedTag = forwardRef<HTMLDivElement, TagProps>(({ className = '', ...props }, ref) => (
   <Tag className={classNames(styles[ROUNDED_CORNERS_CLASS_NAME], className)} {...props} ref={ref} />
 ));
 
+/**
+ * LargeRoundedTag will be removed in the next major release. It will be supported via the default Tag component with the size property.
+ * @deprecated
+ */
 export const LargeRoundedTag = forwardRef<HTMLDivElement, TagProps>(({ className = '', ...props }, ref) => (
   <Tag
     className={classNames(styles[ROUNDED_CORNERS_LARGE_CLASS_NAME], styles[ROUNDED_CORNERS_CLASS_NAME], className)}

--- a/site/src/docs/components/footer/tabs.mdx
+++ b/site/src/docs/components/footer/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # Footer
 
-<StatusLabel variant="rounded" type="alert">Beta</StatusLabel>
+<StatusLabel variant="rounded" type="alert">Draft</StatusLabel>
 <StatusLabel variant="rounded" type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>
@@ -20,8 +20,8 @@ import PageTabs from '../../../components/PageTabs';
   The Footer component is located at the bottom of the page below the main body content. It provides a place for secondary navigation, site-wide actions, and additional information.
 </LeadParagraph>
 
-<Notification label="A visual rework is coming soon!" className="siteNotification">
-  The HDS team will be unifying the Footer component with the Hel.fi project footer in the near future.
+<Notification label="Breaking change" className="siteNotification" type="alert">
+  The Footer component's look and use will be renewed in the next major release in order to have a unified look with Hel.fi.
 </Notification>
 
 <PageTabs pageContext={props.pageContext}>

--- a/site/src/docs/components/tag/index.mdx
+++ b/site/src/docs/components/tag/index.mdx
@@ -4,7 +4,7 @@ title: 'Tag'
 navTitle: 'Tag'
 ---
 
-import { Tag, RoundedTag as RoundedTagComponent, LargeRoundedTag  } from 'hds-react';
+import { Tag, RoundedTag as RoundedTagComponent, LargeRoundedTag, StatusLabel  } from 'hds-react';
 import PlaygroundPreview from '../../../components/Playground';
 import TabsLayout from './tabs.mdx';
 import InternalLink from '../../../components/InternalLink';
@@ -27,6 +27,8 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 - Unlike status labels, **tags can be configured to be clickable and deletable**. You can use this feature to create removable filters/selections or links to category filtered pages.
 
 ### Rectangular variations
+
+<StatusLabel variant="rounded" type="alert">Deprecated</StatusLabel>
 
 #### Default
 By default, Tags are non-interactable elements. They only include a label and do not have any specific styling.

--- a/site/src/docs/components/tag/tabs.mdx
+++ b/site/src/docs/components/tag/tabs.mdx
@@ -20,8 +20,8 @@ import PageTabs from '../../../components/PageTabs';
   Tags are used to show attributes of an object or element such as categories. HDS also uses Tags to present filters selected for searches.
 </LeadParagraph>
 
-<Notification label="New tag variants added" className="siteNotification">
-  The HDS team has added rounded corner variants to the Tag component. The rectangular Tag variants are stable and still supported but may become obsolete in the future.
+<Notification label="Breaking change" className="siteNotification" type="alert">
+  The default rectangular tags are deprecated. The rounded cornered variant will replace the default rectangular Tag in the next major release. As a result the RoundedTag and LargeRoundedTag components will be removed and supported within the default Tag component.
 </Notification>
 
 <PageTabs pageContext={props.pageContext}>


### PR DESCRIPTION
## Description

Mark rectangular Tag as deprecated in code and doc site.

I set RoundedTag and LargeRoundedTags as deprecated because the Tag will be rounded by default and the large size can be handled with `size` prop.

**Bonus:** I changed the Footer component's doc site notification to alert and reworded it about upcoming breaking changes.  

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1576

## Motivation and Context

It's good to notify users beforehand of upcoming breaking changes so they can mull things over and adapt.

## How Has This Been Tested?
Doc site on localhost, testing the components' use in hds-cra
[Demo](https://city-of-helsinki.github.io/hds-demo/tag-deprecate/components/tag)

**How the RoundedTag looks to users:**
![Screenshot 2023-03-15 at 14 12 47](https://user-images.githubusercontent.com/108321134/225305719-2de8a64f-5702-41e8-ae61-767a16a37a70.png)

**How the default Tag looks to users**.
![Screenshot 2023-03-15 at 14 13 58](https://user-images.githubusercontent.com/108321134/225306170-cd127b9c-0516-4291-a7ca-b4ea3b632dfd.png)
