### PR TITLE
Fix FileInput maximum file size to maxSize

### DIFF
--- a/packages/react/src/components/fileInput/FileInput.test.tsx
+++ b/packages/react/src/components/fileInput/FileInput.test.tsx
@@ -142,6 +142,8 @@ describe('<FileInput /> spec', () => {
     const firstFile = new File(['test'], firstFileName, { type: 'image/png' });
     const secondFileName = 'test-file-b';
     const secondFile = new File(['test-file-with-too-long-content'], secondFileName, { type: 'image/png' });
+    const thirdFileName = 'test-file-with-exactly-max-size-bytes';
+    const thirdFile = new File(['0123456789'], thirdFileName, { type: 'image/png' });
     render(
       <FileInput
         id="test-file-input"
@@ -153,10 +155,10 @@ describe('<FileInput /> spec', () => {
       />,
     );
     const fileUpload = screen.getByLabelText(inputLabel);
-    userEvent.upload(fileUpload, [firstFile, secondFile]);
+    userEvent.upload(fileUpload, [firstFile, secondFile, thirdFile]);
     expect(screen.getByText(firstFileName)).toBeInTheDocument();
-    expect(screen.getByText('1/2 file(s) added', { exact: false })).toBeInTheDocument();
-    expect(screen.getByText('File processing failed for 1/2 files:', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('2/3 file(s) added', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('File processing failed for 1/3 files:', { exact: false })).toBeInTheDocument();
     expect(
       screen.getByText(`File, ${secondFileName}, is too large (31 B). The maximum file size is 10 B.`, {
         exact: false,

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -319,7 +319,7 @@ const validateAccept = (language: Language, accept: string) => (file: File): tru
 
 const validateMaxSize = (language: Language, maxSize: number) => (file: File): true | ValidationError => {
   return (
-    file.size < maxSize || {
+    file.size <= maxSize || {
       type: ValidationErrorType.maxSize,
       text: getMaxSizeErrorMessage(language, file, maxSize),
     }


### PR DESCRIPTION
## Description

Currently, if maxSize is set, the file added in FileInput needs to be smaller than the file. If adding a file exactly the size of the limit, we get a confusing validation message:
> - File, test.png, is too large (100 B). The maximum file size is 100 B.

Fix this by allowing the file to be smaller or equal to maxSize.