### PR TITLE
Hds 1626 footer docs

### DIFF
--- a/packages/react/src/components/footer/Footer.stories.tsx
+++ b/packages/react/src/components/footer/Footer.stories.tsx
@@ -10,12 +10,7 @@ import { FooterUtilities } from './components/footerUtilities/FooterUtilities';
 import { FooterUtilityGroup } from './components/footerUtilityGroup/FooterUtilityGroup';
 import { FooterBase } from './components/footerBase/FooterBase';
 import { FooterCustom } from './components/footerCustom/FooterCustom';
-import { FooterVariant } from './Footer.interface';
 
-const footerNavAriaLabel = 'Footer navigation items';
-const footerCustomAriaLabel = 'Custom area';
-const footerUtilityAriaLabel = 'Utility links';
-const footerBaseAriaLabel = 'Copyright information';
 const createArray = (length: number): number[] => Array.from({ length }, (value, index) => index);
 
 const Utilities = () => {
@@ -64,50 +59,24 @@ const Utilities = () => {
     ];
   };
   return (
-    <Footer.Utilities ariaLabel={footerUtilityAriaLabel} soMeLinks={someLinks()}>
-      <Footer.NavigationLink
-        href="https://google.com"
-        onClick={(e) => e.preventDefault()}
-        label="Contact us"
-        variant={FooterVariant.Utility}
-      />
-      <Footer.NavigationLink
-        href="https://google.com"
-        onClick={(e) => e.preventDefault()}
-        label="Give feedback"
-        variant={FooterVariant.Utility}
-      />
-      <Footer.NavigationLink
-        href="https://google.com"
-        onClick={(e) => e.preventDefault()}
-        label="Support"
-        variant={FooterVariant.Utility}
-      />
-      <Footer.NavigationLink
-        href="https://google.com"
-        onClick={(e) => e.preventDefault()}
-        label="About"
-        variant={FooterVariant.Utility}
-      />
+    <Footer.Utilities soMeLinks={someLinks()}>
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="Contact us" />
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="Give feedback" />
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="Support" />
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="About" />
       <Footer.NavigationLink
         href="https://google.com"
         onClick={(e) => e.preventDefault()}
         label="Github page"
         external
         openInNewTab
-        variant={FooterVariant.Utility}
       />
     </Footer.Utilities>
   );
 };
 
 const Base = () => (
-  <Footer.Base
-    copyrightHolder="Copyright"
-    copyrightText="All rights reserved"
-    backToTopLabel="Back to top"
-    ariaLabel={footerBaseAriaLabel}
-  >
+  <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
     {createArray(5).map((index) => (
       <Footer.NavigationLink
         key={index}
@@ -115,7 +84,6 @@ const Base = () => (
         onClick={(e) => e.preventDefault()}
         label="Link"
         className="test"
-        variant={FooterVariant.Base}
         {...(index === 4 && { external: true, openInNewTab: true })}
       />
     ))}
@@ -149,14 +117,13 @@ export default {
 
 export const Default = (args) => (
   <Footer {...args}>
-    <Footer.Navigation ariaLabel={footerNavAriaLabel}>
+    <Footer.Navigation>
       {createArray(8).map((index) => (
         <Footer.NavigationLink
           key={index}
           href="https://google.com"
           onClick={(e) => e.preventDefault()}
           label="Nav item"
-          variant={FooterVariant.Navigation}
         />
       ))}
     </Footer.Navigation>
@@ -175,14 +142,13 @@ NoNav.storyName = 'No navigation';
 
 export const CustomTheme = (args) => (
   <Footer {...args}>
-    <Footer.Navigation ariaLabel={footerNavAriaLabel}>
+    <Footer.Navigation>
       {createArray(8).map((index) => (
         <Footer.NavigationLink
           key={index}
           href="https://google.com"
           onClick={(e) => e.preventDefault()}
           label="Nav item"
-          variant={FooterVariant.Navigation}
         />
       ))}
     </Footer.Navigation>
@@ -209,13 +175,11 @@ CustomTheme.argTypes = {
 
 export const Sitemap = (args) => (
   <Footer {...args}>
-    <Footer.Navigation ariaLabel={footerNavAriaLabel}>
+    <Footer.Navigation>
       {createArray(4).map((index) => (
         <Footer.NavigationGroup
           key={index}
-          headingLink={
-            <Footer.GroupHeading href="https://yourpath.com" label="Main Page" variant={FooterVariant.Navigation} />
-          }
+          headingLink={<Footer.GroupHeading href="https://yourpath.com" label="Main Page" />}
         >
           {createArray(6).map((subIndex) => {
             return (
@@ -224,7 +188,6 @@ export const Sitemap = (args) => (
                 href="https://google.com"
                 onClick={(e) => e.preventDefault()}
                 label="Sub page"
-                variant={FooterVariant.Navigation}
                 subItem
               />
             );
@@ -239,37 +202,16 @@ export const Sitemap = (args) => (
 
 export const Example = (args) => (
   <Footer footerProps={{ lang: 'fi' }} {...args}>
-    <Footer.Navigation ariaLabel="Nostoja palveluista">
-      <Footer.NavigationLink
-        href="https://asiointi.hel.fi/wps/portal/login?locale=fi"
-        label="Sähköinen asiointi"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://palvelukartta.hel.fi/"
-        label="Palvelut kartalla"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://hel.fi/yritystenhelsinki"
-        label="Yritysten Helsinki"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://hel.fi/rekry/fi"
-        label="Avoimet työpaikat"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://helsinkikanava.fi/fi_FI/"
-        label="Videoita kaupungista"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink href="https://helmet.fi/" label="Kirjastot verkossa" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink href="https://reittiopas.fi/" label="Reittiopas" variant={FooterVariant.Navigation} />
+    <Footer.Navigation>
+      <Footer.NavigationLink href="https://asiointi.hel.fi/wps/portal/login?locale=fi" label="Sähköinen asiointi" />
+      <Footer.NavigationLink href="https://palvelukartta.hel.fi/" label="Palvelut kartalla" />
+      <Footer.NavigationLink href="https://hel.fi/yritystenhelsinki" label="Yritysten Helsinki" />
+      <Footer.NavigationLink href="https://hel.fi/rekry/fi" label="Avoimet työpaikat" />
+      <Footer.NavigationLink href="https://helsinkikanava.fi/fi_FI/" label="Videoita kaupungista" />
+      <Footer.NavigationLink href="https://helmet.fi/" label="Kirjastot verkossa" />
+      <Footer.NavigationLink href="https://reittiopas.fi/" label="Reittiopas" />
     </Footer.Navigation>
     <Footer.Utilities
-      ariaLabel={footerUtilityAriaLabel}
       soMeSectionProps={{ 'aria-label': 'Helsinki sosiaalisessa mediassa' }}
       soMeLinks={[
         <Footer.NavigationLink
@@ -279,7 +221,6 @@ export const Example = (args) => (
           openInNewTab
           icon={<IconFacebook aria-hidden="true" />}
           href="https://facebook.com/helsinginkaupunki/"
-          variant={FooterVariant.Utility}
         />,
         <Footer.NavigationLink
           title="Helsingin kaupungin Twitter-tili"
@@ -288,7 +229,6 @@ export const Example = (args) => (
           openInNewTab
           icon={<IconTwitter aria-hidden="true" />}
           href="https://twitter.com/helsinki"
-          variant={FooterVariant.Utility}
         />,
         <Footer.NavigationLink
           title="Helsingin kaupungin Instagram-tili"
@@ -297,7 +237,6 @@ export const Example = (args) => (
           openInNewTab
           icon={<IconInstagram aria-hidden="true" />}
           href="https://instagram.com/helsinki/"
-          variant={FooterVariant.Utility}
         />,
         <Footer.NavigationLink
           title="Helsingin kaupungin LinkedIn-tili"
@@ -306,7 +245,6 @@ export const Example = (args) => (
           openInNewTab
           icon={<IconLinkedin aria-hidden="true" />}
           href="https://linkedin.com/company/city-of-helsinki"
-          variant={FooterVariant.Utility}
         />,
         <Footer.NavigationLink
           title="Helsingin kaupungin Youtube-tili"
@@ -315,41 +253,31 @@ export const Example = (args) => (
           openInNewTab
           icon={<IconYoutube aria-hidden="true" />}
           href="https://youtube.com/channel/UCzJFvpjRB62oRoep4oRgwjg"
-          variant={FooterVariant.Utility}
         />,
       ]}
     >
       <Footer.NavigationLink
         href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/ota-yhteytta/ota-yhteytta"
         label="Yhteystiedot"
-        variant={FooterVariant.Utility}
       />
       <Footer.NavigationLink
         href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta"
         label="Anna ja lue palautetta"
-        variant={FooterVariant.Utility}
       />
-      <Footer.NavigationLink
-        href="https://hel.fi/kanslia/neuvonta-fi"
-        label="Chat-neuvonta"
-        variant={FooterVariant.Utility}
-      />
+      <Footer.NavigationLink href="https://hel.fi/kanslia/neuvonta-fi" label="Chat-neuvonta" />
     </Footer.Utilities>
     <Footer.Base
       copyrightHolder="Helsingin kaupunki"
       copyrightText="Kaikki oikeudet pidetään"
       backToTopLabel="Sivun alkuun"
-      ariaLabel={footerBaseAriaLabel}
     >
       <Footer.NavigationLink
         href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietoa-hel-fista/"
         label="Tietoa palvelusta"
-        variant={FooterVariant.Base}
       />
       <Footer.NavigationLink
         href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/saavutettavuus/saavutettavuus-helfi-sivustolla/"
         label="Saavutettavuusseloste"
-        variant={FooterVariant.Base}
       />
     </Footer.Base>
   </Footer>
@@ -357,36 +285,16 @@ export const Example = (args) => (
 
 export const UtilityGroups = (args) => (
   <Footer footerProps={{ lang: 'fi' }} {...args}>
-    <Footer.Navigation ariaLabel="Nostoja palveluista">
-      <Footer.NavigationLink
-        href="https://asiointi.hel.fi/wps/portal/login?locale=fi"
-        label="Sähköinen asiointi"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://palvelukartta.hel.fi/"
-        label="Palvelut kartalla"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://hel.fi/yritystenhelsinki"
-        label="Yritysten Helsinki"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://hel.fi/rekry/fi"
-        label="Avoimet työpaikat"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink
-        href="https://helsinkikanava.fi/fi_FI/"
-        label="Videoita kaupungista"
-        variant={FooterVariant.Navigation}
-      />
-      <Footer.NavigationLink href="https://helmet.fi/" label="Kirjastot verkossa" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink href="https://reittiopas.fi/" label="Reittiopas" variant={FooterVariant.Navigation} />
+    <Footer.Navigation>
+      <Footer.NavigationLink href="https://asiointi.hel.fi/wps/portal/login?locale=fi" label="Sähköinen asiointi" />
+      <Footer.NavigationLink href="https://palvelukartta.hel.fi/" label="Palvelut kartalla" />
+      <Footer.NavigationLink href="https://hel.fi/yritystenhelsinki" label="Yritysten Helsinki" />
+      <Footer.NavigationLink href="https://hel.fi/rekry/fi" label="Avoimet työpaikat" />
+      <Footer.NavigationLink href="https://helsinkikanava.fi/fi_FI/" label="Videoita kaupungista" />
+      <Footer.NavigationLink href="https://helmet.fi/" label="Kirjastot verkossa" />
+      <Footer.NavigationLink href="https://reittiopas.fi/" label="Reittiopas" />
     </Footer.Navigation>
-    <Footer.Utilities ariaLabel={footerUtilityAriaLabel}>
+    <Footer.Utilities>
       {createArray(3).map((index) => (
         <Footer.UtilityGroup
           key={index}
@@ -395,7 +303,6 @@ export const UtilityGroups = (args) => (
               href="https://google.com"
               onClick={(e) => e.preventDefault()}
               label="Group heading link"
-              variant={FooterVariant.Utility}
             />
           }
         >
@@ -406,16 +313,12 @@ export const UtilityGroups = (args) => (
                 href="https://google.com"
                 onClick={(e) => e.preventDefault()}
                 label="Group link"
-                variant={FooterVariant.Utility}
               />
             );
           })}
         </Footer.UtilityGroup>
       ))}
-      <Footer.UtilityGroup
-        key={6}
-        headingLink={<Footer.GroupHeading label="Social media" variant={FooterVariant.Utility} />}
-      >
+      <Footer.UtilityGroup key={6} headingLink={<Footer.GroupHeading label="Social media" />}>
         <Footer.NavigationLink
           title="Helsingin kaupungin Facebook-tili"
           label="Facebook"
@@ -424,7 +327,6 @@ export const UtilityGroups = (args) => (
           openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
           icon={<IconFacebook aria-hidden="true" />}
           href="https://facebook.com/helsinginkaupunki/"
-          variant={FooterVariant.Utility}
         />
         <Footer.NavigationLink
           title="Helsingin kaupungin Facebook-tili"
@@ -434,7 +336,6 @@ export const UtilityGroups = (args) => (
           openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
           icon={<IconFacebook aria-hidden="true" />}
           href="https://facebook.com/helsinginkaupunki/"
-          variant={FooterVariant.Utility}
         />
         <Footer.NavigationLink
           title="Helsingin kaupungin Twitter-tili"
@@ -444,7 +345,6 @@ export const UtilityGroups = (args) => (
           openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
           icon={<IconTwitter aria-hidden="true" />}
           href="https://twitter.com/helsinki"
-          variant={FooterVariant.Utility}
         />
         <Footer.NavigationLink
           title="Helsingin kaupungin Instagram-tili"
@@ -454,7 +354,6 @@ export const UtilityGroups = (args) => (
           openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
           icon={<IconInstagram aria-hidden="true" />}
           href="https://instagram.com/helsinki/"
-          variant={FooterVariant.Utility}
         />
       </Footer.UtilityGroup>
     </Footer.Utilities>
@@ -462,17 +361,14 @@ export const UtilityGroups = (args) => (
       copyrightHolder="Helsingin kaupunki"
       copyrightText="Kaikki oikeudet pidetään"
       backToTopLabel="Sivun alkuun"
-      ariaLabel={footerBaseAriaLabel}
     >
       <Footer.NavigationLink
         href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietoa-hel-fista/"
         label="Tietoa palvelusta"
-        variant={FooterVariant.Base}
       />
       <Footer.NavigationLink
         href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/saavutettavuus/saavutettavuus-helfi-sivustolla/"
         label="Saavutettavuusseloste"
-        variant={FooterVariant.Base}
       />
     </Footer.Base>
   </Footer>
@@ -480,19 +376,18 @@ export const UtilityGroups = (args) => (
 
 export const CustomSection = (args) => (
   <Footer {...args}>
-    <Footer.Navigation ariaLabel={footerNavAriaLabel}>
+    <Footer.Navigation>
       {createArray(8).map((index) => (
         <Footer.NavigationLink
           key={index}
           href="https://google.com"
           onClick={(e) => e.preventDefault()}
           label="Nav item"
-          variant={FooterVariant.Navigation}
         />
       ))}
     </Footer.Navigation>
     <Utilities />
-    <Footer.Custom ariaLabel={footerCustomAriaLabel}>
+    <Footer.Custom>
       <Footer.GroupHeading label="Partners" id="partners" />
       <div
         aria-label="partners"

--- a/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
+++ b/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, Fragment } from 'react';
+import React, { cloneElement, Fragment, isValidElement } from 'react';
 
 // import base styles
 import '../../../../styles/base.css';
@@ -8,7 +8,8 @@ import { Logo, LogoLanguage } from '../../../logo';
 import { IconArrowUp } from '../../../../icons';
 import getKeyboardFocusableElements from '../../../../utils/getKeyboardFocusableElements';
 import { FooterNavigationLink } from '../footerNavigationLink/FooterNavigationLink';
-import { getChildrenAsArray } from '../../../../utils/getChildren';
+import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
+import { FooterVariant } from '../../Footer.interface';
 
 export type FooterBaseProps = React.PropsWithChildren<{
   /**
@@ -67,7 +68,7 @@ export const FooterBase = ({
   showBackToTopButton = true,
   year = new Date().getFullYear(),
 }: FooterBaseProps) => {
-  const childElements = getChildrenAsArray(children);
+  const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
     <div className={styles.base}>
       <hr className={styles.divider} aria-hidden />
@@ -95,12 +96,14 @@ export const FooterBase = ({
         {children && (
           <div className={styles.links}>
             {childElements.map((child, index) => {
-              if (React.isValidElement(child)) {
+              if (isValidElement(child)) {
                 return (
                   // eslint-disable-next-line react/no-array-index-key
                   <Fragment key={index}>
                     <span className={styles.separator}>|</span>
-                    {cloneElement(child)}
+                    {cloneElement(child as React.ReactElement, {
+                      variant: FooterVariant.Base,
+                    })}
                   </Fragment>
                 );
               }

--- a/packages/react/src/components/footer/components/footerGroupHeading/FooterGroupHeading.tsx
+++ b/packages/react/src/components/footer/components/footerGroupHeading/FooterGroupHeading.tsx
@@ -27,6 +27,7 @@ type ItemProps<T> = React.PropsWithChildren<{
   label?: string | React.ReactNode;
   /**
    * Internal variant to change styles based on context.
+   * @internal
    */
   variant?: FooterVariant.Navigation | FooterVariant.Utility;
 }>;

--- a/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.tsx
+++ b/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.tsx
@@ -1,12 +1,30 @@
-import React from 'react';
+import React, { cloneElement, Fragment, isValidElement } from 'react';
 
 // import base styles
 import '../../../../styles/base.css';
 
 import styles from './FooterNavigation.module.scss';
+import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
+import { FooterVariant } from '../../Footer.interface';
 
 export const FooterNavigation = ({ children }) => {
-  return <div className={styles.navigation}>{children}</div>;
+  const childElements = getChildElementsEvenIfContainersInbetween(children);
+  return (
+    <div className={styles.navigation}>
+      {childElements.map((child, childIndex) => {
+        return (
+          // eslint-disable-next-line react/no-array-index-key
+          <Fragment key={childIndex}>
+            {isValidElement(child)
+              ? cloneElement(child as React.ReactElement, {
+                  variant: FooterVariant.Navigation,
+                })
+              : child}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
 };
 
 FooterNavigation.componentName = 'FooterNavigation';

--- a/packages/react/src/components/footer/components/footerNavigation/__snapshots__/FooterNavigation.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerNavigation/__snapshots__/FooterNavigation.test.tsx.snap
@@ -51,21 +51,21 @@ exports[`<Footer.Navigation /> spec renders the component 1`] = `
           class="navigation"
         >
           <a
-            class="link linkM item"
+            class="link linkM item navigation"
           >
             <span>
               Link 1
             </span>
           </a>
           <a
-            class="link linkM item"
+            class="link linkM item navigation"
           >
             <span>
               Link 2
             </span>
           </a>
           <a
-            class="link linkM item"
+            class="link linkM item navigation"
           >
             <span>
               Link 3

--- a/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.tsx
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { cloneElement, Fragment, isValidElement } from 'react';
 
 // import base styles
 import '../../../../styles/base.css';
 
+import { FooterVariant } from '../../Footer.interface';
 import { useMediaQueryLessThan } from '../../../../hooks/useMediaQuery';
 import styles from './FooterNavigationGroup.module.scss';
 import classNames from '../../../../utils/classNames';
+import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 
 type FooterNavigationGroupProps = React.PropsWithChildren<{
   /**
@@ -23,7 +25,6 @@ type FooterNavigationGroupProps = React.PropsWithChildren<{
    * headingLink={<Footer.GroupHeading
             href="https://yourpath.com"
             label="Main Page"
-            variant={FooterVariant.Navigation}
           />}
     ```
    */
@@ -32,15 +33,37 @@ type FooterNavigationGroupProps = React.PropsWithChildren<{
 export const FooterNavigationGroup = ({ className, children, id, headingLink }: FooterNavigationGroupProps) => {
   // Show only main links in smaller screens
   const shouldRenderOnlyMainLinks = useMediaQueryLessThan('l');
+  const childElements = getChildElementsEvenIfContainersInbetween(children);
+
+  const renderHeading = () => {
+    if (isValidElement(headingLink)) {
+      return cloneElement(headingLink as React.ReactElement, {
+        variant: FooterVariant.Navigation,
+      });
+    }
+    return headingLink;
+  };
 
   // Return headingLink inside a Fragment to avoid erronous return type 'Element | { headingLink: ReactNode; }'.
   return shouldRenderOnlyMainLinks ? (
-    <>{headingLink}</>
+    <>{renderHeading()}</>
   ) : (
     <div id={id} className={classNames(styles.navigationGroup, className)}>
       <div className={styles.navigationGroupList}>
-        {headingLink}
-        {children}
+        {renderHeading()}
+        {childElements.map((child, childIndex) => {
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={childIndex}>
+              {isValidElement(child)
+                ? cloneElement(child as React.ReactElement, {
+                    variant: FooterVariant.Navigation,
+                    subItem: true,
+                  })
+                : child}
+            </Fragment>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/react/src/components/footer/components/footerNavigationGroup/__snapshots__/FooterNavigationGroup.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/__snapshots__/FooterNavigationGroup.test.tsx.snap
@@ -50,41 +50,27 @@ exports[`<Footer.NavigationGroup /> spec renders the navigation groups 1`] = `
         <div
           class="navigation"
         >
-          <div
-            class="navigationGroup"
+          <a
+            class="link linkM item navigation"
           >
-            <div
-              class="navigationGroupList"
-            >
-              <a
-                class="heading navigation"
-                href="https://google.com"
-              >
-                Main Page
-              </a>
-              <a
-                class="link linkM item"
-              >
-                <span>
-                  Link 1
-                </span>
-              </a>
-              <a
-                class="link linkM item"
-              >
-                <span>
-                  Link 2
-                </span>
-              </a>
-              <a
-                class="link linkM item"
-              >
-                <span>
-                  Link 3
-                </span>
-              </a>
-            </div>
-          </div>
+            <span>
+              Link 1
+            </span>
+          </a>
+          <a
+            class="link linkM item navigation"
+          >
+            <span>
+              Link 2
+            </span>
+          </a>
+          <a
+            class="link linkM item navigation"
+          >
+            <span>
+              Link 3
+            </span>
+          </a>
         </div>
       </div>
     </div>

--- a/packages/react/src/components/footer/components/footerNavigationLink/FooterNavigationLink.tsx
+++ b/packages/react/src/components/footer/components/footerNavigationLink/FooterNavigationLink.tsx
@@ -28,6 +28,10 @@ type ItemProps<Element> = React.PropsWithChildren<{
    */
   icon?: React.ReactNode;
   /**
+   * The label for the item.
+   */
+  label?: string;
+  /**
    * Boolean indicating whether the link will open in new tab or not.
    */
   openInNewTab?: boolean;
@@ -40,15 +44,13 @@ type ItemProps<Element> = React.PropsWithChildren<{
    */
   openInExternalDomainAriaLabel?: string;
   /**
-   * The label for the item.
-   */
-  label?: string;
-  /**
    * Set this if this item appears in footer navigation group.
+   * @internal
    */
   subItem?: boolean;
   /**
-   * Internal variant to change styles based on context.
+   * Defines the FooterNavigationLink variant.
+   * @internal
    */
   variant?: FooterVariant.Navigation | FooterVariant.Utility | FooterVariant.Base;
 }>;

--- a/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.tsx
+++ b/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.tsx
@@ -1,10 +1,12 @@
-import React, { cloneElement, isValidElement } from 'react';
+import React, { cloneElement, Fragment, isValidElement } from 'react';
 
 // import base styles
 import '../../../../styles/base.css';
 
 import styles from './FooterUtilities.module.scss';
 import classNames from '../../../../utils/classNames';
+import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
+import { FooterVariant } from '../../Footer.interface';
 
 export type FooterUtilitiesProps = {
   /**
@@ -23,10 +25,24 @@ export type FooterUtilitiesProps = {
 };
 
 export const FooterUtilities = ({ children, soMeLinks, soMeSectionProps }: FooterUtilitiesProps) => {
+  const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
     <div className={styles.utilities}>
       <hr className={styles.divider} aria-hidden />
-      <div className={classNames(styles.links, !soMeLinks && styles.widerLinks)}>{children}</div>
+      <div className={classNames(styles.links, !soMeLinks && styles.widerLinks)}>
+        {childElements.map((child, childIndex) => {
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={childIndex}>
+              {isValidElement(child)
+                ? cloneElement(child as React.ReactElement, {
+                    variant: FooterVariant.Utility,
+                  })
+                : child}
+            </Fragment>
+          );
+        })}
+      </div>
       {soMeLinks && (
         <section className={styles.soMe} {...soMeSectionProps}>
           {soMeLinks.map((link, index) => {

--- a/packages/react/src/components/footer/components/footerUtilities/__snapshots__/FooterUtilities.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerUtilities/__snapshots__/FooterUtilities.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`<Footer.Utilities /> spec renders the component 1`] = `
             class="links widerLinks"
           >
             <a
-              class="link linkM item"
+              class="link linkM item utility"
               href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/ota-yhteytta/ota-yhteytta"
             >
               <span>
@@ -66,7 +66,7 @@ exports[`<Footer.Utilities /> spec renders the component 1`] = `
               </span>
             </a>
             <a
-              class="link linkM item"
+              class="link linkM item utility"
               href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta"
             >
               <span>
@@ -74,7 +74,7 @@ exports[`<Footer.Utilities /> spec renders the component 1`] = `
               </span>
             </a>
             <a
-              class="link linkM item"
+              class="link linkM item utility"
               href="https://hel.fi/kanslia/neuvonta-fi"
             >
               <span>

--- a/packages/react/src/components/footer/components/footerUtilityGroup/FooterUtilityGroup.tsx
+++ b/packages/react/src/components/footer/components/footerUtilityGroup/FooterUtilityGroup.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { Fragment, cloneElement, isValidElement } from 'react';
 
 // import base styles
 import '../../../../styles/base.css';
 
 import styles from './FooterUtilityGroup.module.scss';
 import classNames from '../../../../utils/classNames';
+import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
+import { FooterVariant } from '../../Footer.interface';
 
 type FooterUtilityGroupProps = React.PropsWithChildren<{
   /**
@@ -22,18 +24,33 @@ type FooterUtilityGroupProps = React.PropsWithChildren<{
    * headingLink={<Footer.GroupHeading
             href="https://yourpath.com"
             label="Main Page"
-            variant={FooterVariant.Utility}
           />}
     ```
    */
   headingLink?: React.ReactNode;
 }>;
 export const FooterUtilityGroup = ({ className, children, id, headingLink }: FooterUtilityGroupProps) => {
+  const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
     <div id={id} className={classNames(styles.utilityGroup, className)}>
       <div className={styles.utilityGroup}>
-        {headingLink}
-        {children}
+        {isValidElement(headingLink)
+          ? cloneElement(headingLink as React.ReactElement, {
+              variant: FooterVariant.Utility,
+            })
+          : headingLink}
+        {childElements.map((child, childIndex) => {
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={childIndex}>
+              {isValidElement(child)
+                ? cloneElement(child as React.ReactElement, {
+                    variant: FooterVariant.Utility,
+                  })
+                : child}
+            </Fragment>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/react/src/components/footer/components/footerUtilityGroup/__snapshots__/FooterUtilityGroup.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerUtilityGroup/__snapshots__/FooterUtilityGroup.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`<Footer.UtilityGroup /> spec renders the utility groups 1`] = `
                 </span>
                 <a
                   aria-label="Helsingin kaupungin Facebook-tili"
-                  class="link linkM item"
+                  class="link linkM item utility"
                   href="https://facebook.com/helsinginkaupunki/"
                   title="Helsingin kaupungin Facebook-tili"
                 >
@@ -125,7 +125,7 @@ exports[`<Footer.UtilityGroup /> spec renders the utility groups 1`] = `
                 </a>
                 <a
                   aria-label="Helsingin kaupungin Facebook-tili"
-                  class="link linkM item"
+                  class="link linkM item utility"
                   href="https://facebook.com/helsinginkaupunki/"
                   title="Helsingin kaupungin Facebook-tili"
                 >

--- a/packages/react/src/components/footer/index.ts
+++ b/packages/react/src/components/footer/index.ts
@@ -1,2 +1,2 @@
 export * from './Footer';
-export * from './Footer.interface';
+export { FooterTheme, FooterCustomTheme } from './Footer.interface';

--- a/packages/react/src/utils/test-utils.tsx
+++ b/packages/react/src/utils/test-utils.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 
 import { Navigation } from '../components/navigation';
-import { Footer, FooterVariant } from '../components/footer';
+import { Footer } from '../components/footer';
 import { Header } from '../components/header';
 
 type WrapperProps = PropsWithChildren<Record<string, unknown>>;
@@ -23,11 +23,7 @@ export const FooterNavigationWrapper = ({ children }: PropsWithChildren<Record<s
 export const FooterNavigationGroupsWrapper = ({ children }: PropsWithChildren<Record<string, unknown>>) => (
   <Footer title="Bar">
     <Footer.Navigation>
-      <Footer.NavigationGroup
-        headingLink={
-          <Footer.GroupHeading href="https://google.com" label="Main Page" variant={FooterVariant.Navigation} />
-        }
-      >
+      <Footer.NavigationGroup headingLink={<Footer.GroupHeading href="https://google.com" label="Main Page" />}>
         {children}
       </Footer.NavigationGroup>
     </Footer.Navigation>

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -296,7 +296,17 @@ const Layout = ({ children, pageContext }) => {
           )}
         </div>
         <Footer id="page-footer" className="page-footer" title={footerTitle} footerAriaLabel={footerAriaLabel}>
-          <Footer.Base copyrightHolder="Copyright">
+          <Footer.Navigation>
+            {uiMenuLinks.map(({ name, link, uiId }) => (
+              <Footer.NavigationLink
+                key={uiId}
+                label={name}
+                to={link}
+                as={GatsbyLink}
+              />
+            ))}
+          </Footer.Navigation>
+          <Footer.Base copyrightHolder="Copyright" backToTopLabel="Back to top">
             <Footer.NavigationLink label="Contribution" href={withPrefix('/getting-started/contributing/how-to-contribute')} />
             <Footer.NavigationLink label="Accessibility" href={withPrefix('/about/accessibility/statement')} />
             <Footer.NavigationLink label="GitHub" href="https://github.com/City-of-Helsinki/helsinki-design-system" />

--- a/site/src/docs/components/footer/code.mdx
+++ b/site/src/docs/components/footer/code.mdx
@@ -11,7 +11,6 @@ import {
   IconYoutube,
   IconTiktok,
   Link,
-  FooterVariant,
 } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import Playground from '../../../components/Playground';
@@ -31,86 +30,41 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 import { Footer, IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTiktok } from 'hds-react';
 
 () => (
-  <Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
-    <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
+  <Footer title="Helsinki Design System">
+    <Footer.Navigation>
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
     </Footer.Navigation>
     <Footer.Utilities
       soMeLinks={[
-        <Footer.NavigationLink icon={<IconFacebook />} />,
-        <Footer.NavigationLink icon={<IconTwitter />} />,
-        <Footer.NavigationLink icon={<IconInstagram />} />,
-        <Footer.NavigationLink icon={<IconYoutube />} />,
-        <Footer.NavigationLink icon={<IconTiktok />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Facebook-tili" icon={<IconFacebook />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Twitter-tili" icon={<IconTwitter />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Instagram-tili" icon={<IconInstagram />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Youtube-tili" icon={<IconYoutube />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Tiktok-tili" icon={<IconTiktok />} />,
       ]}
     >
-      <Footer.NavigationLink label="Contact us" variant={FooterVariant.Utility} />
-      <Footer.NavigationLink label="Give feedback" variant={FooterVariant.Utility} />
+      <Footer.NavigationLink label="Contact us" />
+      <Footer.NavigationLink label="Give feedback" />
     </Footer.Utilities>
     <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
     </Footer.Base>
   </Footer>
-);
+)
 ```
 
 </Playground>
 
-### Color variations
-
-<Playground>
-
-```jsx
-import { Footer } from 'hds-react';
-
-() => (
-  <Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
-    <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    </Footer.Navigation>
-    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-    </Footer.Base>
-  </Footer>
-  <br />
-  <Footer title="Helsinki Design System" theme="dark" footerAriaLabel="HDS Footer">
-    <Footer.Navigation navigationAriaLabe variant={FooterVariant.Navigation}l="HDS Footer navigation">
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    </Footer.Navigation>
-    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-      <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-    </Footer.Base>
-  </Footer>)
-```
-
-</Playground>
-
-### Navigation section variations
+#### Color variations
 
 <Playground>
 
@@ -119,44 +73,198 @@ import { Footer } from 'hds-react';
 
 () => (
   <>
-    <Footer title="Default" footerAriaLabel="HDS Footer">
-      <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-        <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
+    <Footer title="Helsinki Design System">
+      <Footer.Navigation>
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+      </Footer.Navigation>
+      <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
+        <Footer.NavigationLink label="Link" />
+        <Footer.NavigationLink label="Link" />
+        <Footer.NavigationLink label="Link" />
+      </Footer.Base>
+    </Footer>
+    <br />
+    <Footer title="Helsinki Design System" theme="dark">
+      <Footer.Navigation>
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+      </Footer.Navigation>
+      <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
+        <Footer.NavigationLink label="Link" />
+        <Footer.NavigationLink label="Link" />
+        <Footer.NavigationLink label="Link" />
+      </Footer.Base>
+    </Footer>
+  </>
+)
+```
+
+</Playground>
+
+#### Navigation section variations
+
+<Playground>
+
+```jsx
+import { Footer } from 'hds-react';
+
+() => (
+  <>
+    <Footer title="Default">
+      <Footer.Navigation>
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
+        <Footer.NavigationLink label="Item" />
       </Footer.Navigation>
     </Footer>
     <br />
     <br />
-    <Footer title="Sitemap" footerAriaLabel="HDS Footer">
-      <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
+    <Footer title="Sitemap">
+      <Footer.Navigation>
         {[1, 2, 3, 4].map((key) => (
           <Footer.NavigationGroup key={key}>
             <Footer.GroupHeading
-              href="http://www.google.com"
               onClick={(e) => e.preventDefault()}
               label="Item"
-              variant={FooterVariant.Navigation}
             />
-            <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-            <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-            <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-            <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-            <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-            <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
+            <Footer.NavigationLink label="Sub item" />
+            <Footer.NavigationLink label="Sub item" />
+            <Footer.NavigationLink label="Sub item" />
+            <Footer.NavigationLink label="Sub item" />
+            <Footer.NavigationLink label="Sub item" />
+            <Footer.NavigationLink label="Sub item" />
           </Footer.NavigationGroup>
         ))}
       </Footer.Navigation>
     </Footer>
     <br />
-    <Footer title="Hidden" footerAriaLabel="HDS Footer" />
+    <Footer title="Hidden" />
   </>
-);
+)
+```
+
+</Playground>
+
+#### Utility section variations
+
+<Playground>
+
+```jsx
+import { Footer } from 'hds-react';
+
+() => (
+  <>
+    <Footer title="Default">
+      <Footer.Utilities soMeLinks={[
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Facebook-tili"
+          ariaLabel="Helsingin kaupungin Facebook-tili"
+          external
+          openInNewTab
+          icon={<IconFacebook aria-hidden />}
+          href="https://facebook.com"
+        />,
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Twitter-tili"
+          ariaLabel="Helsingin kaupungin Twitter-tili"
+          external
+          openInNewTab
+          icon={<IconTwitter aria-hidden />}
+          href="https://twitter.com"
+        />,
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Instagram-tili"
+          ariaLabel="Helsingin kaupungin Instagram-tili"
+          external
+          openInNewTab
+          icon={<IconInstagram aria-hidden />}
+          href="https://instagram.com"
+        />,
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Youtube-tili"
+          ariaLabel="Helsingin kaupungin Youtube-tili"
+          external
+          openInNewTab
+          icon={<IconYoutube aria-hidden />}
+          href="https://youtube.com"
+        />,
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Tiktok-tili"
+          ariaLabel="Helsingin kaupungin Tiktok-tili"
+          external
+          openInNewTab
+          icon={<IconTiktok aria-hidden />}
+          href="https://tiktok.com"
+        />,
+      ]}>
+        <Footer.NavigationLink onClick={(e) => e.preventDefault()} label="Contact us" />
+        <Footer.NavigationLink onClick={(e) => e.preventDefault()} label="Give feedback" />
+        <Footer.NavigationLink onClick={(e) => e.preventDefault()} label="Support" />
+        <Footer.NavigationLink onClick={(e) => e.preventDefault()} label="About" />
+      </Footer.Utilities>
+    </Footer>
+    <br />
+    <br />
+    <Footer title="Utility groups">
+      <Footer.Utilities>
+        <Footer.UtilityGroup
+          headingLink={<Footer.GroupHeading
+            onClick={(e) => e.preventDefault()}
+            label="Group"
+          />}
+        >
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+        </Footer.UtilityGroup>
+        <Footer.UtilityGroup
+          headingLink={<Footer.GroupHeading
+            onClick={(e) => e.preventDefault()}
+            label="Group"
+          />}
+        >
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+        </Footer.UtilityGroup>
+        <Footer.UtilityGroup
+          headingLink={<Footer.GroupHeading
+            onClick={(e) => e.preventDefault()}
+            label="Group"
+          />}
+        >
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+        </Footer.UtilityGroup>
+        <Footer.UtilityGroup
+          headingLink={<Footer.GroupHeading
+            onClick={(e) => e.preventDefault()}
+            label="Group"
+          />}
+        >
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+          <Footer.NavigationLink label="Link" />
+        </Footer.UtilityGroup>
+      </Footer.Utilities>
+    </Footer>
+  </>
+)
 ```
 
 </Playground>

--- a/site/src/docs/components/footer/customisation.mdx
+++ b/site/src/docs/components/footer/customisation.mdx
@@ -3,7 +3,7 @@ slug: '/components/footer/customisation'
 title: 'Footer - Customisation'
 ---
 
-import { Footer, FooterVariant } from 'hds-react';
+import { Footer } from 'hds-react';
 import Playground from '../../../components/Playground';
 import TabsLayout from './tabs.mdx';
 
@@ -22,35 +22,71 @@ You can use the `theme` property to customise the component. See all available t
 | `--footer-divider-color`        | Colour of the divider line between Footer sections     |
 | `--footer-focus-outline-color'` | Colour of the Footer element focus border              |
 
-### Customisation example
+### Colour customisation example
 
 <Playground>
 
 ```jsx
-<Footer
-  title="Helsinki Design System"
-  footerAriaLabel="HDS Footer"
-  theme={{
-    '--footer-background': 'var(--color-engel)',
-    '--footer-color': 'var(--color-black-90)',
-    '--footer-divider-color': 'var(--color-black-90)',
-    '--footer-focus-outline-color': 'var(--color-black-90)',
-  }}
->
-  <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-    <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-    <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-  </Footer.Navigation>
-  <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
-    <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-    <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-    <Footer.NavigationLink label="Link" variant={FooterVariant.Base} />
-  </Footer.Base>
-</Footer>
+import { Footer } from 'hds-react';
+
+() => (
+  <Footer
+    title="Helsinki Design System"
+    theme={{
+      '--footer-background': 'var(--color-engel)',
+      '--footer-color': 'var(--color-black-90)',
+      '--footer-divider-color': 'var(--color-black-90)',
+      '--footer-focus-outline-color': 'var(--color-black-90)',
+    }}
+  >
+    <Footer.Navigation>
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+    </Footer.Navigation>
+    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+    </Footer.Base>
+  </Footer>
+)
+```
+
+</Playground>
+
+### Custom section
+
+<Playground>
+
+```jsx
+import { Footer } from 'hds-react';
+
+() => (
+  <Footer
+    title="Helsinki Design System"
+  >
+    <Footer.Custom>
+      <Footer.GroupHeading label="Partners" id="partners" />
+      <div
+        aria-label="partners"
+        style={{ display: 'flex', flexDirection: 'row', gap: '12px 24px', flexWrap: 'wrap', marginTop: '8px' }}
+      >
+        <Footer.NavigationLink label="Partner 1" external openInNewTab />
+        <Footer.NavigationLink label="Partner 1" external openInNewTab />
+        <Footer.NavigationLink label="Partner 1" external openInNewTab />
+      </div>
+    </Footer.Custom>
+    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+    </Footer.Base>
+  </Footer>
+)
 ```
 
 </Playground>

--- a/site/src/docs/components/footer/index.mdx
+++ b/site/src/docs/components/footer/index.mdx
@@ -36,12 +36,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
         <Footer.NavigationLink icon={<IconTiktok />} />,
       ]}
     >
-      <Footer.NavigationLink label="Contact us" />
-      <Footer.NavigationLink label="Give feedback" />
+      <Footer.NavigationLink label="Contact us"  />
+      <Footer.NavigationLink label="Give feedback"  />
     </Footer.Utilities>
     <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
-      <Footer.NavigationLink label="Link" />
-      <Footer.NavigationLink label="Link" />
       <Footer.NavigationLink label="Link" />
       <Footer.NavigationLink label="Link" />
       <Footer.NavigationLink label="Link" />
@@ -56,25 +54,26 @@ Footer stays consistent throughout the site and is often the place where users s
 - **It is strongly recommended to always include the footer component in your service and on every page of the service.**
 - Always position the footer to the bottom of the page.
 - Footer component is built to follow HDS <InternalLink href="/foundation/design-tokens/breakpoints">breakpoint tokens</InternalLink>. While it is recommended to follow HDS breakpoint tokens, you may alter footer width to fit your service's needs.
-- Keep the order of footer sections (navigation, utility, base) and actions consistent. Do not change the default order without a good reason.
+- Keep the order of footer sections (navigation, utility, custom, base) and actions consistent. Do not change the default order without a good reason.
 - The footer navigation should follow the same structure and labelling as the primary navigation. All top level pages included in the primary navigation should also be visible in footer navigation.
 - If sub-pages are included in the footer, they should also follow the same structure and labelling as in the primary navigation. All same-level sub-pages should be visible.
 
 ### Variations
 
-The Footer consists of three sections: navigation, utility and base. Each section is customisable to fit the needs of the service. **It is recommended that the footer includes at least navigation and base sections.** The Utility section can be omitted entirely if not needed. Parts of the sections can also be hidden.
+The Footer consists of four possible sections: navigation, utility, custom and base. Each section is customisable to fit the needs of the service. **It is recommended that the footer includes at least navigation and base sections.** The utility and custom sections can be omitted entirely if not needed.
 
-- **Navigation section** contains the Helsinki framed logo, the name of the service and footer navigation. Navigation section variations for more information about customising the footer navigation.
-- **Utility section** contains links and actions not listed in main navigation, for example, social media icons, and links to contact info, feedback, or back to top.
-- **Base section** is used for supplementary information, For example copyright information and links to other meta information, e.g. accessibility statement, privacy policy, terms of use, etc.
+- **Navigation section (recommended)** contains the name of the service and footer navigation. See the [Navigation section variations](#navigation-section-variations) for more information about customising the footer navigation.
+- **Utility section (optional)** contains links and actions not listed in main navigation, for example, social media icons, and links to contact info, feedback, or back to top. See the [Utility section variations](#utility-section-variations) for more information.
+- **Custom section (optional)** is for any content that you wish to include in the footer that doesn't fit elsewhere. You can put whatever you wish there but we recommend to keep the styling consistent with the rest of the Footer.
+- **Base section (recommended)** contains the Helsinki framed logo and is used for supplementary information, for example copyright information and links to other meta information, e.g. accessibility statement, privacy policy, terms of use, etc.
 
 #### Default
 
-The default footer uses the black text colour variant and includes all three sections.
+The default footer uses the black text colour variant and includes three sections.
 
-- The navigation section shows the Helsinki framed logo, service name, and navigation. Navigation is optimised for up to eight menu items.
-- Utility section is optimised to display up to five social media icons and three action links. An icon can be added to action links.
-- Base section includes a text field for copyright or other meta information and is optimised for up to five supplementary links, depending on link length.
+- The navigation section shows the service name and navigation. Navigation is optimised for up to eight menu items.
+- Utility section is optimised to display up to three action links and five social media icons. An icon can be added to action links.
+- Base section includes the Helsinki framed logo, text for copyright or other meta information. The base section is optimised for up to five supplementary links, depending on link length.
 
 <PlaygroundPreview>
   <Footer title="Helsinki Design System" footerAriaLabel="HDS Footer">
@@ -90,11 +89,11 @@ The default footer uses the black text colour variant and includes all three sec
     </Footer.Navigation>
     <Footer.Utilities
       soMeLinks={[
-        <Footer.NavigationLink icon={<IconFacebook />} />,
-        <Footer.NavigationLink icon={<IconTwitter />} />,
-        <Footer.NavigationLink icon={<IconInstagram />} />,
-        <Footer.NavigationLink icon={<IconYoutube />} />,
-        <Footer.NavigationLink icon={<IconTiktok />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Facebook-tili" icon={<IconFacebook />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Twitter-tili" icon={<IconTwitter />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Instagram-tili" icon={<IconInstagram />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Youtube-tili" icon={<IconYoutube />} />,
+        <Footer.NavigationLink title="Helsingin kaupungin Tiktok-tili" icon={<IconTiktok />} />,
       ]}
     >
       <Footer.NavigationLink label="Contact us" />
@@ -103,6 +102,42 @@ The default footer uses the black text colour variant and includes all three sec
     <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
       <Footer.NavigationLink label="Link" />
       <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+    </Footer.Base>
+  </Footer>
+</PlaygroundPreview>
+
+#### Colour variations
+
+The Footer component supports light and dark themes.
+
+<PlaygroundPreview>
+  <Footer title="Helsinki Design System">
+    <Footer.Navigation>
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+    </Footer.Navigation>
+    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+      <Footer.NavigationLink label="Link" />
+    </Footer.Base>
+  </Footer>
+  <br />
+  <Footer title="Helsinki Design System" theme="dark">
+    <Footer.Navigation>
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+    </Footer.Navigation>
+    <Footer.Base copyrightHolder="Copyright" copyrightText="All rights reserved" backToTopLabel="Back to top">
       <Footer.NavigationLink label="Link" />
       <Footer.NavigationLink label="Link" />
       <Footer.NavigationLink label="Link" />
@@ -115,20 +150,20 @@ The default footer uses the black text colour variant and includes all three sec
 Navigation section two different layout options:
 
 - **Default navigation** includes only the main level navigation items. The layout is optimised for up to eight menu items.
-- **Sitemap navigation** includes also second-level sub-pages. Sitemap can be used in footer to help the user find pages quickly from a complicated page hierarchy.
-- The navigation can also be hidden altogether.
+- **Sitemap navigation** includes also second-level sub-pages. Sitemap can be used in footer to help the user find pages quickly from a complicated page hierarchy. Note that on smaller screens the second-level sub-pages are hidden.
+- The navigation can also be omitted.
 
 <PlaygroundPreview>
   <Footer title="Default" footerAriaLabel="HDS Footer">
     <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
-      <Footer.NavigationLink label="Item" variant={FooterVariant.Navigation} />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
+      <Footer.NavigationLink label="Item" />
     </Footer.Navigation>
   </Footer>
   <br />
@@ -136,18 +171,143 @@ Navigation section two different layout options:
   <Footer title="Sitemap" footerAriaLabel="HDS Footer">
     <Footer.Navigation navigationAriaLabel="HDS Footer navigation">
       {[1, 2, 3, 4].map((key) => (
-        <Footer.NavigationGroup key={key}>
-          <Footer.GroupHeading href="http://www.google.com" onClick={(e) => e.preventDefault()} label="Item" variant={FooterVariant.Navigation}/>
-          <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-          <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-          <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-          <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-          <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
-          <Footer.NavigationLink label="Sub item" variant={FooterVariant.Navigation} />
+        <Footer.NavigationGroup key={key} headingLink={<Footer.GroupHeading href="http://www.google.com" onClick={(e) => e.preventDefault()} label="Item" />}>
+          <Footer.NavigationLink label="Sub item" />
+          <Footer.NavigationLink label="Sub item" />
+          <Footer.NavigationLink label="Sub item" />
+          <Footer.NavigationLink label="Sub item" />
+          <Footer.NavigationLink label="Sub item" />
+          <Footer.NavigationLink label="Sub item" />
         </Footer.NavigationGroup>
       ))}
     </Footer.Navigation>
   </Footer>
   <br />
   <Footer title="Hidden" footerAriaLabel="HDS Footer" />
+</PlaygroundPreview>
+
+#### Utility section variations
+
+Utility section has two different layout options:
+- **Default**: optimised to display up to three action links and five social media icons.
+- **Utility groups**: optimised to display up to four groups of utility links.
+- The utility section can also be omitted.
+
+<PlaygroundPreview>
+  <Footer title="Default" footerAriaLabel="HDS Footer">
+    <Footer.Utilities soMeLinks={[
+      <Footer.NavigationLink
+        title="Helsingin kaupungin Facebook-tili"
+        ariaLabel="Helsingin kaupungin Facebook-tili"
+        external
+        openInNewTab
+        icon={<IconFacebook aria-hidden />}
+        href="https://facebook.com"
+      />,
+      <Footer.NavigationLink
+        title="Helsingin kaupungin Twitter-tili"
+        ariaLabel="Helsingin kaupungin Twitter-tili"
+        external
+        openInNewTab
+        icon={<IconTwitter aria-hidden />}
+        href="https://twitter.com"
+      />,
+      <Footer.NavigationLink
+        title="Helsingin kaupungin Instagram-tili"
+        ariaLabel="Helsingin kaupungin Instagram-tili"
+        external
+        openInNewTab
+        icon={<IconInstagram aria-hidden />}
+        href="https://instagram.com"
+      />,
+      <Footer.NavigationLink
+        title="Helsingin kaupungin Youtube-tili"
+        ariaLabel="Helsingin kaupungin Youtube-tili"
+        external
+        openInNewTab
+        icon={<IconYoutube aria-hidden />}
+        href="https://youtube.com"
+      />,
+      <Footer.NavigationLink
+        title="Helsingin kaupungin Tiktok-tili"
+        ariaLabel="Helsingin kaupungin Tiktok-tili"
+        external
+        openInNewTab
+        icon={<IconTiktok aria-hidden />}
+        href="https://tiktok.com"
+      />,
+    ]}>
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="Contact us" />
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="Give feedback" />
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="Support" />
+      <Footer.NavigationLink href="https://google.com" onClick={(e) => e.preventDefault()} label="About" />
+    </Footer.Utilities>
+  </Footer>
+  <br />
+  <br />
+  <Footer title="Utility groups" footerAriaLabel="HDS Footer">
+    <Footer.Utilities>
+      {[{}, {}, {}].map((index) => (
+        <Footer.UtilityGroup
+          key={index}
+          headingLink={
+            <Footer.GroupHeading
+              href="https://google.com"
+              onClick={(e) => e.preventDefault()}
+              label="Group heading link"
+            />
+          }
+        >
+          {[{}, {}, {}].map((subIndex) => {
+            return (
+              <Footer.NavigationLink
+                key={subIndex}
+                href="https://google.com"
+                onClick={(e) => e.preventDefault()}
+                label="Group link"
+              />
+            );
+          })}
+        </Footer.UtilityGroup>
+      ))}
+      <Footer.UtilityGroup key={6} headingLink={<Footer.GroupHeading label="Social media" />}>
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Facebook-tili"
+          label="Facebook"
+          ariaLabel="Helsingin kaupungin Facebook-tili"
+          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
+          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          icon={<IconFacebook aria-hidden="true" />}
+          href="https://facebook.com/helsinginkaupunki/"
+        />
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Facebook-tili"
+          label="Facebook"
+          ariaLabel="Helsingin kaupungin Facebook-tili"
+          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
+          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          icon={<IconFacebook aria-hidden="true" />}
+          href="https://facebook.com/helsinginkaupunki/"
+        />
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Twitter-tili"
+          label="Twitter"
+          ariaLabel="Helsingin kaupungin Twitter-tili"
+          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
+          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          icon={<IconTwitter aria-hidden="true" />}
+          href="https://twitter.com/helsinki"
+        />
+        <Footer.NavigationLink
+          title="Helsingin kaupungin Instagram-tili"
+          label="Instagram"
+          ariaLabel="Helsingin kaupungin Instagram-tili"
+          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
+          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          icon={<IconInstagram aria-hidden="true" />}
+          href="https://instagram.com/helsinki/"
+        />
+      </Footer.UtilityGroup>
+    </Footer.Utilities>
+  </Footer>
 </PlaygroundPreview>


### PR DESCRIPTION
## Description

Update Footer documentation to serve the new components.

**Refactored Footer.NavigationLink component** so that user does not need to add `variant={FooterVariant.Navigation}` for every link or `subItem` for navigation groups! Those props are passed automatically by wrapper components.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1626

## How Has This Been Tested?
Locally
[Demo](https://city-of-helsinki.github.io/hds-demo/footer-docs)