### PR TITLE
HDS-1815-fix-site-textInput-styles

### DIFF
--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -35,6 +35,7 @@ const sanitizeConfig = {
       'patternunits',
       'placeholder',
       'points',
+      'readonly',
       'rel',
       'required',
       'role',


### PR DESCRIPTION
Add readonly to allowed attributes in PlayGround sanitize configuration

## Description
Fix site read-only text input example for core side by adding `readonly` as allowed attribute in the sanitizer. It was removed previously which caused the input not being read-only.

## Related Issue
[HDS-1815](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1815)

## How Has This Been Tested?

Local machine

## Screenshots (if appropriate):

![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/95d9ce6a-ef54-4bd5-9d11-4a8b660031c9)



[HDS-1815]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ