### PR TITLE
HDS-1871 Show logo at the bottom of action bar navigation

### DIFF
--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
@@ -70,9 +70,11 @@
   .normal > & {
     @include typography.title-normal;
   }
+
   .bold > & {
     @include typography.title-bold;
   }
+
   .black > & {
     @include typography.title-black;
   }

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
@@ -15,7 +15,7 @@
   padding-left: var(--header-margin);
   padding-right: var(--header-margin);
   position: relative;
-  
+
   hr {
     border: 0;
     border-left: 1px solid var(--color-black-20);
@@ -57,7 +57,7 @@
     outline-offset: var(--header-focus-outline-width);
   }
 
-  &:not([href]):not([tabindex="0"]) {
+  &:not([href]):not([tabindex='0']) {
     cursor: auto;
   }
 }
@@ -67,21 +67,19 @@
   margin-top: -2px;
   padding: 1px;
 
-  .normal > & { @include typography.title-normal }
-  .bold > & { @include typography.title-bold }
-  .black > & { @include typography.title-black }
+  .normal > & {
+    @include typography.title-normal;
+  }
+  .bold > & {
+    @include typography.title-bold;
+  }
+  .black > & {
+    @include typography.title-black;
+  }
 }
 
 .logo {
   align-self: center;
   box-sizing: content-box;
   height: var(--logo-height);
-}
-
-.logoWrapper {
-  align-items: center;
-  display: flex;
-  height: 100%;
-  max-height: 100%;
-  max-width: 100%;
 }

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -155,7 +155,7 @@ export const HeaderActionBar = ({
         </div>
       </div>
       <HeaderLanguageSelector fullWidthForMobile />
-      <HeaderActionBarNavigationMenu />
+      <HeaderActionBarNavigationMenu logo={logo} logoProps={logoProps} />
     </>
   );
 };

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -8,6 +8,7 @@ import { HeaderLanguageSelector } from '../headerLanguageSelector';
 import { useCallbackIfDefined, useEnterOrSpacePressCallback } from '../../../../utils/useCallback';
 import { HeaderActionBarMenuItem } from '../headerActionBarItem';
 import styles from './HeaderActionBar.module.scss';
+import HeaderActionBarLogo from './HeaderActionBarLogo';
 
 const classNames = styleBoundClassNames(styles);
 
@@ -133,9 +134,7 @@ export const HeaderActionBar = ({
     <>
       <div className={styles.headerActionBarContainer}>
         <div className={classNames(styles.headerActionBar, className)} role={role} aria-label={ariaLabel}>
-          <LinkItem {...logoProps}>
-            <span className={styles.logoWrapper}>{logo}</span>
-          </LinkItem>
+          <HeaderActionBarLogo logo={logo} logoProps={logoProps} />
           {title && (
             <LinkItem {...titleProps}>
               <span className={classNames(styles.title)}>{title}</span>
@@ -155,7 +154,7 @@ export const HeaderActionBar = ({
         </div>
       </div>
       <HeaderLanguageSelector fullWidthForMobile />
-      <HeaderActionBarNavigationMenu logo={<span className={styles.logoWrapper}>{logo}</span>} logoProps={logoProps} />
+      <HeaderActionBarNavigationMenu logo={logo} logoProps={logoProps} />
     </>
   );
 };

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -155,7 +155,10 @@ export const HeaderActionBar = ({
         </div>
       </div>
       <HeaderLanguageSelector fullWidthForMobile />
-      <HeaderActionBarNavigationMenu logo={logo} logoProps={logoProps} />
+      <HeaderActionBarNavigationMenu
+        logo={logoProps?.href ? <span className={styles.logoWrapper}>{logo}</span> : logo}
+        logoProps={logoProps}
+      />
     </>
   );
 };

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -134,7 +134,7 @@ export const HeaderActionBar = ({
       <div className={styles.headerActionBarContainer}>
         <div className={classNames(styles.headerActionBar, className)} role={role} aria-label={ariaLabel}>
           <LinkItem {...logoProps}>
-            {logoProps?.href ? <span className={styles.logoWrapper}>{logo}</span> : logo}
+            <span className={styles.logoWrapper}>{logo}</span>
           </LinkItem>
           {title && (
             <LinkItem {...titleProps}>
@@ -155,10 +155,7 @@ export const HeaderActionBar = ({
         </div>
       </div>
       <HeaderLanguageSelector fullWidthForMobile />
-      <HeaderActionBarNavigationMenu
-        logo={logoProps?.href ? <span className={styles.logoWrapper}>{logo}</span> : logo}
-        logoProps={logoProps}
-      />
+      <HeaderActionBarNavigationMenu logo={<span className={styles.logoWrapper}>{logo}</span>} logoProps={logoProps} />
     </>
   );
 };

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarLogo.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarLogo.module.scss
@@ -1,0 +1,7 @@
+.logoWrapper {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  max-height: 100%;
+  max-width: 100%;
+}

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarLogo.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarLogo.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
+import styles from './HeaderActionBarLogo.module.scss';
+
+type HeaderActionBarLogoProps = {
+  /**
+   * Logo properties
+   */
+  logoProps: LinkProps;
+  /**
+   * Logo to use
+   */
+  logo: JSX.Element;
+};
+
+const HeaderActionBarLogo = ({ logoProps, logo }: HeaderActionBarLogoProps) => {
+  return (
+    <LinkItem {...logoProps}>
+      <span className={styles.logoWrapper}>{logo}</span>
+    </LinkItem>
+  );
+};
+
+export default HeaderActionBarLogo;

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/common.scss";
+@import '../../../../styles/common.scss';
 
 .headerNavigationMenu {
   background-color: var(--color-silver-light);
@@ -41,4 +41,12 @@
   .universalLink.universalLink {
     font-size: var(--fontsize-body-m);
   }
+}
+
+.logoLink {
+  box-sizing: content-box;
+  display: flex;
+  height: calc(var(--logo-height) * 1.5);
+  justify-content: center;
+  margin-bottom: var(--spacing-m);
 }

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
@@ -44,9 +44,7 @@
 }
 
 .logoLink {
-  box-sizing: content-box;
-  display: flex;
-  height: calc(var(--logo-height) * 1.5);
+  height: calc(var(--logo-height) * 1.5) !important;
   justify-content: center;
   margin-bottom: var(--spacing-m);
 }

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -4,9 +4,23 @@ import { HeaderNavigationMenuContextProvider } from '../headerNavigationMenu/Hea
 import { useHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import styles from './HeaderActionBarNavigationMenu.module.scss';
+import parentStyles from './HeaderActionBar.module.scss';
 import { HeaderNavigationMenuContent } from '../headerNavigationMenu';
+import { Logo } from '../../../logo';
+import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
 
-export const HeaderActionBarNavigationMenu = () => {
+type HeaderActionBarNavigationMenuProps = {
+  /**
+   * Logo to use
+   */
+  logo: React.ReactElement<typeof Logo>;
+  /**
+   * Logo properties
+   */
+  logoProps: LinkProps;
+};
+
+export const HeaderActionBarNavigationMenu = ({ logo, logoProps }: HeaderActionBarNavigationMenuProps) => {
   const {
     hasNavigationContent,
     isNotLargeScreen,
@@ -42,6 +56,9 @@ export const HeaderActionBarNavigationMenu = () => {
           })}
         </ul>
       )}
+      <LinkItem {...logoProps} className={styles.logoLink}>
+        {logoProps?.href ? <span className={parentStyles.logoWrapper}>{logo}</span> : logo}
+      </LinkItem>
     </div>
   );
 };

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -5,7 +5,8 @@ import { useHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import styles from './HeaderActionBarNavigationMenu.module.scss';
 import { HeaderNavigationMenuContent } from '../headerNavigationMenu';
-import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
+import { LinkProps } from '../../../../internal/LinkItem';
+import HeaderActionBarLogo from './HeaderActionBarLogo';
 
 type HeaderActionBarNavigationMenuProps = {
   /**
@@ -54,9 +55,13 @@ export const HeaderActionBarNavigationMenu = ({ logo, logoProps }: HeaderActionB
           })}
         </ul>
       )}
-      <LinkItem {...logoProps} className={styles.logoLink}>
-        {logo}
-      </LinkItem>
+      <HeaderActionBarLogo
+        logoProps={{
+          ...logoProps,
+          className: classNames(logoProps.className, styles.logoLink),
+        }}
+        logo={logo}
+      />
     </div>
   );
 };

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -4,16 +4,14 @@ import { HeaderNavigationMenuContextProvider } from '../headerNavigationMenu/Hea
 import { useHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import styles from './HeaderActionBarNavigationMenu.module.scss';
-import parentStyles from './HeaderActionBar.module.scss';
 import { HeaderNavigationMenuContent } from '../headerNavigationMenu';
-import { Logo } from '../../../logo';
 import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
 
 type HeaderActionBarNavigationMenuProps = {
   /**
    * Logo to use
    */
-  logo: React.ReactElement<typeof Logo>;
+  logo: JSX.Element;
   /**
    * Logo properties
    */
@@ -57,7 +55,7 @@ export const HeaderActionBarNavigationMenu = ({ logo, logoProps }: HeaderActionB
         </ul>
       )}
       <LinkItem {...logoProps} className={styles.logoLink}>
-        {logoProps?.href ? <span className={parentStyles.logoWrapper}>{logo}</span> : logo}
+        {logo}
       </LinkItem>
     </div>
   );

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBar.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBar.test.tsx.snap
@@ -17,12 +17,16 @@ exports[`<HeaderActionBar /> spec renders the component 1`] = `
           <span
             class="titleAndLogoContainer logo"
           >
-            <img
-              alt="Helsingin kaupunki"
-              class="logo"
-              data-testid="action-bar-logo"
-              src="dummySrc"
-            />
+            <span
+              class="logoWrapper"
+            >
+              <img
+                alt="Helsingin kaupunki"
+                class="logo"
+                data-testid="action-bar-logo"
+                src="dummySrc"
+              />
+            </span>
           </span>
           <span
             class="titleAndLogoContainer title normal"


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Header logo should be in mobile navigation menu.

**Note:** navigation mobile styles are incorrect for dark theme, will be addressed in https://github.com/City-of-Helsinki/helsinki-design-system/pull/1120. At the moment there is not enough contrast between the logo and the background.
## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1871](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1871)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):
<img width="417" alt="Screenshot 2023-09-21 at 9 50 10" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/66477579/9ed2f4e1-b212-4f6c-972c-a8fc35bd7cbf">



[HDS-1871]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ