### PR TITLE
Hds 1850 subnav chevron fix

### DIFF
--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
@@ -5,6 +5,7 @@
 .headerActionBar {
   align-items: stretch;
   box-sizing: border-box;
+  color: var(--header-color);
   display: flex;
   gap: calc(var(--header-margin) / 2);
   height: var(--action-bar-container-height);
@@ -14,7 +15,6 @@
   padding-left: var(--header-margin);
   padding-right: var(--header-margin);
   position: relative;
-  color: var(--header-color);
   
   hr {
     border: 0;

--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.module.scss
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.module.scss
@@ -19,9 +19,9 @@
 
 .languageSelectorDropdown {
   align-items: flex-start;
+  background-color: var(--lang-selector-dropdown-background-color);
   display: flex;
   flex-flow: column nowrap;
-  background-color: var(--lang-selector-dropdown-background-color);
 
   > * {
     line-height: var(--lineheight-l);

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.module.scss
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.module.scss
@@ -7,8 +7,8 @@
   --link-visited-color: none;
 
   border: 0;
-  display: flex;
   color: var(--nav-link-font-color);
+  display: flex;
   line-height: var(--lineheight-l);
   margin: 0;
   text-decoration: none;

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
@@ -1,4 +1,12 @@
-import React, { MouseEventHandler, cloneElement, useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  MouseEventHandler,
+  cloneElement,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 // import base styles
@@ -159,6 +167,13 @@ export const HeaderLink = <T extends React.ElementType = 'a'>({
   const containerRef = useRef<HTMLSpanElement>(null);
   const isSubNavLink = openSubNavIndex !== undefined && setOpenSubNavIndex !== undefined;
 
+  const [menuSize, setMenuSize] = useState<DOMRect>(undefined);
+
+  useLayoutEffect(() => {
+    const size = containerRef?.current?.getBoundingClientRect();
+    setMenuSize(size);
+  }, []);
+
   const handleDynamicMenuPosition = (val: boolean) => {
     // Null position when false so if user resizes browser, the calculation is done again
     if (!val) setDynamicPosition(null);
@@ -175,6 +190,19 @@ export const HeaderLink = <T extends React.ElementType = 'a'>({
         setDynamicPosition(position);
       }
     }
+  };
+
+  const getPosition = () => {
+    // eslint-disable-next-line no-lonely-if
+    if (menuSize) {
+      // Calculate which side has more space for the menu
+      const { x: leftPosition, width } = menuSize;
+      const rightPosition = leftPosition + width;
+      const position1 =
+        leftPosition > window.innerWidth - rightPosition ? DropdownMenuPosition.Left : DropdownMenuPosition.Right;
+      return position1;
+    }
+    return undefined;
   };
 
   // Handle dropdown open state by calling either internal state or context
@@ -274,6 +302,7 @@ export const HeaderLink = <T extends React.ElementType = 'a'>({
           openDropdownAriaButtonLabel={openDropdownAriaButtonLabel}
           closeDropdownAriaButtonLabel={closeDropdownAriaButtonLabel}
           dropdownButtonClassName={dropdownButtonClassName}
+          getPosition={getPosition}
         >
           {dropdownLinks.map((child) => {
             return cloneElement(child as React.ReactElement, {

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
@@ -161,16 +161,17 @@ export const HeaderLink = <T extends React.ElementType = 'a'>({
   const isSubNavLink = openSubNavIndex !== undefined && setOpenSubNavIndex !== undefined;
 
   const getDropdownPosition = () => {
-    let position;
     // On SSR just set the menu on the right
-    if (window === undefined) position = DropdownMenuPosition.Right;
-    else if (containerRef.current != null) {
+    if (window === undefined) {
+      return DropdownMenuPosition.Right;
+    }
+    if (containerRef.current != null) {
+      /* Calculate does right side have enough space for dropdown. If not, put it to the left. */
       const { x: leftPosition, width } = containerRef.current.getBoundingClientRect();
       const rightPosition = leftPosition + width;
-      position =
-        leftPosition > window.innerWidth - rightPosition ? DropdownMenuPosition.Left : DropdownMenuPosition.Right;
+      return leftPosition > window.innerWidth - rightPosition ? DropdownMenuPosition.Left : DropdownMenuPosition.Right;
     }
-    return position;
+    return DropdownMenuPosition.Right;
   };
 
   useIsomorphicLayoutEffect(() => {
@@ -269,7 +270,7 @@ export const HeaderLink = <T extends React.ElementType = 'a'>({
           index={index}
           depth={depth + 1}
           className={dropdownClassName}
-          dynamicPosition={dynamicPosition}
+          position={dynamicPosition}
           openDropdownAriaButtonLabel={openDropdownAriaButtonLabel}
           closeDropdownAriaButtonLabel={closeDropdownAriaButtonLabel}
           dropdownButtonClassName={dropdownButtonClassName}

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.module.scss
@@ -4,12 +4,12 @@ button.button {
   background-color: var(--nav-button-background-color);
   border: none;
   box-sizing: content-box;
+  color: var(--nav-drop-down-icon-color);
   display: block;
   height: 24px;
   margin: 0 0 0 var(--spacing-s);
   padding: 0;
   width: 24px;
-  color: var(--nav-drop-down-icon-color);
   
   &.isNotLargeScreen {
     background: transparent;
@@ -41,6 +41,19 @@ button.button {
 
 .chevronOpen {
   transform: rotate(180deg);
+
+  &.direction-left,
+  &.direction-right {
+    transform: rotate(0deg);
+  }
+}
+
+.chevronRight {
+  transform: rotate(-90deg);
+}
+
+.chevronLeft {
+  transform: rotate(90deg);
 }
 
 .hidden {

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.module.scss
@@ -41,19 +41,6 @@ button.button {
 
 .chevronOpen {
   transform: rotate(180deg);
-
-  &.direction-left,
-  &.direction-right {
-    transform: rotate(0deg);
-  }
-}
-
-.chevronRight {
-  transform: rotate(-90deg);
-}
-
-.chevronLeft {
-  transform: rotate(90deg);
 }
 
 .hidden {

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
@@ -3,7 +3,7 @@ import React, { cloneElement, isValidElement, useRef, useState } from 'react';
 // import base styles
 import '../../../../../styles/base.css';
 import styles from './HeaderLinkDropdown.module.scss';
-import { IconAngleDown } from '../../../../../icons';
+import { IconAngleDown, IconAngleLeft, IconAngleRight } from '../../../../../icons';
 import { useHeaderContext } from '../../../HeaderContext';
 import classNames from '../../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../../utils/getChildren';
@@ -56,11 +56,6 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
    * @internal
    */
   depth: number;
-  /**
-   * Function that return dropdown direction.
-   * @internal
-   */
-  getPosition: () => DropdownMenuPosition;
 }>;
 
 export const HeaderLinkDropdown = ({
@@ -74,12 +69,12 @@ export const HeaderLinkDropdown = ({
   closeDropdownAriaButtonLabel,
   openDropdownAriaButtonLabel,
   dropdownButtonClassName,
-  getPosition,
 }: NavigationLinkDropdownProps) => {
   // State for which nested dropdown link is open
   const { isNotLargeScreen } = useHeaderContext();
   const [openSubNavIndex, setOpenSubNavIndex] = useState<number>(-1);
   const ref = useRef<HTMLUListElement>(null);
+  const chevronClassName = open ? classNames(styles.chevron, styles.chevronOpen) : styles.chevron;
   const depthClassName = styles[`depth-${depth - 1}`];
   const dropdownDirectionClass = dynamicPosition
     ? classNames(styles.dropdownMenu, styles[dynamicPosition])
@@ -93,16 +88,15 @@ export const HeaderLinkDropdown = ({
     return openDropdownAriaButtonLabel || defaultOpenDropdownAriaLabel;
   };
 
-  const getChevronClassName = () => {
-    const position = getPosition();
-    if (open) return classNames(styles.chevron, styles.chevronOpen, depth > 1 && styles[`direction-${position}`]);
-    if (depth > 1 && DropdownMenuPosition.Left.toString() === position)
-      return classNames(styles.chevron, styles.chevronLeft);
-    if (depth > 1) return classNames(styles.chevron, styles.chevronRight);
-    return classNames(styles.chevron);
-  };
-
   const childElements = getChildElementsEvenIfContainersInbetween(children);
+
+  const renderIcon = () => {
+    if (depth > 1 && dynamicPosition === DropdownMenuPosition.Right)
+      return <IconAngleRight className={chevronClassName} />;
+    if (depth > 1 && dynamicPosition === DropdownMenuPosition.Left)
+      return <IconAngleLeft className={chevronClassName} />;
+    return <IconAngleDown className={chevronClassName} />;
+  };
 
   return (
     <>
@@ -114,7 +108,7 @@ export const HeaderLinkDropdown = ({
         aria-label={getDefaultButtonAriaLabel()}
         aria-expanded={open}
       >
-        <IconAngleDown className={getChevronClassName()} />
+        {renderIcon()}
       </button>
       <ul
         className={classNames(dropdownDirectionClass, { isNotLargeScreen }, className)}

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
@@ -56,6 +56,11 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
    * @internal
    */
   depth: number;
+  /**
+   * Function that return dropdown direction.
+   * @internal
+   */
+  getPosition: () => DropdownMenuPosition;
 }>;
 
 export const HeaderLinkDropdown = ({
@@ -69,12 +74,12 @@ export const HeaderLinkDropdown = ({
   closeDropdownAriaButtonLabel,
   openDropdownAriaButtonLabel,
   dropdownButtonClassName,
+  getPosition,
 }: NavigationLinkDropdownProps) => {
   // State for which nested dropdown link is open
   const { isNotLargeScreen } = useHeaderContext();
   const [openSubNavIndex, setOpenSubNavIndex] = useState<number>(-1);
   const ref = useRef<HTMLUListElement>(null);
-  const chevronClasses = open ? classNames(styles.chevron, styles.chevronOpen) : styles.chevron;
   const depthClassName = styles[`depth-${depth - 1}`];
   const dropdownDirectionClass = dynamicPosition
     ? classNames(styles.dropdownMenu, styles[dynamicPosition])
@@ -86,6 +91,15 @@ export const HeaderLinkDropdown = ({
   const getDefaultButtonAriaLabel = () => {
     if (open) return closeDropdownAriaButtonLabel || defaultCloseDropdownAriaLabel;
     return openDropdownAriaButtonLabel || defaultOpenDropdownAriaLabel;
+  };
+
+  const getChevronClassName = () => {
+    const position = getPosition();
+    if (open) return classNames(styles.chevron, styles.chevronOpen, depth > 1 && styles[`direction-${position}`]);
+    if (depth > 1 && DropdownMenuPosition.Left.toString() === position)
+      return classNames(styles.chevron, styles.chevronLeft);
+    if (depth > 1) return classNames(styles.chevron, styles.chevronRight);
+    return classNames(styles.chevron);
   };
 
   const childElements = getChildElementsEvenIfContainersInbetween(children);
@@ -100,7 +114,7 @@ export const HeaderLinkDropdown = ({
         aria-label={getDefaultButtonAriaLabel()}
         aria-expanded={open}
       >
-        <IconAngleDown className={chevronClasses} />
+        <IconAngleDown className={getChevronClassName()} />
       </button>
       <ul
         className={classNames(dropdownDirectionClass, { isNotLargeScreen }, className)}

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
@@ -33,7 +33,7 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
    * Direction for dropdown position.
    * @default DropdownMenuPosition.Right
    */
-  dynamicPosition?: DropdownMenuPosition;
+  position?: DropdownMenuPosition;
   /**
    * Element index given by parent mapping.
    * @internal
@@ -60,7 +60,7 @@ export type NavigationLinkDropdownProps = React.PropsWithChildren<{
 
 export const HeaderLinkDropdown = ({
   children,
-  dynamicPosition = DropdownMenuPosition.Right,
+  position = DropdownMenuPosition.Right,
   className,
   index,
   open,
@@ -76,9 +76,7 @@ export const HeaderLinkDropdown = ({
   const ref = useRef<HTMLUListElement>(null);
   const chevronClassName = open ? classNames(styles.chevron, styles.chevronOpen) : styles.chevron;
   const depthClassName = styles[`depth-${depth - 1}`];
-  const dropdownDirectionClass = dynamicPosition
-    ? classNames(styles.dropdownMenu, styles[dynamicPosition])
-    : styles.dropdownMenu;
+  const dropdownDirectionClass = position ? classNames(styles.dropdownMenu, styles[position]) : styles.dropdownMenu;
 
   const handleMenuButtonClick = () => setOpen(!open, NavigationLinkInteraction.Click);
   const defaultOpenDropdownAriaLabel = 'Avaa alasvetovalikko.';
@@ -91,10 +89,8 @@ export const HeaderLinkDropdown = ({
   const childElements = getChildElementsEvenIfContainersInbetween(children);
 
   const renderIcon = () => {
-    if (depth > 1 && dynamicPosition === DropdownMenuPosition.Right)
-      return <IconAngleRight className={chevronClassName} />;
-    if (depth > 1 && dynamicPosition === DropdownMenuPosition.Left)
-      return <IconAngleLeft className={chevronClassName} />;
+    if (depth > 1 && position === DropdownMenuPosition.Right) return <IconAngleRight className={chevronClassName} />;
+    if (depth > 1 && position === DropdownMenuPosition.Left) return <IconAngleLeft className={chevronClassName} />;
     return <IconAngleDown className={chevronClassName} />;
   };
 


### PR DESCRIPTION
## Description

Header's nested dropdowns chevron should point to the direction where the dropdown is opening. Original work àla Minna. Modified code to work with existing logic regarding the dropdown position and change the nested menu icon to point to the opposite direction when opened.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1850

## Screenshots (if appropriate):
<img width="319" alt="Screenshot 2023-09-04 at 8 54 15" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/108321134/f96aacf9-323f-47af-b236-cb916c578579">

**To do**
- [x] When nested dropdown is open, the arrow should point to the opposite direction, not down
- [x] Make a fail safe for SSR cases, i.e. menu is always on right because we can't touch window object
- [x] Test on SSR (site demo counts?)

[Storybook demo](https://city-of-helsinki.github.io/hds-demo/chevron-fix-react/?path=/story/components-header--with-full-features)
[Site demo](https://city-of-helsinki.github.io/hds-demo/chevron-fix/components/header/)
