### PR TITLE
HDS-1979: Shift mobile menu 1px down

### DIFF
--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
@@ -177,6 +177,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  margin-top: 1px;
   max-height: 100vh;
 }
 


### PR DESCRIPTION
The menu should not cover the bottom-border of the ActionBar

## Description

Mobile menu was 1px too low and covered the separator.

## Related Issue

Closes [HDS-1979](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1979)

## How Has This Been Tested?

Only visual changes - but Loki tests do not cover this.

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1979-menu-pos/?path=/story/components-header--with-full-features) 

Changes only visible in mobile view.




[HDS-1979]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ