### PR TITLE
HDS-2028-fix-checkbox-label-added-to-DOM-even-if-not-given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Header.NavigationMenu] Fixed navigation menu on mobile
+- [Checbox] Fixed Checkbox label taking space even if label not given (when using an external component as the label for it)
 
 ### Core
 
@@ -46,6 +47,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Checkbox] Small changes to styles not to add padding when label not used (by using `hds-checkbox__label--hidden` class)
 
 ### Documentation
 
@@ -61,6 +63,7 @@ Changes that are not related to specific components
 
 Changes that are not related to specific components
 - [Component] What has been changed
+- [Checkbox] Small addition to guide not to use the label-property at all when using an external label for the Checkbox
 
 #### Fixed
 

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -28,6 +28,7 @@
   display: flex;
   flex-wrap: wrap;
   min-height: var(--size);
+  min-width: var(--size);
   position: relative;
 }
 

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -133,10 +133,10 @@
   padding-left: calc(var(--size) + var(--label-padding));
   padding-top: calc((var(--size) - (var(--label-font-size) * var(--lineheight-m))) / 2);
   position: relative;
+}
 
-  &.hds-checkbox__no-label {
-    padding-left: 0;
-  }
+.hds-checkbox .hds-checkbox__label--hidden {
+  padding-left: 0;
 }
 
 /* ERROR */

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -134,6 +134,10 @@
   padding-left: calc(var(--size) + var(--label-padding));
   padding-top: calc((var(--size) - (var(--label-font-size) * var(--lineheight-m))) / 2);
   position: relative;
+
+  &.hds-checkbox__no-label {
+    padding-left: 0;
+  }
 }
 
 /* ERROR */

--- a/packages/core/src/components/checkbox/checkbox.css
+++ b/packages/core/src/components/checkbox/checkbox.css
@@ -28,7 +28,6 @@
   display: flex;
   flex-wrap: wrap;
   min-height: var(--size);
-  min-width: var(--size);
   position: relative;
 }
 

--- a/packages/react/src/components/checkbox/Checkbox.module.css
+++ b/packages/react/src/components/checkbox/Checkbox.module.css
@@ -11,7 +11,7 @@
 }
 
 .noLabel {
-  composes: hds-checkbox__no-label from 'hds-core/lib/components/checkbox/checkbox.css';
+  composes: hds-checkbox__label--hidden from 'hds-core/lib/components/checkbox/checkbox.css';
 }
 
 .errorText {

--- a/packages/react/src/components/checkbox/Checkbox.module.css
+++ b/packages/react/src/components/checkbox/Checkbox.module.css
@@ -10,6 +10,10 @@
   composes: hds-checkbox__label from 'hds-core/lib/components/checkbox/checkbox.css';
 }
 
+.noLabel {
+  composes: hds-checkbox__no-label from 'hds-core/lib/components/checkbox/checkbox.css';
+}
+
 .errorText {
   composes: hds-checkbox__error-text from 'hds-core/lib/components/checkbox/checkbox.css';
 }

--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -125,9 +125,11 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           aria-describedby={ariaDescribedBy.length > 0 ? ariaDescribedBy : null}
           {...rest}
         />
-        <label htmlFor={id} className={classNames(styles.label)}>
-          {label}
-        </label>
+        {label && (
+          <label htmlFor={id} className={classNames(styles.label)}>
+            {label}
+          </label>
+        )}
         {tooltipText && (
           <Tooltip className={styles.tooltipButton} buttonLabel={tooltipButtonLabel} tooltipLabel={tooltipLabel}>
             {tooltipText}

--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -125,11 +125,9 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           aria-describedby={ariaDescribedBy.length > 0 ? ariaDescribedBy : null}
           {...rest}
         />
-        {label && (
-          <label htmlFor={id} className={classNames(styles.label)}>
-            {label}
-          </label>
-        )}
+        <label htmlFor={id} className={classNames(styles.label, !label ? styles.noLabel : '')}>
+          {label}
+        </label>
         {tooltipText && (
           <Tooltip className={styles.tooltipButton} buttonLabel={tooltipButtonLabel} tooltipLabel={tooltipLabel}>
             {tooltipText}

--- a/site/src/docs/components/checkbox/index.mdx
+++ b/site/src/docs/components/checkbox/index.mdx
@@ -58,6 +58,7 @@ export const CheckboxExample = () => {
 - If Checkboxes are related to each other, use <InternalLink href="/components/selection-group">HDS Selection group</InternalLink> to achieve that.
 - Checkboxes should not have any immediate effects. The checkbox selection takes effect when the user presses a submit button (e.g. in a form). If you need the selection to have an immediate effect, use <InternalLink href="/components/toggle-button">HDS Toggle button component</InternalLink> instead. Also see <InternalLink href="/foundation/guidelines/checkbox-radiobutton-toggle">guidelines for choosing between radio buttons, checkboxes and toggles.</InternalLink>
 - Checkbox can be provided with additional tooltip. Tooltip information should be considered as extra information. You can find more information about Tooltips how they are used from the <InternalLink href="/components/tooltip">Tooltip documentation page</InternalLink>.
+- If some other component is used as the label for the checkbox by using `<label for="checkbox_id">`, the label parameter of the checkbox itself should not be given at all (affects the layout).
 ### Variations
 
 #### Default


### PR DESCRIPTION
## Description
The label is needed to style the checkbox correctly so fixing this issue was to add a class to remove the padding-left of the label when the label is not used.

## Related Issue
[HDS-2028](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2028)

## How Has This Been Tested
- running local tests

[HDS-2028]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ