### PR TITLE
HDS-2025: header button shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- [Component] What is added?
+- [Header.ActionBarItem] New property "preventButtonResize" to prevent menu button shifting when clicked
 
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -39,6 +40,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -58,6 +60,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 - Updated grid documentation with information about the new Header
 
@@ -78,6 +81,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -97,6 +101,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -164,6 +169,7 @@ Changes that are not related to specific components
 ### Sketch & Abstract
 
 #### Changed
+
 - Updated HDS Sketch libraries to Sketch version 99.1. Please update your Sketch and files accordingly
 
 ### Icons

--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -289,6 +289,7 @@ export const WithFullFeatures = (args) => {
               icon={<IconUser />}
               id="action-bar-login"
               closeLabel={I18n.close}
+              preventButtonResize
             >
               <h3>{I18n.loginOptions}</h3>
             </Header.ActionBarItem>
@@ -644,6 +645,7 @@ export const ManualLanguageSorting = (args) => {
             icon={<IconUser />}
             id="action-bar-login"
             closeLabel={I18n.close}
+            preventButtonResize
           >
             <h3>{I18n.loginOptions}</h3>
           </Header.ActionBarItem>

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.module.scss
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.module.scss
@@ -50,3 +50,37 @@ button.actionBarItem {
 .fixedRightPosition {
   display: block;
 }
+
+@mixin hiddenButTakingHorizontalSpace {
+  height: 0;
+  opacity: 0;
+}
+
+@mixin visibleAndTakingSpace {
+  height: auto;
+  opacity: 1;
+}
+
+.activeStateContent {
+  @include hiddenButTakingHorizontalSpace;
+
+  background-color: var(--actionbar-background-color);
+}
+
+.activeStateContentLabel {
+  white-space: break-spaces;
+}
+
+.isActive {
+  .activeStateContent {
+    @include visibleAndTakingSpace;
+  }
+
+  > .actionBarItemIcon {
+    display: none;
+  }
+
+  > .actionBarItemLabel {
+    @include hiddenButTakingHorizontalSpace;
+  }
+}

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.test.tsx
@@ -1,0 +1,88 @@
+import React, { useRef } from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { HeaderActionBarItem, HeaderActionBarItemProps } from './HeaderActionBarItem';
+
+const clickHandler = jest.fn();
+
+const defaultLabel = 'button label';
+const fakeIconTestId = 'fake-icon-test-id';
+const defaultIcon = <span data-testid={fakeIconTestId} />;
+const activeStateLabel = 'close label';
+const activeStateIconTestId = 'close-icon-test-id';
+const activeStateIcon = <span data-testid={activeStateIconTestId} />;
+const ariaControlsId = 'aria-controls-id';
+const ariaLabel = 'aria label';
+
+const defaultProps: HeaderActionBarItemProps = {
+  onClick: clickHandler,
+  label: defaultLabel,
+  icon: defaultIcon,
+  'aria-expanded': false,
+  'aria-label': ariaLabel,
+  'aria-controls': ariaControlsId,
+  labelOnRight: false,
+  fixedRightPosition: false,
+  isActive: false,
+};
+
+const activeStateProps: Pick<HeaderActionBarItemProps, 'activeStateIcon' | 'activeStateLabel'> = {
+  activeStateLabel,
+  activeStateIcon,
+};
+
+const RenderTestScenario = (props?: Partial<HeaderActionBarItemProps> & JSX.IntrinsicElements['button']) => {
+  const ref = useRef<HTMLButtonElement>(null);
+  const combinedProps = { ...defaultProps, ...props };
+  return <HeaderActionBarItem {...combinedProps} ref={ref} data-testid="button" />;
+};
+
+describe('HeaderActionBarItem spec', () => {
+  it('renders the component correctly and adds all classNames from props', () => {
+    const { asFragment } = render(
+      <RenderTestScenario labelOnRight fixedRightPosition className="extra-class" {...activeStateProps} />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should not have basic accessibility issues', async () => {
+    const { container } = render(<RenderTestScenario />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Label and icon are set', async () => {
+    const { getByText, getAllByTestId } = render(<RenderTestScenario />);
+    expect(() => getByText(defaultLabel)).not.toThrow();
+    expect(() => getAllByTestId(fakeIconTestId)).not.toThrow();
+  });
+  it('Aria attributes are set', async () => {
+    const { getByTestId } = render(<RenderTestScenario aria-expanded />);
+    const button = getByTestId('button') as HTMLElement;
+    expect(button.getAttribute('aria-label')).toBe(ariaLabel);
+    expect(button.getAttribute('aria-controls')).toBe(ariaControlsId);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+  });
+  it('ActiveState content is rendered when "isActive" is true and "activeStateLabel" or "activeStateIcon" are passed', async () => {
+    const { getByText, getAllByTestId } = render(<RenderTestScenario isActive {...activeStateProps} />);
+    expect(() => getByText(defaultLabel)).not.toThrow();
+    expect(() => getAllByTestId(fakeIconTestId)).not.toThrow();
+    expect(() => getByText(activeStateLabel)).not.toThrow();
+    expect(() => getAllByTestId(activeStateIconTestId)).not.toThrow();
+  });
+  it('ActiveState content is also rendered when isActive is false and "activeStateLabel" or "activeStateIcon" are passed', async () => {
+    const { getByText, getAllByTestId } = render(<RenderTestScenario {...activeStateProps} />);
+    expect(() => getByText(defaultLabel)).not.toThrow();
+    expect(() => getAllByTestId(fakeIconTestId)).not.toThrow();
+    expect(() => getByText(activeStateLabel)).not.toThrow();
+    expect(() => getAllByTestId(activeStateIconTestId)).not.toThrow();
+  });
+  it('ActiveState content is not rendered even if isActive is true, but neither "activeStateLabel" or "activeStateIcon" are passed', async () => {
+    const { getByText, getAllByTestId } = render(<RenderTestScenario isActive />);
+    expect(() => getByText(defaultLabel)).not.toThrow();
+    expect(() => getAllByTestId(fakeIconTestId)).not.toThrow();
+    expect(() => getByText(activeStateLabel)).toThrow();
+    expect(() => getAllByTestId(activeStateIconTestId)).toThrow();
+  });
+});

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
@@ -31,18 +31,102 @@ export interface HeaderActionBarItemProps extends ButtonAttributes {
    * @internal
    */
   labelOnRight?: boolean;
+  /**
+   * Label shown only visually when button is in active state. Screenreaders see only the "label".
+   */
+  activeStateLabel?: string | JSX.Element;
+  /**
+   * Icon shown when button is in active state.
+   */
+  activeStateIcon?: ReactNode;
+  /**
+   * Indicates button is in active state
+   */
+  isActive?: boolean;
 }
 
 export const HeaderActionBarItem = forwardRef<HTMLButtonElement, HeaderActionBarItemProps>(
-  ({ icon, label, labelOnRight, fixedRightPosition, className, ariaLabel, ariaControls, ...rest }, ref) => {
+  (
+    {
+      icon,
+      label,
+      labelOnRight,
+      fixedRightPosition,
+      className,
+      ariaLabel,
+      ariaControls,
+      activeStateLabel,
+      activeStateIcon,
+      isActive,
+      ...rest
+    },
+    ref,
+  ) => {
+    const hasActiveState = !!(activeStateLabel || activeStateIcon);
     const buttonClassName = classNames({
       [classes.actionBarItem]: true,
       [className]: true,
       [classes.fixedRightPosition]: fixedRightPosition,
+      [classes.isActive]: hasActiveState && isActive,
     });
     const iconClassName = classNames({ [classes.actionBarItemIcon]: true, [classes.labelOnRight]: labelOnRight });
     const labelClassName = classNames({ [classes.actionBarItemLabel]: true, [classes.labelOnRight]: labelOnRight });
 
+    const Icon = ({
+      element,
+      elementClassName,
+    }: {
+      element: HeaderActionBarItemProps['icon'];
+      elementClassName?: string;
+    }) => {
+      if (!element && !React.isValidElement(element)) {
+        return null;
+      }
+      return (
+        <span className={elementClassName}>{cloneElement(element as React.ReactElement, { 'aria-hidden': true })}</span>
+      );
+    };
+
+    const Label = ({
+      text,
+      isForActiveState,
+    }: {
+      text: HeaderActionBarItemProps['label'];
+      isForActiveState?: boolean;
+    }) => {
+      if (!text) {
+        return null;
+      }
+      return (
+        <span
+          className={classNames(labelClassName, isForActiveState && classes.activeStateContentLabel)}
+          {...(isForActiveState ? { 'aria-hidden': true } : {})}
+        >
+          {text}
+        </span>
+      );
+    };
+
+    const Content = () => {
+      return (
+        <>
+          <Icon element={icon} elementClassName={iconClassName} />
+          <Label text={label} />
+        </>
+      );
+    };
+
+    const ActiveStateContent = () => {
+      if (!hasActiveState) {
+        return null;
+      }
+      return (
+        <div className={classes.activeStateContent}>
+          <Icon element={activeStateIcon} elementClassName={iconClassName} />
+          <Label text={activeStateLabel} isForActiveState />
+        </div>
+      );
+    };
     return (
       <button
         type="button"
@@ -52,10 +136,8 @@ export const HeaderActionBarItem = forwardRef<HTMLButtonElement, HeaderActionBar
         className={buttonClassName}
         ref={ref}
       >
-        {icon && React.isValidElement(icon) && (
-          <span className={iconClassName}>{cloneElement(icon, { 'aria-hidden': true })}</span>
-        )}
-        {label && <span className={labelClassName}>{label}</span>}
+        <Content />
+        <ActiveStateContent />
       </button>
     );
   },

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemWithDropdown.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemWithDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 import { IconCross } from '../../../../icons';
-import { HeaderActionBarItem } from './HeaderActionBarItem';
+import { HeaderActionBarItem, HeaderActionBarItemProps } from './HeaderActionBarItem';
 import classNames from '../../../../utils/classNames';
 import classes from './HeaderActionBarItemWithDropdown.module.scss';
 
@@ -50,6 +50,10 @@ type HeaderActionBarItemWithDropdownProps = React.PropsWithChildren<{
    * Fix the item position to the right side of the action bar.
    */
   fixedRightPosition?: boolean;
+  /**
+   * Menu button resizing is prevented by rendering button's active state to a separate element.
+   */
+  preventButtonResize?: boolean;
 }> &
   React.ComponentPropsWithoutRef<'div'>;
 
@@ -64,10 +68,11 @@ export const HeaderActionBarItemWithDropdown = (properties: HeaderActionBarItemW
     dropdownClassName: dropdownClassNameProp,
     closeLabel,
     icon,
-    closeIcon = IconCross,
+    closeIcon = <IconCross />,
     ariaLabel,
     labelOnRight,
     fixedRightPosition,
+    preventButtonResize,
     ...props
   } = properties;
   const dropdownContentElementRef = useRef<HTMLElement>(null);
@@ -108,8 +113,8 @@ export const HeaderActionBarItemWithDropdown = (properties: HeaderActionBarItemW
     setHasContent(dropdownContentElementRef.current?.childNodes.length !== 0);
   }, [children]);
 
-  const iconLabel = visible ? closeLabel : label;
-  const iconClass = visible ? closeIcon : icon;
+  const iconLabel = visible && !preventButtonResize ? closeLabel : label;
+  const iconClass = visible && !preventButtonResize ? closeIcon : icon;
   const visibilityClasses = {
     visible,
     [classes.visible]: visible,
@@ -119,7 +124,12 @@ export const HeaderActionBarItemWithDropdown = (properties: HeaderActionBarItemW
   const className = classNames(classes.container, classNameProp, visibilityClasses);
   const iconClassName = classNames(classes.icon, iconClassNameProp);
   const dropdownClassName = classNames(classes.dropdown, dropdownClassNameProp, visibilityClasses);
-
+  const buttonOverlayProps: Pick<HeaderActionBarItemProps, 'activeStateIcon' | 'activeStateLabel'> = preventButtonResize
+    ? {
+        activeStateIcon: closeIcon,
+        activeStateLabel: closeLabel,
+      }
+    : {};
   /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
   return (
     <div {...props} id={id} className={className} ref={containerElementRef} onBlur={handleBlur}>
@@ -133,6 +143,8 @@ export const HeaderActionBarItemWithDropdown = (properties: HeaderActionBarItemW
         aria-controls={`${id}-dropdown`}
         labelOnRight={labelOnRight}
         fixedRightPosition={fixedRightPosition}
+        isActive={visible}
+        {...buttonOverlayProps}
       />
       <div className={classes.dropdownWrapper}>
         <aside id={`${id}-dropdown`} className={dropdownClassName} ref={dropdownContentElementRef}>

--- a/packages/react/src/components/header/components/headerActionBarItem/__snapshots__/HeaderActionBarItem.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBarItem/__snapshots__/HeaderActionBarItem.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeaderActionBarItem spec renders the component correctly and adds all classNames from props 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="aria-controls-id"
+    aria-expanded="false"
+    aria-label="aria label"
+    class="actionBarItem extra-class fixedRightPosition"
+    data-testid="button"
+    type="button"
+  >
+    <span
+      class="actionBarItemIcon labelOnRight"
+    >
+      <span
+        aria-hidden="true"
+        data-testid="fake-icon-test-id"
+      />
+    </span>
+    <span
+      class="actionBarItemLabel labelOnRight"
+    >
+      button label
+    </span>
+    <div
+      class="activeStateContent"
+    >
+      <span
+        class="actionBarItemIcon labelOnRight"
+      >
+        <span
+          aria-hidden="true"
+          data-testid="close-icon-test-id"
+        />
+      </span>
+      <span
+        aria-hidden="true"
+        class="actionBarItemLabel labelOnRight activeStateContentLabel"
+      >
+        close label
+      </span>
+    </div>
+  </button>
+</DocumentFragment>
+`;

--- a/site/src/docs/components/header/code.mdx
+++ b/site/src/docs/components/header/code.mdx
@@ -270,6 +270,7 @@ import { Header, IconSearch, IconUser, Logo, logoFi, logoSv, logoSvDark } from '
             icon={<IconUser />}
             id="action-bar-login"
             closeLabel={I18n.close}
+            preventButtonResize
           >
             <h3>{I18n.loginOptions}</h3>
           </Header.ActionBarItem>
@@ -731,11 +732,14 @@ import { Header, Logo, logoFi } from 'hds-react';
 | `role`                                | ARIA role to describe the contents.                    | `string`                                      | -             |
 | [Table 4:Header.ActionBar properties] |
 
-| Property                                  | Description                         | Values                 | Default value |
-| ----------------------------------------- | ----------------------------------- | ---------------------- | ------------- |
-| `ariaLabel`                               | Aria-label for describing the item. | `string`               | -             |
-| `icon`                                    | Icon for the item.                  | `ReactNode`            | -             |
-| `label`                                   | Label for the action bar item.      | `string` `JSX.Element` | -             |
+| Property                                  | Description                                                                                             | Values                 | Default value |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- | ------------- |
+| `ariaLabel`                               | Aria-label for describing the item.                                                                     | `string`               | -             |
+| `ariaControls`                            | Id of the controlled dropdown element.                                                                  | `string`               | -             |
+| `fixedRightPosition`                      | Boolean to set the item in a fixed position on the right side of the action bar behind a dividing line. | `boolean`              | `false`       |
+| `icon`                                    | Icon for the item.                                                                                      | `ReactNode`            | -             |
+| `label`                                   | Label for the item.                                                                                     | `string` `JSX.Element` | -             |
+| `preventButtonResize`                     | If true, menu button resizing is prevented by rendering button's active state to a separate element.    | `boolean`              | `false`       |
 | [Table 5:Header.ActionBarItem properties] |
 
 | Property                                     | Description                                            | Values             | Default value |
@@ -751,20 +755,11 @@ import { Header, Logo, logoFi } from 'hds-react';
 | `onSubmit`                         | Callback function for when input is submitted. | `(inputValue: string) => void` | -             |
 | [Table 7:Header.Search properties] |
 
-| Property                                  | Description                                                                                             | Values                 | Default value |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- | ------------- |
-| `ariaLabel`                               | Aria-label for describing the item.                                                                     | `string`               | -             |
-| `ariaControls`                            | Id of the controlled dropdown element.                                                                  | `string`               | -             |
-| `fixedRightPosition`                      | Boolean to set the item in a fixed position on the right side of the action bar behind a dividing line. | `boolean`              | `false`       |
-| `icon`                                    | Icon for the item.                                                                                      | `ReactNode`            | -             |
-| `label`                                   | Label for the item.                                                                                     | `string` `JSX.Element` | -             |
-| [Table 8:Header.ActionBarItem properties] |
-
 | Property                                   | Description                               | Values   | Default value |
 | ------------------------------------------ | ----------------------------------------- | -------- | ------------- |
 | `ariaLabel`                                | Aria-label for describing NavigationMenu. | `string` | -             |
 | `id`                                       | ID for the NavigationMenu.                | `string` | -             |
-| [Table 9:Header.NavigationMenu properties] |
+| [Table 8:Header.NavigationMenu properties] |
 
 | Property                          | Description                                                                 | Values            | Default value                                           |
 | --------------------------------- | --------------------------------------------------------------------------- | ----------------- | ------------------------------------------------------- |
@@ -782,4 +777,4 @@ import { Header, Logo, logoFi } from 'hds-react';
 | `id`                              | ID for the link.                                                            | `string`          | -                                                       |
 | `openDropdownAriaButtonLabel`     | Aria-label for the dropdown button to describe the opening of the dropdown. | `string`          | -                                                       |
 | `wrapperClassName`                | Additional classNames for the element wrapping the link.                    | `string`          | -                                                       |
-| [Table 10:Header.Link properties] |
+| [Table 9:Header.Link properties] |


### PR DESCRIPTION
## Description

When Dropdown button has different close label and/or icon, its size probably changes when active. This causes the button and header to shift a bit.

The active state (close icon + "Sulje") is now always rendered but invisible when not active. If the active state contents are wider than inactive state, the contents won't overflow. The button is as wide as the widest text.

visibility:hidden is not used with label, because it will hide it from screenreaders.

## Related Issue

Closes [HDS-2025](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2025)

## How Has This Been Tested?

Locally. Visual tests do not cover user interactions.

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-2025-header-button/?path=/story/components-header--with-full-features-custom-theme)

[Docs](https://city-of-helsinki.github.io/hds-demo//hds-2025-header-button-docs/components/header/code/)


[HDS-2025]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ