### PR TITLE
[WIP] HDS-1630 Header replace React.Children API

### DIFF
--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -32,96 +32,104 @@ export const WithFullFeatures = (args) => (
   <>
     <StoryWIPAlert />
     <Header {...args}>
-      <Header.UniversalBar primaryLinkText="Helsingin kaupunki" primaryLinkHref="#">
-        <Header.NavigationLink href="#" label="Link 1" />
-        <Header.NavigationLink href="#" label="Link 2" />
-        <Header.NavigationLink href="#" label="Link 3" />
-      </Header.UniversalBar>
-      <Header.NavigationMenu>
-        <Header.NavigationLink
-          href="#"
-          label="Link 1"
-          onClick={(event) => event.preventDefault()}
-          active
-          dropdownLinks={[
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              active
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-          ]}
-        />
-        <Header.NavigationLink
-          href="#"
-          label="Link 2"
-          dropdownLinks={[
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              active
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-          ]}
-        />
-        <Header.NavigationLink href="#" label="Link 3" />
-        <Header.NavigationLink href="#" label="Link 3" />
-        <Header.NavigationLink href="#" label="Link 3" />
-        <Header.NavigationLink
-          href="#"
-          label="Link 2"
-          dropdownLinks={[
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              active
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-          ]}
-        />
-      </Header.NavigationMenu>
+      <Header.UniversalBar
+        primaryLinkText="Helsingin kaupunki"
+        primaryLinkHref="#"
+        items={[
+          [
+            <Header.NavigationLink href="#" label="Link 1" />,
+            <Header.NavigationLink href="#" label="Link 2" />,
+            <Header.NavigationLink href="#" label="Link 3" />,
+          ],
+        ]}
+      />
+      <Header.NavigationMenu
+        items={[
+          <Header.NavigationLink
+            href="#"
+            label="Link 1"
+            onClick={(event) => event.preventDefault()}
+            active
+            dropdownLinks={[
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                active
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+            ]}
+          />,
+          <Header.NavigationLink
+            href="#"
+            label="Link 2"
+            dropdownLinks={[
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                active
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+            ]}
+          />,
+          <Header.NavigationLink href="#" label="Link 3" />,
+          <Header.NavigationLink href="#" label="Link 3" />,
+          <Header.NavigationLink href="#" label="Link 3" />,
+          <Header.NavigationLink
+            href="#"
+            label="Link 2"
+            dropdownLinks={[
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                active
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+            ]}
+          />,
+        ]}
+      />
     </Header>
   </>
 );
@@ -130,11 +138,15 @@ export const WithUniversalBar = (args) => (
   <>
     <StoryWIPAlert />
     <Header {...args}>
-      <Header.UniversalBar primaryLinkText="Helsingin kaupunki" primaryLinkHref="#">
-        <Header.NavigationLink href="#" label="Link 1" />
-        <Header.NavigationLink href="#" label="Link 2" />
-        <Header.NavigationLink href="#" label="Link 3" />
-      </Header.UniversalBar>
+      <Header.UniversalBar
+        primaryLinkText="Helsingin kaupunki"
+        primaryLinkHref="#"
+        items={[
+          <Header.NavigationLink href="#" label="Link 1" />,
+          <Header.NavigationLink href="#" label="Link 2" />,
+          <Header.NavigationLink href="#" label="Link 3" />,
+        ]}
+      />
     </Header>
   </>
 );
@@ -143,63 +155,65 @@ export const WithNavigationMenu = (args) => (
   <>
     <StoryWIPAlert />
     <Header {...args}>
-      <Header.NavigationMenu>
-        <Header.NavigationLink
-          href="#"
-          label="Link 1"
-          onClick={(event) => event.preventDefault()}
-          active
-          dropdownLinks={[
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              active
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-          ]}
-        />
-        <Header.NavigationLink
-          href="#"
-          label="Link 2"
-          dropdownLinks={[
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              active
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-            <Header.NavigationLink
-              href="#"
-              label="Test"
-              dropdownDirection={DropdownDirection.Dynamic}
-              dropdownLinks={[
-                <Header.NavigationLink href="#" label="Nested" />,
-                <Header.NavigationLink href="#" label="Nested" />,
-              ]}
-            />,
-          ]}
-        />
-        <Header.NavigationLink href="#" label="Link 3" />
-      </Header.NavigationMenu>
+      <Header.NavigationMenu
+        items={[
+          <Header.NavigationLink
+            href="#"
+            label="Link 1"
+            onClick={(event) => event.preventDefault()}
+            active
+            dropdownLinks={[
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                active
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+            ]}
+          />,
+          <Header.NavigationLink
+            href="#"
+            label="Link 2"
+            dropdownLinks={[
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                active
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+              <Header.NavigationLink
+                href="#"
+                label="Test"
+                dropdownDirection={DropdownDirection.Dynamic}
+                dropdownLinks={[
+                  <Header.NavigationLink href="#" label="Nested" />,
+                  <Header.NavigationLink href="#" label="Nested" />,
+                ]}
+              />,
+            ]}
+          />,
+          <Header.NavigationLink href="#" label="Link 3" />,
+        ]}
+      />
     </Header>
   </>
 );

--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -36,11 +36,9 @@ export const WithFullFeatures = (args) => (
         primaryLinkText="Helsingin kaupunki"
         primaryLinkHref="#"
         items={[
-          [
-            <Header.NavigationLink href="#" label="Link 1" />,
-            <Header.NavigationLink href="#" label="Link 2" />,
-            <Header.NavigationLink href="#" label="Link 3" />,
-          ],
+          <Header.NavigationLink href="#" label="Link 1" />,
+          <Header.NavigationLink href="#" label="Link 2" />,
+          <Header.NavigationLink href="#" label="Link 3" />,
         ]}
       />
       <Header.NavigationMenu

--- a/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
@@ -1,61 +1,61 @@
-import React, { Children, cloneElement, useContext, useState } from 'react';
+import React, { cloneElement, useContext, useState } from 'react';
 
 // import core base styles
 import 'hds-core';
 import styles from './HeaderNavigationMenu.module.scss';
 import { HeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
-import { getChildElementsEvenIfContainerInbetween } from '../../../../utils/getChildren';
 import { HeaderNavigationMenuContext, HeaderNavigationMenuContextProps } from './HeaderNavigationMenuContext';
 
-export type HeaderNavigationMenuProps = React.PropsWithChildren<{
+export type HeaderNavigationMenuProps = {
   /**
    * aria-label for describing universal bar.
    */
   ariaLabel?: string;
   /**
-   * Children are expected to be NavigationLink components or a container with NavigationLink components inside.
+   * Items are expected to be NavigationLink components.
    */
-  children?: React.ReactNode;
+  items?: React.ReactNode[];
   /**
    * ID of the header element.
    */
   id?: string;
-}>;
+};
 
-export const HeaderNavigationMenu = ({ ariaLabel, children, id }: HeaderNavigationMenuProps) => {
+export const HeaderNavigationMenu = ({ ariaLabel, items, id }: HeaderNavigationMenuProps) => {
   const { isMediumScreen } = useContext(HeaderContext);
   const [openIndex, setOpenIndex] = useState<number>(-1);
   /* On medium screen return null for now. Later when ActionBar's first version is done,
   we could see if this component with its contents (altered for medium screens) could be 
   sent to HeaderContext and used in ActionBar? */
   if (isMediumScreen) return null;
-  const childElements = getChildElementsEvenIfContainerInbetween(children);
+
   const context: HeaderNavigationMenuContextProps = { openMainNavIndex: openIndex, setOpenMainNavIndex: setOpenIndex };
 
   return (
     <nav role="navigation" aria-label={ariaLabel} id={id} className={styles.headerNavigationMenu}>
       <ul className={styles.headerNavigationMenuList}>
         <HeaderNavigationMenuContext.Provider value={context}>
-          {Children.map(childElements, (child, index) => {
-            if (React.isValidElement(child)) {
-              const linkContainerClasses = child.props.active
-                ? classNames(styles.headerNavigationMenuLinkContent, styles.headerNavigationMenuLinkContentActive)
-                : styles.headerNavigationMenuLinkContent;
-              return (
-                // eslint-disable-next-line react/no-array-index-key
-                <li key={index} className={styles.headerNavigationMenuLinkContainer}>
-                  <span className={linkContainerClasses}>
-                    {cloneElement(child as React.ReactElement, {
-                      className: classNames(child.props.className, styles.headerNavigationMenuLink),
-                      index,
-                    })}
-                  </span>
-                </li>
-              );
-            }
-            return null;
-          })}
+          {items &&
+            items.map((child, index) => {
+              if (React.isValidElement(child)) {
+                const linkContainerClasses = child.props.active
+                  ? classNames(styles.headerNavigationMenuLinkContent, styles.headerNavigationMenuLinkContentActive)
+                  : styles.headerNavigationMenuLinkContent;
+                return (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <li key={index} className={styles.headerNavigationMenuLinkContainer}>
+                    <span className={linkContainerClasses}>
+                      {cloneElement(child as React.ReactElement, {
+                        className: classNames(child.props.className, styles.headerNavigationMenuLink),
+                        index,
+                      })}
+                    </span>
+                  </li>
+                );
+              }
+              return null;
+            })}
         </HeaderNavigationMenuContext.Provider>
       </ul>
     </nav>

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement, useContext } from 'react';
+import React, { cloneElement, useContext } from 'react';
 
 // import core base styles
 import 'hds-core';
@@ -6,9 +6,8 @@ import styles from './HeaderUniversalBar.module.scss';
 import { NavigationLink } from '../navigationLink';
 import { HeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
-import { getChildElementsEvenIfContainerInbetween } from '../../../../utils/getChildren';
 
-export type HeaderUniversalBarProps = React.PropsWithChildren<{
+export type HeaderUniversalBarProps = {
   /**
    * aria-label for describing universal bar.
    */
@@ -18,9 +17,9 @@ export type HeaderUniversalBarProps = React.PropsWithChildren<{
    */
   className?: string;
   /**
-   * Children are expected to be NavigationLink components or a container with NavigationLink components inside.
+   * Items are expected to be NavigationLink components.
    */
-  children?: React.ReactNode;
+  items?: React.ReactNode[];
   /**
    * ID of the header element.
    */
@@ -35,18 +34,17 @@ export type HeaderUniversalBarProps = React.PropsWithChildren<{
    * @default 'Helsingin kaupunki'
    */
   primaryLinkText?: string;
-}>;
+};
 
 export const HeaderUniversalBar = ({
   ariaLabel,
-  children,
+  items,
   id,
   primaryLinkHref,
   primaryLinkText,
 }: HeaderUniversalBarProps) => {
   const { isSmallScreen } = useContext(HeaderContext);
   if (isSmallScreen) return null;
-  const childElements = getChildElementsEvenIfContainerInbetween(children);
 
   return (
     <nav role="navigation" aria-label={ariaLabel} id={id} className={styles.headerUniversalBar}>
@@ -54,19 +52,20 @@ export const HeaderUniversalBar = ({
         <li className={styles.universalBarMainLinkContainer}>
           <NavigationLink href={primaryLinkHref} label={primaryLinkText} className={styles.universalBarLink} />
         </li>
-        {Children.map(childElements, (child, index) => {
-          if (React.isValidElement(child)) {
-            return (
-              // eslint-disable-next-line react/no-array-index-key
-              <li key={`secondary-link-${index}`} className={styles.universalBarSecondaryLinkContainer}>
-                {cloneElement(child as React.ReactElement, {
-                  className: classNames(child.props.className, styles.universalBarLink),
-                })}
-              </li>
-            );
-          }
-          return null;
-        })}
+        {items &&
+          items.map((child, index) => {
+            if (React.isValidElement(child)) {
+              return (
+                // eslint-disable-next-line react/no-array-index-key
+                <li key={`secondary-link-${index}`} className={styles.universalBarSecondaryLinkContainer}>
+                  {cloneElement(child as React.ReactElement, {
+                    className: classNames(child.props.className, styles.universalBarLink),
+                  })}
+                </li>
+              );
+            }
+            return null;
+          })}
       </ul>
     </nav>
   );

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.test.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.test.tsx
@@ -19,9 +19,11 @@ describe('<NavigationLink /> spec', () => {
   });
 
   it('should open dropdown when the button is clicked', async () => {
-    render(<NavigationLink href="#" label="Link" dropdownLinks={[<NavigationLink href="#" label="Test" />]} />, {
-      wrapper: HeaderNavigationMenuWrapper,
-    });
+    render(
+      HeaderNavigationMenuWrapper({
+        items: [<NavigationLink href="#" label="Link" dropdownLinks={[<NavigationLink href="#" label="Test" />]} />],
+      }),
+    );
 
     userEvent.click(screen.getByTestId('dropdown-button-0'));
     expect(screen.getByTestId('dropdown-menu-0')).toBeVisible();
@@ -29,11 +31,20 @@ describe('<NavigationLink /> spec', () => {
 
   it('should have only one main dropdown active', async () => {
     render(
-      <>
-        <NavigationLink href="#" label="Link 1" dropdownLinks={[<NavigationLink href="#" label="Link 1 nested" />]} />
-        <NavigationLink href="#" label="Link 2" dropdownLinks={[<NavigationLink href="#" label="Link 2 nested" />]} />
-      </>,
-      { wrapper: HeaderNavigationMenuWrapper },
+      HeaderNavigationMenuWrapper({
+        items: [
+          <NavigationLink
+            href="#"
+            label="Link 1"
+            dropdownLinks={[<NavigationLink href="#" label="Link 1 nested" />]}
+          />,
+          <NavigationLink
+            href="#"
+            label="Link 2"
+            dropdownLinks={[<NavigationLink href="#" label="Link 2 nested" />]}
+          />,
+        ],
+      }),
     );
 
     // Click the first main navigation link's dropdown button

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.test.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.test.tsx
@@ -19,33 +19,25 @@ describe('<NavigationLink /> spec', () => {
   });
 
   it('should open dropdown when the button is clicked', async () => {
-    render(
-      HeaderNavigationMenuWrapper({
-        items: [<NavigationLink href="#" label="Link" dropdownLinks={[<NavigationLink href="#" label="Test" />]} />],
-      }),
-    );
+    const wrapper = HeaderNavigationMenuWrapper({
+      items: [<NavigationLink href="#" label="Link" dropdownLinks={[<NavigationLink href="#" label="Test" />]} />],
+    });
+
+    render(wrapper);
 
     userEvent.click(screen.getByTestId('dropdown-button-0'));
     expect(screen.getByTestId('dropdown-menu-0')).toBeVisible();
   });
 
   it('should have only one main dropdown active', async () => {
-    render(
-      HeaderNavigationMenuWrapper({
-        items: [
-          <NavigationLink
-            href="#"
-            label="Link 1"
-            dropdownLinks={[<NavigationLink href="#" label="Link 1 nested" />]}
-          />,
-          <NavigationLink
-            href="#"
-            label="Link 2"
-            dropdownLinks={[<NavigationLink href="#" label="Link 2 nested" />]}
-          />,
-        ],
-      }),
-    );
+    const wrapper = HeaderNavigationMenuWrapper({
+      items: [
+        <NavigationLink href="#" label="Link 1" dropdownLinks={[<NavigationLink href="#" label="Link 1 nested" />]} />,
+        <NavigationLink href="#" label="Link 2" dropdownLinks={[<NavigationLink href="#" label="Link 2 nested" />]} />,
+      ],
+    });
+
+    render(wrapper);
 
     // Click the first main navigation link's dropdown button
     userEvent.click(screen.getByTestId('dropdown-button-0'));

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
@@ -177,13 +177,12 @@ export const NavigationLink = ({
           setOpen={handleDropdownOpen}
           index={index}
           dynamicPosition={dynamicPosition}
-        >
-          {React.Children.map(dropdownLinks, (child, childIndex) => {
-            return cloneElement(child as React.ReactElement, {
+          items={dropdownLinks.map((child, childIndex) =>
+            cloneElement(child as React.ReactElement, {
               key: childIndex,
-            });
-          })}
-        </NavigationLinkDropdown>
+            }),
+          )}
+        />
       )}
     </span>
   );

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -14,7 +14,8 @@ export enum DropdownMenuPosition {
   Left = 'left',
   Right = 'right',
 }
-export type NavigationLinkDropdownProps = React.PropsWithChildren<{
+
+export type NavigationLinkDropdownProps = {
   /**
    * Direction for dropdown position.
    * @default DropdownMenuPosition.Right
@@ -30,16 +31,20 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
    */
   open: boolean;
   /**
+   * Items are expected to be NavigationLink components.
+   */
+  items?: React.ReactNode[];
+  /**
    * Function that is called when open value is changed.
    */
   setOpen: (isOpen: boolean, interaction: NavigationLinkInteraction) => void;
-}>;
+};
 
 export const NavigationLinkDropdown = ({
-  children,
   dynamicPosition = DropdownMenuPosition.Right,
   index,
   open,
+  items,
   setOpen,
 }: NavigationLinkDropdownProps) => {
   // State for which nested dropdown link is open
@@ -68,23 +73,24 @@ export const NavigationLinkDropdown = ({
         data-testid={`dropdown-menu-${index}`}
         ref={ref}
       >
-        {React.Children.map(children, (child, childIndex) => {
-          return (
-            // eslint-disable-next-line react/no-array-index-key
-            <li key={index}>
-              {isValidElement(child)
-                ? cloneElement(child as React.ReactElement, {
-                    index: childIndex,
-                    openSubNavIndex,
-                    setOpenSubNavIndex,
-                    className: child.props.active
-                      ? classNames(styles.dropdownLink, styles.activeLink)
-                      : styles.dropdownLink,
-                  })
-                : child}
-            </li>
-          );
-        })}
+        {items &&
+          items.map((child, childIndex) => {
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={index}>
+                {isValidElement(child)
+                  ? cloneElement(child as React.ReactElement, {
+                      index: childIndex,
+                      openSubNavIndex,
+                      setOpenSubNavIndex,
+                      className: child.props.active
+                        ? classNames(styles.dropdownLink, styles.activeLink)
+                        : styles.dropdownLink,
+                    })
+                  : child}
+              </li>
+            );
+          })}
       </ul>
     </div>
   );

--- a/packages/react/src/utils/test-utils.tsx
+++ b/packages/react/src/utils/test-utils.tsx
@@ -15,8 +15,8 @@ export const FooterWrapper = ({ children }: PropsWithChildren<Record<string, unk
   <Footer title="Bar">{children}</Footer>
 );
 
-export const HeaderNavigationMenuWrapper = ({ children }: PropsWithChildren<Record<string, unknown>>) => (
+export const HeaderNavigationMenuWrapper = ({ items }: { items: React.ReactNode[] }) => (
   <Header>
-    <HeaderNavigationMenu>{children}</HeaderNavigationMenu>
+    <HeaderNavigationMenu items={items} />
   </Header>
 );


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Replace React.Children API in the new header components:
- HeaderNavigationMenu.tsx
- HeaderUniversalBar.tsx
- NavigationLink.tsx
- NavigationLinkDropdown.tsx

No visual changes.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1630](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1630)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Children API has been marked legacy, and will eventually be deprecated. Referring to alternatives in [React documentation](https://react.dev/reference/react/Children#alternatives), I concluded that passing array of object/component is the easiest solution and requires least refactoring.

## How Has This Been Tested?
- Tested on local machine
- Unit & visual testing

## Screenshots (if appropriate):


[HDS-1630]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ