### PR TITLE
HDS-1861 Fix doc site table caption

### DIFF
--- a/site/src/components/Table.js
+++ b/site/src/components/Table.js
@@ -12,8 +12,9 @@ const resolveCaptionStrings = (captionString) => {
 };
 
 const Table = (props) => {
-  const thead = props.children[0].type.name === 'TableHead' ? props.children[0] : [];
-  const tbody = props.children[1].type.name === 'TableBody' ? props.children[1] : []
+  // TableHead and body can't be identified by type.name because it doesn't exist in prod build.
+  const thead = props.children[0];
+  const tbody = props.children[1];
   const tbodyRows = tbody.props?.children || [];
   const rowsArray = Array.isArray(tbodyRows) ? tbodyRows : [tbodyRows];
 

--- a/site/src/components/Table.js
+++ b/site/src/components/Table.js
@@ -1,7 +1,56 @@
-import React from 'react';
+import React, { isValidElement } from 'react';
 
-const Table = (props) => <div class="hds-table-container" tabindex="0">
-<table class="hds-table hds-table--dark" aria-label="Service users (dark variant)">{props.children}</table></div>
+const captionPrefix = '[';
+const captionSuffix = ']';
+
+const isCaption = (cellContent) =>
+  typeof cellContent === 'string' && cellContent.startsWith(captionPrefix) && cellContent.endsWith(captionSuffix);
+
+const resolveCaptionStrings = (captionString) => {
+  const withoutSuffixes = captionString.replace(captionPrefix, '').replace(captionSuffix, '');
+  return withoutSuffixes.split(':');
+};
+
+const Table = (props) => {
+  const thead = props.children[0].type.name === 'TableHead' ? props.children[0] : [];
+  const tbody = props.children[1].type.name === 'TableBody' ? props.children[1] : []
+  const tbodyRows = tbody.props?.children || [];
+  const rowsArray = Array.isArray(tbodyRows) ? tbodyRows : [tbodyRows];
+
+  const [rows, captionString] = rowsArray
+    .filter((child) => isValidElement(child))
+    .reduce(
+      (acc, row, i, arr) => {
+        if (
+          i >= arr.length - 1 &&
+          row.props.children &&
+          row.props.children[0] &&
+          isCaption(row.props.children[0].props.children)
+        ) {
+          return [acc[0], row.props.children[0].props.children];
+        } else {
+          return [[...acc[0], row], acc[1]];
+        }
+      },
+      [[], ''],
+    );
+
+  const tableChildrenWithoutCaption = [thead, { ...tbody, props: { ...tbody.props, children: rows } }];
+  const [tableName, caption] = captionString ? resolveCaptionStrings(captionString) : [undefined, undefined];
+
+  return (
+    <div class="hds-table-container" tabindex="0">
+      <table class="hds-table hds-table--dark" aria-label="Service users (dark variant)">
+        {tableName && caption && (
+          <caption className="hds-table__caption">
+            <b>{tableName}</b>: {caption}
+          </caption>
+        )}
+        {tableChildrenWithoutCaption}
+      </table>
+    </div>
+  )
+}
 
 const TableHead = (props) => {
     const rowWithClassName = {

--- a/site/src/components/Table.js
+++ b/site/src/components/Table.js
@@ -22,12 +22,8 @@ const Table = (props) => {
     .filter((child) => isValidElement(child))
     .reduce(
       (acc, row, i, arr) => {
-        if (
-          i >= arr.length - 1 &&
-          row.props.children &&
-          row.props.children[0] &&
-          isCaption(row.props.children[0].props.children)
-        ) {
+        if ( i === arr.length - 1 && isCaption(row.props.children?.[0].props.children))
+         {
           return [acc[0], row.props.children[0].props.children];
         } else {
           return [[...acc[0], row], acc[1]];


### PR DESCRIPTION
## Description

Table captions were displayed wrong under the table and with no styles. This was fixed by implementing the old table caption logic in doc site component Table.js and making it work with the new mdx table object.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1861

## How Has This Been Tested?
Local host
[Demo](https://city-of-helsinki.github.io/hds-demo/docs-table-caption)
