### PR TITLE
HDS-1668-improve-accordion-examples-and-documentation

### DIFF
--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -55,9 +55,14 @@ const components = {
     </h4>
   ),
   h5: (props) => (
-    <h4 {...props} className={classNames('page-heading-5 heading-xs', props.className)}>
+    <h5 {...props} className={classNames('page-heading-5 heading-xs', props.className)}>
       {props.children}
-    </h4>
+    </h5>
+  ),
+  h6: (props) => (
+    <h6 {...props} className={classNames('page-heading-6 heading-xxs', props.className)}>
+      {props.children}
+    </h6>
   ),
 };
 

--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -122,6 +122,10 @@ body {
   margin: var(--spacing-l) 0 var(--spacing-3-xs) 0;
 }
 
+.page-heading-6 {
+  margin: var(--spacing-l) 0 var(--spacing-3-xs) 0;
+}
+
 .front-page-link-list {
   box-sizing: border-box;
   margin: 0 0 var(--spacing-layout-xl);

--- a/site/src/docs/components/accordion/index.mdx
+++ b/site/src/docs/components/accordion/index.mdx
@@ -25,6 +25,8 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 - Use accordions to allow the user to quickly glance at the information and then choose to open sections that are interesting to them.
 - **Accordions must be given a header that describes the accordion content.** This header also acts as the label for the expand button. The header level can be chosen depending on the structure of the page.
+  - The `headerLevel` given to the Accordion should be higher than the header in the page content preceeding it (if there is one). Making the content semantically correct. For example if the Accordion is nested inside content with a header `h2` then the `headerLevel` for the Accordion should be 3.
+  - Also the Accordion size variant should be chosen so that it nicely fits the content, not putting a really large sized Accordion deep in the page structure.
 - **Do not put essential or must-read information inside accordions.** If the user is expected to open all of the accordions while using the service, then it is likely that the information should not be inside accordions.
   - Accordions work well when the user usually needs only part of the information. You may also consider placing parts of lower importance inside accordions while the most important parts are always visible.
 - By default, accordions include a close button that is visible at the bottom of an expanded accordion. This is meant to allow the user to close the accordion quickly if needed.
@@ -85,6 +87,25 @@ HDS Accordion includes three (3) size variants; small, default, and large. You c
   </Accordion>
   <Accordion size="l" card border heading="How to publish data?" language="en" style={{ maxWidth: '360px', marginTop: 'var(--spacing-s)' }}>
     To publish your data, open your profile settings and click the button 'Publish'.
+  </Accordion>
+</PlaygroundPreview>
+
+#### Accordions, heading elements and `headingLevel`-property
+
+When using multiple Accordions as a group with a common header or the page content has a header preceeding the Accordion(s) remember to use the `headingLevel` property accordingly.
+
+Keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion a higher (semantically lower) `headingLevel` than the content's header the Accordion is nested in.
+
+<PlaygroundPreview>
+  <h5>Header element for the content in which the following Accordions are nested in. (Here this is an h5 element)</h5>
+  <Accordion headingLevel="6" size="s" card border heading="headingLevel 6" language="en" style={{ maxWidth: '360px' }}>
+    This is an Accordion with headingLevel 6
+  </Accordion>
+  <Accordion headingLevel="6" size="s" card border heading="headingLevel 6" language="en" style={{ maxWidth: '360px', marginTop: 0, borderTop: 0 }}>
+    This is an Accordion with headingLevel 6
+  </Accordion>
+  <Accordion headingLevel="6" size="s" card border heading="headingLevel 6" language="en" style={{ maxWidth: '360px', marginTop: 0, borderTop: 0 }}>
+    This is an Accordion with headingLevel 6
   </Accordion>
 </PlaygroundPreview>
 

--- a/site/src/docs/components/accordion/index.mdx
+++ b/site/src/docs/components/accordion/index.mdx
@@ -25,7 +25,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 - Use accordions to allow the user to quickly glance at the information and then choose to open sections that are interesting to them.
 - **Accordions must be given a header that describes the accordion content.** This header also acts as the label for the expand button. The header level can be chosen depending on the structure of the page.
-  - The `headingLevel` given to the Accordion should be higher than the header in the page content preceeding it (if there is one). Making the content semantically correct. For example if the Accordion is nested inside content with a header `h2` then the `headingLevel` for the Accordion should be 3.
+  - The `headingLevel` given to the Accordion should be higher than the header in the page content preceeding it (if there is one). For example if the Accordion is nested inside content with a header `h2` then the `headingLevel` for the Accordion should be 3.
   - Also the Accordion size variant should be chosen so that it nicely fits the content, not putting a really large sized Accordion deep in the page structure.
 - **Do not put essential or must-read information inside accordions.** If the user is expected to open all of the accordions while using the service, then it is likely that the information should not be inside accordions.
   - Accordions work well when the user usually needs only part of the information. You may also consider placing parts of lower importance inside accordions while the most important parts are always visible.
@@ -92,9 +92,7 @@ HDS Accordion includes three (3) size variants; small, default, and large. You c
 
 #### Accordions, heading elements and `headingLevel`-property
 
-When using multiple Accordions as a group with a common header or the page content has a header preceeding the Accordion(s) remember to use the `headingLevel` property accordingly.
-
-Keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion a higher (semantically lower) `headingLevel` than the content's header the Accordion is nested in.
+When using multiple Accordions as a group with a common header or the page content has a header preceeding the Accordion(s) keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion the proper `headingLevel` according to it's position.
 
 <PlaygroundPreview>
   <h5>Header element for the content in which the following Accordions are nested in. (Here this is an h5 element)</h5>

--- a/site/src/docs/components/accordion/index.mdx
+++ b/site/src/docs/components/accordion/index.mdx
@@ -91,7 +91,7 @@ HDS Accordion includes three (3) size variants; small, default, and large. You c
 
 #### Accordions, heading elements and `headingLevel`-property
 
-When using multiple Accordions as a group with a shared header or the page content has a header preceding the Accordion(s), keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion the proper `headingLevel` according to it's position.
+When using multiple Accordions as a group with a shared header or the page content has a header preceding the Accordion(s), keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion the proper `headingLevel` according to its position.
 
 <PlaygroundPreview>
   <h5>Header element for the content in which the following Accordions are nested in. (Here this is an h5 element)</h5>

--- a/site/src/docs/components/accordion/index.mdx
+++ b/site/src/docs/components/accordion/index.mdx
@@ -26,7 +26,6 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 - Use accordions to allow the user to quickly glance at the information and then choose to open sections that are interesting to them.
 - **Accordions must be given a header that describes the accordion content.** This header also acts as the label for the expand button. The header level can be chosen depending on the structure of the page.
   - The `headingLevel` given to the Accordion should be higher than the header in the page content preceeding it (if there is one). For example if the Accordion is nested inside content with a header `h2` then the `headingLevel` for the Accordion should be 3.
-  - Also the Accordion size variant should be chosen so that it nicely fits the content, not putting a really large sized Accordion deep in the page structure.
 - **Do not put essential or must-read information inside accordions.** If the user is expected to open all of the accordions while using the service, then it is likely that the information should not be inside accordions.
   - Accordions work well when the user usually needs only part of the information. You may also consider placing parts of lower importance inside accordions while the most important parts are always visible.
 - By default, accordions include a close button that is visible at the bottom of an expanded accordion. This is meant to allow the user to close the accordion quickly if needed.
@@ -92,7 +91,7 @@ HDS Accordion includes three (3) size variants; small, default, and large. You c
 
 #### Accordions, heading elements and `headingLevel`-property
 
-When using multiple Accordions as a group with a common header or the page content has a header preceeding the Accordion(s) keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion the proper `headingLevel` according to it's position.
+When using multiple Accordions as a group with a shared header or the page content has a header preceding the Accordion(s), keep in mind the basics of using the header elements, h1 being the most important header on the page down to h6 being the least important and give the Accordion the proper `headingLevel` according to it's position.
 
 <PlaygroundPreview>
   <h5>Header element for the content in which the following Accordions are nested in. (Here this is an h5 element)</h5>

--- a/site/src/docs/components/accordion/index.mdx
+++ b/site/src/docs/components/accordion/index.mdx
@@ -25,7 +25,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 - Use accordions to allow the user to quickly glance at the information and then choose to open sections that are interesting to them.
 - **Accordions must be given a header that describes the accordion content.** This header also acts as the label for the expand button. The header level can be chosen depending on the structure of the page.
-  - The `headerLevel` given to the Accordion should be higher than the header in the page content preceeding it (if there is one). Making the content semantically correct. For example if the Accordion is nested inside content with a header `h2` then the `headerLevel` for the Accordion should be 3.
+  - The `headingLevel` given to the Accordion should be higher than the header in the page content preceeding it (if there is one). Making the content semantically correct. For example if the Accordion is nested inside content with a header `h2` then the `headingLevel` for the Accordion should be 3.
   - Also the Accordion size variant should be chosen so that it nicely fits the content, not putting a really large sized Accordion deep in the page structure.
 - **Do not put essential or must-read information inside accordions.** If the user is expected to open all of the accordions while using the service, then it is likely that the information should not be inside accordions.
   - Accordions work well when the user usually needs only part of the information. You may also consider placing parts of lower importance inside accordions while the most important parts are always visible.


### PR DESCRIPTION
## Description

Add instructions and an example how to use Accordion `headingLevel`-property and page content headings and their semantic levels properly. Also fixes small style concerning the header styles in Gatsby (not fixing dynamic sizing though, the styles were missing the h5 and h6).

## Related Issue

[HDS-1668](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1668)
[HDS-1706](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1706)

## Screenshots

<img width="866" alt="image" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/aeb594b0-2881-4e21-8635-9e9e999c5d0f">

...

<img width="818" alt="image" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/f3ad585a-ce71-48a3-b20d-6512c18f3823">


The above screenshots are taken from the Accordion's usage page. Updated Principle-texts are highlighted in the screenshot.

## How Has This Been Tested?

Local machine


[HDS-1668]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HDS-1706]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ