### PR TITLE
() Add missing imports in layout.css

### DIFF
--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -1,6 +1,10 @@
 @charset "utf-8";
-@import "~hds-design-tokens/lib/all.scss";
+@import "~hds-core/lib/base.min.css";
 @import "~hds-core/lib/components/all.min.css";
+@import "~hds-core/lib/components/table/table.css";
+@import "~hds-core/lib/icons/icon.min.css";
+@import "~hds-core/lib/icons/icons.min.css";
+@import "~hds-design-tokens/lib/all.scss";
 @import "utils.scss";
 
 :root {

--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -1,7 +1,6 @@
 @charset "utf-8";
 @import "~hds-core/lib/base.min.css";
 @import "~hds-core/lib/components/all.min.css";
-@import "~hds-core/lib/components/table/table.css";
 @import "~hds-core/lib/icons/icon.min.css";
 @import "~hds-core/lib/icons/icons.min.css";
 @import "~hds-design-tokens/lib/all.scss";


### PR DESCRIPTION
## Description

Fixes missing icons etc. since some imports were still missing in site layout.css

## How Has This Been Tested?

Local machine

## Screenshots (if appropriate):

From: 
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/c493b78e-ac58-4b7d-aa8f-47f9439798b7)
To:
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/9d3ae6bf-59a6-45f8-9c73-557bf49365f0)

