### PR TITLE
HDS-769-fix-search-input-icon-positioning

### DIFF
--- a/packages/core/src/components/search-input/search-input.css
+++ b/packages/core/src/components/search-input/search-input.css
@@ -68,13 +68,13 @@
   display: flex;
   font-size: 1rem;
   justify-content: center;
-  margin-right: calc(var(--spacing-s) - var(--spacing-xs));
+  margin-right: calc(var(--spacing-s) - var(--spacing-xs) / 2);
   position: absolute;
   right: 0;
   top: 0;
 }
 
-.hds-search-input__buttons .hds-search-input__button {
+.hds-search-input__button {
   appearance: none;
   background: none;
   border: none;
@@ -83,9 +83,8 @@
   cursor: pointer;
   display: flex;
   font: inherit;
-  margin-left: var(--spacing-3-xs);
   outline: none;
-  padding: var(--spacing-xs);
+  padding: var(--spacing-xs) calc(var(--spacing-xs) / 2);
 }
 
 .hds-search-input__buttons .hds-search-input__button:focus {

--- a/packages/react/src/components/searchInput/SearchInput.module.scss
+++ b/packages/react/src/components/searchInput/SearchInput.module.scss
@@ -19,12 +19,12 @@
 }
 
 .buttons {
-  composes: hds-text-input__buttons from 'hds-core/lib/components/text-input/text-input.css';
+  composes: hds-search-input__buttons from 'hds-core/lib/components/search-input/search-input.css';
 }
 
 .button {
   color: var(--dropdown-color-default);
-  composes: hds-text-input__button from 'hds-core/lib/components/text-input/text-input.css';
+  composes: hds-search-input__button from 'hds-core/lib/components/search-input/search-input.css';
 
   &.hidden {
     @extend %hiddenFromScreen;


### PR DESCRIPTION
## Description

Fixes getting/composing wrong styles in search input

## Related Issue

[HDS-769](https://helsinkisolutionoffice.atlassian.net/browse/HDS-769)

## Motivation and Context

The styles were different Core vs. React and composed from wrong file.

## How Has This Been Tested?

Local machine


[HDS-769]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ