### PR TITLE
Remove multiple @types/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
     "rimraf": "^5.0.1"
   },
   "resolutions": {
+    "@types/react": "17.0.2",
+    "@types/react-dom": "17.0.2",
+    "@types/react-dom/@types/react": "17.0.2",
+    "@types/react-dom/**/@types/react": "17.0.2",
+    "**/@types/react-dom/**/@types/react": "17.0.2",
     "multer": "1.4.4-lts.1",
     "jpeg-js": "0.4.4",
     "json5": "2.2.2"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,7 +61,6 @@
     "@testing-library/react": "11.2.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.8.1",
-    "@types/cleave.js": "1.4.4",
     "@types/jest": "^26.0.1",
     "@types/jest-axe": "^3.5.3",
     "@types/react": "17.0.2",
@@ -154,7 +153,6 @@
     "yup": "^1.0.2"
   },
   "resolutions": {
-    "@types/react": "17.0.2",
     "babel-jest": "^26.0.1",
     "eslint-plugin-react": "7.27.1",
     "jest": "^26.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6658,13 +6658,6 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
-"@types/cleave.js@1.4.4":
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/@types/cleave.js/-/cleave.js-1.4.4.tgz#66f0ee5218283f2c9623c49074eb3f34333952ac"
-  integrity sha512-uYFjWMPSBGBfbgfPna6yDenevtDSgqfkDXb/3dct6DXHiFs3InI3fpw51wb94zW8kHcNh1MUadboN55RAvSLEw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
@@ -7105,16 +7098,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16":
-  version "18.2.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.18.tgz#c8b233919eef1bdc294f6f34b37f9727ad677516"
-  integrity sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@17.0.2":
+"@types/react@*", "@types/react@17.0.2", "@types/react@>=16":
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
   integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
@@ -7148,11 +7132,6 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
-
-"@types/scheduler@*":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
-  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/semver@^7.3.12", "@types/semver@^7.3.9":
   version "7.5.0"


### PR DESCRIPTION
Some packages have dependency @types/react: "*".

This installs @types/react 17 and 18 and causes ts errors.

Added types to esolutions in react/packages.json do not work, so added them to root.

Site does not use typescript, so it is not a problem that types 17 are fixed in root.

@types/cleave.js is not used, so removed it. It installed React 18 too.

## Related Issue

No Jira issue.

## Motivation and Context

VSCode shows a lot of false errors, because it messes up types/react 17 & 18. This is annoying and may hide actual errors.

## How Has This Been Tested?

Ran all linters and build scripts locally. No errors.

To test this run these commands:
- yarn cleanup
- yarn
- yarn build
- cd packages/react
- yarn ts-check
- yarn build-storybook

Also open some files that used to show errors like Login.stories.tsx