### PR TITLE
Hds 1948 translate universal links in mobile menu

### DIFF
--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -49,7 +49,6 @@ export const HeaderUniversalBar = ({
   role,
 }: HeaderUniversalBarProps) => {
   const { isNotLargeScreen } = useHeaderContext();
-  if (isNotLargeScreen) return null;
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   const { setUniversalContent } = useSetHeaderContext();
 
@@ -57,6 +56,8 @@ export const HeaderUniversalBar = ({
     const universalContent = getChildElementsEvenIfContainersInbetween(children);
     setUniversalContent(universalContent);
   }, [children]);
+
+  if (isNotLargeScreen) return null;
 
   return (
     <div className={styles.headerUniversalBarContainer}>


### PR DESCRIPTION
## Description

When changing languages, the universal links are not translated in mobile menu. This was because the universalContent property in HeaderContext was not set from UniversalBar because the component had too early of a `return null;`

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1948

## How Has This Been Tested?
Locally with a dummy test case for switching languages
[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1948-universal-links-in-mobile/?path=/story/components-header--with-full-features)

