### PR TITLE
HDS-2043 Hide separator in header from screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Header.NavigationMenu] Fixed navigation menu on mobile
+- [Header.ActionBar] Added `aria-hidden` for separator
 - [Checbox] Fixed Checkbox label taking space even if label not given (when using an external component as the label for it)
 
 ### Core

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -261,7 +261,7 @@ export const HeaderActionBar = ({
             <HeaderActionBarMenuItem ariaLabel={menuButtonAriaLabel} onClick={onMenuClick} />
             {childrenRight.length > 0 && (
               <>
-                <hr />
+                <hr aria-hidden="true" />
                 {childrenRight}
               </>
             )}


### PR DESCRIPTION
## Description

Hide separator in header from screen reader by adding aria-hidden="true" for hr element.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-2043

## Motivation and Context

Screenreader reads hr element when it should not.

## How Has This Been Tested?
Chrome, safari, firefox + VoiceOver
