### PR TITLE
HDS-1771: Renamed one Hero core css-class name 

### DIFF
--- a/packages/core/src/components/hero/hero.css
+++ b/packages/core/src/components/hero/hero.css
@@ -131,7 +131,7 @@
   object-position: var(--image-position);
 }
 
-.hds-hero--with-background__contentcolumns {
+.hds-hero--with-background__content-columns {
   display: flex;
   margin: 0 auto;
   max-width: var(--container-width-xl);

--- a/packages/core/src/components/hero/hero.stories.js
+++ b/packages/core/src/components/hero/hero.stories.js
@@ -92,7 +92,7 @@ export const DiagonalKoros = () => `
   <div class="hds-hero custom-theme hds-hero--diagonal-koros">
     <div class="hds-hero--with-background__container">
       <div class="hds-hero__content">
-        <div class="hds-hero--with-background__contentcolumns">
+        <div class="hds-hero--with-background__content-columns">
           ${card}
           <div class="hds-hero--with-background__empty-column"></div>
         </div>

--- a/packages/react/src/components/hero/Hero.module.scss
+++ b/packages/react/src/components/hero/Hero.module.scss
@@ -81,7 +81,7 @@
 }
 
 .contentColums {
-  composes: hds-hero--with-background__contentcolumns from 'hds-core/lib/components/hero/hero.css';
+  composes: hds-hero--with-background__content-columns from 'hds-core/lib/components/hero/hero.css';
 }
 
 .emptyColumn {

--- a/site/src/docs/components/hero/code.mdx
+++ b/site/src/docs/components/hero/code.mdx
@@ -60,7 +60,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   <div class="hds-hero custom-theme hds-hero--diagonal-koros">
     <div class="hds-hero--with-background__container">
       <div class="hds-hero__content">
-        <div class="hds-hero--with-background__contentColumns">
+        <div class="hds-hero--with-background__content-columns">
           <div class="hds-hero__card">
             <h1 class="hds-hero__title">Hero title</h1>
             <p class="hds-hero__text">


### PR DESCRIPTION
## Description

Small fix to Hero core class name so the name is solid with other core class names

## Motivation and Context

[HDS-1771](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1771)

## How Has This Been Tested?

Tested locally

## Demos 

- [ React](https://city-of-helsinki.github.io/hds-demo/HDS-1771-hero-doc-site-fix-react/?path=/story/components-hero--diagonal-koros)
- [Core](https://city-of-helsinki.github.io/hds-demo/HDS-1771-hero-doc-site-fix-core/?path=/story/components-hero--diagonal-koros)
- [Documentation](https://city-of-helsinki.github.io/hds-demo/HDS-1771-hero-doc-site-fix/components/hero/code)





[HDS-1771]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ