### PR TITLE
HDS-1632 SelectionGroup replace React.Children API

### DIFF
--- a/packages/react/src/components/footer/footerItemGroup/FooterItemGroup.tsx
+++ b/packages/react/src/components/footer/footerItemGroup/FooterItemGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { isValidElement } from 'react';
 
 // import base styles
 import '../../../styles/base.css';
@@ -11,8 +11,12 @@ export const FooterItemGroup = ({ children }: React.PropsWithChildren<Record<str
   return (
     <div className={styles.itemGroup}>
       {childrenAsArray.map((child) => {
-        const { subItem } = child.props;
-        return !subItem ? <h3 key={`h3-${child.key}`}>{child}</h3> : child;
+        if (isValidElement(child)) {
+          const { subItem } = child.props;
+          return !subItem ? <h3 key={`h3-${child.key}`}>{child}</h3> : child;
+        }
+
+        return null;
       })}
     </div>
   );

--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { isValidElement, useEffect, useState } from 'react';
 
 import styles from './Navigation.module.scss';
 import classNames from '../../utils/classNames';
@@ -92,12 +92,14 @@ export type NavigationProps = React.PropsWithChildren<{
  * @param {React.ReactElement[]} children
  * @param {boolean} authenticated
  */
-const rearrangeChildrenForMobile = (children: React.ReactElement[], authenticated: boolean): React.ReactElement[] => {
+const rearrangeChildrenForMobile = (children: React.ReactNode[], authenticated: boolean): React.ReactNode[] => {
   const rearrangedChildren = [...children];
 
   // moves the component to the start of the array
   const moveComponentToTop = (name: string) => {
-    const index = rearrangedChildren.findIndex((item) => (item?.type as FCWithName)?.componentName === name);
+    const index = rearrangedChildren.findIndex(
+      (item) => isValidElement(item) && (item?.type as FCWithName)?.componentName === name,
+    );
     if (index > -1) {
       const component = rearrangedChildren.splice(index, 1)[0];
       rearrangedChildren.splice(0, 0, component);
@@ -114,9 +116,10 @@ const rearrangeChildrenForMobile = (children: React.ReactElement[], authenticate
 
 const getNavigationVariantFromChild = (children: React.ReactNode): NavigationVariant => {
   const navigationRow = getChildrenAsArray(children).find(
-    (child) => (child.type as FCWithName).componentName === 'NavigationRow',
+    (child) => isValidElement(child) && (child.type as FCWithName).componentName === 'NavigationRow',
   );
-  return navigationRow?.props?.variant || 'default';
+
+  return (isValidElement(navigationRow) && navigationRow?.props?.variant) || 'default';
 };
 
 /**
@@ -206,12 +209,14 @@ export const Navigation = ({
 
   // Mobile navigation actions
   const mobileActions = getChildrenAsArray(children).find(
-    (child) => (child.type as FCWithName).componentName === 'NavigationActions',
-  )?.props?.children;
+    (child) => isValidElement(child) && (child.type as FCWithName).componentName === 'NavigationActions',
+  );
+
+  const mobileActionsChildren = isValidElement(mobileActions) && mobileActions.props.children;
 
   // filter out the NavigationLanguageSelector, so that it can be rendered in the header instead of the mobile menu
   const [mobileLanguageSelector, mobileActionsWithoutLanguageSelector] = getComponentFromChildren(
-    mobileActions,
+    mobileActionsChildren,
     'NavigationLanguageSelector',
   );
 

--- a/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx
@@ -67,17 +67,6 @@ export const Default = ({ numberOfItems, ...args }) => {
   const radiobuttons = getRadioButtonItems(numberOfItems, radioValue, handleRadioChange);
   return (
     <>
-      <SelectionGroup {...args}>
-        <Checkbox
-          id="test-checkbox0"
-          label="Option 1"
-          name="test-checkbox0"
-          key="test-checkbox0" // eslint-disable-line react/no-array-index-key
-          checked={false}
-        />
-      </SelectionGroup>
-      <br />
-      <br />
       <SelectionGroup {...args}>{checkboxes}</SelectionGroup>
       <br />
       <br />

--- a/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx
@@ -67,6 +67,17 @@ export const Default = ({ numberOfItems, ...args }) => {
   const radiobuttons = getRadioButtonItems(numberOfItems, radioValue, handleRadioChange);
   return (
     <>
+      <SelectionGroup {...args}>
+        <Checkbox
+          id="test-checkbox0"
+          label="Option 1"
+          name="test-checkbox0"
+          key="test-checkbox0" // eslint-disable-line react/no-array-index-key
+          checked={false}
+        />
+      </SelectionGroup>
+      <br />
+      <br />
       <SelectionGroup {...args}>{checkboxes}</SelectionGroup>
       <br />
       <br />

--- a/packages/react/src/components/selectionGroup/SelectionGroup.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.tsx
@@ -65,23 +65,25 @@ export const SelectionGroup = ({
   ...fieldSetProps
 }: SelectionGroupProps) => {
   useEffect(() => {
-    let hasRadios = false;
-    let hasCheckedRadios = false;
-    React.Children.forEach(children, (child) => {
-      const reactElement = child as React.ReactElement;
-      const { displayName } = reactElement.type as React.FunctionComponent;
-      if (displayName === 'RadioButton') {
-        hasRadios = true;
-        if (reactElement.props.checked === true) {
-          hasCheckedRadios = true;
+    if (Array.isArray(children)) {
+      let hasRadios = false;
+      let hasCheckedRadios = false;
+      children.forEach((child) => {
+        const reactElement = child as React.ReactElement;
+        const { displayName } = reactElement.type as React.FunctionComponent;
+        if (displayName === 'RadioButton') {
+          hasRadios = true;
+          if (reactElement.props.checked === true) {
+            hasCheckedRadios = true;
+          }
         }
+      });
+      if (hasRadios && !hasCheckedRadios) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'All radio buttons in a SelectionGroup are unchecked. One radio button should be checked by default.',
+        );
       }
-    });
-    if (hasRadios && !hasCheckedRadios) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'All radio buttons in a SelectionGroup are unchecked. One radio button should be checked by default.',
-      );
     }
   }, [children]);
   return (
@@ -95,9 +97,11 @@ export const SelectionGroup = ({
         </Tooltip>
       )}
       <div className={classNames(styles.items, styles[direction])}>
-        {React.Children.map(children, (child) => (
-          <div className={styles.item}>{child}</div>
-        ))}
+        {Array.isArray(children) ? (
+          children.map((child) => <div className={styles.item}>{child}</div>)
+        ) : (
+          <div className={styles.item}>{children}</div>
+        )}
       </div>
       {errorText && <div className={styles.errorText}>{errorText}</div>}
       {helperText && <div className={styles.helperText}>{helperText}</div>}

--- a/packages/react/src/components/selectionGroup/SelectionGroup.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { isValidElement, useEffect } from 'react';
 
 // import base styles
 import '../../styles/base.css';
@@ -7,6 +7,7 @@ import styles from './SelectionGroup.module.scss';
 import classNames from '../../utils/classNames';
 import { RequiredIndicator } from '../../internal/required-indicator/RequiredIndicator';
 import { Tooltip } from '../tooltip';
+import { getChildrenAsArray } from '../../utils/getChildren';
 
 export type Direction = 'vertical' | 'horizontal';
 
@@ -64,26 +65,26 @@ export const SelectionGroup = ({
   className,
   ...fieldSetProps
 }: SelectionGroupProps) => {
+  const childElements = getChildrenAsArray(children);
+
   useEffect(() => {
-    if (Array.isArray(children)) {
-      let hasRadios = false;
-      let hasCheckedRadios = false;
-      children.forEach((child) => {
-        const reactElement = child as React.ReactElement;
-        const { displayName } = reactElement.type as React.FunctionComponent;
-        if (displayName === 'RadioButton') {
-          hasRadios = true;
-          if (reactElement.props.checked === true) {
-            hasCheckedRadios = true;
-          }
+    let hasRadios = false;
+    let hasCheckedRadios = false;
+    childElements.forEach((child) => {
+      const reactElement = child as React.ReactElement;
+      const { displayName } = reactElement.type as React.FunctionComponent;
+      if (displayName === 'RadioButton') {
+        hasRadios = true;
+        if (reactElement.props.checked === true) {
+          hasCheckedRadios = true;
         }
-      });
-      if (hasRadios && !hasCheckedRadios) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'All radio buttons in a SelectionGroup are unchecked. One radio button should be checked by default.',
-        );
       }
+    });
+    if (hasRadios && !hasCheckedRadios) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'All radio buttons in a SelectionGroup are unchecked. One radio button should be checked by default.',
+      );
     }
   }, [children]);
   return (
@@ -97,10 +98,13 @@ export const SelectionGroup = ({
         </Tooltip>
       )}
       <div className={classNames(styles.items, styles[direction])}>
-        {Array.isArray(children) ? (
-          children.map((child) => <div className={styles.item}>{child}</div>)
-        ) : (
-          <div className={styles.item}>{children}</div>
+        {childElements.map(
+          (child) =>
+            isValidElement(child) && (
+              <div key={child.props.id} className={styles.item}>
+                {child}
+              </div>
+            ),
         )}
       </div>
       {errorText && <div className={styles.errorText}>{errorText}</div>}

--- a/packages/react/src/utils/getChildren.ts
+++ b/packages/react/src/utils/getChildren.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { isValidElement } from 'react';
 
 import { FCWithName } from '../common/types';
 
@@ -6,20 +6,20 @@ import { FCWithName } from '../common/types';
  * Returns the children as a flat array with keys assigned to each child
  * @param children  Children
  */
-export const getChildrenAsArray = (children: React.ReactNode): React.ReactElement[] =>
-  React.Children.toArray(children) as React.ReactElement[];
+export const getChildrenAsArray = (children: React.ReactNode): React.ReactNode[] =>
+  Array.isArray(children) ? children : [children];
 
 /**
  * Filters out a component from the children and returns it and the children without the filtered out component
  * @param children      Children
  * @param componentName Name of the component that should be filtered out
  */
-export const getComponentFromChildren = (children: React.ReactNode, componentName: string): React.ReactElement[][] => {
+export const getComponentFromChildren = (children: React.ReactNode, componentName: string): React.ReactNode[][] => {
   // copy and ensure that children is an array
   const childrenAsArray = [...getChildrenAsArray(children)];
-  const componentIndex = childrenAsArray.findIndex(
-    (child) => (child.type as FCWithName)?.componentName === componentName,
-  );
+  const componentIndex = childrenAsArray.findIndex((child) => {
+    return isValidElement(child) && (child.type as FCWithName)?.componentName === componentName;
+  });
   const component = componentIndex >= 0 ? childrenAsArray.splice(componentIndex, 1) : [];
 
   // return the component and the children without the removed component


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Replace React.Children API in SelectionGroup component. Refactoring to getChildrenAsArray utility function and Navigation components that use it. No visual changes.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1632](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1632)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Children API has been marked legacy, and will eventually be deprecated.

## How Has This Been Tested?
- Tested on local machine
- Unit & visual testing

## Screenshots (if appropriate):


[HDS-1632]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ