### PR TITLE
HDS-1593 Deprecation warnings for Navigation

### DIFF
--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -168,6 +168,10 @@ const HeaderWrapper = ({ children, logoLanguage, onTitleClick, title, titleAriaL
   );
 };
 
+/**
+ * Navigation will be removed in the next major release. Upcoming Header component will be the replacement.
+ * @deprecated
+ */
 export const Navigation = ({
   children,
   className,

--- a/packages/react/src/components/navigation/navigationActions/NavigationActions.tsx
+++ b/packages/react/src/components/navigation/navigationActions/NavigationActions.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 import styles from './NavigationActions.module.scss';
 
+/**
+ * NavigationActions will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationActions = ({ children }: React.PropsWithChildren<Record<string, unknown>>) => (
   <div className={styles.navigationActions}>{children}</div>
 );

--- a/packages/react/src/components/navigation/navigationDropdown/NavigationDropdown.tsx
+++ b/packages/react/src/components/navigation/navigationDropdown/NavigationDropdown.tsx
@@ -9,6 +9,10 @@ export type NavigationDropdownProps = MenuButtonProps & {
   active?: boolean;
 };
 
+/**
+ * NavigationDropdown will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationDropdown = ({ label, children, ...rest }: NavigationDropdownProps) => (
   <MenuButton label={label} {...rest}>
     {children}

--- a/packages/react/src/components/navigation/navigationDropdownLink/NavigationDropdownLink.tsx
+++ b/packages/react/src/components/navigation/navigationDropdownLink/NavigationDropdownLink.tsx
@@ -26,6 +26,10 @@ export type NavigationDropdownLinkProps = MenuButtonProps & {
   id?: string;
 };
 
+/**
+ * NavigationDropdownLink will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationDropdownLink = ({
   label,
   href,

--- a/packages/react/src/components/navigation/navigationItem/NavigationItem.tsx
+++ b/packages/react/src/components/navigation/navigationItem/NavigationItem.tsx
@@ -36,6 +36,10 @@ export type NavigationItemProps<Element extends React.ElementType = 'a'> = {
   as?: Element;
 } & MergeElementProps<Element, ItemProps | SupplementaryItemProps>;
 
+/**
+ * NavigationItem will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationItem = <T extends React.ElementType = 'a'>({
   active,
   as,

--- a/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
+++ b/packages/react/src/components/navigation/navigationLanguageSelector/NavigationLanguageSelector.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import styles from './NavigationLanguageSelector.module.scss';
 import { MenuButton, MenuButtonProps } from '../../../internal/menuButton/MenuButton';
 
+/**
+ * NavigationLanguageSelector will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationLanguageSelector = ({ children, id = 'languageSelector', label, ...rest }: MenuButtonProps) => {
   React.useEffect(() => {
     React.Children.forEach(children, (child: React.ReactElement) => {

--- a/packages/react/src/components/navigation/navigationRow/NavigationRow.tsx
+++ b/packages/react/src/components/navigation/navigationRow/NavigationRow.tsx
@@ -23,6 +23,10 @@ export type NavigationRowProps = React.PropsWithChildren<{
   ariaLabel?: string;
 }>;
 
+/**
+ * NavigationRow will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationRow = ({ variant = 'default', ariaLabel, children }: NavigationRowProps) => {
   const { setNavigationVariant } = useContext(NavigationContext);
 

--- a/packages/react/src/components/navigation/navigationSearch/NavigationSearch.tsx
+++ b/packages/react/src/components/navigation/navigationSearch/NavigationSearch.tsx
@@ -42,6 +42,10 @@ export type NavigationSearchProps = {
   searchPlaceholder?: string;
 };
 
+/**
+ * NavigationSearch will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationSearch = ({
   onBlur = () => null,
   onFocus = () => null,

--- a/packages/react/src/components/navigation/navigationUser/NavigationUser.tsx
+++ b/packages/react/src/components/navigation/navigationUser/NavigationUser.tsx
@@ -26,6 +26,10 @@ export type NavigationUserProps = MenuButtonProps & {
   userName?: React.ReactNode;
 };
 
+/**
+ * NavigationUser will be removed in the next major release. Upcoming Header component will provide the replacement component.
+ * @deprecated
+ */
 export const NavigationUser = ({
   authenticated = false,
   children,

--- a/site/src/docs/components/navigation/tabs.mdx
+++ b/site/src/docs/components/navigation/tabs.mdx
@@ -11,7 +11,7 @@ import PageTabs from '../../../components/PageTabs';
 
 # Navigation
 
-<StatusLabel variant="rounded" type="alert">Beta</StatusLabel>
+<StatusLabel variant="rounded">Deprecated</StatusLabel>
 <StatusLabel variant="rounded" type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
   Accessible
 </StatusLabel>
@@ -20,8 +20,8 @@ import PageTabs from '../../../components/PageTabs';
   A navigation component is the main way for users to navigate and locate themselves when using a service. It includes some key features present in most services to keep user experience consistent between them.
 </LeadParagraph>
 
-<Notification label="A visual rework is coming soon!" className="siteNotification">
-  The HDS team will be unifying the Navigation component with the Hel.fi project navigation in the near future.
+<Notification label="Deprecated" className="siteNotification" type="alert">
+  The Navigation component and all of its subcomponents are deprecated and will be removed in the next major release. Upcoming Header component will provide all the existing functionalities with a new look to match hel.fi designs.
 </Notification>
 
 <PageTabs pageContext={props.pageContext}>


### PR DESCRIPTION
## Description

Declare Navigation and all of its subcomponents as deprecated and that they will be removed in the next major release. 

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1593

## Motivation and Context

It's good to give the users a heads up about deprecating components.

## How Has This Been Tested?
Locally on Mac
[Demo](https://city-of-helsinki.github.io/hds-demo/deprecate-navigation)

## Screenshots
How the components look in VSCode
![Screenshot 2023-03-20 at 14 00 34](https://user-images.githubusercontent.com/108321134/226338371-9e9dc704-f5c3-49e5-b80e-816b402291d1.png)

