### PR TITLE
HDS-1800: Added missing status label tooltips

### DIFF
--- a/site/src/docs/components/breadcrumb/tabs.mdx
+++ b/site/src/docs/components/breadcrumb/tabs.mdx
@@ -12,8 +12,11 @@ import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 
 # Breadcrumb
 
-<StatusLabel type="alert">Beta</StatusLabel>
-<StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+<div class="status-label-description">
+  <StatusLabel type="alert">Beta</StatusLabel>
+  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+  <StatusLabelTooltip/>
+</div>
 
 <LeadParagraph>Breadcrumb is a navigational element that provides links back to each previous page the user navigated through and
   shows the user's current location on a website.</LeadParagraph>

--- a/site/src/docs/components/step-by-step/tabs.mdx
+++ b/site/src/docs/components/step-by-step/tabs.mdx
@@ -5,6 +5,7 @@ title: 'StepByStep'
 
 import { StatusLabel } from 'hds-react';
 
+import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
 
@@ -13,6 +14,7 @@ import PageTabs from '../../../components/PageTabs';
 <div class="status-label-description">
   <StatusLabel type="alert">Beta</StatusLabel>
   <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+  <StatusLabelTooltip/>
 </div>
 
 <LeadParagraph>StepByStep component is useful for visualising a process in steps. The component supports numbered list for cases where the steps must be completed in a specific order, and unnumbered list for cases where the steps are more of a guideline.</LeadParagraph>


### PR DESCRIPTION
## Description

This PR adds missing StatusLabelTooltip for component's status labels.

## Motivation and Context

[HDS-1800](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1800)

## How Has This Been Tested?

Tested locally

## Demo

[Site](https://city-of-helsinki.github.io/hds-demo/status-label-tooltip-site)



[HDS-1800]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ