### PR TITLE
HDS-1841 UniversalBar's contents inside mobile menu

### DIFF
--- a/packages/react/src/components/header/HeaderContext.tsx
+++ b/packages/react/src/components/header/HeaderContext.tsx
@@ -11,19 +11,27 @@ export type HeaderContextType = {
   hasNavigationContent?: boolean;
   navigationContent?: React.ReactNode;
   languageSelectorContent?: React.ReactNode;
+  hasUniversalContent?: boolean;
+  universalContent?: React.ReactNode;
 };
 
 export type HeaderDispatchContextType = {
   setNavigationContent?: (children: React.ReactNode) => void;
   setLanguageSelectorContent?: (children: React.ReactNode) => void;
   setMobileMenuOpen?: (state: boolean) => void;
+  setUniversalContent?: (children: React.ReactNode) => void;
 };
 
-const HeaderContext = createContext<HeaderContextType>({ navigationContent: null, languageSelectorContent: null });
+const HeaderContext = createContext<HeaderContextType>({
+  navigationContent: null,
+  languageSelectorContent: null,
+  universalContent: null,
+});
 const HeaderDispatchContext = createContext<HeaderDispatchContextType>({
   setNavigationContent() {}, // eslint-disable-line @typescript-eslint/no-empty-function
   setLanguageSelectorContent() {}, // eslint-disable-line @typescript-eslint/no-empty-function
   setMobileMenuOpen() {}, // eslint-disable-line @typescript-eslint/no-empty-function
+  setUniversalContent() {}, // eslint-disable-line @typescript-eslint/no-empty-function
 });
 HeaderContext.displayName = 'HeaderContext';
 HeaderDispatchContext.displayName = 'HeaderDispatchContext';
@@ -33,21 +41,26 @@ export const HeaderContextProvider: React.FC<React.ReactNode> = ({ children }) =
   const [navigationContent, setNavigationContent] = useState(null);
   const [languageSelectorContent, setLanguageSelectorContent] = useState(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [universalContent, setUniversalContent] = useState(null);
 
   useEffect(() => setMobileMenuOpen(false), [isNotLargeScreen]);
 
   const hasNavigationContent = !!navigationContent;
+  const hasUniversalContent = !!navigationContent;
   const context: HeaderContextType = {
     isNotLargeScreen,
     mobileMenuOpen,
     navigationContent,
     hasNavigationContent,
     languageSelectorContent,
+    hasUniversalContent,
+    universalContent,
   };
   const dispatchContext: HeaderDispatchContextType = {
     setNavigationContent,
     setLanguageSelectorContent,
     setMobileMenuOpen,
+    setUniversalContent,
   };
 
   return (

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
@@ -1,6 +1,7 @@
 @import "../../../../styles/common.scss";
 
 .headerNavigationMenu {
+  background-color: var(--color-silver-light);
   max-height: 0;
   overflow: hidden;
   transition: 200ms max-height;
@@ -8,15 +9,6 @@
 
 .mobileMenuOpen {
   max-height: 100vh;
-
-  ul {
-    li {
-      align-items: center;
-      border-top: 1px solid var(--color-black-20);
-      display: flex;
-      min-height: var(--action-bar-dropdown-menu-primary-item-height);
-    }
-  }
 }
 
 .headerNavigationMenuList {
@@ -24,4 +16,29 @@
   margin: 0;
   margin-top: -1px;
   padding: 0;
+}
+
+.navigation {
+  background-color: var(--color-white);
+  border-bottom: 1px solid var(--color-black-20);
+
+  ul li {
+    align-items: center;
+    border-top: 1px solid var(--color-black-20);
+    display: flex;
+    min-height: var(--action-bar-dropdown-menu-primary-item-height);
+  }
+}
+
+.universalList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m) 0;
+  list-style: none;
+  margin-bottom: 43px;
+  padding: 0;
+
+  .universalLink.universalLink {
+    font-size: var(--fontsize-body-m);
+  }
 }

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 
 import { HeaderNavigationMenuContextProvider } from '../headerNavigationMenu/HeaderNavigationMenuContext';
 import { useHeaderContext } from '../../HeaderContext';
@@ -7,18 +7,41 @@ import styles from './HeaderActionBarNavigationMenu.module.scss';
 import { HeaderNavigationMenuContent } from '../headerNavigationMenu';
 
 export const HeaderActionBarNavigationMenu = () => {
-  const { hasNavigationContent, isNotLargeScreen, mobileMenuOpen } = useHeaderContext();
+  const {
+    hasNavigationContent,
+    isNotLargeScreen,
+    mobileMenuOpen,
+    hasUniversalContent,
+    universalContent,
+  } = useHeaderContext();
   const className = classNames(styles.headerNavigationMenu, mobileMenuOpen && styles.mobileMenuOpen);
 
   if (!hasNavigationContent || !isNotLargeScreen) return null;
 
   return (
-    <nav className={className}>
-      <ul className={styles.headerNavigationMenuList}>
-        <HeaderNavigationMenuContextProvider>
-          <HeaderNavigationMenuContent />
-        </HeaderNavigationMenuContextProvider>
-      </ul>
-    </nav>
+    <div className={className}>
+      <nav className={styles.navigation}>
+        <ul className={styles.headerNavigationMenuList}>
+          <HeaderNavigationMenuContextProvider>
+            <HeaderNavigationMenuContent />
+          </HeaderNavigationMenuContextProvider>
+        </ul>
+      </nav>
+      {hasUniversalContent && (
+        <ul className={styles.universalList}>
+          {Children.map(universalContent, (child, index) => {
+            if (!isValidElement(child)) return null;
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={index}>
+                {cloneElement(child, {
+                  className: styles.universalLink,
+                })}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
   );
 };

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -1,10 +1,10 @@
-import React, { cloneElement } from 'react';
+import React, { cloneElement, useEffect } from 'react';
 
 // import base styles
 import '../../../../styles/base.css';
 import styles from './HeaderUniversalBar.module.scss';
 import { HeaderLink } from '../headerLink/HeaderLink';
-import { useHeaderContext } from '../../HeaderContext';
+import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 
@@ -51,6 +51,12 @@ export const HeaderUniversalBar = ({
   const { isNotLargeScreen } = useHeaderContext();
   if (isNotLargeScreen) return null;
   const childElements = getChildElementsEvenIfContainersInbetween(children);
+  const { setUniversalContent } = useSetHeaderContext();
+
+  useEffect(() => {
+    const universalContent = getChildElementsEvenIfContainersInbetween(children);
+    setUniversalContent(universalContent);
+  }, [children]);
 
   return (
     <div className={styles.headerUniversalBarContainer}>


### PR DESCRIPTION
## Description

UniversalBar's links should move inside the actionbar's navigation menu in mobile views.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1841

## How Has This Been Tested?
Locally
[Demo](https://city-of-helsinki.github.io/hds-demo/universal-links-move/?path=/story/components-header--with-full-features)