### PR TITLE
Inherit background color for dropdown button with placeholder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Changes that are not related to specific components
 
 - [Component] What has been changed
+- [Select] Placeholder text inherits background color
 
 #### Fixed
 

--- a/packages/react/src/components/dropdown/select/Select.module.scss
+++ b/packages/react/src/components/dropdown/select/Select.module.scss
@@ -26,6 +26,7 @@
   width: 100%;
 
   &.placeholder {
+    background-color: inherit;
     color: var(--placeholder-color);
   }
 


### PR DESCRIPTION
## Description
Adding a background color to dropdown buttons that have placeholder in order to help working with automated accessibility tools like Siteimprove.

## Related Issue

Sorry, I do not have an issue for this at the moment.

## Motivation and Context

Some automated tools like Siteimprove may have problems checking contrast for absolutely positioned elements with transparent background. HDS dropdown has such an element when a HDS dropdown has placeholder text in it. The button triggering opening the dropdown is absolutely positioned and has a transparent background.

This change will make the button inherit the background color of its parent. It should make it easier for automated accessibility tools to check the color contrast of the placeholder text thus reducing manual work on large sites like helfi.

## How Has This Been Tested?

* The CSS change itself has been tested on the HDS Components page using browser devtools.
* This has been discussed briefly in Slack channel #dev-helfi-hds
    * Tuomo K. could not think of any problems that this could cause.
* This code change has not been tested in React environment

## Screenshots (if appropriate):

Screenshot of current transparent button background style
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/14687ca2-1b5e-411c-ba3e-3ff252b910dd)

Screenshot after changing the button to inherit its parents background color. (There should be no visible difference between these two screenshots)
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/6d670239-f6dc-41b2-a654-86763f0ec35f)

Screenshot of the same buttons with rgba(255,0,0,0.5) set as their background to show where the changes could be visible if there were any.
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/4e7a3902-d8b1-46b6-8968-1056ced1895f)
