### PR TITLE
Feature 447 Token for focus color

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -306,7 +306,7 @@ input[type="submit"].hds-button--small {
   --color-focus: var(--color-white);
   --color-hover-focus: var(--color-white);
   --color-disabled: var(--color-white);
-  --focus-outline-color: var(--color-coat-of-arms);
+  --focus-outline-color: var(--color-focus-outline);
   --submit-input-focus-gutter-color: var(--color-white);
 }
 
@@ -329,7 +329,7 @@ input[type="submit"].hds-button--small {
   --color-focus: var(--color-bus);
   --color-hover-focus: var(--color-bus-dark);
   --color-disabled: var(--color-black-40);
-  --focus-outline-color: var(--color-coat-of-arms);
+  --focus-outline-color: var(--color-focus-outline);
   --submit-input-focus-gutter-color: var(--color-white);
 }
 
@@ -343,8 +343,8 @@ input[type="submit"].hds-button--small {
   --background-color-disabled: transparent;
   --border-color: transparent;
   --border-color-hover: transparent;
-  --border-color-focus: var(--color-coat-of-arms);
-  --border-color-hover-focus: var(--color-coat-of-arms);
+  --border-color-focus: var(--color-focus-outline);
+  --border-color-hover-focus: var(--color-focus-outline);
   --border-color-disabled: transparent;
   --color: var(--color-bus);
   --color-hover: var(--color-bus-dark);
@@ -393,7 +393,7 @@ input[type="submit"].hds-button--small {
   --color-hover: var(--color-white);
   --color-focus: var(--color-white);
   --color-hover-focus: var(--color-white);
-  --focus-outline-color: var(--color-coat-of-arms);
+  --focus-outline-color: var(--color-focus-outline);
 }
 
 /* danger */
@@ -410,7 +410,7 @@ input[type="submit"].hds-button--small {
   --color-hover: var(--color-white);
   --color-focus: var(--color-white);
   --color-hover-focus: var(--color-white);
-  --focus-outline-color: var(--color-coat-of-arms);
+  --focus-outline-color: var(--color-focus-outline);
 }
 
 /* THEMES */
@@ -453,8 +453,8 @@ input[type="submit"].hds-button--small {
   --background-color-hover-focus: var(--color-coat-of-arms-light);
   --border-color: transparent;
   --border-color-hover: transparent;
-  --border-color-focus: var(--color-coat-of-arms);
-  --border-color-hover-focus: var(--color-coat-of-arms);
+  --border-color-focus: var(--color-focus-outline);
+  --border-color-hover-focus: var(--color-focus-outline);
   --color: var(--color-coat-of-arms);
   --color-hover: var(--color-coat-of-arms);
   --color-focus: var(--color-coat-of-arms);
@@ -499,8 +499,8 @@ input[type="submit"].hds-button--small {
   --background-color-hover-focus: var(--color-black-5);
   --border-color: transparent;
   --border-color-hover: transparent;
-  --border-color-focus: var(--color-coat-of-arms);
-  --border-color-hover-focus: var(--color-coat-of-arms-dark);
+  --border-color-focus: var(--color-focus-outline);
+  --border-color-hover-focus: var(--color-focus-outline);
   --color: var(--color-black);
   --color-hover: var(--color-black);
   --color-focus: var(--color-black);

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -25,7 +25,6 @@
   --icon-color-unselected: transparent;
   --icon-color-selected: var(--color-white);
   --icon-color-disabled: var(--color-white);
-  --focus-outline-color: var(--color-coat-of-arms);
   --label-color: var(--color-black-90);
   --label-color-disabled: var(--color-black-40);
   --icon-size: var(--spacing-m);
@@ -94,7 +93,7 @@
 }
 
 .hds-checkbox .hds-checkbox__input:focus + .hds-checkbox__label:before {
-  box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
+  box-shadow: 0 0 0 var(--outline-width) var(--color-focus-outline);
   transform: translate3d(0, 0, 0);
   transition: 85ms ease-out;
   transition-property: box-shadow, transform;

--- a/packages/core/src/components/link/link.css
+++ b/packages/core/src/components/link/link.css
@@ -20,7 +20,7 @@
 }
 
 .hds-link:focus {
-  border: 3px solid var(--color-coat-of-arms);
+  border: 3px solid var(--color-focus-outline);
   outline: none;
 }
 

--- a/packages/core/src/components/notification/notification.css
+++ b/packages/core/src/components/notification/notification.css
@@ -10,7 +10,6 @@
   --notification-border-width: var(--spacing-2-xs);
   --notification-icon-color: var(--color-info);
   --notification-color: var(--color-black-90);
-  --notification-focus-outline-color: var(--color-coat-of-arms);
   --notification-max-width-inline: none;
   --notification-max-width-toast: 21rem;
   --notification-z-index-inline: auto;
@@ -119,7 +118,7 @@
 }
 
 .hds-notification__close-button:focus {
-  box-shadow: 0 0 0 3px var(--notification-focus-outline-color);
+  box-shadow: 0 0 0 3px var(--color-focus-outline);
 }
 
 /* TOAST POSITIONS */

--- a/packages/core/src/components/pagination/pagination.css
+++ b/packages/core/src/components/pagination/pagination.css
@@ -77,7 +77,7 @@ we can not use this position for the actual button as it's in incorrect source o
 }
 
 .hds-pagination__item-link:focus, .hds-pagination__item-link:active {
-  outline: solid var(--color-coat-of-arms) 3px;
+  outline: solid var(--color-focus-outline) 3px;
   outline-offset: 1px;
 }
 

--- a/packages/core/src/components/radio-button/radio-button.css
+++ b/packages/core/src/components/radio-button/radio-button.css
@@ -23,7 +23,6 @@
   --icon-color-unselected: transparent;
   --icon-color-hover: var(--color-bus-dark);
   --icon-color-disabled: var(--color-black-10);
-  --focus-outline-color: var(--color-coat-of-arms);
   --label-color: var(--color-black-90);
   --label-color-disabled: var(--color-black-40);
 
@@ -156,7 +155,7 @@
 
 /* background - focus */
 .hds-radio-button .hds-radio-button__input:focus + .hds-radio-button__label:before {
-  box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
+  box-shadow: 0 0 0 var(--outline-width) var(--color-focus-outline);
   transform: translate3d(0, 0, 0);
 }
 

--- a/packages/core/src/components/search-input/search-input.css
+++ b/packages/core/src/components/search-input/search-input.css
@@ -12,7 +12,6 @@
   --input-border-color-focus: var(--color-black-90);
   --input-color-default: var(--color-black-90);
   --label-color-default: var(--color-black-90);
-  --focus-outline-color: var(--color-coat-of-arms);
 }
 
 /* LABEL */
@@ -56,7 +55,7 @@
 
 /* FOCUS OUTLINE */
 .hds-search-input .hds-search-input__input:not([readonly]):focus {
-  outline: var(--outline-width) solid var(--focus-outline-color);
+  outline: var(--outline-width) solid var(--color-focus-outline);
   transform: translate3d(0, 0, 0);
 }
 
@@ -89,7 +88,7 @@
 }
 
 .hds-search-input__buttons .hds-search-input__button:focus {
-  outline: var(--outline-width) solid var(--focus-outline-color);
+  outline: var(--outline-width) solid var(--color-focus-outline);
 }
 
 /* HELPER TEXT */

--- a/packages/core/src/components/table/table.css
+++ b/packages/core/src/components/table/table.css
@@ -3,7 +3,7 @@
 }
 
 .hds-table-container:focus {
-  outline: var(--color-coat-of-arms) 3px solid;
+  outline: var(--color-focus-outline) 3px solid;
 }
 
 .hds-table {

--- a/packages/core/src/components/tag/tag.css
+++ b/packages/core/src/components/tag/tag.css
@@ -4,7 +4,6 @@
 .hds-tag {
   --tag-background: var(--color-black-10);
   --tag-color: var(--color-black-90);
-  --tag-focus-outline-color: var(--color-coat-of-arms);
   --tag-font-size: var(--fontsize-body-s);
   --tag-padding: var(--spacing-2-xs);
   --tag-height: 32px;
@@ -22,7 +21,7 @@
 
 .hds-tag:focus,
 .hds-tag:focus-within {
-  box-shadow: 0 0 0 3px var(--tag-focus-outline-color);
+  box-shadow: 0 0 0 3px var(--color-focus-outline);
 }
 
 .hds-tag[tabindex='0'] {

--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -28,7 +28,6 @@
   --label-color-default: var(--color-black-90);
   --label-color-invalid: var(--color-black-90);
   --placeholder-color: var(--color-black-60);
-  --focus-outline-color: var(--color-coat-of-arms);
 }
 
 .hds-text-input .hds-text-input__input {
@@ -81,7 +80,7 @@
 }
 
 .hds-text-input__input-wrapper:focus-within .hds-text-input__input:not([readonly]) {
-  box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
+  box-shadow: 0 0 0 var(--outline-width) var(--color-focus-outline);
   transform: translate3d(0, 0, 0);
   transition: 85ms ease-out;
   transition-property: box-shadow, transform;
@@ -294,5 +293,5 @@
 }
 
 .hds-text-input__button:focus {
-  outline: var(--outline-width) solid var(--focus-outline-color);
+  outline: var(--outline-width) solid var(--color-focus-outline);
 }

--- a/packages/design-tokens/tokens/color/ui/focus.json
+++ b/packages/design-tokens/tokens/color/ui/focus.json
@@ -1,0 +1,10 @@
+{
+  "color": {
+    "focus": {
+      "outline": {
+        "value": "#0072c6",
+        "type": "color"
+      }
+    }
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -140,6 +140,7 @@
     "react-spring": "9.3.0",
     "react-use-measure": "2.0.1",
     "react-virtual": "2.10.4",
+    "uuid": "^9.0.0",
     "yup": "^1.0.2"
   },
   "resolutions": {


### PR DESCRIPTION
## Description

Created `color-focus-outline` -token for focus color. Modified all focusable core components to use it

## Related Issue

[https://helsinkisolutionoffice.atlassian.net/browse/HDS-447](https://helsinkisolutionoffice.atlassian.net/browse/HDS-447)

Closes #

## Motivation and Context

This makes a change of focus color possible.

## How Has This Been Tested?

All focus colors should look the same as before. 

To test if the new token works, you can try to change the focus color of all focusable components just by changing the color value in `/design-tokens/tokens/color/ui/focus.json`.  Build project and go to see your color change in Storybook

## Screenshots (if appropriate):
