### PR TITLE
Change old hds-core style imports

### DIFF
--- a/packages/react/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import 'hds-core';
+// import base styles
+import '../../styles/base.css';
+
 import styles from './Breadcrumb.module.scss';
 import { Link } from '../link';
 import { IconAngleLeft, IconAngleRight } from '../../icons';

--- a/packages/react/src/components/hero/Hero.tsx
+++ b/packages/react/src/components/hero/Hero.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-// import core base styles
-import 'hds-core';
+// import base styles
+import '../../styles/base.css';
+
 import styles from './Hero.module.scss';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';


### PR DESCRIPTION
Imports in other components were already changed in another PR.

These components were missed, because their PR were open at the same time.

## How Has This Been Tested?

Visually with Loki 