### PR TITLE
HDS-1873 Site Header component preview

### DIFF
--- a/site/src/docs/components/header/code.mdx
+++ b/site/src/docs/components/header/code.mdx
@@ -125,6 +125,8 @@ import { Header, IconSearch } from 'hds-react';
 
 </Playground>
 
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features">view full header example in Storybook</Link>.
+
 #### Custom Link
 
 The Header.Link component has the `as` prop which you can use to use your own navigation link instead of our Header.Link, which uses <InternalLink href="/components/">HDS Link</InternalLink> underneath. You can pass it as an element `as={<CustomLink />}` or as a component `as={CustomLink}`.
@@ -221,6 +223,8 @@ import { Link } from 'gatsby';
 
 </Playground>
 
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features">view full header example in Storybook</Link>.
+
 #### Dark theme
 
 <Playground scope={{ Header, IconSearch }}>
@@ -298,6 +302,7 @@ import { Header, IconSearch } from 'hds-react';
 
 </Playground>
 
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features-dark-theme">view full header with dark theme example in Storybook</Link>.
 
 ### Packages
 

--- a/site/src/docs/components/header/index.mdx
+++ b/site/src/docs/components/header/index.mdx
@@ -95,6 +95,8 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
   </Header>
 </PlaygroundPreview>
 
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features">view full header example in Storybook</Link>.
+
 ### Principles
 
 - **It is strongly recommended to always include the header component on every page in your service.**
@@ -143,6 +145,8 @@ Use the Header.SkipLink component to help keyboard-only users skip to the main c
   </Header>
 </PlaygroundPreview>
 
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--minimal">view minimal header example with skip link in Storybook</Link>.
+
 #### With universal bar
 
 Header.UniversalBar is aimed to provide easy access for frequently visited and useful links, e.g. feedback and news.
@@ -169,6 +173,8 @@ Header.UniversalBar is aimed to provide easy access for frequently visited and u
     />
   </Header>
 </PlaygroundPreview>
+
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features">view full header example with universal bar in Storybook</Link>.
 
 #### With action bar
 
@@ -202,6 +208,8 @@ Header.ActionBar is the section that makes your service recognizeable. It provid
     </Header.ActionBar>
   </Header>
 </PlaygroundPreview>
+
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--minimal">view minimal header example with action bar in Storybook</Link>.
 
 ##### With language selector
 
@@ -246,6 +254,8 @@ The Header.Search component is to be used for whole site wide search.
     </Header.ActionBar>
   </Header>
 </PlaygroundPreview>
+
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--minimal">view minimal header example with search in Storybook</Link>.
 
 ##### ActionBarItem
 
@@ -329,6 +339,8 @@ The Header.ActionBarItem is a generic component for displaying icon buttons on t
   </Header>
 </PlaygroundPreview>
 
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--minimal">view minimal header example with action bar in Storybook</Link>.
+
 #### With navigation menu
 
 The Header.NavigationMenu is enables users to navigate to different pages of the service. The navigation menu supports up to 3 levels of page hierarchy. For more levels and recommendations, see also Navigation pattern.
@@ -411,6 +423,8 @@ The Header.NavigationMenu is enables users to navigate to different pages of the
     </Header.NavigationMenu>
   </Header>
 </PlaygroundPreview>
+
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features">view full header example with navigation menu in Storybook</Link>.
 
 #### Colour variations
 
@@ -517,3 +531,5 @@ Header offers two variations with different backgrounds - one with white and one
     </Header.NavigationMenu>
   </Header>
 </PlaygroundPreview>
+
+**Note:** Header is designed to be used full width at the top of the page above the main content. Preview here might not scale correctly, <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-header--with-full-features-dark-theme">view full header with dark theme example in Storybook</Link>.


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Add note on documentation site about Header component, explaining that component is designed to be used full width at the top of the page, and therefore might not scale correctly on preview. Also add links to Storybook to stories that include relevant components. 

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1873](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1873)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on local machine

## Screenshots (if appropriate):
<img width="973" alt="Screenshot 2023-09-08 at 13 38 18" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/66477579/6f234a29-12f1-4337-bf0c-70e5691f57b8">


[HDS-1873]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ