### PR TITLE
HDS-1952 fix StatusLabel playground scope

### DIFF
--- a/site/src/docs/components/status-label/code.mdx
+++ b/site/src/docs/components/status-label/code.mdx
@@ -53,7 +53,7 @@ import { StatusLabel } from 'hds-react';
 
 #### With an icon
 
-<Playground scope={{ StatusLabel }}>
+<Playground scope={{ StatusLabel, IconInfoCircle, IconCheckCircle, IconAlertCircle, IconError }}>
 
 ```jsx
 import { StatusLabel, IconInfoCircle, IconCheckCircle, IconAlertCircle, IconError } from 'hds-react';


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Fixing StatusLabel With an icon playground scope

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-1952](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1952)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):


[HDS-1952]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ