### PR TITLE
HDS 1773: Set loadingSpinner role to status

### DIFF
--- a/packages/react/src/components/loadingSpinner/useNotificationArea.ts
+++ b/packages/react/src/components/loadingSpinner/useNotificationArea.ts
@@ -10,7 +10,7 @@ const createNotificationAreaElement = (): HTMLElement => {
   const element = document.createElement('div');
   element.id = notificationAreaId;
   element.className = styles.notificationArea;
-  element.setAttribute('role', 'alert');
+  element.setAttribute('role', 'status');
   document.body.appendChild(element);
   return element;
 };


### PR DESCRIPTION
## Description
Loading spinner adds invisible `role="alert"` element with loading text to the DOM. This role can potentially interrupt screen reader if currently reading other content. Changing to `role="status"` will act as polite alert.
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1773](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1773)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

<img width="817" alt="Screenshot 2023-09-04 at 15 16 23" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/66477579/60d297a2-5e4a-44ad-924e-33f0ec2b2d0c">

[HDS-1773]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ