### PR TITLE
HDS-1943 language options focus fix

### DIFF
--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.module.scss
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.module.scss
@@ -45,7 +45,7 @@
   }
 
   > button {
-    border: 3px solid transparent;
+    border: var(--header-focus-outline-width) solid transparent;
   }
 }
 
@@ -53,16 +53,14 @@ button.item,
 [type='button'].item {
   appearance: none;
   background: transparent;
-  border: none;
   color: var(--lang-selector-item-font-color);
   cursor: pointer;
   line-height: var(--lineheight-l);
+  outline: 0;
   white-space: nowrap;
 
   &:focus-visible {
-    border: none;
-    outline: var(--header-focus-outline-width) solid var(--header-focus-outline-color);
-    outline-offset: var(--header-focus-outline-width);
+    border: var(--header-focus-outline-width) solid var(--header-focus-outline-color);
   }
 }
 
@@ -80,7 +78,15 @@ button.item,
 
   button.item,
   [type='button'].item {
+    align-self: center;
+    border: none;
     padding: 0;
+
+    &:focus-visible {
+      border: none;
+      outline: var(--header-focus-outline-width) solid var(--header-focus-outline-color);
+      outline-offset: var(--header-focus-outline-width);
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Button focus outlines were outside the container and primary language buttons were too high

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1943-focus/?path=/story/components-header--minimal-with-localization)

Closes [HDS-1942](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1942)



## How Has This Been Tested?

Local + visual tests


[HDS-1942]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ