### PR TITLE
HDS-1633 SideNavigation replace React.Children API

### DIFF
--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -217,7 +217,7 @@ export const Navigation = ({
 
   const mobileActionsChildren = isValidElement(mobileActions) && mobileActions.props.children;
 
-  // filter out the Navigatio nLanguageSelector, so that it can be rendered in the header instead of the mobile menu
+  // filter out the NavigationLanguageSelector, so that it can be rendered in the header instead of the mobile menu
   const [mobileLanguageSelector, mobileActionsWithoutLanguageSelector] = getComponentFromChildren(
     mobileActionsChildren,
     'NavigationLanguageSelector',

--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -118,7 +118,6 @@ const getNavigationVariantFromChild = (children: React.ReactNode): NavigationVar
   const navigationRow = getChildrenAsArray(children).find(
     (child) => isValidElement(child) && (child.type as FCWithName).componentName === 'NavigationRow',
   );
-
   return (isValidElement(navigationRow) && navigationRow?.props?.variant) || 'default';
 };
 
@@ -218,7 +217,7 @@ export const Navigation = ({
 
   const mobileActionsChildren = isValidElement(mobileActions) && mobileActions.props.children;
 
-  // filter out the NavigationLanguageSelector, so that it can be rendered in the header instead of the mobile menu
+  // filter out the Navigatio nLanguageSelector, so that it can be rendered in the header instead of the mobile menu
   const [mobileLanguageSelector, mobileActionsWithoutLanguageSelector] = getComponentFromChildren(
     mobileActionsChildren,
     'NavigationLanguageSelector',

--- a/packages/react/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.tsx
@@ -85,7 +85,7 @@ export const SideNavigation = ({
 
   const mainLevels = childElements.map((child, index) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'MainLevel') {
-      return cloneElement(child, { key: index });
+      return cloneElement(child, { key: index, index });
     }
     return null;
   });

--- a/packages/react/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.tsx
@@ -13,6 +13,7 @@ import { IconAngleDown, IconAngleUp } from '../../icons';
 import { MainLevel } from './mainLevel/MainLevel';
 import { SubLevel } from './subLevel/SubLevel';
 import { useTheme } from '../../hooks/useTheme';
+import { getChildrenAsArray } from '../../utils/getChildren';
 
 export interface SideNavigationCustomTheme {
   '--side-navigation-background-color'?: string;
@@ -80,7 +81,9 @@ export const SideNavigation = ({
   const isMobile = useMobile();
   const shouldRenderMenu = !(isMobile && !mobileMenuOpen);
 
-  const mainLevels = React.Children.map(children, (child, index) => {
+  const childElements = getChildrenAsArray(children);
+
+  const mainLevels = childElements.map((child, index) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'MainLevel') {
       return cloneElement(child, { index });
     }

--- a/packages/react/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.tsx
@@ -85,7 +85,7 @@ export const SideNavigation = ({
 
   const mainLevels = childElements.map((child, index) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'MainLevel') {
-      return cloneElement(child, { index });
+      return cloneElement(child, { key: index });
     }
     return null;
   });

--- a/packages/react/src/components/sideNavigation/mainLevel/MainLevel.tsx
+++ b/packages/react/src/components/sideNavigation/mainLevel/MainLevel.tsx
@@ -162,10 +162,11 @@ export const MainLevel = ({
 
   const childElements = getChildrenAsArray(children);
 
-  const subLevels = childElements.map((child) => {
+  const subLevels = childElements.map((child, childIndex) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'SubLevel') {
       return cloneElement(child, {
         mainLevelIndex: index,
+        key: childIndex,
       });
     }
     return null;
@@ -193,8 +194,6 @@ export const MainLevel = ({
     }
     setIsActiveParent(isActive);
   }, [activeParentLevel, index, setIsOpen, setIsActiveParent]);
-
-  console.log(id);
 
   return (
     <li

--- a/packages/react/src/components/sideNavigation/mainLevel/MainLevel.tsx
+++ b/packages/react/src/components/sideNavigation/mainLevel/MainLevel.tsx
@@ -5,6 +5,7 @@ import styles from './MainLevel.module.scss';
 import SideNavigationContext from '../SideNavigationContext';
 import { FCWithName } from '../../../common/types';
 import { IconAngleDown, IconAngleUp, IconLinkExternal } from '../../../icons';
+import { getChildrenAsArray } from '../../../utils/getChildren';
 
 type MainLevelCommonProps = {
   /**
@@ -159,7 +160,9 @@ export const MainLevel = ({
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpenMainLevels.includes(index as number));
   const [isActiveParent, setIsActiveParent] = useState<boolean>(false);
 
-  const subLevels = React.Children.map(children, (child) => {
+  const childElements = getChildrenAsArray(children);
+
+  const subLevels = childElements.map((child) => {
     if (isValidElement(child) && (child.type as FCWithName).componentName === 'SubLevel') {
       return cloneElement(child, {
         mainLevelIndex: index,
@@ -190,6 +193,8 @@ export const MainLevel = ({
     }
     setIsActiveParent(isActive);
   }, [activeParentLevel, index, setIsOpen, setIsActiveParent]);
+
+  console.log(id);
 
   return (
     <li

--- a/packages/react/src/utils/getChildren.ts
+++ b/packages/react/src/utils/getChildren.ts
@@ -6,8 +6,13 @@ import { FCWithName } from '../common/types';
  * Returns the children as a flat array with keys assigned to each child
  * @param children  Children
  */
-export const getChildrenAsArray = (children: React.ReactNode): React.ReactNode[] =>
-  Array.isArray(children) ? children : [children];
+export const getChildrenAsArray = (children: React.ReactNode): React.ReactNode[] => {
+  if (children === undefined) {
+    return [];
+  }
+
+  return Array.isArray(children) ? children : [children];
+};
 
 /**
  * Filters out a component from the children and returns it and the children without the filtered out component


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Replace React.Children API in SideNavigation and MainLevel components. Refactoring to getChildrenAsArray utility function and Navigation + Footer components that use it. No visual changes.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1633](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1633)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Children API has been marked legacy, and will eventually be deprecated.

## How Has This Been Tested?
- Tested on local machine
- Unit & visual testing

## Screenshots (if appropriate):

[HDS-1633]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ