### PR TITLE
HDS-1872 Fix this-is-hds presentation page

### DIFF
--- a/site/gatsby-browser.js
+++ b/site/gatsby-browser.js
@@ -9,6 +9,6 @@ const Layout = require('./src/components/layout').default;
 
 // Wraps every page in a component
 exports.wrapPageElement = ({ element, props }) => {
-  if (props.location.pathname.includes("this-is-hds")) return null
+  if (props.location.pathname.includes("this-is-hds")) return <React.Fragment {...props}>{element}</React.Fragment>
   return <Layout {...props}>{element}</Layout>;
 };

--- a/site/gatsby-ssr.js
+++ b/site/gatsby-ssr.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { getCriticalHdsRules, hdsStyles } from 'hds-react';
 import { renderToString } from 'react-dom/server';
 import Layout from './src/components/layout';
@@ -19,6 +19,6 @@ export const replaceRenderer = async ({ bodyComponent, setHeadComponents }) => {
 }
 
 export const wrapPageElement = ({ element, props }) => {
-  if (props.location.pathname.includes("this-is-hds")) return null
+  if (props.location.pathname.includes("this-is-hds")) return <Fragment {...props}>{element}</Fragment>
   return <Layout {...props}>{element}</Layout>
 }

--- a/site/src/docs/about/this-is-hds/index.jsx
+++ b/site/src/docs/about/this-is-hds/index.jsx
@@ -3,6 +3,7 @@ import {
   Button,
   Card,
   Container,
+  Hero,
   IconGlobe,
   IconPersonWheelchair,
   IconStar,
@@ -10,9 +11,8 @@ import {
   IconHeart,
   Footer,
   ImageWithCard,
-  Koros,
   Logo,
-  logoFi,
+  logoFiDark,
   Link,
   Tag,
   Table,
@@ -20,7 +20,7 @@ import {
 
 import Seo from '../../../components/Seo';
 
-import './../../../components/layout.scss';
+import '../../../components/layout.scss';
 import './styles.scss';
 import { navigate, withPrefix } from 'gatsby';
 import { FooterVariant } from '../../../../../packages/react/src/components/footer/Footer.interface';
@@ -85,38 +85,29 @@ const DemoPage = () => {
         pageTitle="This is HDS"
         description="The Helsinki Design System is a tool to create a consistent, user-friendly and accessible digital user experience for the City of Helsinki."
       ></Seo>
-      <div className="hero-container">
-        <div className="hero-wrapper">
-          <div className="hero">
-            <div className="hero-content">
-              <div className="hero-content-shape" />
-              <Logo src={logoFi} aria-hidden className="info-page-hero-logo" />
-              <h1 className="hero-title info-page-hero-title">Helsinki Design System (HDS)</h1>
-              <p className="hero-text">
-                The Helsinki Design System focuses on usability and accessibility. It aims to improve the quality and
-                consistency of the City of Helsinki's digital services – making the user experience better for everyone.
-              </p>
-              <Button
-                variant="primary"
-                className="front-page-hero-button"
-                role="link"
-                onClick={() => {
-                  navigate('/getting-started');
-                }}
-              >
-                Visit hds.hel.fi
-              </Button>
-            </div>
-            <Koros className="hero-koros hero-koros-rotated" flipVertical rotate="45deg" />
-            <Koros className="hero-koros hero-koros-vertical" flipVertical />
-          </div>
-        </div>
-        <div
-          className="hero-bg-image"
-          style={{ backgroundImage: `url(${withPrefix('/images/about/this-is-hds/tripla.jpg')}` }}
-        />
-      </div>
-
+      <Hero
+        variant="diagonalKoros"
+        imageSrc={withPrefix('/images/about/this-is-hds/tripla.jpg')}
+        theme={{
+          '--background-color': 'var(--color-coat-of-arms)',
+          '--color': 'var(--color-white)',
+        }}
+      >
+        <Logo src={logoFiDark} aria-hidden className="info-page-hero-logo" />
+        <Hero.Title>Helsinki Design System (HDS)</Hero.Title>
+        <Hero.Text>Helsinki Design System (HDS)</Hero.Text>
+        <Button
+          variant="primary"
+          className="front-page-hero-button"
+          role="link"
+          onClick={() => {
+            navigate('/getting-started');
+          }}
+        >
+          Visit hds.hel.fi
+        </Button>
+      </Hero>
+     
       <Container className="info-page-content text-body">
         <div className="info-page-image-card-container">
           <ImageWithCard
@@ -513,9 +504,21 @@ const DemoPage = () => {
       </Container>
       <Footer id="page-footer" className="page-footer" title="Helsinki Design System">
         <Footer.Base copyrightHolder="Copyright">
-          <Footer.Link variant={FooterVariant.Base} label="Contribution" href={withPrefix('/getting-started/contributing/before-contributing')} />
-          <Footer.Link variant={FooterVariant.Base} label="Accessibility" href={withPrefix('/about/accessibility/statement')} />
-          <Footer.Link variant={FooterVariant.Base} label="GitHub" href="https://github.com/City-of-Helsinki/helsinki-design-system" />
+          <Footer.Link
+            variant={FooterVariant.Base}
+            label="Contribution"
+            href={withPrefix('/getting-started/contributing/before-contributing')}
+          />
+          <Footer.Link
+            variant={FooterVariant.Base}
+            label="Accessibility"
+            href={withPrefix('/about/accessibility/statement')}
+          />
+          <Footer.Link
+            variant={FooterVariant.Base}
+            label="GitHub"
+            href="https://github.com/City-of-Helsinki/helsinki-design-system"
+          />
         </Footer.Base>
       </Footer>
     </>

--- a/site/src/docs/about/this-is-hds/index.jsx
+++ b/site/src/docs/about/this-is-hds/index.jsx
@@ -88,10 +88,7 @@ const DemoPage = () => {
       <Hero
         variant="diagonalKoros"
         imageSrc={withPrefix('/images/about/this-is-hds/tripla.jpg')}
-        theme={{
-          '--background-color': 'var(--color-coat-of-arms)',
-          '--color': 'var(--color-white)',
-        }}
+        className="front-page-hero"
       >
         <Logo src={logoFiDark} aria-hidden className="info-page-hero-logo" />
         <Hero.Title>Helsinki Design System (HDS)</Hero.Title>

--- a/site/src/docs/about/this-is-hds/styles.scss
+++ b/site/src/docs/about/this-is-hds/styles.scss
@@ -13,6 +13,7 @@
 }
 
 .info-page-hero-logo {
+  height: unset;
   margin-left: 0;
   width: 100px;
 

--- a/site/src/docs/about/this-is-hds/styles.scss
+++ b/site/src/docs/about/this-is-hds/styles.scss
@@ -12,7 +12,13 @@
   margin-top: var(--spacing-s);
 }
 
-.info-page-hero-logo {
+.front-page-hero.front-page-hero {
+  --background-color: var(--color-coat-of-arms);
+  --color: var(--color-white);
+  --koros-color: var(--color-coat-of-arms);
+}
+
+.info-page-hero-logo.info-page-hero-logo {
   height: unset;
   margin-left: 0;
   width: 100px;

--- a/site/src/docs/components/hero/code.mdx
+++ b/site/src/docs/components/hero/code.mdx
@@ -14,6 +14,8 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 #### Diagonal koros
 
+Note that in order to customise the colour of the background with `variant="diagonalKoros"`, you need to set the `--koros-color` CSS variable.
+
 <Playground scope={{ Hero, Button }}>
 
 ```jsx
@@ -24,8 +26,8 @@ import { Fieldset, TextInput } from 'hds-react';
     imageSrc="https://hds.hel.fi/images/homepage/amos58.jpg"
     variant="diagonalKoros"
     theme={{
-      '--background-color': '#f5a3c7',
       '--color': '#000',
+      '--koros-color': '#f5a3c7'
     }}
   >
     <Hero.Title>Hero title</Hero.Title>
@@ -47,8 +49,7 @@ import { Fieldset, TextInput } from 'hds-react';
 ```html
 <style scoped>
   .custom-theme {
-    --background-color: #f5a3c7;
-    --koros-color: var(--background-color);
+    --koros-color: #f5a3c7;
     --color: #000;
     --koros-height: 34px;
   }


### PR DESCRIPTION
## Description

Fix this-is-hds presentation page. The blank page effect was fixed by tuning `wrapPageElement` function which most likely changed in a Gatsby package update. The page still had issues with deprecated Hero usage which was fixed by implementing new syntax and switching from core to react version for an easier maintainability.

For reviewing purposes, here are the [designs](https://www.figma.com/file/7jHkZHYcb9Y12i7WfGbxQn/HDS-%E2%80%93-The-Best-Design-System?type=design&node-id=1%3A1268&mode=design&t=1WctAktc13PrZxjU-1) for presentation page (without newest text content).

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1872

## Motivation and Context

The page wasn't working before, it just showed a blank page.

## How Has This Been Tested?
Localhost
[Demo](https://city-of-helsinki.github.io/hds-demo/fix-hds-page/about/this-is-hds/)

To do:
- [x] Supplement Hero theming docs about background-color & koros-color interplay