### PR TITLE
HDS-585: Updated documentation for Focus Colour tokens

### DIFF
--- a/site/src/components/examples/FocusColorExample.js
+++ b/site/src/components/examples/FocusColorExample.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const FocusColorExample = ({ color, background, style = {}, contentStyle = {}, children }) => (
   <div
-    aria-label="Visualized example"
+    aria-label="Visualized focus example"
     role="img"
     style={{
       fontSize: 'var(--fontsize-body-l)',

--- a/site/src/components/examples/FocusColorExample.js
+++ b/site/src/components/examples/FocusColorExample.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const FocusColorExample = ({ color, background, style = {}, contentStyle = {}, children }) => (
+  <div
+    aria-label="Visualized example"
+    role="img"
+    style={{
+      fontSize: 'var(--fontsize-body-l)',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      display: 'flex',
+      background: `${background}`,
+      ...style,
+    }}
+  >
+    <div
+      style={{
+        border: '3px solid',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '0.25rem',
+        borderColor: `${color}`,
+        ...contentStyle,
+      }}>
+      {children && children}  
+    </div>
+  </div>
+);
+
+FocusColorExample.propTypes = {
+  color: PropTypes.string.isRequired,
+  background: PropTypes.string.isRequired,
+  style: PropTypes.object,
+};
+
+export default FocusColorExample;

--- a/site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -78,13 +78,13 @@ Brand colours also have dark, medium light and light variants. You can find thes
 
 Status colours are reserved exclusively for indicating valid, invalid, or informational states on the service.
 
-| Status name              | Usage                                                                                                   | Example message                             | Example                                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Info                     | State which does not indicate clear success or failure but can be useful extra information to the user. | _"You have received new messages."_         | <ColorExample color="var(--color-info)" name="Info status colour example" />        |
-| Success                  | Positive state to inform user about success.                                                            | _"Form submit was successful!"_             | <ColorExample color="var(--color-success)" name="Success status colour example" />  |
-| Alert                    | Warning state to catch users attention but does not require immediate actions.                          | _"Loading is taking longer than expected."_ | <ColorExample color="var(--color-alert)" name="Alert status colour example" />      |
-| Error                    | Error state which requires users immediate action.                                                      | _"Form is missing critical information."_   | <ColorExample color="var(--color-error)" name="Error status colour example" />      |
-| Focus                    | Focus colour adds blue outline around the focused element.                                              |                                             | <FocusColorExample color="#0072c6" contentStyle={{height: '28px', width: '28px'}}/> |
+| Status name              | Usage                                                                                                   | Example message                             | Example                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Info                     | State which does not indicate clear success or failure but can be useful extra information to the user. | _"You have received new messages."_         | <ColorExample color="var(--color-info)" name="Info status colour example" />                           |
+| Success                  | Positive state to inform user about success.                                                            | _"Form submit was successful!"_             | <ColorExample color="var(--color-success)" name="Success status colour example" />                     |
+| Alert                    | Warning state to catch users attention but does not require immediate actions.                          | _"Loading is taking longer than expected."_ | <ColorExample color="var(--color-alert)" name="Alert status colour example" />                         |
+| Error                    | Error state which requires users immediate action.                                                      | _"Form is missing critical information."_   | <ColorExample color="var(--color-error)" name="Error status colour example" />                         |
+| Focus                    | Focus colour adds blue outline around the focused element.                                              |                                             | <FocusColorExample color="var(--color-focus-outline)" contentStyle={{height: '28px', width: '28px'}}/> |
 | [Table 2:Status colours] |
 
 #### Grayscale

--- a/site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -84,7 +84,7 @@ Status colours are reserved exclusively for indicating valid, invalid, or inform
 | Success                  | Positive state to inform user about success.                                                            | _"Form submit was successful!"_             | <ColorExample color="var(--color-success)" name="Success status colour example" />                     |
 | Alert                    | Warning state to catch users attention but does not require immediate actions.                          | _"Loading is taking longer than expected."_ | <ColorExample color="var(--color-alert)" name="Alert status colour example" />                         |
 | Error                    | Error state which requires users immediate action.                                                      | _"Form is missing critical information."_   | <ColorExample color="var(--color-error)" name="Error status colour example" />                         |
-| Focus                    | Focus colour adds blue outline around the focused element.                                              |                                             | <FocusColorExample color="var(--color-focus-outline)" contentStyle={{height: '28px', width: '28px'}}/> |
+| Focus                    | Indication for active selected element which helps users navigating the page with a keyboard.           |                                             | <FocusColorExample color="var(--color-focus-outline)" contentStyle={{height: '28px', width: '28px'}}/> |
 | [Table 2:Status colours] |
 
 #### Grayscale

--- a/site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -6,6 +6,7 @@ navTitle: 'Colour'
 
 import ColorExample from '../../../../components/examples/ColorExample';
 import ExternalLink from '../../../../components/ExternalLink';
+import FocusExample from '../../../../components/examples/FocusExample';
 import InternalLink from '../../../../components/InternalLink';
 import TabsLayout from './tabs.mdx';
 
@@ -33,6 +34,7 @@ The design system uses a colour theme that includes:
 - **Secondary and Tertiary colours:** these provide more ways for accenting select UI elements and distinguishing your service. The secondary and tertiary colours should be applied sparingly and with intent.
 - **UI colours:** the common colours for feedback (error, warning, success, info).
 - **Grayscale:** neutral colour shades.
+- **Focus colors:** the common colours for focus.
 
 The colour palette also provides lighter and darker variants for the base colours.
 
@@ -92,3 +94,12 @@ Grayscale colours are neutral shades that can be used for all user interface pur
 | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | <ColorExample color="var(--color-black)" name="Black colour example" /> | <ColorExample color="var(--color-black-90)" name="Black-90 colour example" /> | <ColorExample color="var(--color-black-80)" name="Black-80 colour example" /> | <ColorExample color="var(--color-black-70)" name="Black-70 colour example" /> | <ColorExample color="var(--color-black-60)" name="Black-60 colour example" /> | <ColorExample color="var(--color-black-50)" name="Blac-50 colour example" /> | <ColorExample color="var(--color-black-40)" name="Black-40 colour example" /> | <ColorExample color="var(--color-black-30)" name="Black-30 colour example" /> | <ColorExample color="var(--color-black-20)" name="Black-20 colour example" /> | <ColorExample color="var(--color-black-10)" name="Black-10 colour example" /> | <ColorExample color="var(--color-black-5)" name="Black-5 colour example" /> | <ColorExample color="var(--color-white)" name="White colour example" /> |
 | [Table 3:Grayscale]                                                     |
+
+#### Focus Colour
+
+Focus colour indicates focus state and adds blue outline around the element.
+
+| Focus                                              |                                                                                    |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| <FocusExample color="var(--color-focus-outline)"/> | <FocusExample color="var(--color-focus-outline)" background="var(--color-engel)"/> |
+| [Table 4:Focus Colors]                             |

--- a/site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -6,7 +6,7 @@ navTitle: 'Colour'
 
 import ColorExample from '../../../../components/examples/ColorExample';
 import ExternalLink from '../../../../components/ExternalLink';
-import FocusExample from '../../../../components/examples/FocusExample';
+import FocusColorExample from '../../../../components/examples/FocusColorExample';
 import InternalLink from '../../../../components/InternalLink';
 import TabsLayout from './tabs.mdx';
 
@@ -78,12 +78,13 @@ Brand colours also have dark, medium light and light variants. You can find thes
 
 Status colours are reserved exclusively for indicating valid, invalid, or informational states on the service.
 
-| Status name              | Usage                                                                                                   | Example message                             | Example                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Info                     | State which does not indicate clear success or failure but can be useful extra information to the user. | _"You have received new messages."_         | <ColorExample color="var(--color-info)" name="Info status colour example" />       |
-| Success                  | Positive state to inform user about success.                                                            | _"Form submit was successful!"_             | <ColorExample color="var(--color-success)" name="Success status colour example" /> |
-| Alert                    | Warning state to catch users attention but does not require immediate actions.                          | _"Loading is taking longer than expected."_ | <ColorExample color="var(--color-alert)" name="Alert status colour example" />     |
-| Error                    | Error state which requires users immediate action.                                                      | _"Form is missing critical information."_   | <ColorExample color="var(--color-error)" name="Error status colour example" />     |
+| Status name              | Usage                                                                                                   | Example message                             | Example                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Info                     | State which does not indicate clear success or failure but can be useful extra information to the user. | _"You have received new messages."_         | <ColorExample color="var(--color-info)" name="Info status colour example" />        |
+| Success                  | Positive state to inform user about success.                                                            | _"Form submit was successful!"_             | <ColorExample color="var(--color-success)" name="Success status colour example" />  |
+| Alert                    | Warning state to catch users attention but does not require immediate actions.                          | _"Loading is taking longer than expected."_ | <ColorExample color="var(--color-alert)" name="Alert status colour example" />      |
+| Error                    | Error state which requires users immediate action.                                                      | _"Form is missing critical information."_   | <ColorExample color="var(--color-error)" name="Error status colour example" />      |
+| Focus                    | Focus colour adds blue outline around the focused element.                                              |                                             | <FocusColorExample color="#0072c6" contentStyle={{height: '28px', width: '28px'}}/> |
 | [Table 2:Status colours] |
 
 #### Grayscale
@@ -94,12 +95,3 @@ Grayscale colours are neutral shades that can be used for all user interface pur
 | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | <ColorExample color="var(--color-black)" name="Black colour example" /> | <ColorExample color="var(--color-black-90)" name="Black-90 colour example" /> | <ColorExample color="var(--color-black-80)" name="Black-80 colour example" /> | <ColorExample color="var(--color-black-70)" name="Black-70 colour example" /> | <ColorExample color="var(--color-black-60)" name="Black-60 colour example" /> | <ColorExample color="var(--color-black-50)" name="Blac-50 colour example" /> | <ColorExample color="var(--color-black-40)" name="Black-40 colour example" /> | <ColorExample color="var(--color-black-30)" name="Black-30 colour example" /> | <ColorExample color="var(--color-black-20)" name="Black-20 colour example" /> | <ColorExample color="var(--color-black-10)" name="Black-10 colour example" /> | <ColorExample color="var(--color-black-5)" name="Black-5 colour example" /> | <ColorExample color="var(--color-white)" name="White colour example" /> |
 | [Table 3:Grayscale]                                                     |
-
-#### Focus Colour
-
-Focus colour indicates focus state and adds blue outline around the element.
-
-| Focus                                              |                                                                                    |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| <FocusExample color="var(--color-focus-outline)"/> | <FocusExample color="var(--color-focus-outline)" background="var(--color-engel)"/> |
-| [Table 4:Focus Colors]                             |

--- a/site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -34,7 +34,7 @@ The design system uses a colour theme that includes:
 - **Secondary and Tertiary colours:** these provide more ways for accenting select UI elements and distinguishing your service. The secondary and tertiary colours should be applied sparingly and with intent.
 - **UI colours:** the common colours for feedback (error, warning, success, info).
 - **Grayscale:** neutral colour shades.
-- **Focus colors:** the common colours for focus.
+- **Focus colours:** the common colours for focus.
 
 The colour palette also provides lighter and darker variants for the base colours.
 

--- a/site/src/docs/foundation/design-tokens/colour/tokens.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/tokens.mdx
@@ -68,13 +68,13 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 | `--color-tram-light`               | `$color-tram-light`               | `#dff7eb` | <TextAndColorExample color="var(--color-tram-light)" name="Tram example" />                        |
 [Table 2:Brand colour variation tokens]|
 
-| CSS variable           | SASS variable         | HEX value | Example                                                                                                                                              |
-| ---------------------- | --------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--color-info`         | `$color-info`         | `#0062b9` | <TextAndColorExample color="var(--color-info)" name="Info example" />                                                                                |
-| `--color-success`      | `$color-success`      | `#007a64` | <TextAndColorExample color="var(--color-success)" name="Success example" />                                                                          |
-| `--color-alert`        | `$color-alert`        | `#ffda07` | <TextAndColorExample color="var(--color-alert)" name="Alert example" />                                                                              |
-| `--color-error`        | `$color-error`        | `#b01038` | <TextAndColorExample color="var(--color-error)" name="Error example" />                                                                              |
-| `--color-focus-outline`| `$color-focus-outline`| `#0072c6` | <FocusColorExample color="#0072c6"><TextAndColorExample style={{margin: 'auto'}} color="var(--color-info)" name="Info example" /></FocusColorExample>|
+| CSS variable           | SASS variable         | HEX value | Example                                                                                                                             |
+| ---------------------- | --------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `--color-info`         | `$color-info`         | `#0062b9` | <TextAndColorExample color="var(--color-info)" name="Info example" />                                                               |
+| `--color-success`      | `$color-success`      | `#007a64` | <TextAndColorExample color="var(--color-success)" name="Success example" />                                                         |
+| `--color-alert`        | `$color-alert`        | `#ffda07` | <TextAndColorExample color="var(--color-alert)" name="Alert example" />                                                             |
+| `--color-error`        | `$color-error`        | `#b01038` | <TextAndColorExample color="var(--color-error)" name="Error example" />                                                             |
+| `--color-focus-outline`| `$color-focus-outline`| `#0072c6` | <FocusColorExample color="var(--color-focus-outline)"><TextAndColorExample color="var(--color-focus-outline)"/></FocusColorExample> |
 [Table 3:UI colour tokens]|
 
 | CSS variable           | SASS variable         | HEX value | Example                                                                                         |

--- a/site/src/docs/foundation/design-tokens/colour/tokens.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/tokens.mdx
@@ -4,6 +4,7 @@ title: 'Colour tokens - Tokens'
 ---
 
 import TextAndColorExample from '../../../../components/examples/TextAndColorExample';
+import FocusExample from '../../../../components/examples/FocusExample';
 
 import TabsLayout from './tabs.mdx';
 
@@ -70,18 +71,22 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 | CSS variable           | SASS variable         | HEX value | Example                                                                                         |
 | ---------------------- | --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
 | `--color-info`         | `$color-info`         | `#0062b9` | <TextAndColorExample color="var(--color-info)" name="Info example" />                           |
+| `--color-success`      | `$color-success`      | `#007a64` | <TextAndColorExample color="var(--color-success)" name="Success example" />                     |
+| `--color-alert`        | `$color-alert`        | `#ffda07` | <TextAndColorExample color="var(--color-alert)" name="Alert example" />                         |
+| `--color-error`        | `$color-error`        | `#b01038` | <TextAndColorExample color="var(--color-error)" name="Error example" />                         |
+[Table 3:UI colour tokens]|
+
+| CSS variable           | SASS variable         | HEX value | Example                                                                                         |
+| ---------------------- | --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
 | `--color-info-dark`    | `$color-info-dark`    | `#004f94` | <TextAndColorExample color="var(--color-info-dark)" name="Info dark variant example" />         |
 | `--color-info-light`   | `$color-info-light`   | `#e5eff8` | <TextAndColorExample color="var(--color-info-light)" name="Info light variant example" />       |
-| `--color-success`      | `$color-success`      | `#007a64` | <TextAndColorExample color="var(--color-success)" name="Success example" />                     |
 | `--color-success-dark` | `$color-success-dark` | `#006250` | <TextAndColorExample color="var(--color-success-dark)" name="Success dark variant example" />   |
 | `--color-success-light`| `$color-success-light`| `#e2f5f3` | <TextAndColorExample color="var(--color-success-light)" name="Success light variant example" /> |
-| `--color-alert`        | `$color-alert`        | `#ffda07` | <TextAndColorExample color="var(--color-alert)" name="Alert example" />                         |
 | `--color-alert-dark`   | `$color-alert-dark`   | `#d18200` | <TextAndColorExample color="var(--color-alert-dark)" name="Alert dark variant example" />       |
 | `--color-alert-light`  | `$color-alert-light`  | `#fff4b4` | <TextAndColorExample color="var(--color-alert-light)" name="Alert light variant example" />     |
-| `--color-error`        | `$color-error`        | `#b01038` | <TextAndColorExample color="var(--color-error)" name="Error example" />                         |
 | `--color-error-dark`   | `$color-error-dark`   | `#8d0d2d` | <TextAndColorExample color="var(--color-error-dark)" name="Error dark variant example" />       |
 | `--color-error-light`  | `$color-error-light`  | `#f6e2e6` | <TextAndColorExample color="var(--color-error-light)" name="Error light variant example" />     |
-[Table 3:Brand colour tokens]|
+[Table 4:UI colour variation tokens]|
 
 | CSS variable           | SASS variable         | HEX value | Example                                                                                         |
 | ---------------------- | --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
@@ -97,4 +102,9 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 | `--color-black-10`     | `$color-black-10`     | `#e6e6e6` | <TextAndColorExample color="var(--color-black-10)" name="Black-10 example" />                   |
 | `--color-black-5`      | `$color-black-5`      | `#f2f2f2` | <TextAndColorExample color="var(--color-black-5)" name="Black-5 example" />                     |
 | `--color-white`        | `$color-white`        | `#ffffff` | <TextAndColorExample color="var(--color-white)" name="White example" />                         |
-[Table 4:Grayscale tokens]|
+[Table 5:Grayscale tokens]|
+
+| CSS variable              | SASS variable         | HEX value | Example                                                                            |
+| ------------------------- | --------------------- | --------- | -----------------------------------------------------------------------------------|
+| `--color-focus-outline`   | `$color-focus-outline`| `#0072c6` | <FocusExample color="#0072c6"/>                                                    |
+[Table 6:Focus colour token]|

--- a/site/src/docs/foundation/design-tokens/colour/tokens.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/tokens.mdx
@@ -4,7 +4,7 @@ title: 'Colour tokens - Tokens'
 ---
 
 import TextAndColorExample from '../../../../components/examples/TextAndColorExample';
-import FocusExample from '../../../../components/examples/FocusExample';
+import FocusColorExample from '../../../../components/examples/FocusColorExample';
 
 import TabsLayout from './tabs.mdx';
 
@@ -68,12 +68,13 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 | `--color-tram-light`               | `$color-tram-light`               | `#dff7eb` | <TextAndColorExample color="var(--color-tram-light)" name="Tram example" />                        |
 [Table 2:Brand colour variation tokens]|
 
-| CSS variable           | SASS variable         | HEX value | Example                                                                                         |
-| ---------------------- | --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
-| `--color-info`         | `$color-info`         | `#0062b9` | <TextAndColorExample color="var(--color-info)" name="Info example" />                           |
-| `--color-success`      | `$color-success`      | `#007a64` | <TextAndColorExample color="var(--color-success)" name="Success example" />                     |
-| `--color-alert`        | `$color-alert`        | `#ffda07` | <TextAndColorExample color="var(--color-alert)" name="Alert example" />                         |
-| `--color-error`        | `$color-error`        | `#b01038` | <TextAndColorExample color="var(--color-error)" name="Error example" />                         |
+| CSS variable           | SASS variable         | HEX value | Example                                                                                                                                              |
+| ---------------------- | --------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--color-info`         | `$color-info`         | `#0062b9` | <TextAndColorExample color="var(--color-info)" name="Info example" />                                                                                |
+| `--color-success`      | `$color-success`      | `#007a64` | <TextAndColorExample color="var(--color-success)" name="Success example" />                                                                          |
+| `--color-alert`        | `$color-alert`        | `#ffda07` | <TextAndColorExample color="var(--color-alert)" name="Alert example" />                                                                              |
+| `--color-error`        | `$color-error`        | `#b01038` | <TextAndColorExample color="var(--color-error)" name="Error example" />                                                                              |
+| `--color-focus-outline`| `$color-focus-outline`| `#0072c6` | <FocusColorExample color="#0072c6"><TextAndColorExample style={{margin: 'auto'}} color="var(--color-info)" name="Info example" /></FocusColorExample>|
 [Table 3:UI colour tokens]|
 
 | CSS variable           | SASS variable         | HEX value | Example                                                                                         |
@@ -103,8 +104,3 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 | `--color-black-5`      | `$color-black-5`      | `#f2f2f2` | <TextAndColorExample color="var(--color-black-5)" name="Black-5 example" />                     |
 | `--color-white`        | `$color-white`        | `#ffffff` | <TextAndColorExample color="var(--color-white)" name="White example" />                         |
 [Table 5:Grayscale tokens]|
-
-| CSS variable              | SASS variable         | HEX value | Example                                                                            |
-| ------------------------- | --------------------- | --------- | -----------------------------------------------------------------------------------|
-| `--color-focus-outline`   | `$color-focus-outline`| `#0072c6` | <FocusExample color="#0072c6"/>                                                    |
-[Table 6:Focus colour token]|


### PR DESCRIPTION
## Description

This PR adds documentation for focus color tokens. Also updated examples for color tokens 

## Motivation and Context

[HDS-585](https://helsinkisolutionoffice.atlassian.net/browse/HDS-585)

## How Has This Been Tested?

Tested locally

## Demo

[Site Demo](https://city-of-helsinki.github.io/hds-demo/focus-colour-demo-site/foundation/design-tokens/colour/)
[Button Demo](https://city-of-helsinki.github.io/hds-demo/focus-colour-demo-react/?path=/story/components-button--primary)

## TODO

- [ ] fix text to use consistently british english "colour"
- [ ] move focus color to ui colous section
- [ ] improve text so that it doesn't mention the blue (as it can be changed anyway)

[HDS-585]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ