### PR TITLE
HDS-1954 Fix core code examples in doc site

### DIFF
--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 @import "~hds-design-tokens/lib/all.scss";
-@import "~hds-core/lib/components/table/table.css";
+@import "~hds-core/lib/components/all.min.css";
 @import "utils.scss";
 
 :root {


### PR DESCRIPTION
## Description

Core code examples don't have proper HDS styles. This was fixed by importing hds styles in `layout.scss` file that is included on every page.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1954


## How Has This Been Tested?
Localhost
[Demo](https://city-of-helsinki.github.io/hds-demo/core-docs-fix/components/buttons/code)

