### PR TITLE
Hds 1850 Header navigation sub menu arrow fix

### DIFF
--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
@@ -5,6 +5,7 @@
 .headerActionBar {
   align-items: stretch;
   box-sizing: border-box;
+  color: var(--header-color);
   display: flex;
   gap: calc(var(--header-margin) / 2);
   height: var(--action-bar-container-height);
@@ -14,7 +15,6 @@
   padding-left: var(--header-margin);
   padding-right: var(--header-margin);
   position: relative;
-  color: var(--header-color);
   
   hr {
     border: 0;

--- a/packages/react/src/components/header/components/navigationLanguageSelector/NavigationLanguageSelector.module.scss
+++ b/packages/react/src/components/header/components/navigationLanguageSelector/NavigationLanguageSelector.module.scss
@@ -19,9 +19,9 @@
 
 .languageSelectorDropdown {
   align-items: flex-start;
+  background-color: var(--lang-selector-dropdown-background-color);
   display: flex;
   flex-flow: column nowrap;
-  background-color: var(--lang-selector-dropdown-background-color);
 
   > * {
     line-height: var(--lineheight-l);

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.module.scss
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.module.scss
@@ -7,8 +7,8 @@
   --link-visited-color: none;
 
   border: 0;
-  display: flex;
   color: var(--nav-link-font-color);
+  display: flex;
   line-height: var(--lineheight-l);
   margin: 0;
   text-decoration: none;

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
@@ -1,4 +1,12 @@
-import React, { MouseEventHandler, cloneElement, useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  MouseEventHandler,
+  cloneElement,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 // import base styles
@@ -161,6 +169,14 @@ export const NavigationLink = <T extends React.ElementType = 'a'>({
   const { openMainNavIndex, setOpenMainNavIndex } = useHeaderNavigationMenuContext();
   const containerRef = useRef<HTMLSpanElement>(null);
   const isSubNavLink = openSubNavIndex !== undefined && setOpenSubNavIndex !== undefined;
+  const [menuSize, setMenuSize] = useState<DOMRect>(undefined);
+
+  useLayoutEffect(() => {
+    const size = containerRef?.current?.getBoundingClientRect();
+    // eslint-disable-next-line no-console
+    console.log('MENU SIZE', size);
+    setMenuSize(size);
+  }, []);
 
   const handleDynamicMenuPosition = (val: boolean) => {
     // Null position when false so if user resizes browser, the calculation is done again
@@ -178,6 +194,19 @@ export const NavigationLink = <T extends React.ElementType = 'a'>({
         setDynamicPosition(position);
       }
     }
+  };
+
+  const getPosition = () => {
+    // eslint-disable-next-line no-lonely-if
+    if (menuSize) {
+      // Calculate which side has more space for the menu
+      const { x: leftPosition, width } = menuSize;
+      const rightPosition = leftPosition + width;
+      const position1 =
+        leftPosition > window.innerWidth - rightPosition ? DropdownMenuPosition.Left : DropdownMenuPosition.Right;
+      return position1;
+    }
+    return undefined;
   };
 
   // Handle dropdown open state by calling either internal state or context
@@ -277,6 +306,7 @@ export const NavigationLink = <T extends React.ElementType = 'a'>({
           openDropdownAriaButtonLabel={openDropdownAriaButtonLabel}
           closeDropdownAriaButtonLabel={closeDropdownAriaButtonLabel}
           dropdownButtonClassName={dropdownButtonClassName}
+          getPosition={getPosition}
         >
           {dropdownLinks.map((child) => {
             return cloneElement(child as React.ReactElement, {

--- a/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
+++ b/packages/react/src/components/header/components/navigationLink/NavigationLink.tsx
@@ -173,8 +173,6 @@ export const NavigationLink = <T extends React.ElementType = 'a'>({
 
   useLayoutEffect(() => {
     const size = containerRef?.current?.getBoundingClientRect();
-    // eslint-disable-next-line no-console
-    console.log('MENU SIZE', size);
     setMenuSize(size);
   }, []);
 

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
@@ -37,7 +37,7 @@
   transition: transform 0.2s ease-in;
 }
 
-.chevronOpen {
+.chevronOpen:not(.direction-right, .direction-left) {
   transform: rotate(180deg);
 }
 

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
@@ -41,6 +41,14 @@
   transform: rotate(180deg);
 }
 
+.chevronRight {
+  transform: rotate(-90deg);
+}
+
+.chevronLeft {
+  transform: rotate(90deg);
+}
+
 .hidden {
   display: none;
 }

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
@@ -39,8 +39,9 @@
 
 .chevronOpen {
   transform: rotate(180deg);
-  &.direction-right,
-  &.direction-left {
+
+  &.direction-left,
+  &.direction-right {
     transform: rotate(0deg);
   }
 }

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
@@ -37,8 +37,12 @@
   transition: transform 0.2s ease-in;
 }
 
-.chevronOpen:not(.direction-right, .direction-left) {
+.chevronOpen {
   transform: rotate(180deg);
+  &.direction-right,
+  &.direction-left {
+    transform: rotate(0deg);
+  }
 }
 
 .chevronRight {

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.module.scss
@@ -2,12 +2,12 @@
   background-color: var(--nav-button-background-color);
   border: none;
   box-sizing: content-box;
+  color: var(--nav-drop-down-icon-color);
   display: block;
   height: 24px;
   margin: 0 0 0 var(--spacing-s);
   padding: 0;
   width: 24px;
-  color: var(--nav-drop-down-icon-color);
   
   &.isNotLargeScreen {
     background: transparent;

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -79,7 +79,6 @@ export const NavigationLinkDropdown = ({
   const { isNotLargeScreen } = useHeaderContext();
   const [openSubNavIndex, setOpenSubNavIndex] = useState<number>(-1);
   const ref = useRef<HTMLUListElement>(null);
-  // const chevronClasses = open ? classNames(styles.chevron, styles.chevronOpen) : styles.chevron;
   const depthClassName = styles[`depth-${depth - 1}`];
   const dropdownDirectionClass = dynamicPosition
     ? classNames(styles.dropdownMenu, styles[dynamicPosition])

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -58,6 +58,7 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
   depth: number;
   /**
    * Function that return dropdown direction.
+   * @internal
    */
   getPosition: () => DropdownMenuPosition;
 }>;

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -56,6 +56,10 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
    * @internal
    */
   depth: number;
+  /**
+   *
+   */
+  getPosition: () => DropdownMenuPosition;
 }>;
 
 export const NavigationLinkDropdown = ({
@@ -69,12 +73,13 @@ export const NavigationLinkDropdown = ({
   closeDropdownAriaButtonLabel,
   openDropdownAriaButtonLabel,
   dropdownButtonClassName,
+  getPosition,
 }: NavigationLinkDropdownProps) => {
   // State for which nested dropdown link is open
   const { isNotLargeScreen } = useHeaderContext();
   const [openSubNavIndex, setOpenSubNavIndex] = useState<number>(-1);
   const ref = useRef<HTMLUListElement>(null);
-  const chevronClasses = open ? classNames(styles.chevron, styles.chevronOpen) : styles.chevron;
+  // const chevronClasses = open ? classNames(styles.chevron, styles.chevronOpen) : styles.chevron;
   const depthClassName = styles[`depth-${depth - 1}`];
   const dropdownDirectionClass = dynamicPosition
     ? classNames(styles.dropdownMenu, styles[dynamicPosition])
@@ -86,6 +91,14 @@ export const NavigationLinkDropdown = ({
   const getDefaultButtonAriaLabel = () => {
     if (open) return closeDropdownAriaButtonLabel || defaultCloseDropdownAriaLabel;
     return openDropdownAriaButtonLabel || defaultOpenDropdownAriaLabel;
+  };
+  const getClassName = () => {
+    const position = getPosition();
+    if (open) return classNames(styles.chevron, styles.chevronOpen);
+    if (depth > 1 && DropdownMenuPosition.Left.toString() === position)
+      return classNames(styles.chevron, styles.chevronLeft);
+    if (depth > 1) return classNames(styles.chevron, styles.chevronRight);
+    return classNames(styles.chevron);
   };
 
   const childElements = getChildElementsEvenIfContainersInbetween(children);
@@ -100,7 +113,7 @@ export const NavigationLinkDropdown = ({
         aria-label={getDefaultButtonAriaLabel()}
         aria-expanded={open}
       >
-        <IconAngleDown className={chevronClasses} />
+        <IconAngleDown className={getClassName()} />
       </button>
       <ul
         className={classNames(dropdownDirectionClass, { isNotLargeScreen }, className)}

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -57,7 +57,7 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
    */
   depth: number;
   /**
-   *
+   * Function that return dropdown direction.
    */
   getPosition: () => DropdownMenuPosition;
 }>;

--- a/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/navigationLink/navigationLinkDropdown/NavigationLinkDropdown.tsx
@@ -93,7 +93,7 @@ export const NavigationLinkDropdown = ({
   };
   const getClassName = () => {
     const position = getPosition();
-    if (open) return classNames(styles.chevron, styles.chevronOpen);
+    if (open) return classNames(styles.chevron, styles.chevronOpen, depth > 1 && styles[`direction-${position}`]);
     if (depth > 1 && DropdownMenuPosition.Left.toString() === position)
       return classNames(styles.chevron, styles.chevronLeft);
     if (depth > 1) return classNames(styles.chevron, styles.chevronRight);


### PR DESCRIPTION
## Description

This pr fixes closed sub-menu arrow direction based on Figma's design

## Motivation and Context

[HDS-1850](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1850)

## How Has This Been Tested?

Tested locally
(Browsers: Firefox, Chrome, Safari)

## Demo

[Storybook](https://city-of-helsinki.github.io/hds-demo/header-dropdown-arrow-fix)

## Screenshots (if appropriate):



[HDS-1850]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<img width="285" alt="arrow-right" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/1567533/8fde790a-47f0-4e7e-b00b-4567efce8977">
<img width="285" alt="arrow-left" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/1567533/783d9baa-8730-432d-8fd3-da82ceeee923">
