### PR TITLE
HDS-1636 Doc site replace React.Children API

### DIFF
--- a/site/src/components/PageTabs.js
+++ b/site/src/components/PageTabs.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { navigate } from 'gatsby';
 import { Tabs } from 'hds-react';
@@ -19,9 +19,11 @@ const pageTabComponentName = 'PageTab';
 
 const PageTabs = ({ pageContext, children }) => {
   const slug = pageContext.frontmatter.slug;
-  const mdxChildren = React.Children.toArray(children);
-  const tabList = mdxChildren.find((reactChild) => reactChild.type.componentName === pageTabListComponentName);
-  const tabPanel = mdxChildren.find((reactChild) => reactChild.type.componentName === pageTabPanelComponentName);
+
+  const mdxChildren = Array.isArray(children) ? children : [children];
+
+  const tabList = mdxChildren.find((reactChild) => isValidElement(reactChild) && reactChild.type.componentName === pageTabListComponentName);
+  const tabPanel = mdxChildren.find((reactChild) => isValidElement(reactChild) && reactChild.type.componentName === pageTabPanelComponentName);
   const tabs = tabList.props?.children.filter((reactChild) => reactChild.type.componentName === pageTabComponentName);
   const tabActiveIndex = tabs.findIndex((tab) => slug.endsWith(tab.props.href));
   const activeIndex = tabActiveIndex === -1 ? 0 : tabActiveIndex;

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { isValidElement, useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
@@ -270,13 +270,18 @@ const EditorWithLive = withLive(Editor);
 
 export const PlaygroundBlock = (props) => {
   const scopeComponents = useMDXScope();
-  const codeBlocks = React.Children.toArray(props.children).map(({ props }) => {
-    const childrenProps = props.children.props;
-    return {
-      code: childrenProps.children,
-      language: childrenProps.className && childrenProps.className.split('-')[1],
-    };
-  });
+
+  const childrenArray = Array.isArray(props.children) ? props.children : [props.children];
+
+  const codeBlocks = childrenArray
+    .filter((child) => isValidElement(child))
+    .map(({ props }) => {
+      const childrenProps = props.children.props;
+      return {
+        code: childrenProps.children,
+        language: childrenProps.className && childrenProps.className.split('-')[1],
+      };
+    });
   const codeByLanguage = codeBlocks.reduce((acc, block) => {
     acc[block.language] = block.code;
     return acc;

--- a/site/src/components/Table.js
+++ b/site/src/components/Table.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { isValidElement } from 'react';
 
 const captionPrefix = '[';
 const captionSuffix = ']';
@@ -15,21 +15,25 @@ const Table = (props) => {
   const thead = (props.children || []).find(({ props }) => props.originalType === 'thead');
   const tbody = (props.children || []).find(({ props }) => props.originalType === 'tbody');
   const tbodyRows = tbody.props?.children || [];
-  const [rows, captionString] = React.Children.toArray(tbodyRows).reduce(
-    (acc, row, i, arr) => {
-      if (
-        i >= arr.length - 1 &&
-        row.props.children &&
-        row.props.children[0] &&
-        isCaption(row.props.children[0].props.children)
-      ) {
-        return [acc[0], row.props.children[0].props.children];
-      } else {
-        return [[...acc[0], row], acc[1]];
-      }
-    },
-    [[], ''],
-  );
+  const rowsArray = Array.isArray(tbodyRows) ? tbodyRows : [tbodyRows];
+
+  const [rows, captionString] = rowsArray
+    .filter((child) => isValidElement(child))
+    .reduce(
+      (acc, row, i, arr) => {
+        if (
+          i >= arr.length - 1 &&
+          row.props.children &&
+          row.props.children[0] &&
+          isCaption(row.props.children[0].props.children)
+        ) {
+          return [acc[0], row.props.children[0].props.children];
+        } else {
+          return [[...acc[0], row], acc[1]];
+        }
+      },
+      [[], ''],
+    );
 
   const tableChildrenWithoutCaption = [thead, { ...tbody, props: { ...tbody.props, children: rows } }];
   const [tableName, caption] = captionString ? resolveCaptionStrings(captionString) : [undefined, undefined];


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Replace React.Children API in doc site internal components.
- PageTabs.js
- Playground.js
- Table.js


No visual changes.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1636](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1636)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Children API has been marked legacy, and will eventually be deprecated.

## How Has This Been Tested?
- Tested on local machine
- Unit & visual testing

## Screenshots (if appropriate):


[HDS-1636]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ