### PR TITLE
Hds 2038 unify visual test and update scripts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@
 - [Nvm](https://github.com/nvm-sh/nvm)
 - [Node](https://nodejs.org/en/)
 - [Yarn](https://yarnpkg.com/)
-- [Docker](https://www.docker.com/) (for visual regression tests)
+- [Docker](https://www.docker.com/) (For visual regression tests. Read more [here](https://github.com/City-of-Helsinki/helsinki-design-system/blob/development/packages/react/DEVELOPMENT.md#visual-regression-tests).)
 
 ### Setting up local development environment
 

--- a/packages/react/DEVELOPMENT.md
+++ b/packages/react/DEVELOPMENT.md
@@ -52,13 +52,9 @@ To run the visual regression tests, you must first build the storybook by runnin
 
 ### Updating reference images
 
-When adding a new component or after making visual changes to some existing component, you must update the corresponding reference image. Before you can do this, you must start the local react storybook by issuing the following command in the root of the whole project:
+When adding a new component or after making visual changes to some existing component, you must update the corresponding reference image. Before you can do this, you must first build the storybook by running `yarn build-storybook`.
 
-```bash
-yarn start:react
-```
-
-Then leave the storybook on the background and switch to another terminal window. Go to packages/react and issue this command:
+Then you can issue this command:
 
 ```bash
 yarn update-reference-images --storiesFilter "<name or part of the name of the story>"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "test": "jest --env=jest-environment-jsdom-sixteen",
     "prepublishOnly": "cp -r ./lib/. .",
     "visual-test": "loki test --requireReference --verboseRenderer --reactUri file:./storybook-static",
-    "update-reference-images": "loki update"
+    "update-reference-images": "loki update --requireReference --verboseRenderer --reactUri file:./storybook-static"
   },
   "devDependencies": {
     "@babel/core": "7.11.6",


### PR DESCRIPTION
## Description

Unifies the Loki parameters of `visual-test` and `update-reference-images` scripts so that prerequisites for running them are the same (storybook is built).  There is no need to keep storybook running on background for update.


## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-2038

## Motivation and Context

Makes scripts easier to run and improves documentation.

## How Has This Been Tested?
So far just running the scripts