### PR TITLE
Hds 701 landmarks for header and footer

### DIFF
--- a/packages/react/src/components/footer/Footer.stories.tsx
+++ b/packages/react/src/components/footer/Footer.stories.tsx
@@ -115,23 +115,6 @@ export default {
   },
 };
 
-export const Default = (args) => (
-  <Footer {...args}>
-    <Footer.Navigation>
-      {createArray(8).map((index) => (
-        <Footer.NavigationLink
-          key={index}
-          href="https://google.com"
-          onClick={(e) => e.preventDefault()}
-          label="Nav item"
-        />
-      ))}
-    </Footer.Navigation>
-    <Utilities />
-    <Base />
-  </Footer>
-);
-
 export const NoNav = (args) => (
   <Footer {...args}>
     <Utilities />

--- a/packages/react/src/components/footer/Footer.tsx
+++ b/packages/react/src/components/footer/Footer.tsx
@@ -19,6 +19,10 @@ import { useTheme } from '../../hooks/useTheme';
 
 export type FooterProps = React.PropsWithChildren<{
   /**
+   * aria-label for describing Footer.
+   */
+  ariaLabel?: string;
+  /**
    * Additional class names to apply to the footer
    */
   className?: string;
@@ -41,6 +45,7 @@ export type FooterProps = React.PropsWithChildren<{
 }>;
 
 export const Footer = ({
+  ariaLabel,
   children,
   className,
   footerProps,
@@ -61,6 +66,7 @@ export const Footer = ({
         customThemeClass,
         className,
       )}
+      aria-label={ariaLabel}
     >
       <Koros className={classNames(styles.koros, styles[korosType])} type={korosType} />
       <div className={styles.footerContent}>

--- a/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
+++ b/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
@@ -13,6 +13,10 @@ import { FooterVariant } from '../../Footer.interface';
 
 export type FooterBaseProps = React.PropsWithChildren<{
   /**
+   * aria-label for describing Footer.Base.
+   */
+  ariaLabel?: string;
+  /**
    * Label for the "Back to top" button
    */
   backToTopLabel?: string | React.ReactNode;
@@ -38,6 +42,10 @@ export type FooterBaseProps = React.PropsWithChildren<{
    */
   onBackToTopClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /**
+   * ARIA role to describe the contents.
+   */
+  role?: string;
+  /**
    * Whether the "Back to top" button should be shown
    */
   showBackToTopButton?: boolean;
@@ -58,6 +66,7 @@ const handleBackToTop = (): void => {
 };
 
 export const FooterBase = ({
+  ariaLabel,
   backToTopLabel,
   children,
   copyrightHolder,
@@ -65,12 +74,13 @@ export const FooterBase = ({
   logoHref,
   logoLanguage = 'fi',
   onBackToTopClick,
+  role,
   showBackToTopButton = true,
   year = new Date().getFullYear(),
 }: FooterBaseProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
-    <div className={styles.base}>
+    <div className={styles.base} aria-label={ariaLabel} role={role}>
       <hr className={styles.divider} aria-hidden />
       <div className={styles.logoWrapper}>
         <FooterNavigationLink

--- a/packages/react/src/components/footer/components/footerCustom/FooterCustom.tsx
+++ b/packages/react/src/components/footer/components/footerCustom/FooterCustom.tsx
@@ -8,6 +8,10 @@ import classNames from '../../../../utils/classNames';
 
 export type FooterCustomProps = React.PropsWithChildren<{
   /**
+   * aria-label for describing Footer.Custom.
+   */
+  ariaLabel?: string;
+  /**
    * Additional class names to apply.
    */
   className?: string;
@@ -15,11 +19,15 @@ export type FooterCustomProps = React.PropsWithChildren<{
    * ID of the navigation element.
    */
   id?: string;
+  /**
+   * ARIA role to describe the contents.
+   */
+  role?: string;
 }>;
 
-export const FooterCustom = ({ children, className, id }: FooterCustomProps) => {
+export const FooterCustom = ({ ariaLabel, children, className, id, role }: FooterCustomProps) => {
   return (
-    <div className={classNames(styles.custom, className)} id={id}>
+    <div className={classNames(styles.custom, className)} id={id} aria-label={ariaLabel} role={role}>
       <hr className={styles.divider} aria-hidden />
       {children}
     </div>

--- a/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.tsx
+++ b/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.tsx
@@ -7,10 +7,20 @@ import styles from './FooterNavigation.module.scss';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 import { FooterVariant } from '../../Footer.interface';
 
-export const FooterNavigation = ({ children }) => {
+export type FooterNavigationProps = React.PropsWithChildren<{
+  /**
+   * aria-label for describing Footer.Navigation.
+   */
+  ariaLabel?: string;
+  /**
+   * ARIA role to describe the contents.
+   */
+  role?: string;
+}>;
+export const FooterNavigation = ({ ariaLabel, children, role }: FooterNavigationProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
-    <div className={styles.navigation}>
+    <div className={styles.navigation} aria-label={ariaLabel} role={role}>
       {childElements.map((child, childIndex) => {
         return (
           // eslint-disable-next-line react/no-array-index-key

--- a/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.tsx
+++ b/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.tsx
@@ -10,6 +10,10 @@ import { FooterVariant } from '../../Footer.interface';
 
 export type FooterUtilitiesProps = {
   /**
+   * aria-label for describing Footer.Utilities.
+   */
+  ariaLabel?: string;
+  /**
    * Children elements to render.
    */
   children: React.ReactNode;
@@ -22,12 +26,16 @@ export type FooterUtilitiesProps = {
    * Can be used to pass aria attributes that describes the SoMe section to screen reader users.
    */
   soMeSectionProps?: React.ComponentPropsWithoutRef<'section'>;
+  /**
+   * ARIA role to describe the contents.
+   */
+  role?: string;
 };
 
-export const FooterUtilities = ({ children, soMeLinks, soMeSectionProps }: FooterUtilitiesProps) => {
+export const FooterUtilities = ({ ariaLabel, children, soMeLinks, soMeSectionProps, role }: FooterUtilitiesProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
-    <div className={styles.utilities}>
+    <div className={styles.utilities} aria-label={ariaLabel} role={role}>
       <hr className={styles.divider} aria-hidden />
       <div className={classNames(styles.links, !soMeLinks && styles.widerLinks)}>
         {childElements.map((child, childIndex) => {

--- a/packages/react/src/components/header/Header.tsx
+++ b/packages/react/src/components/header/Header.tsx
@@ -21,6 +21,10 @@ type HeaderAttributes = JSX.IntrinsicElements['header'];
 
 export interface HeaderNodeProps extends HeaderAttributes {
   /**
+   * aria-label for describing Footer.
+   */
+  ariaLabel?: string;
+  /**
    * Additional class names to apply to the header.
    */
   className?: string;
@@ -34,11 +38,11 @@ export interface HeaderProps extends HeaderNodeProps {
   onDidChangeLanguage?: (string) => void;
 }
 
-const HeaderNode: ComponentType<HeaderNodeProps> = ({ children, className, ...props }) => {
+const HeaderNode: ComponentType<HeaderNodeProps> = ({ ariaLabel, children, className, ...props }) => {
   const { isNotLargeScreen } = useHeaderContext();
   const headerClassNames = classNames('hds-header', styles.header, className, { isNotLargeScreen });
   return (
-    <header className={headerClassNames} {...props}>
+    <header className={headerClassNames} {...props} aria-label={ariaLabel}>
       <div className={styles.headerBackgroundWrapper}>{children}</div>
     </header>
   );

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -19,6 +19,10 @@ export enum TitleStyleType {
 
 export type HeaderActionBarProps = PropsWithChildren<{
   /**
+   * aria-label for describing ActionBar.
+   */
+  ariaLabel?: string;
+  /**
    * Additional class names to apply.
    */
   className?: string;
@@ -74,6 +78,10 @@ export type HeaderActionBarProps = PropsWithChildren<{
    * the default menu toggling function.
    */
   onMenuButtonClick?: MouseEventHandler;
+  /**
+   * ARIA role to describe the contents.
+   */
+  role?: string;
 }>;
 
 export const HeaderActionBar = ({
@@ -89,6 +97,8 @@ export const HeaderActionBar = ({
   onMenuButtonClick,
   children,
   className,
+  ariaLabel,
+  role,
 }: HeaderActionBarProps) => {
   const language = useActiveLanguage();
   const handleClick = useCallbackIfDefined(onTitleClick);
@@ -122,7 +132,7 @@ export const HeaderActionBar = ({
   return (
     <>
       <div className={styles.headerActionBarContainer}>
-        <div className={classNames(styles.headerActionBar, className)}>
+        <div className={classNames(styles.headerActionBar, className)} role={role} aria-label={ariaLabel}>
           <LinkItem {...logoProps}>
             {logoProps?.href ? (
               <span className={styles.logoWrapper}>

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -13,7 +13,7 @@ export const HeaderActionBarNavigationMenu = () => {
   if (!hasNavigationContent || !isNotLargeScreen) return null;
 
   return (
-    <nav role="navigation" className={className}>
+    <nav className={className}>
       <ul className={styles.headerNavigationMenuList}>
         <HeaderNavigationMenuContextProvider>
           <HeaderNavigationMenuContent />

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -10,7 +10,7 @@ import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/get
 
 export type HeaderUniversalBarProps = React.PropsWithChildren<{
   /**
-   * aria-label for describing universal bar.
+   * aria-label for describing UniversalBar.
    */
   ariaLabel?: string;
   /**
@@ -35,6 +35,10 @@ export type HeaderUniversalBarProps = React.PropsWithChildren<{
    * @default 'Helsingin kaupunki'
    */
   primaryLinkText?: string;
+  /**
+   * ARIA role to describe the contents.
+   */
+  role?: string;
 }>;
 
 export const HeaderUniversalBar = ({
@@ -44,6 +48,7 @@ export const HeaderUniversalBar = ({
   id,
   primaryLinkHref,
   primaryLinkText,
+  role,
 }: HeaderUniversalBarProps) => {
   const { isNotLargeScreen } = useHeaderContext();
   if (isNotLargeScreen) return null;
@@ -51,7 +56,7 @@ export const HeaderUniversalBar = ({
 
   return (
     <div className={styles.headerUniversalBarContainer}>
-      <nav id={id} className={classNames(styles.headerUniversalBar, className)} aria-label={ariaLabel}>
+      <div role={role} aria-label={ariaLabel} id={id} className={classNames(styles.headerUniversalBar, className)}>
         <ul className={styles.headerUniversalBarList}>
           <li className={styles.universalBarMainLinkContainer}>
             <NavigationLink href={primaryLinkHref} label={primaryLinkText} className={styles.universalBarLink} />
@@ -70,7 +75,7 @@ export const HeaderUniversalBar = ({
             return null;
           })}
         </ul>
-      </nav>
+      </div>
     </div>
   );
 };

--- a/packages/react/src/components/header/components/headerUniversalBar/__snapshots__/HeaderUniversalBar.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerUniversalBar/__snapshots__/HeaderUniversalBar.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<HeaderUniversalBar /> spec renders the component 1`] = `
       <div
         class="headerUniversalBarContainer"
       >
-        <nav
+        <div
           class="headerUniversalBar"
         >
           <ul
@@ -32,7 +32,7 @@ exports[`<HeaderUniversalBar /> spec renders the component 1`] = `
               </span>
             </li>
           </ul>
-        </nav>
+        </div>
       </div>
     </div>
   </header>

--- a/packages/react/src/components/header/components/navigationSearch/NavigationSearch.tsx
+++ b/packages/react/src/components/header/components/navigationSearch/NavigationSearch.tsx
@@ -31,7 +31,7 @@ export const NavigationSearch = ({ onChange, onSubmit, label }: NavigationSearch
   };
 
   return (
-    <div className={styles.searchContainer}>
+    <div className={styles.searchContainer} role="search">
       <SearchInput label={label} onSubmit={handleSubmit} onChange={setInputValue} />
     </div>
   );

--- a/packages/react/src/components/header/components/navigationSearch/__snapshots__/NavigationSearch.test.tsx.snap
+++ b/packages/react/src/components/header/components/navigationSearch/__snapshots__/NavigationSearch.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`<Header.NavigationSearch /> spec renders the component 1`] = `
           >
             <div
               class="searchContainer"
+              role="search"
             >
               <div
                 class="root"

--- a/site/src/docs/components/footer/accessibility.mdx
+++ b/site/src/docs/components/footer/accessibility.mdx
@@ -15,3 +15,4 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 - HDS Footer is designed to support many different brand colours. When customising colours, refer to <InternalLink href="/foundation/design-tokens/colour">colour guidelines</InternalLink> to ensure accessibility.
 - **When designing the footer link hierarchy, always think about keyboard and screen reader users.** Remember that keyboard users need to manually navigate to each element.
+- Footer landmark is provided automatically by the wrapping `<footer>` element. In case you want more landmarks, all the Footer sub components support `role` prop which should be used together with a descriptive `ariaLabel` prop. Just remember that landmarks should be used sparingly in order to avoid "noise" for screen readers and making the overall page layout difficult to understand.

--- a/site/src/docs/components/header/accessibility.mdx
+++ b/site/src/docs/components/header/accessibility.mdx
@@ -1,0 +1,18 @@
+---
+slug: '/components/header/accessibility'
+title: 'Header - Accessibility'
+---
+
+import TabsLayout from './tabs.mdx';
+import InternalLink from '../../../components/InternalLink';
+
+
+export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
+
+## Accessibility
+
+### Pay attention to
+
+- HDS Navigation is designed to support many different brand colours. When customising colours, refer to <InternalLink href="/foundation/design-tokens/colour">colour guidelines</InternalLink> to ensure accessibility.
+- **When designing a menu link hierarchy, always think about keyboard and screen reader users.** First, make sure top-level menu labels are clear, and submenu items contextually fit under it. Next, make sure the menu option order is logical and reasonable. Remember that keyboard users need to manually navigate to each element and thus placing a commonly used menu option last is not optimal.
+- Landmarks are provided by the wrapping `<header>` element, `<nav>` element in the Header.NavigationMenu component and with `role="search"` attribute on the Header.NavigationSearch component. In case you want more landmarks, the Header.UniversalBar, Header.ActionBar and Header.NavigationSearch components support `role` prop which should be used together with a descriptive `ariaLabel` prop. Just remember that landmarks should be used sparingly in order to avoid "noise" for screen readers and making the overall page layout difficult to understand.

--- a/site/src/docs/components/header/tabs.mdx
+++ b/site/src/docs/components/header/tabs.mdx
@@ -27,6 +27,7 @@ import PageTabs from '../../../components/PageTabs';
   <PageTabs.TabList>
     <PageTabs.Tab href="/">Usage</PageTabs.Tab>
     <PageTabs.Tab href="/code">Code</PageTabs.Tab>
+    <PageTabs.Tab href="/accessibility">Accessibility</PageTabs.Tab>
   </PageTabs.TabList>
   <PageTabs.TabPanel>{props.children}</PageTabs.TabPanel>
 </PageTabs>


### PR DESCRIPTION
## Description

Users had expressed a need for adding their own landmarks. However the `<header>`, `nav` and `<footer>` elements provide landmarks automatically so I don't think we should add more in order to keep the page layout clear for screen readers [(more about the matter here)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles).

- Add search landmark
- Add support for `role` and `ariaLabel` props to Header and Footer sub components
- Add information about the topic in Header and Footer documentation

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-701

## How Has This Been Tested?
Locally
[Storybook demo](https://city-of-helsinki.github.io/hds-demo/landmarks/?path=/story/components-footer--example)
[Site demo](https://city-of-helsinki.github.io/hds-demo/landmarks-docs)