### PR TITLE
HDS-1984 language change fix

### DIFF
--- a/packages/react/src/components/header/LanguageContext.test.tsx
+++ b/packages/react/src/components/header/LanguageContext.test.tsx
@@ -1,0 +1,265 @@
+import React, { useState } from 'react';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+import {
+  DEFAULT_LANGUAGE,
+  LanguageOption,
+  LanguageProvider,
+  LanguageProviderProps,
+  useActiveLanguage,
+  useAvailableLanguages,
+  useSetAvailableLanguages,
+  useSetLanguage,
+} from './LanguageContext';
+
+type StrFn = (str: string) => string;
+type TestScenarioProps = LanguageProviderProps & { listDefault?: boolean };
+
+const defaultLanguages: LanguageOption[] = [
+  { label: 'Suomi', value: 'fi' },
+  { label: 'Svenska', value: 'sv' },
+  { label: 'English', value: 'en' },
+  { label: 'Spanish', value: 'es', isPrimary: false },
+  { label: 'Norway', value: 'no', isPrimary: false },
+];
+
+const newLanguages: LanguageOption[] = [
+  { label: 'AF', value: 'af' },
+  { label: 'DE', value: 'de' },
+];
+
+const getLanguageLabelByValue: StrFn = (val) =>
+  [...defaultLanguages, ...newLanguages].find((obj) => obj.value === val)?.label || '';
+const listLanguageCodes = (languages: LanguageOption[]) => languages.map((language) => language.value).join(',');
+const handleLanguageChange = jest.fn();
+const activeLanguageTestId = 'active-language';
+const availableLanguagesTestId = 'available-languages';
+const setNewLanguagesButtonTestId = 'set-languages-button';
+const reRenderButtonTestId = 're-render-button';
+const renderCounterTestId = 'render-count';
+const renderTimeTestId = 'render-time';
+
+const RenderActiveLanguage = () => {
+  const activeLanguage = useActiveLanguage();
+  return <span data-testid={activeLanguageTestId}>{activeLanguage}</span>;
+};
+
+const RenderUpdateTime = () => {
+  return <span data-testid={renderTimeTestId}>{Date.now()}</span>;
+};
+
+const RenderAvailableLanguageCodes = () => {
+  const languages = useAvailableLanguages();
+  return <span data-testid={availableLanguagesTestId}>{listLanguageCodes(languages)}</span>;
+};
+
+const RenderAvailableLanguagesSetter = () => {
+  const setNewLanguages = useSetAvailableLanguages();
+  return (
+    <button data-testid={setNewLanguagesButtonTestId} onClick={() => setNewLanguages(newLanguages)} type="button">
+      Set languages
+    </button>
+  );
+};
+
+const LanguageChanger = ({ listDefault = true }: { listDefault?: boolean } = {}) => {
+  const setLanguage = useSetLanguage();
+  const list = listDefault ? defaultLanguages : useAvailableLanguages();
+  const LanguageSelector = ({ value, label }: LanguageOption) => {
+    return (
+      <button lang={value} onClick={() => setLanguage(value)} type="button">
+        {label}
+      </button>
+    );
+  };
+  return (
+    <div id="language-changer">
+      {list.map(({ value, label }) => {
+        return <LanguageSelector key={value} value={value} label={label} />;
+      })}
+      <RenderActiveLanguage />
+      <RenderAvailableLanguageCodes />
+      <RenderAvailableLanguagesSetter />
+      <RenderUpdateTime />
+    </div>
+  );
+};
+
+const TestScenario = ({
+  onDidChangeLanguage = handleLanguageChange,
+  languages = defaultLanguages,
+  defaultLanguage,
+  listDefault = true,
+}: TestScenarioProps) => {
+  const [renderCount, setRenderCount] = useState(0);
+  const forceRender = () => {
+    setRenderCount((n) => n + 1);
+  };
+  return (
+    <div id="test-scenario">
+      <LanguageProvider
+        onDidChangeLanguage={onDidChangeLanguage}
+        defaultLanguage={defaultLanguage}
+        languages={languages}
+      >
+        <LanguageChanger listDefault={listDefault} />
+      </LanguageProvider>
+      <button data-testid={reRenderButtonTestId} onClick={() => forceRender()} type="button">
+        Re-render
+      </button>
+      <span data-testid={renderCounterTestId}>{renderCount}</span>
+    </div>
+  );
+};
+
+const renderTestScenario = (props: TestScenarioProps = {}) => {
+  const renderResult = render(<TestScenario {...props} />);
+  const { getByText, getByTestId } = renderResult;
+
+  const clickButton = (buttonEl?: HTMLElement) => {
+    if (!buttonEl) {
+      throw new Error('No element for clickButton');
+    }
+    fireEvent.click(buttonEl as HTMLButtonElement);
+  };
+
+  const fireLanguageChangeEvent = (languageCode: string) => {
+    const buttonText = getLanguageLabelByValue(languageCode);
+    clickButton(getByText(buttonText));
+  };
+
+  const getActiveLanguage = () => {
+    const container = getByTestId(activeLanguageTestId) as HTMLElement;
+    return container.innerHTML;
+  };
+  const getRenderCount = () => {
+    return (getByTestId(renderCounterTestId) as HTMLElement).innerHTML;
+  };
+
+  const getRenderTime = () => {
+    return (getByTestId(renderTimeTestId) as HTMLElement).innerHTML;
+  };
+
+  const reRender = async () => {
+    const currentCount = getRenderCount();
+    clickButton(getByTestId(reRenderButtonTestId));
+    await waitFor(() => {
+      if (getRenderCount() === currentCount) {
+        throw new Error('Not updated');
+      }
+    });
+  };
+  // this will always resolve, so catchig is not required
+  const createReRenderChecker = async (initializer: () => void) => {
+    const lastRenderTime = getRenderTime();
+    initializer();
+    return new Promise((resolve) => {
+      waitFor(
+        () => {
+          if (getRenderTime() === lastRenderTime) {
+            throw new Error('Not re-rendered');
+          }
+        },
+        { timeout: 1000 },
+      )
+        .then(() => resolve(true))
+        .catch(() => resolve(false));
+    });
+  };
+
+  return {
+    ...renderResult,
+    fireLanguageChangeEvent,
+    getActiveLanguage,
+    reRender,
+    clickButton,
+    createReRenderChecker,
+  };
+};
+
+describe('<LanguageContext />', () => {
+  beforeEach(() => {
+    handleLanguageChange.mockClear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('Sets the defaultLanguage to DEFAULT_LANGUAGE by default', async () => {
+    const { getActiveLanguage } = renderTestScenario();
+    expect(getActiveLanguage()).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+  });
+  it('Sets the defaultLanguage to given language', async () => {
+    const newDefault = 'no';
+    const { getActiveLanguage, reRender } = renderTestScenario({ defaultLanguage: newDefault });
+    expect(getActiveLanguage()).toBe(newDefault);
+    await reRender();
+    expect(getActiveLanguage()).toBe(newDefault);
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+  });
+
+  it("useSetLanguage changes the language and re-render won't change it back to default", async () => {
+    const { fireLanguageChangeEvent, getActiveLanguage, reRender } = renderTestScenario();
+
+    // onDidChangeLanguage is called on first render
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls[0][0]).toBe(DEFAULT_LANGUAGE);
+
+    const svCode = 'sv';
+    fireLanguageChangeEvent(svCode);
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls[1][0]).toBe(svCode);
+    expect(getActiveLanguage()).toBe(svCode);
+
+    await reRender();
+
+    expect(getActiveLanguage()).toBe(svCode);
+    fireLanguageChangeEvent(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(3);
+    expect(handleLanguageChange.mock.calls[2][0]).toBe(DEFAULT_LANGUAGE);
+    expect(getActiveLanguage()).toBe(DEFAULT_LANGUAGE);
+  });
+
+  it("Selecting same language again won't trigger a re-render or onDidChangeLanguage", async () => {
+    const { fireLanguageChangeEvent, createReRenderChecker } = renderTestScenario();
+
+    // onDidChangeLanguage is called on first render
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+
+    const willNotRender = await createReRenderChecker(() => fireLanguageChangeEvent(DEFAULT_LANGUAGE));
+    expect(willNotRender).toBeFalsy();
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+
+    const svCode = 'sv';
+    const willRender = await createReRenderChecker(() => fireLanguageChangeEvent(svCode));
+    expect(willRender).toBeTruthy();
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+
+    const willNotRenderEither = await createReRenderChecker(() => fireLanguageChangeEvent(svCode));
+    expect(willNotRenderEither).toBeFalsy();
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+  });
+
+  it('useAvailableLanguages lists all languages', async () => {
+    const { getByTestId } = renderTestScenario();
+    const list = getByTestId(availableLanguagesTestId) as HTMLElement;
+    expect(list.innerHTML).toBe(listLanguageCodes(defaultLanguages));
+  });
+
+  it('useSetAvailableLanguages changes languages and new language can be set', async () => {
+    const { getByTestId, fireLanguageChangeEvent, getActiveLanguage, clickButton } = renderTestScenario({
+      listDefault: false,
+    });
+    clickButton(getByTestId(setNewLanguagesButtonTestId));
+    await waitFor(() => {
+      const list = getByTestId(availableLanguagesTestId) as HTMLElement;
+      expect(list.innerHTML).toBe(listLanguageCodes(newLanguages));
+    });
+    const newSelection = newLanguages[0].value;
+    fireLanguageChangeEvent(newSelection);
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls[1][0]).toBe(newSelection);
+    expect(getActiveLanguage()).toBe(newSelection);
+  });
+});

--- a/packages/react/src/components/header/LanguageContext.test.tsx
+++ b/packages/react/src/components/header/LanguageContext.test.tsx
@@ -12,24 +12,19 @@ import {
   useSetLanguage,
 } from './LanguageContext';
 
-type StrFn = (str: string) => string;
 type TestScenarioProps = LanguageProviderProps & { listDefault?: boolean };
 
 const defaultLanguages: LanguageOption[] = [
   { label: 'Suomi', value: 'fi' },
   { label: 'Svenska', value: 'sv' },
-  { label: 'English', value: 'en' },
-  { label: 'Spanish', value: 'es', isPrimary: false },
-  { label: 'Norway', value: 'no', isPrimary: false },
 ];
-
 const newLanguages: LanguageOption[] = [
   { label: 'AF', value: 'af' },
   { label: 'DE', value: 'de' },
 ];
+const allLanguageOptions = [...defaultLanguages, ...newLanguages];
 
-const getLanguageLabelByValue: StrFn = (val) =>
-  [...defaultLanguages, ...newLanguages].find((obj) => obj.value === val)?.label || '';
+const getLanguageLabelByValue = (val: string) => allLanguageOptions.find((obj) => obj.value === val)?.label || '';
 const listLanguageCodes = (languages: LanguageOption[]) => languages.map((language) => language.value).join(',');
 const handleLanguageChange = jest.fn();
 const activeLanguageTestId = 'active-language';
@@ -185,60 +180,58 @@ describe('<LanguageContext />', () => {
     cleanup();
   });
 
-  it('Sets the defaultLanguage to DEFAULT_LANGUAGE by default', async () => {
+  it('Sets the defaultLanguage to DEFAULT_LANGUAGE by default. onDidChangeLanguage is not called ', async () => {
     const { getActiveLanguage } = renderTestScenario();
     expect(getActiveLanguage()).toBe(DEFAULT_LANGUAGE);
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
   });
+
   it('Sets the defaultLanguage to given language', async () => {
     const newDefault = 'no';
     const { getActiveLanguage, reRender } = renderTestScenario({ defaultLanguage: newDefault });
     expect(getActiveLanguage()).toBe(newDefault);
     await reRender();
     expect(getActiveLanguage()).toBe(newDefault);
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
   });
 
   it("useSetLanguage changes the language and re-render won't change it back to default", async () => {
     const { fireLanguageChangeEvent, getActiveLanguage, reRender } = renderTestScenario();
 
-    // onDidChangeLanguage is called on first render
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
-    expect(handleLanguageChange.mock.calls[0][0]).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
 
     const svCode = 'sv';
     fireLanguageChangeEvent(svCode);
-    expect(handleLanguageChange.mock.calls.length).toBe(2);
-    expect(handleLanguageChange.mock.calls[1][0]).toBe(svCode);
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls[0][0]).toBe(svCode);
     expect(getActiveLanguage()).toBe(svCode);
 
     await reRender();
 
     expect(getActiveLanguage()).toBe(svCode);
     fireLanguageChangeEvent(DEFAULT_LANGUAGE);
-    expect(handleLanguageChange.mock.calls.length).toBe(3);
-    expect(handleLanguageChange.mock.calls[2][0]).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls[1][0]).toBe(DEFAULT_LANGUAGE);
     expect(getActiveLanguage()).toBe(DEFAULT_LANGUAGE);
   });
 
   it("Selecting same language again won't trigger a re-render or onDidChangeLanguage", async () => {
     const { fireLanguageChangeEvent, createReRenderChecker } = renderTestScenario();
 
-    // onDidChangeLanguage is called on first render
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
 
     const willNotRender = await createReRenderChecker(() => fireLanguageChangeEvent(DEFAULT_LANGUAGE));
     expect(willNotRender).toBeFalsy();
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
 
     const svCode = 'sv';
     const willRender = await createReRenderChecker(() => fireLanguageChangeEvent(svCode));
     expect(willRender).toBeTruthy();
-    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
 
     const willNotRenderEither = await createReRenderChecker(() => fireLanguageChangeEvent(svCode));
     expect(willNotRenderEither).toBeFalsy();
-    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
   });
 
   it('useAvailableLanguages lists all languages', async () => {
@@ -247,7 +240,7 @@ describe('<LanguageContext />', () => {
     expect(list.innerHTML).toBe(listLanguageCodes(defaultLanguages));
   });
 
-  it('useSetAvailableLanguages changes languages and new language can be set', async () => {
+  it('useSetAvailableLanguages changes languages and new language can be selected.', async () => {
     const { getByTestId, fireLanguageChangeEvent, getActiveLanguage, clickButton } = renderTestScenario({
       listDefault: false,
     });
@@ -258,8 +251,8 @@ describe('<LanguageContext />', () => {
     });
     const newSelection = newLanguages[0].value;
     fireLanguageChangeEvent(newSelection);
-    expect(handleLanguageChange.mock.calls.length).toBe(2);
-    expect(handleLanguageChange.mock.calls[1][0]).toBe(newSelection);
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls[0][0]).toBe(newSelection);
     expect(getActiveLanguage()).toBe(newSelection);
   });
 });

--- a/packages/react/src/components/header/LanguageContext.tsx
+++ b/packages/react/src/components/header/LanguageContext.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, createContext, useContext, useEffect, useState } from 'react';
+import React, { PropsWithChildren, createContext, useContext, useState } from 'react';
 
 export const DEFAULT_LANGUAGE = 'fi';
 
@@ -19,7 +19,7 @@ export type LanguageDispatchContextType = {
 };
 export type LanguageProviderProps = PropsWithChildren<{
   defaultLanguage?: LanguageType;
-  onDidChangeLanguage?: (string) => void;
+  onDidChangeLanguage?: (newLanguage: string) => void;
   languages?: LanguageOption[];
 }>;
 
@@ -36,14 +36,14 @@ export function LanguageProvider({ children, defaultLanguage, onDidChangeLanguag
   const [activeLanguage, setActiveLanguage] = useState(defaultLanguage);
   const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>(languages || []);
 
-  useEffect(() => {
-    if (onDidChangeLanguage) onDidChangeLanguage(activeLanguage);
-  }, [activeLanguage]);
-
   const setLanguage = (language: LanguageType) => {
+    if (activeLanguage === language) {
+      return;
+    }
     if (languageOptions.map((option) => option.value).indexOf(language) === -1)
       throw new TypeError('Language not found in available languages');
     setActiveLanguage(language);
+    if (onDidChangeLanguage) onDidChangeLanguage(language);
   };
   const setAvailableLanguages = (newLanguages: LanguageOption[]) => {
     setLanguageOptions(newLanguages);

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.test.tsx
@@ -72,8 +72,7 @@ describe('<HeaderActionBar /> spec', () => {
       return logoElement.getAttribute('src');
     };
 
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
-    expect(handleLanguageChange.mock.calls[0][0]).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
 
     const text = getLanguageLabelByValue(DEFAULT_LANGUAGE);
     const svText = getLanguageLabelByValue('sv');
@@ -82,13 +81,13 @@ describe('<HeaderActionBar /> spec', () => {
     expect(getLogoSrc()).toBe(logoFi);
 
     fireEvent.click(svButtonSpan);
-    expect(handleLanguageChange.mock.calls.length).toBe(2);
-    expect(handleLanguageChange.mock.calls[1][0]).toBe('sv');
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls[0][0]).toBe('sv');
     expect(getLogoSrc()).toBe(logoSv);
 
     fireEvent.click(defaultLanguageButton);
-    expect(handleLanguageChange.mock.calls.length).toBe(3);
-    expect(handleLanguageChange.mock.calls[2][0]).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls[1][0]).toBe(DEFAULT_LANGUAGE);
     expect(getLogoSrc()).toBe(logoFi);
   });
 });

--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.test.tsx
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.test.tsx
@@ -142,18 +142,17 @@ describe('<Header.LanguageSelector /> spec', () => {
   it('Clicking buttons changes the selected language', async () => {
     render(LanguageSelectorWithActionBar({ onDidChangeLanguage: handleLanguageChange, renderActiveLanguage: true }));
 
-    expect(handleLanguageChange.mock.calls.length).toBe(1);
-    expect(handleLanguageChange.mock.calls[0][0]).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(0);
     expect(getActiveLanguage()).toBe(DEFAULT_LANGUAGE);
 
     fireLanguageChangeEvent('sv');
-    expect(handleLanguageChange.mock.calls.length).toBe(2);
-    expect(handleLanguageChange.mock.calls[1][0]).toBe('sv');
+    expect(handleLanguageChange.mock.calls.length).toBe(1);
+    expect(handleLanguageChange.mock.calls[0][0]).toBe('sv');
     expect(getActiveLanguage()).toBe('sv');
 
     fireLanguageChangeEvent(DEFAULT_LANGUAGE);
-    expect(handleLanguageChange.mock.calls.length).toBe(3);
-    expect(handleLanguageChange.mock.calls[2][0]).toBe(DEFAULT_LANGUAGE);
+    expect(handleLanguageChange.mock.calls.length).toBe(2);
+    expect(handleLanguageChange.mock.calls[1][0]).toBe(DEFAULT_LANGUAGE);
     expect(getActiveLanguage()).toBe(DEFAULT_LANGUAGE);
   });
 });


### PR DESCRIPTION
## Description

`onDidChangeLanguage` was always called on first render. Also when the language changed, the callback was called after a re-render (inside `useEffect`) causing parent components to (probably) render again and causing a new render also for the Header.

Added first tests for the LanguageContext and then fixed bug and changed tests to match changed code.

Closes [HDS-1984]( https://helsinkisolutionoffice.atlassian.net/browse/HDS-1984)

## How Has This Been Tested?

Added unit tests and tested locally in Storybook.

## Demo

https://city-of-helsinki.github.io/hds-demo/hds-1984-lang-fix 


[HDS-1984]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ