### PR TITLE
Remove underline from "a href" hds-button CTA links

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -40,6 +40,7 @@
   min-width: var(--min-size);
   padding: 0 var(--spacing-2-xs);
   position: relative;
+  text-decoration: none;
 
   /*
   * Normalize.css rule


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Remove underline from CTA (Call To Action) links

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
Slightly related to: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1958
<!-- If fixing a bug, please link to the issue here: -->

Closes no ticket at the moment

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Current styles in HDS create underline to CTA buttons done with 
```
<a href="#" class="hds-button hds-button--primary">
  <span class="hds-button__label">Primary</span>
</a>
```
This little oneliner removes the underline from such buttons.


## How Has This Been Tested?

I checked in chrome that this simple fix removes the underline in all button states using current hds.hel.fi documentation and dev tools. (So not really truly tested, but it's really simple oneliner) 🤷 


## Screenshots (if appropriate):

Before fix:
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/5e980f5b-c075-4cf3-bb14-be339c495371)

After fix:
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/36c0d097-151d-42d5-b20a-e128529fda24)

