### PR TITLE
HDS-1611 Improve Stepper's a11y docs

### DIFF
--- a/packages/react/src/components/stepper/Stepper.tsx
+++ b/packages/react/src/components/stepper/Stepper.tsx
@@ -90,7 +90,7 @@ export type StepperProps = {
    */
   renderCustomStepHeading?: (stepIndex: number, totalNumberOfSteps: number, label: string) => string;
   /**
-   * The index of the selected step
+   * The index of the selected step. Used to set the aria-current="step" attribute to the active step
    */
   selectedStep?: number;
   /**

--- a/site/src/docs/components/stepper/accessibility.mdx
+++ b/site/src/docs/components/stepper/accessibility.mdx
@@ -18,3 +18,4 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 - Each form step should have a heading element of the correct level. It is recommended to use `stepHeading` property to render the heading automatically.
   - If you render the step heading separately, make sure the focus is moved to that heading when the user is moving between steps. This has been taken care of for you if you use the `stepHeading` variant.
   - You can control the aria level of the heading with the `stepHeadingAriaLevel` property.
+- The component adds the `aria-current="step"` attribute to the active step automatically when the `selectedStep` prop is provided and it matches the currently active step's index. 


### PR DESCRIPTION
## Description

Add information about `aria-current="step"` attribute to Stepper documentation site and component props.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1611

## Motivation and Context

There was no information about the a11y attribute which was confusing for users and we got questions about it.

## How Has This Been Tested?
Locally on Mac