### PR TITLE
Tabs replace React.Children API

### DIFF
--- a/packages/react/src/components/navigation/Navigation.tsx
+++ b/packages/react/src/components/navigation/Navigation.tsx
@@ -118,7 +118,6 @@ const getNavigationVariantFromChild = (children: React.ReactNode): NavigationVar
   const navigationRow = getChildrenAsArray(children).find(
     (child) => isValidElement(child) && (child.type as FCWithName).componentName === 'NavigationRow',
   );
-
   return (isValidElement(navigationRow) && navigationRow?.props?.variant) || 'default';
 };
 

--- a/packages/react/src/components/tabs/TabList.tsx
+++ b/packages/react/src/components/tabs/TabList.tsx
@@ -9,6 +9,7 @@ import { FCWithName } from '../../common/types';
 import { TabsContext } from './TabsContext';
 import { IconAngleLeft, IconAngleRight } from '../../icons';
 import { getChildByIndex, isElementOutsideLeftEdge, isElementOutsideRightEdge } from './tabUtils';
+import { getChildrenAsArray } from '../../utils/getChildren';
 
 export type TabListProps = React.PropsWithChildren<{
   /**
@@ -31,12 +32,15 @@ export const TabList = ({ children, className, style = {} }: TabListProps) => {
   const [showNextButton, setShowNextButton] = useState(true);
   const [scrollValue, setScrollValue] = useState<number>(0);
 
+  const childElements = getChildrenAsArray(children);
+
   /**
    * Pass the index as prop to each tab element
    */
-  const tabs = React.Children.map(children, (child, index) => {
+  const tabs = childElements.map((child, index) => {
     if (React.isValidElement(child) && (child.type as FCWithName).componentName === 'Tab') {
-      return React.cloneElement(child, { index });
+      // eslint-disable-next-line react/no-array-index-key
+      return React.cloneElement(child, { index, key: index });
     }
     return null;
   });

--- a/packages/react/src/components/tabs/Tabs.tsx
+++ b/packages/react/src/components/tabs/Tabs.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { TabList } from './TabList';
 import { TabPanel } from './TabPanel';
 import { Tab } from './Tab';
+import { getChildrenAsArray } from '../../utils/getChildren';
 
 export interface TabsCustomTheme {
   '--tablist-border-color'?: string;
@@ -48,24 +49,27 @@ export const Tabs = ({ children, initiallyActiveTab = 0, small = false, theme }:
   // custom theme class that is applied to the root element
   const customThemeClass = useTheme<TabsCustomTheme>(styles.tabs, theme);
 
+  const childElements = getChildrenAsArray(children);
+
   /**
    * Get the TabList from children
    */
-  const tabList = React.Children.toArray(children).filter((child) => {
+  const tabList = childElements.filter((child) => {
     return React.isValidElement(child) && (child.type as FCWithName).componentName === 'TabList';
   });
 
   /**
    * Get TabPanels from children
    */
-  const tabPanels = React.Children.toArray(children)
+  const tabPanels = childElements
     .filter((child) => {
       return React.isValidElement(child) && (child.type as FCWithName).componentName === 'TabPanel';
     })
     .map((child, index) => {
       if (React.isValidElement(child)) {
         // Pass index prop to the TabPanel
-        return React.cloneElement(child, { index });
+        // eslint-disable-next-line react/no-array-index-key
+        return React.cloneElement(child, { index, key: index });
       }
       return child;
     });

--- a/packages/react/src/utils/getChildren.ts
+++ b/packages/react/src/utils/getChildren.ts
@@ -6,8 +6,13 @@ import { FCWithName } from '../common/types';
  * Returns the children as a flat array with keys assigned to each child
  * @param children  Children
  */
-export const getChildrenAsArray = (children: React.ReactNode): React.ReactNode[] =>
-  Array.isArray(children) ? children : [children];
+export const getChildrenAsArray = (children: React.ReactNode): React.ReactNode[] => {
+  if (children === undefined) {
+    return [];
+  }
+
+  return Array.isArray(children) ? children : [children];
+};
 
 /**
  * Filters out a component from the children and returns it and the children without the filtered out component


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Replace React.Children API in Tabs and Tablist components. Refactoring to getChildrenAsArray utility function and Navigation + Footer components that use it. No visual changes.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1634](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1634)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Children API has been marked legacy, and will eventually be deprecated.

## How Has This Been Tested?
- Tested on local machine
- Unit & visual testing

## Screenshots (if appropriate):

[HDS-1634]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ