### PR TITLE
Hds 1752 Open dropdown menu only from click

### DIFF
--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.test.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.test.tsx
@@ -18,11 +18,19 @@ describe('<NavigationLink /> spec', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('should open dropdown when the link is hovered', async () => {
+  it('should not open dropdown when the link is hovered', async () => {
     render(<NavigationLink href="#" label="Link" dropdownLinks={[<NavigationLink href="#" label="Test" />]} />, {
       wrapper: HeaderNavigationMenuWrapper,
     });
     userEvent.hover(screen.getByText('Link'));
+    expect(screen.getByTestId('dropdown-menu-0')).not.toBeVisible();
+  });
+
+  it('should open dropdown when the link is clicked', async () => {
+    render(<NavigationLink href="#" label="Link" dropdownLinks={[<NavigationLink href="#" label="Test" />]} />, {
+      wrapper: HeaderNavigationMenuWrapper,
+    });
+    userEvent.click(screen.getByText('Link'));
     expect(screen.getByTestId('dropdown-menu-0')).toBeVisible();
   });
 
@@ -35,12 +43,12 @@ describe('<NavigationLink /> spec', () => {
       { wrapper: HeaderNavigationMenuWrapper },
     );
 
-    // Hover the first main navigation link
-    userEvent.hover(screen.getByText('Link 1'));
+    // Click the first main navigation link
+    userEvent.click(screen.getByText('Link 1'));
     expect(screen.getByTestId('dropdown-menu-0')).toBeVisible();
 
-    // Hoer the second main navigation link
-    userEvent.hover(screen.getByText('Link 2'));
+    // Click the second main navigation link
+    userEvent.click(screen.getByText('Link 2'));
 
     // Now the second dropdown should show
     expect(screen.getByTestId('dropdown-menu-1')).toBeVisible();

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
@@ -244,14 +244,10 @@ export const NavigationLink = <T extends React.ElementType = 'a'>({
   return (
     <span
       className={navigationWrapperLinkClassName}
-      {...(dropdownLinks &&
-        dropdownOpenedBy === NavigationLinkInteraction.Hover && {
-          onMouseLeave: () => handleDropdownOpen(false),
-        })}
       ref={containerRef}
       {...(dropdownLinks &&
         dropdownOpenedBy !== NavigationLinkInteraction.Click && {
-          onMouseEnter: () => handleDropdownOpen(true, NavigationLinkInteraction.Hover),
+          onClick: () => handleDropdownOpen(true, NavigationLinkInteraction.Click),
         })}
     >
       <Item


### PR DESCRIPTION
## Description

For accessibility reasons, dropdown -menu is opened only from click

## Motivation and Context

[HDS-1752](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1752)

## How Has This Been Tested?

Tested locally

## Demo:

React [In Storybook](https://city-of-helsinki.github.io/hds-demo/HDS-1752-remove-open-menu-on-hover/?path=/story/components-header--with-full-features)


[HDS-1752]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ