### PR TITLE
HDS-1642 Merge queue

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,6 +2,7 @@ name: development
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,9 +3,6 @@ name: development
 on:
   pull_request:
   merge_group:
-    branches:
-      - master
-      - hds-1642-merge-queue
   push:
     branches:
       - master

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,6 +3,9 @@ name: development
 on:
   pull_request:
   merge_group:
+    branches:
+      - master
+      - hds-1642-merge-queue
   push:
     branches:
       - master

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Development environment
 
-> Helsinki Önkkötönkkö Design System uses [**Lerna**](https://lerna.js.org/) for running scripts across the repo as well as versioning and creating releases of the packages. [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/) is used to manage dependencies. This allows the separate packages to reference each other via symlinks during local development.
+> Helsinki Design System uses [**Lerna**](https://lerna.js.org/) for running scripts across the repo as well as versioning and creating releases of the packages. [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/) is used to manage dependencies. This allows the separate packages to reference each other via symlinks during local development.
 
 ### Prerequisites
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Development environment
 
-> Helsinki Yntsynts Design System uses [**Lerna**](https://lerna.js.org/) for running scripts across the repo as well as versioning and creating releases of the packages. [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/) is used to manage dependencies. This allows the separate packages to reference each other via symlinks during local development.
+> Helsinki Design System uses [**Lerna**](https://lerna.js.org/) for running scripts across the repo as well as versioning and creating releases of the packages. [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/) is used to manage dependencies. This allows the separate packages to reference each other via symlinks during local development.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Description

Use the merge groups event to trigger GitHub Actions when a pull request is added to a merge queue to master branch. 

### How merge queue works
You press Merge when ready button and when you want to merge, press Confirm when ready button. Then the PR goes to the queue and is quite quickly merged and the workflows start to run. If another PR is sent to the queue, it will merge on its turn or if there are conflicts, it's removed from queue and the conflict must be resolved. The PR owner is informed about this. [Here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue#adding-a-pull-request-to-a-merge-queue) is Github's guide about this with pictures.

❗ Note that merge queue doesn't run tests until it's merging to protected branch! But it might be possible later if Github develops this feature further that tests could be ran on temp branch where merge queued PRs are built.

### What's next
If we approve this change, the merge queue should be put on from master branch settings.

Information about merge queues [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1642

## Motivation and Context
Test to see if it speeds up release process.

## How Has This Been Tested?
Tested by merging branches to this one (with merge queue on).
