### PR TITLE
HDS-1945 Fix input buttons focus

### DIFF
--- a/packages/react/src/components/cookieConsent/CookieConsent.module.scss
+++ b/packages/react/src/components/cookieConsent/CookieConsent.module.scss
@@ -8,7 +8,7 @@
   z-index: 999;
 
   --common-spacing: var(--spacing-s);
-  --focus-outline-color: var(--color-coat-of-arms);
+  --focus-outline-color: var(--color-focus-outline);
   --outline-width: 3px;
 }
 

--- a/packages/react/src/components/cookieConsent/CookieConsent.module.scss
+++ b/packages/react/src/components/cookieConsent/CookieConsent.module.scss
@@ -1,15 +1,13 @@
 @import '../../styles/common.scss';
 
 .container {
+  --common-spacing: var(--spacing-s);
+  
   bottom: 0;
   left: 0;
   position: fixed;
   width: 100vw;
   z-index: 999;
-
-  --common-spacing: var(--spacing-s);
-  --focus-outline-color: var(--color-focus-outline);
-  --outline-width: 3px;
 }
 
 .aligner {
@@ -70,6 +68,9 @@
 }
 
 .content {
+  --focus-outline-color: var(--color-focus-outline);
+  --outline-width: 3px;
+
   box-sizing: border-box;
   margin: 0 auto;
   padding-left: var(--spacing-layout-2-xs);

--- a/packages/react/src/components/dropdown/_dropdown.common.scss
+++ b/packages/react/src/components/dropdown/_dropdown.common.scss
@@ -24,7 +24,7 @@
   --dropdown-border-color-disabled: var(--color-black-10);
   --dropdown-color-default: var(--color-black-90);
   --dropdown-color-disabled: var(--color-black-40);
-  --focus-outline-color: var(--color-coat-of-arms);
+  --focus-outline-color: var(--color-focus-outline);
   --helper-color-default: var(--color-black-60);
   --helper-color-invalid: var(--color-error);
   --menu-divider-color: var(--color-black-20);

--- a/packages/react/src/components/fileInput/FileInput.module.scss
+++ b/packages/react/src/components/fileInput/FileInput.module.scss
@@ -56,7 +56,7 @@ $componentMaxWidth: 500px;
   &:focus-within > button:after {
     --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
 
-    border-color: var(--focus-outline-color);
+    border-color: var(--color-focus-outline);
   }
 }
 

--- a/packages/react/src/components/numberInput/NumberInput.module.scss
+++ b/packages/react/src/components/numberInput/NumberInput.module.scss
@@ -83,7 +83,7 @@
   }
 
   &:focus {
-    outline: 3px solid var(--focus-outline-color);
+    outline: 3px solid var(--color-focus-outline);
     outline-offset: -5px;
   }
 }

--- a/packages/react/src/components/searchInput/SearchInput.module.scss
+++ b/packages/react/src/components/searchInput/SearchInput.module.scss
@@ -29,10 +29,10 @@
   &.hidden {
     @extend %visuallyHidden;
   }
+}
 
-  &:focus {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-  }
+.button:focus.button:focus {
+  outline: 3px solid var(--color-focus-outline);
 }
 
 .searchIcon {

--- a/packages/react/src/components/textInput/TextInput.module.css
+++ b/packages/react/src/components/textInput/TextInput.module.css
@@ -60,5 +60,5 @@
 }
 
 .button:focus {
-  outline: var(--outline-width) solid var(--focus-outline-color);
+  outline: var(--outline-width) solid var(--color-focus-outline);
 }

--- a/packages/react/src/components/timeInput/TimeInput.module.scss
+++ b/packages/react/src/components/timeInput/TimeInput.module.scss
@@ -53,7 +53,7 @@
   will-change: transform, box-shadow;
 
   &:focus {
-    box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
+    box-shadow: 0 0 0 var(--outline-width) var(--color-focus-outline);
     outline: none;
     transform: translate3d(0, 0, 0);
 

--- a/packages/react/src/internal/selectedItems/SelectedItems.module.scss
+++ b/packages/react/src/internal/selectedItems/SelectedItems.module.scss
@@ -79,7 +79,7 @@
   z-index: 1;
 
   &:focus {
-    box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-outline-color);
+    box-shadow: 0 0 0 var(--focus-outline-width) var(--color-focus-outline);
   }
 
   &.noToggle {

--- a/packages/react/src/styles/_common.scss
+++ b/packages/react/src/styles/_common.scss
@@ -69,14 +69,14 @@
 /*
  * Add an outline attribute for element's &:focus pseudo class
  */
-@mixin focusOutline($color: var(--focus-outline-color), $width: var(--outline-width), $radius: false, $offset: false) {
+@mixin focusOutline($color: var(--color-focus-outline), $width: var(--outline-width), $radius: false, $offset: false) {
   @include withFocus(focus, $color, $width, $offset, $radius)
 }
 
 /*
  * Add an outline attribute for element's &:focus-visible pseudo class
  */
-@mixin focusVisible($color: var(--focus-outline-color), $width: var(--outline-width), $radius: false, $offset: false) {
+@mixin focusVisible($color: var(--color-focus-outline), $width: var(--outline-width), $radius: false, $offset: false) {
   &:focus-visible {
     @if $radius {
       border-radius: $radius;


### PR DESCRIPTION
## Description

None the buttons inside React input components can be focused. This was caused by using a wrong variable name. Core has no issues.

Affected components that underwent changes in this PR:
- CookieConsent
- Dropdown
- FileInput
- NumberInput
- SearchInput
- TextInput
- (internal) SelectedItems

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1945

## How Has This Been Tested?
Localhost
[Storybook demo](https://city-of-helsinki.github.io/hds-demo/fix-input-button-focus/)

To do
- [x] Fix cookie consent accordion show/hide button focus