### PR TITLE
HDS-2032 Update grid and breakpoint docs about Header max width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Changes that are not related to specific components
 
 Changes that are not related to specific components
 - [Component] What has been changed
+- Updated grid documentation with information about the new Header
 
 #### Fixed
 

--- a/site/src/docs/foundation/design-tokens/breakpoints/index.mdx
+++ b/site/src/docs/foundation/design-tokens/breakpoints/index.mdx
@@ -39,6 +39,6 @@ The breakpoint tokens are divided into two sets;
 - **Breakpoint tokens** define exact widths (in pixels) where the next breakpoint comes into effect.
 - **Container width token** defines maximum container width.
 
-When breakpoints change the left and right padding of the container changes. It is recommended to use the provided padding values because they match with <InternalLink href="/components/navigation">HDS Navigation</InternalLink> and <InternalLink href="/components/footer">HDS Footer</InternalLink> paddings. You can find these paddings on the <InternalLink href="/foundation/design-tokens/breakpoints/tokens">HDS Breakpoints tokens tab.</InternalLink>
+When breakpoints change the left and right padding of the container changes. It is recommended to use the provided padding values because they match with <InternalLink href="/components/footer">HDS Footer</InternalLink> paddings. You can find these paddings on the <InternalLink href="/foundation/design-tokens/breakpoints/tokens">HDS Breakpoints tokens tab.</InternalLink>
 
-The maximum content container width is always `--container-width-xl` (1200px). When the viewport width is below this value, the content container always takes all available space.
+The maximum content container width is always `--container-width-xl` (1200px). When the viewport width is below this value, the content container always takes all available space. Note that the <InternalLink href="/components/header">Header component</InternalLink> is an exception with maximum width of 1440 pixels so it should not be placed inside the grid container.

--- a/site/src/docs/foundation/guidelines/grid.mdx
+++ b/site/src/docs/foundation/guidelines/grid.mdx
@@ -22,6 +22,7 @@ import InternalLink from '../../../components/InternalLink';
 ## Principles
 
 - HDS uses a standard 12 column grid whose maximum width is 1200 pixels. Container width and the number of columns change each breakpoint.
+  - The <InternalLink href="/components/header">Header component</InternalLink> is an exception with maximum width of 1440 pixels so it should not be placed inside the grid container.
 - Larger screen sizes use 24-pixel gutters while on mobile screen widths they shrink to 16 pixels and eventually to 12 pixels in the smallest breakpoint.
 - Even though HDS does not include grid implementation, it recommends and suggests methods how to handle changing amount of columns and column stacking. See [Layout columns](#layout-columns) for more information.
   - HDS also offers a Container component that helps to follow breakpoints and container widths. For more info refer to <InternalLink href="/foundation/design-tokens/breakpoints">Breakpoints documentation.</InternalLink>


### PR DESCRIPTION
## Description

Grid docs have deprecated information about how grid and current header/navigation works. Updated the docs to match current implementation. 

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-2032

## How Has This Been Tested?
Locally
[Demo grid page](https://city-of-helsinki.github.io/hds-demo/hds-2032-grid-dox-width/foundation/guidelines/grid/)
[Demo breakpoints page](https://city-of-helsinki.github.io/hds-demo/hds-2032-grid-dox-width/foundation/design-tokens/breakpoints/)