### PR TITLE
HDS-1630 Header replace React.Children API

### DIFF
--- a/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
@@ -1,7 +1,5 @@
-import React, { Children, cloneElement, useContext, useState } from 'react';
+import React, { cloneElement, useContext, useState } from 'react';
 
-// import core base styles
-import 'hds-core';
 import styles from './HeaderNavigationMenu.module.scss';
 import { HeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
@@ -37,7 +35,7 @@ export const HeaderNavigationMenu = ({ ariaLabel, children, id }: HeaderNavigati
     <nav role="navigation" aria-label={ariaLabel} id={id} className={styles.headerNavigationMenu}>
       <ul className={styles.headerNavigationMenuList}>
         <HeaderNavigationMenuContext.Provider value={context}>
-          {Children.map(childElements, (child, index) => {
+          {childElements.map((child, index) => {
             if (React.isValidElement(child)) {
               const linkContainerClasses = child.props.active
                 ? classNames(styles.headerNavigationMenuLinkContent, styles.headerNavigationMenuLinkContentActive)

--- a/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
@@ -1,5 +1,7 @@
 import React, { cloneElement, useContext, useState } from 'react';
 
+// import core base styles
+import 'hds-core';
 import styles from './HeaderNavigationMenu.module.scss';
 import { HeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -1,5 +1,7 @@
 import React, { cloneElement, useContext } from 'react';
 
+// import core base styles
+import 'hds-core';
 import styles from './HeaderUniversalBar.module.scss';
 import { NavigationLink } from '../navigationLink';
 import { HeaderContext } from '../../HeaderContext';
@@ -25,10 +27,12 @@ export type HeaderUniversalBarProps = React.PropsWithChildren<{
   id?: string;
   /**
    * Hypertext reference of the primary link.
+   * @default 'https://hel.fi'
    */
-  primaryLinkHref: string;
+  primaryLinkHref?: string;
   /**
    * Link text for the primary link.
+   * @default 'Helsingin kaupunki'
    */
   primaryLinkText?: string;
 }>;

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -1,7 +1,5 @@
-import React, { Children, cloneElement, useContext } from 'react';
+import React, { cloneElement, useContext } from 'react';
 
-// import core base styles
-import 'hds-core';
 import styles from './HeaderUniversalBar.module.scss';
 import { NavigationLink } from '../navigationLink';
 import { HeaderContext } from '../../HeaderContext';
@@ -27,12 +25,10 @@ export type HeaderUniversalBarProps = React.PropsWithChildren<{
   id?: string;
   /**
    * Hypertext reference of the primary link.
-   * @default 'https://hel.fi'
    */
-  primaryLinkHref?: string;
+  primaryLinkHref: string;
   /**
    * Link text for the primary link.
-   * @default 'Helsingin kaupunki'
    */
   primaryLinkText?: string;
 }>;
@@ -54,7 +50,7 @@ export const HeaderUniversalBar = ({
         <li className={styles.universalBarMainLinkContainer}>
           <NavigationLink href={primaryLinkHref} label={primaryLinkText} className={styles.universalBarLink} />
         </li>
-        {Children.map(childElements, (child, index) => {
+        {childElements.map((child, index) => {
           if (React.isValidElement(child)) {
             return (
               // eslint-disable-next-line react/no-array-index-key

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
@@ -1,5 +1,7 @@
 import React, { cloneElement, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
+// import core base styles
+import 'hds-core';
 import styles from './NavigationLink.module.scss';
 import classNames from '../../../../utils/classNames';
 import { Link } from '../../../link';

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
@@ -1,7 +1,5 @@
 import React, { cloneElement, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
-// import core base styles
-import 'hds-core';
 import styles from './NavigationLink.module.scss';
 import classNames from '../../../../utils/classNames';
 import { Link } from '../../../link';
@@ -178,7 +176,7 @@ export const NavigationLink = ({
           index={index}
           dynamicPosition={dynamicPosition}
         >
-          {React.Children.map(dropdownLinks, (child, childIndex) => {
+          {dropdownLinks.map((child, childIndex) => {
             return cloneElement(child as React.ReactElement, {
               key: childIndex,
             });

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -1,10 +1,9 @@
 import React, { cloneElement, isValidElement, useRef, useState } from 'react';
 
-// import core base styles
-import 'hds-core';
 import styles from './NavigationLinkDropdown.module.scss';
 import { IconAngleDown } from '../../../../../icons';
 import classNames from '../../../../../utils/classNames';
+import { getChildElementsEvenIfContainerInbetween } from '../../../../../utils/getChildren';
 
 export enum NavigationLinkInteraction {
   Hover = 'hover',
@@ -52,6 +51,8 @@ export const NavigationLinkDropdown = ({
 
   const handleMenuButtonClick = () => setOpen(!open, NavigationLinkInteraction.Click);
 
+  const childElements = getChildElementsEvenIfContainerInbetween(children);
+
   return (
     <div className={styles.navigationLinkDropdownContainer}>
       <button
@@ -68,10 +69,10 @@ export const NavigationLinkDropdown = ({
         data-testid={`dropdown-menu-${index}`}
         ref={ref}
       >
-        {React.Children.map(children, (child, childIndex) => {
+        {childElements.map((child, childIndex) => {
           return (
             // eslint-disable-next-line react/no-array-index-key
-            <li key={index}>
+            <li key={`link-dropdown-${index}-${childIndex}`}>
               {isValidElement(child)
                 ? cloneElement(child as React.ReactElement, {
                     index: childIndex,

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -1,5 +1,7 @@
 import React, { cloneElement, isValidElement, useRef, useState } from 'react';
 
+// import core base styles
+import 'hds-core';
 import styles from './NavigationLinkDropdown.module.scss';
 import { IconAngleDown } from '../../../../../icons';
 import classNames from '../../../../../utils/classNames';

--- a/packages/react/src/utils/getChildren.ts
+++ b/packages/react/src/utils/getChildren.ts
@@ -30,8 +30,9 @@ export const getComponentFromChildren = (children: React.ReactNode, componentNam
  * Get the child elements even if there is a parent container element.
  * @param children
  */
-export const getChildElementsEvenIfContainerInbetween = (children: React.ReactNode) => {
-  const arrayChildren = React.Children.toArray(children);
+export const getChildElementsEvenIfContainerInbetween = (children: React.ReactNode): React.ReactNode[] => {
+  const arrayChildren: React.ReactNode[] = Array.isArray(children) ? children : [children];
+
   const childrenHasContainer =
     arrayChildren.length === 1 &&
     React.isValidElement(arrayChildren[0]) &&
@@ -40,7 +41,8 @@ export const getChildElementsEvenIfContainerInbetween = (children: React.ReactNo
 
   /* If there's a container element in between, we dig out the child elements from within. */
   if (childrenHasContainer && React.isValidElement(arrayChildren[0])) {
-    return React.Children.toArray(arrayChildren[0].props.children);
+    return [...arrayChildren[0].props.children];
   }
+
   return arrayChildren;
 };


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Replace React.Children API in the new header components:
- HeaderNavigationMenu.tsx
- HeaderUniversalBar.tsx
- NavigationLink.tsx
- NavigationLinkDropdown.tsx

No visual changes.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1630](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1630)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Children API has been marked legacy, and will eventually be deprecated.

## How Has This Been Tested?
- Tested on local machine
- Unit & visual testing

## Screenshots (if appropriate):

[HDS-1630]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ