### PR TITLE
HDS-1937: Fixed inconsistent way of using inline styles

### DIFF
--- a/site/src/docs/components/header/index.mdx
+++ b/site/src/docs/components/header/index.mdx
@@ -524,9 +524,9 @@ When customising colours, refer to <InternalLink href="/foundation/design-tokens
 <PlaygroundPreview>
   <div
     style={{
-      'margin-bottom': '1rem',
+      marginBottom: '1rem',
       position: 'relative',
-      'z-index': '13',
+      zIndex: '13',
     }}
   >
     <Header
@@ -583,9 +583,9 @@ When customising colours, refer to <InternalLink href="/foundation/design-tokens
   </div>
   <div
     style={{
-      'margin-bottom': '1rem',
+      marginBottom: '1rem',
       position: 'relative',
-      'z-index': '12',
+      zIndex: '12',
     }}
   >
     <Header theme="dark">
@@ -642,7 +642,7 @@ When customising colours, refer to <InternalLink href="/foundation/design-tokens
   <div
     style={{
       position: 'relative',
-      'z-index': '11',
+      zIndex: '11',
     }}
   >
     <Header


### PR DESCRIPTION
## Description

Fixed inconsistent way of using inline styles.
Instead of using the non-standard way of quoting the style keys, using the React Standard way of camelCase for properties with dashes.

## Related Issue

[HDS-1937](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1937)


[HDS-1937]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ