### PR TITLE
(HDS-2045) add customizable close-button theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - [DateInput] Support for customising date styles
+- [Accordion] Support for customising close button styles
 
 #### Changed
 
@@ -64,6 +65,7 @@ Changes that are not related to specific components
 Changes that are not related to specific components
 - [Component] What has been changed
 - [Checkbox] Small addition to guide not to use the label-property at all when using an external label for the Checkbox
+- [Accordion] Add close button theming properties
 
 #### Fixed
 

--- a/packages/react/src/components/accordion/Accordion.module.scss
+++ b/packages/react/src/components/accordion/Accordion.module.scss
@@ -7,6 +7,25 @@
   --content-font-size: var(--fontsize-body-m);
   --content-line-height: var(--lineheight-l);
 
+  /* Close button */
+  --close-button-background-color-disabled: inherit;
+  --close-button-background-color-focus: transparent;
+  --close-button-background-color-hover-focus: var(--color-black-5);
+  --close-button-background-color-hover: var(--color-black-5);
+  --close-button-background-color: inherit;
+  --close-button-border-color-active: var(--header-focus-outline-color);
+  --close-button-border-color-disabled: inherit;
+  --close-button-border-color-focus: var(--header-focus-outline-color);
+  --close-button-border-color-hover-focus: var(--header-focus-outline-color);
+  --close-button-border-color-hover: inherit;
+  --close-button-border-color: inherit;
+  --close-button-color-disabled: inherit;
+  --close-button-color-focus: var(--color-black);
+  --close-button-color-hover-focus: var(--color-black);
+  --close-button-color-hover: var(--color-black);
+  --close-button-color: var(--content-font-color);
+  --close-button-focus-outline-color: transparent;
+
   &:not(.card) {
     border-bottom: 1px solid var(--border-color);
   }
@@ -91,9 +110,30 @@
 
   .closeButton {
     bottom: 0;
-    color: var(--content-font-color);
     position: absolute;
     right: 0;
+
+    &:not(:disabled):active {
+      border-color: var(--close-button-border-color-active);
+    }
+
+    --background-color-disabled: var(--close-button-background-color-disabled);
+    --background-color-focus: var(--close-button-background-color-focus);
+    --background-color-hover-focus: var(--close-button-background-color-hover-focus);
+    --background-color-hover: var(--close-button-background-color-hover);
+    --background-color: var(--close-button-background-color);
+    --border-color-active: var(--close-button-border-color-active);
+    --border-color-disabled: var(--close-button-border-color-disabled);
+    --border-color-focus: var(--close-button-border-color-focus);
+    --border-color-hover-focus: var(--close-button-border-color-hover-focus);
+    --border-color-hover: var(--close-button-border-color-hover);
+    --border-color: var(--close-button-border-color);
+    --color-disabled: var(--close-button-color-disabled);
+    --color-focus: var(--close-button-color-focus);
+    --color-hover-focus: var(--close-button-color-hover-focus);
+    --color-hover: var(--close-button-color-hover);
+    --color: var(--close-button-color);
+    --focus-outline-color: var(--close-button-focus-outline-color);
   }
 }
 

--- a/packages/react/src/components/accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/accordion/Accordion.stories.tsx
@@ -95,6 +95,7 @@ export const CustomTheme = (args) => (
         '--background-color': 'var(--color-bus)',
         '--padding-horizontal': 'var(--spacing-m)',
         '--padding-vertical': '20px',
+        '--header-focus-outline-color': 'var(--color-gold)',
         '--header-font-color': 'var(--color-white)',
         '--header-font-size': 'var(--fontsize-heading-s)',
         '--header-font-weight': '500',
@@ -105,6 +106,7 @@ export const CustomTheme = (args) => (
         '--content-font-color': 'var(--color-white)',
         '--content-font-size': 'var(--fontsize-body-m)',
         '--content-line-height': 'var(--lineheight-l)',
+        '--close-button-background-color-focus': 'var(--color-white)',
       }}
     />
   </>

--- a/packages/react/src/components/accordion/Accordion.tsx
+++ b/packages/react/src/components/accordion/Accordion.tsx
@@ -25,6 +25,23 @@ export interface AccordionCustomTheme {
   '--header-focus-outline-color'?: string;
   '--content-font-size'?: string;
   '--content-line-height'?: string;
+  '--close-button-background-color-disabled'?: string;
+  '--close-button-background-color-focus'?: string;
+  '--close-button-background-color-hover-focus'?: string;
+  '--close-button-background-color-hover'?: string;
+  '--close-button-background-color'?: string;
+  '--close-button-border-color-active'?: string;
+  '--close-button-border-color-disabled'?: string;
+  '--close-button-border-color-focus'?: string;
+  '--close-button-border-color-hover-focus'?: string;
+  '--close-button-border-color-hover'?: string;
+  '--close-button-border-color'?: string;
+  '--close-button-color-disabled'?: string;
+  '--close-button-color-focus'?: string;
+  '--close-button-color-hover-focus'?: string;
+  '--close-button-color-hover'?: string;
+  '--close-button-color'?: string;
+  '--close-button-focus-outline-color'?: string;
 }
 
 type Language = 'en' | 'fi' | 'sv';
@@ -141,6 +158,24 @@ export const Accordion = ({
     '--content-font-color': theme['--content-font-color'],
     '--content-font-size': theme['--content-font-size'],
     '--content-line-height': theme['--content-line-height'],
+
+    '--close-button-background-color-disabled': theme['--close-button-background-color-disabled'],
+    '--close-button-background-color-focus': theme['--close-button-background-color-focus'],
+    '--close-button-background-color-hover-focus': theme['--close-button-background-color-hover-focus'],
+    '--close-button-background-color-hover': theme['--close-button-background-color-hover'],
+    '--close-button-background-color': theme['--close-button-background-color'],
+    '--close-button-border-color-active': theme['--close-button-border-color-active'],
+    '--close-button-border-color-disabled': theme['--close-button-border-color-disabled'],
+    '--close-button-border-color-focus': theme['--close-button-border-color-focus'],
+    '--close-button-border-color-hover-focus': theme['--close-button-border-color-hover-focus'],
+    '--close-button-border-color-hover': theme['--close-button-border-color-hover'],
+    '--close-button-border-color': theme['--close-button-border-color'],
+    '--close-button-color-disabled': theme['--close-button-color-disabled'],
+    '--close-button-color-focus': theme['--close-button-color-focus'],
+    '--close-button-color-hover-focus': theme['--close-button-color-hover-focus'],
+    '--close-button-color-hover': theme['--close-button-color-hover'],
+    '--close-button-color': theme['--close-button-color'],
+    '--close-button-focus-outline-color': theme['--close-button-focus-outline-color'],
   };
 
   const filteredSovereignThemeVariables = pickBy(sovereignThemeVariables);

--- a/site/src/docs/components/accordion/customisation.mdx
+++ b/site/src/docs/components/accordion/customisation.mdx
@@ -63,7 +63,7 @@ import { Accordion } from 'hds-react';
   }}
   theme={{
     '--background-color': 'var(--color-bus)',
-    '--header-focus-outline-color': 'var(--color-white)',
+    '--header-focus-outline-color': 'var(--color-gold)',
     '--button-size': '28px',
     '--content-font-color': 'var(--color-white)',
     '--content-font-size': 'var(--fontsize-body-m)',

--- a/site/src/docs/components/accordion/customisation.mdx
+++ b/site/src/docs/components/accordion/customisation.mdx
@@ -27,6 +27,23 @@ You can use the `theme` property to customise the component. See all available t
 | <code>--header-line-height</code>         | Line height of the accordion header.            |
 | <code>--padding-horizontal</code>         | Left and right padding of the accordion.        |
 | <code>--padding-vertical</code>           | Top and bottom padding of the accordion.        |
+| <code>--close-button-background-color-disabled</code> | Self explanatory styles for closing button |
+| <code>--close-button-background-color-focus</code> |  |
+| <code>--close-button-background-color-hover-focus</code> |  |
+| <code>--close-button-background-color-hover</code> |  |
+| <code>--close-button-background-color</code> |  |
+| <code>--close-button-border-color-active</code> |  |
+| <code>--close-button-border-color-disabled</code> |  |
+| <code>--close-button-border-color-focus</code> |  |
+| <code>--close-button-border-color-hover-focus</code> |  |
+| <code>--close-button-border-color-hover</code> |  |
+| <code>--close-button-border-color</code> |  |
+| <code>--close-button-color-disabled</code> |  |
+| <code>--close-button-color-focus</code> |  |
+| <code>--close-button-color-hover-focus</code> |  |
+| <code>--close-button-color-hover</code> |  |
+| <code>--close-button-color</code> |  |
+| <code>--close-button-focus-outline-color</code> |  |
 
 
 ### Customisation example
@@ -55,7 +72,11 @@ import { Accordion } from 'hds-react';
     '--header-font-size': 'var(--fontsize-heading-s)',
     '--header-line-height': 'var(--lineheight-s)',
     '--padding-horizontal': 'var(--spacing-m)',
-    '--padding-vertical': '20px'
+    '--padding-vertical': '20px',
+    '--close-button-color-hover': 'var(--color-black)',
+    '--close-button-color-focus': 'var(--color-black)',
+    '--close-button-color-hover-focus': 'var(--color-black)',
+    '--close-button-background-color-focus': 'var(--color-white)',
   }}
 >
   In order to customise the accordion component, use the theme property.


### PR DESCRIPTION
## Description

Add possibility to style the close-button with theming in Accordion

## Related Issue

[HDS-2045](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2045)

## How Has This Been Tested?

- local machine
- can be seen in site -> Accordion -> customisation and storybook

## Screenshots (if appropriate):

![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/9400109b-b0cc-41ba-9749-f16ee9b57f34)



[HDS-2045]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ