### PR TITLE
HDS-1680-update-github-readme-development-branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are open even if you don't have a finished solution yet. HDS team 
 
 ## Sending a pull request
 
-Send pull requests to `master` branch. Right now all pull requests are welcome. If you do not feel that the PR is anywhere near ready, consider opening a draft pull request. Allowing edits for maintainers is also recommended.
+Send pull requests to `development` branch. Right now all pull requests are welcome. If you do not feel that the PR is anywhere near ready, consider opening a draft pull request. Allowing edits for maintainers is also recommended.
 
 1. Set up your local development environment by following the steps in [DEVELOPMENT.md](/DEVELOPMENT.md). Use short and descriptive commit messages e.g. "Add rotate property for Koros component".
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,10 +52,10 @@ yarn start:react
 
 This project uses the [Git Feature Branch Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow). Happy branching!
 
-1. Get the latest updates from the `master` branch.
+1. Get the latest updates from the `development` branch. The `master` branch is only updated during the release process containing the latest released features while `development` branch has the latest features waiting for a new release. 
 
 ```bash
-git checkout master
+git checkout development
 git pull
 ```
 


### PR DESCRIPTION
Update docs to specify the use of development branch.

## Description

Update the GitHub docs to correspond the new use of `development` branch instead of `master`.

## Related Issue

[HDS-1680](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1680)


[HDS-1680]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ