### PR TITLE
Button.css fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes that are not related to specific components
 - [Component] What has been changed
+- [Button] CSS supports reset and button types
 
 #### Fixed
 
@@ -40,6 +41,7 @@ Changes that are not related to specific components
 
 Changes that are not related to specific components
 - [Component] What has been changed
+- [Button] CSS supports reset and button types
 
 #### Fixed
 

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -163,19 +163,25 @@
 }
 
 input[type="submit"].hds-button,
+input[type="reset"].hds-button,
+input[type="button"].hds-button,
 .hds-button__label {
   font-weight: inherit;
   line-height: 1.25em;
   padding: var(--spacing-s);
 }
 
-input[type="submit"].hds-button {
+input[type="submit"].hds-button,
+input[type="reset"].hds-button,
+input[type="button"].hds-button {
   cursor: pointer;
   padding: var(--spacing-s) var(--spacing-l);
 }
 
-/* submit input */
-input[type="submit"].hds-button:focus-visible {
+/* submit/reset/button input */
+input[type="submit"].hds-button:focus-visible,
+input[type="reset"].hds-button:focus-visible,
+input[type="button"].hds-button:focus-visible {
   box-shadow: 0 0 0 var(--outline-gutter) var(--submit-input-focus-gutter-color), 0 0 0 calc(var(--outline-gutter) + var(--outline-width)) var(--focus-outline-color);
 }
 
@@ -185,6 +191,8 @@ input[type="submit"].hds-button:focus-visible {
 }
 
 input[type="submit"].hds-button--small,
+input[type="reset"].hds-button--small,
+input[type="button"].hds-button--small,
 .hds-button--small .hds-button__label {
   line-height: var(--lineheight-s);
   padding: var(--spacing-2-xs) var(--spacing-xs);
@@ -216,7 +224,9 @@ input[type="submit"].hds-button--small,
   padding: 0;
 }
 
-input[type="submit"].hds-button--small {
+input[type="submit"].hds-button--small,
+input[type="reset"].hds-button--small,
+input[type="button"].hds-button--small {
   padding: var(--spacing-2-xs) var(--spacing-m);
 }
 

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -190,9 +190,6 @@ input[type="button"].hds-button:focus-visible {
   margin: 0 var(--spacing-2-xs);
 }
 
-input[type="submit"].hds-button--small,
-input[type="reset"].hds-button--small,
-input[type="button"].hds-button--small,
 .hds-button--small .hds-button__label {
   line-height: var(--lineheight-s);
   padding: var(--spacing-2-xs) var(--spacing-xs);
@@ -227,6 +224,7 @@ input[type="button"].hds-button--small,
 input[type="submit"].hds-button--small,
 input[type="reset"].hds-button--small,
 input[type="button"].hds-button--small {
+  line-height: var(--lineheight-s);
   padding: var(--spacing-2-xs) var(--spacing-m);
 }
 

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -105,12 +105,7 @@
   color: var(--color-hover);
 }
 
-.hds-button:focus-visible {
-  background-color: var(--background-color-focus, transparent);
-  color: var(--color-focus);
-  outline: none;
-}
-
+.hds-button:focus-visible,
 .hds-button:active {
   background-color: var(--background-color-focus, transparent);
   color: var(--color-focus);
@@ -128,10 +123,7 @@
   cursor: not-allowed;
 }
 
-.hds-button:focus-visible:hover {
-  background-color: var(--background-color-hover-focus, transparent);
-}
-
+.hds-button:focus-visible:hover,
 .hds-button:active:hover {
   background-color: var(--background-color-hover-focus, transparent);
 }
@@ -140,19 +132,12 @@
   border-color: var(--border-color-hover, transparent);
 }
 
-.hds-button:not(:disabled):focus-visible {
-  border-color: var(--border-color-focus, transparent);
-}
-
+.hds-button:not(:disabled):focus-visible,
 .hds-button:not(:disabled):active {
   border-color: var(--border-color-focus, transparent);
 }
 
-.hds-button:not(:disabled):focus-visible:hover {
-  border-color: var(--border-color-hover-focus, transparent);
-  color: var(--color-hover-focus);
-}
-
+.hds-button:not(:disabled):focus-visible:hover,
 .hds-button:not(:disabled):active:hover {
   border-color: var(--border-color-hover-focus, transparent);
   color: var(--color-hover-focus);
@@ -170,12 +155,7 @@
   width: var(--size);
 }
 
-.hds-button:focus-visible::after {
-  --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
-
-  border-color: var(--focus-outline-color);
-}
-
+.hds-button:focus-visible::after,
 .hds-button:active::after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
 

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -51,11 +51,11 @@
 }
 
 .hds-button,
-.hds-button::before,
-.hds-button::after,
+.hds-button:before,
+.hds-button:after,
 .hds-button *,
-.hds-button *::before,
-.hds-button *::after {
+.hds-button *:before,
+.hds-button *:after {
   box-sizing: border-box;
 }
 
@@ -73,10 +73,10 @@
  * Normalize.css rules
  * Remove the inner border and padding in Firefox.
  */
-.hds-button::-moz-focus-inner,
-.hds-button[type="button"]::-moz-focus-inner,
-.hds-button[type="reset"]::-moz-focus-inner,
-.hds-button[type="submit"]::-moz-focus-inner {
+.hds-button:-moz-focus-inner,
+.hds-button[type="button"]:-moz-focus-inner,
+.hds-button[type="reset"]:-moz-focus-inner,
+.hds-button[type="submit"]:-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -145,7 +145,7 @@
 
 /* FOCUS OUTLINE */
 
-.hds-button::after {
+.hds-button:after {
   --size: 100%;
 
   border: var(--outline-width) solid transparent;
@@ -155,8 +155,8 @@
   width: var(--size);
 }
 
-.hds-button:focus-visible::after,
-.hds-button:active::after {
+.hds-button:focus-visible:after,
+.hds-button:active:after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
 
   border-color: var(--focus-outline-color);

--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -51,11 +51,11 @@
 }
 
 .hds-button,
-.hds-button:before,
-.hds-button:after,
+.hds-button::before,
+.hds-button::after,
 .hds-button *,
-.hds-button *:before,
-.hds-button *:after {
+.hds-button *::before,
+.hds-button *::after {
   box-sizing: border-box;
 }
 
@@ -63,7 +63,9 @@
  * Normalize.css rules
  * Correct the inability to style clickable types in iOS and Safari.
  */
-.hds-button[type="button"], .hds-button[type="reset"], .hds-button[type="submit"] {
+.hds-button[type="button"],
+.hds-button[type="reset"],
+.hds-button[type="submit"] {
   -webkit-appearance: button;
 }
 
@@ -71,7 +73,10 @@
  * Normalize.css rules
  * Remove the inner border and padding in Firefox.
  */
-.hds-button::-moz-focus-inner, .hds-button[type="button"]::-moz-focus-inner, .hds-button[type="reset"]::-moz-focus-inner, .hds-button[type="submit"]::-moz-focus-inner {
+.hds-button::-moz-focus-inner,
+.hds-button[type="button"]::-moz-focus-inner,
+.hds-button[type="reset"]::-moz-focus-inner,
+.hds-button[type="submit"]::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -80,7 +85,10 @@
  * Normalize.css rules
  * Restore the focus styles unset by the previous rule.
  */
-.hds-button:-moz-focusring, .hds-button[type="button"]:-moz-focusring, .hds-button[type="reset"]:-moz-focusring, .hds-button[type="submit"]:-moz-focusring {
+.hds-button:-moz-focusring,
+.hds-button[type="button"]:-moz-focusring,
+.hds-button[type="reset"]:-moz-focusring,
+.hds-button[type="submit"]:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
@@ -152,7 +160,7 @@
 
 /* FOCUS OUTLINE */
 
-.hds-button:after {
+.hds-button::after {
   --size: 100%;
 
   border: var(--outline-width) solid transparent;
@@ -162,13 +170,13 @@
   width: var(--size);
 }
 
-.hds-button:focus-visible:after {
+.hds-button:focus-visible::after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
 
   border-color: var(--focus-outline-color);
 }
 
-.hds-button:active:after {
+.hds-button:active::after {
   --size: calc(100% + calc(var(--outline-width) * 2 + var(--border-width) * 2 + var(--outline-gutter) * 2));
 
   border-color: var(--focus-outline-color);
@@ -201,7 +209,6 @@ input[type="submit"].hds-button--small,
   line-height: var(--lineheight-s);
   padding: var(--spacing-2-xs) var(--spacing-xs);
 }
-
 
 /* supplementary with right icon */
 .hds-button--supplementary .hds-button__label:first-child {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

* Fix syntax problems from button.css
    * ~`::` - notation for pseudo-elements like `::after`~
        * Build test linter was being nasty about this, so, I reverted it. I still think `::after` notation is better, as the last browser that required single-colon-notation was ie8 (R.I.P. 💀) as it did not support the double-colon version. As far as I know, ie8 is not on the HDS supported browsers list nor has it updated within last 6 months (try 14 years). So I'd recommend moving with the ages towards at least allowing the correct notation for pseudo elements.
    * Added newline after selector commas for readability and uniformity with the rest of the code. (I'd add this rule to the linter for future)
* `focus-visible` and `active` had duplicated property-sets.. ..that were simplified in this PR.
* Add better support for buttons of `type="reset"` and `type="button"` as only `type="submit"` was fully supported.
* Avoid duplicate selectors and overriding properties unnecessarily

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Does not close an issue, just fixed things that seemed broken while working with our end of the code.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
We're building on top of HDS button styles at hel.fi and having a cleaner and more readable source makes it easier to follow.

There's still plenty wrong on the button.css, but these were the easy to fix issues that came up. 

* We'd really recommend considering to move towards removing requirement for the `<span class="hds-button__label">...</span>` child element.
* We'd recommend strongly getting rid of the multiple margins and paddings inside buttons. 
* The logic of the button inner spacing would benefit of a major redesign towards more uniform and simpler style.
    * Why is the label closer to the edge on oppiside side of the button only when the button has an icon?
    * Why are the supplementary styles so different from other button styles? 
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/a5a00638-5525-48a6-9bc9-9abfc9100dbf) 
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/3436147c-41a3-4ad0-916f-b1a9ad6a3875)
    * Why are the button icons so far from the button labels?


We can help with these changes if you wish to move towards a more sane button style as we have a working alternative with matching styles to the current design.

## How Has This Been Tested?

This change is not really tested by us, as we indeed have our own version we're using. I hope the changes speak for themself and to me it looks like this should not be a breaking change.

## Screenshots (if appropriate):

None related to the changes in this PR, a couple above related to point out the issues with current design (that this PR should not change in any way)