### PR TITLE
HDS-1975 mobile submenu fixes

### DIFF
--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -79,7 +79,7 @@ const translations = {
     basicEducation: 'Basic education',
     business: 'Business',
     businessAndWork: 'Business and work',
-    childHoodAndEducation: 'Childhood and education',
+    childhoodAndEducation: 'Childhood and education',
     clearFinnish: 'Clear finnish',
     close: 'Close',
     dentalCare: 'Dental care',
@@ -96,8 +96,8 @@ const translations = {
     headerLogin: 'Login',
     headerMenuTitle: 'Other languages',
     headerTitle: 'City of Helsinki',
-    healtcare: 'Healt care',
-    healthAndndSocialServices: 'Health and social services',
+    healthCare: 'Health care',
+    healthAndSocialServices: 'Health and social services',
     infoOtherLanguages: 'Information in other languages',
     jobSeekers: 'Jobseekers',
     loginOptions: 'Login options',
@@ -118,7 +118,7 @@ const translations = {
     basicEducation: 'Perusopetus',
     business: 'Yritykset',
     businessAndWork: 'Yritykset ja työ',
-    childHoodAndEducation: 'Kasvatus ja koulutus',
+    childhoodAndEducation: 'Kasvatus ja koulutus',
     clearFinnish: 'Selkosuomi',
     close: 'Sulje',
     dentalCare: 'Hammashoito',
@@ -135,8 +135,8 @@ const translations = {
     headerLogin: 'Kirjaudu',
     headerMenuTitle: 'Tietoa muilla kielillä',
     headerTitle: 'Helsingin kaupunki',
-    healtcare: 'Terveydenhoito',
-    healthAndndSocialServices: 'Sosiaali- ja terveyspalvelut',
+    healthCare: 'Terveydenhoito',
+    healthAndSocialServices: 'Sosiaali- ja terveyspalvelut',
     infoOtherLanguages: 'Tietoa muilla kielillä',
     jobSeekers: 'Työnhakijat',
     loginOptions: 'Kirjautumisvalinnat',
@@ -157,7 +157,7 @@ const translations = {
     basicEducation: 'Grundläggande utbildning',
     business: 'Företag',
     businessAndWork: 'Företag och arbete',
-    childHoodAndEducation: 'Fostran och utbildning',
+    childhoodAndEducation: 'Fostran och utbildning',
     clearFinnish: 'Klara finska',
     close: 'Stäng',
     dentalCare: 'Tandvård',
@@ -174,8 +174,8 @@ const translations = {
     headerLogin: 'Logga in',
     headerMenuTitle: 'Andra språk',
     headerTitle: 'Helsingfors Stad',
-    healtcare: 'Hälsovärd',
-    healthAndndSocialServices: 'Social- och hälsovårdstjänster',
+    healthCare: 'Hälsovärd',
+    healthAndSocialServices: 'Social- och hälsovårdstjänster',
     infoOtherLanguages: 'information på andra språk',
     jobSeekers: 'Arbetssökande',
     loginOptions: 'Logga in optioner',
@@ -196,7 +196,7 @@ const translations = {
     basicEducation: 'École élémentaire',
     business: 'Enteprises',
     businessAndWork: 'Entreprises et travail',
-    childHoodAndEducation: 'Éducation',
+    childhoodAndEducation: 'Éducation',
     clearFinnish: 'Finnois simple',
     close: 'Fermer',
     dentalCare: 'Soins dentaires',
@@ -213,8 +213,8 @@ const translations = {
     headerLogin: 'Se connecter',
     headerMenuTitle: 'Autres langues',
     headerTitle: 'Ville de Helsinki',
-    healtcare: 'Soins de santé',
-    healthAndndSocialServices: 'Services sociaux et de santé',
+    healthCare: 'Soins de santé',
+    healthAndSocialServices: 'Services sociaux et de santé',
     infoOtherLanguages: 'Information en autres langues',
     jobSeekers: "Demandeurs d'emploi",
     loginOptions: 'Choix pour se connecter',
@@ -276,11 +276,19 @@ const FullFeaturedActionBar = ({ I18n, lang, theme }) => {
   );
 };
 
-const FullFeaturedNavigationMenu = ({ I18n, href, setHref }) => {
+const FullFeaturedNavigationMenu = ({
+  I18n,
+  href,
+  setHref,
+}: {
+  I18n: typeof translations['fi'];
+  href: string;
+  setHref: (anchor: string) => void;
+}) => {
   return (
     <Header.NavigationMenu>
       <Header.Link
-        label={I18n.healthAndndSocialServices}
+        label={I18n.healthAndSocialServices}
         onClick={(event) => {
           event.preventDefault();
           setHref('#sosiaali-_ja_terveyspalvelut');
@@ -292,7 +300,7 @@ const FullFeaturedNavigationMenu = ({ I18n, href, setHref }) => {
               event.preventDefault();
               setHref('#sosiaali-_ja_terveyspalvelut#terveydenhoito');
             }}
-            label={I18n.healtcare}
+            label={I18n.healthCare}
             active={href.includes('#terveydenhoito')}
             dropdownLinks={[
               <Header.Link
@@ -321,7 +329,7 @@ const FullFeaturedNavigationMenu = ({ I18n, href, setHref }) => {
           event.preventDefault();
           setHref('#kasvatus_ja_koulutus');
         }}
-        label={I18n.childHoodAndEducation}
+        label={I18n.childhoodAndEducation}
         dropdownLinks={[
           <Header.Link
             active={href.includes('#varhaiskasvatus')}
@@ -574,7 +582,7 @@ export const ManualLanguageSorting = (args) => {
 
       <Header.NavigationMenu>
         <Header.Link
-          label={I18n.healthAndndSocialServices}
+          label={I18n.healthAndSocialServices}
           onClick={(event) => {
             event.preventDefault();
             setHref('#sosiaali-_ja_terveyspalvelut');
@@ -587,7 +595,7 @@ export const ManualLanguageSorting = (args) => {
             event.preventDefault();
             setHref('#kasvatus_ja_koulutus');
           }}
-          label={I18n.childHoodAndEducation}
+          label={I18n.childhoodAndEducation}
         />
       </Header.NavigationMenu>
     </Header>
@@ -623,7 +631,7 @@ export const ManualLanguageOptions = (args) => {
 
       <Header.NavigationMenu>
         <Header.Link
-          label={I18n.healthAndndSocialServices}
+          label={I18n.healthAndSocialServices}
           onClick={(event) => {
             event.preventDefault();
             setHref('#sosiaali-_ja_terveyspalvelut');
@@ -636,7 +644,7 @@ export const ManualLanguageOptions = (args) => {
             event.preventDefault();
             setHref('#kasvatus_ja_koulutus');
           }}
-          label={I18n.childHoodAndEducation}
+          label={I18n.childhoodAndEducation}
         />
       </Header.NavigationMenu>
     </Header>

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
@@ -45,7 +45,9 @@
   overflow: hidden;
   position: absolute;
   transform: translateY(-100%) translateY(1px);
-  transition: var(--animation-duration-dropwdown) transform var(--animation-close-delay-dropdown), var(--animation-duration-dropwdown) min-height calc(var(--animation-duration-dropwdown) + var(--animation-close-delay-dropdown));
+  transition: var(--animation-duration-dropwdown) transform var(--animation-close-delay-dropdown),
+    var(--animation-duration-dropwdown) min-height
+      calc(var(--animation-duration-dropwdown) + var(--animation-close-delay-dropdown));
   width: 100%;
 }
 
@@ -209,21 +211,20 @@
   display: flex;
   min-height: calc(100vh - var(--action-bar-container-height));
   overflow: hidden;
+  transform: translateX(0);
+  transition: transform 0.3s ease;
   width: 300%;
 
   &.left0 {
     transform: translateX(0);
-    transition: transform 0.3s ease;
   }
 
   &.left100 {
     transform: translateX(-100vw);
-    transition: transform 0.3s ease;
   }
 
   &.left200 {
     transform: translateX(-200vw);
-    transition: transform 0.3s ease;
   }
 }
 

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.test.tsx
@@ -1,0 +1,468 @@
+import { RenderResult, fireEvent, render, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import { getActiveElement } from '../../../cookieConsent/test.util';
+import { Header } from '../../Header';
+// eslint-disable-next-line jest/no-mocks-import
+import mockWindowLocation from '../../../login/__mocks__/mockWindowLocation';
+
+jest.mock('../../../../hooks/useMediaQuery', () => ({
+  ...(jest.requireActual('../../../../hooks/useMediaQuery') as Record<string, unknown>),
+  useMediaQueryLessThan: () => {
+    // if this returns true, mobile menu is rendered.
+    return true;
+  },
+}));
+
+type MenuItem = {
+  id: string;
+  submenus?: MenuItem[];
+};
+
+type TestTools = RenderResult & {
+  openMobileMenu: () => Promise<void>;
+  closeMobileMenu: () => Promise<void>;
+  findVisibleSectionLinksByMenuIds: (menuIds: string[]) => Promise<HTMLElement[]>;
+  getNavSections: () => ReturnType<HTMLElement['querySelectorAll']>;
+  getActiveLink: () => HTMLAnchorElement;
+  getPreviousLink: () => HTMLAnchorElement | null;
+  selectMenuItem: (menuItem: MenuItem) => Promise<HTMLElement[]>;
+  verifyActiveItem: (menuItem: MenuItem | string) => boolean;
+  verifyPreviousItem: (menuItem: MenuItem | string | null) => boolean;
+  triggerAnimationEnd: (focusedItem: MenuItem | string) => Promise<void>;
+  getFocusedElement: () => Element | null;
+  navigateTo: (menuItem: MenuItem) => Promise<void>;
+  navigateBack: (waitForParentItem: MenuItem | string) => Promise<void>;
+};
+
+const mockedWindowControls = mockWindowLocation();
+
+const onClickTracker = jest.fn();
+
+const onClickHandler = (e: React.MouseEvent) => {
+  e.preventDefault();
+  onClickTracker(e);
+};
+
+const frontPageLabel = 'frontPageLabel';
+const titleHref = 'https://domain.fi';
+
+const menus: MenuItem[] = [
+  {
+    id: '0',
+    submenus: [
+      {
+        id: '0_0',
+        submenus: [{ id: '0_0_0' }, { id: '0_0_1' }],
+      },
+      {
+        id: '0_1',
+      },
+      {
+        id: '0_2',
+        submenus: [{ id: '0_2_0' }, { id: '0_2_1' }, { id: '0_2_2' }],
+      },
+    ],
+  },
+  {
+    id: '1',
+    submenus: [
+      {
+        id: '1_0',
+        submenus: [{ id: '1_0_0' }, { id: '1_0_1' }, { id: '1_0_2' }],
+      },
+    ],
+  },
+  {
+    id: '2',
+  },
+  {
+    id: '3',
+    submenus: [
+      {
+        id: '3_0',
+      },
+      {
+        id: '3_1',
+        submenus: [{ id: '3_1_0' }, { id: '3_1_1' }, { id: '3_1_2' }],
+      },
+      {
+        id: '3_2',
+        submenus: [{ id: '3_2_0' }, { id: '3_2_1' }, { id: '3_2_2' }],
+      },
+    ],
+  },
+];
+
+const getMenuItem = (path: number[]): MenuItem => {
+  return path.reduce(
+    (current, index) => {
+      return (current.submenus as MenuItem[])[index] as MenuItem;
+    },
+    { submenus: menus } as MenuItem,
+  );
+};
+
+const createLabel = (id: string) => `TestLabel_${id}`;
+const createHref = (id: string) => `http://test-link-${id}.com`;
+
+const HeaderWithMenus = () => {
+  return (
+    <Header>
+      <Header.ActionBar
+        title="title"
+        frontPageLabel={frontPageLabel}
+        titleAriaLabel="titleAriaLabel"
+        titleHref={titleHref}
+        logo={<span />}
+        logoAriaLabel="logoAriaLabel"
+        logoHref="https://hel.fi"
+        menuButtonAriaLabel="menuButtonAriaLabel"
+        openFrontPageLinksAriaLabel="openFrontPageLinksAriaLabel"
+      >
+        ActionBar
+      </Header.ActionBar>
+      <Header.NavigationMenu>
+        {menus.map((item) => {
+          // these mappings are a bit akward way to create link structure,
+          // but NavigationMenu child components are cloned and their props are copied and re-used,
+          // so cannot use other components or funcs to return components for dropdownLinks.
+          return (
+            <Header.Link
+              key={item.id}
+              label={createLabel(item.id)}
+              href={createHref(item.id)}
+              onClick={(event) => {
+                onClickHandler(event);
+              }}
+              dropdownLinks={
+                item.submenus
+                  ? item.submenus.map((i) => (
+                      <Header.Link
+                        key={i.id}
+                        label={createLabel(i.id)}
+                        href={createHref(i.id)}
+                        onClick={(event) => {
+                          onClickHandler(event);
+                        }}
+                        dropdownLinks={
+                          i.submenus
+                            ? i.submenus.map((jj) => (
+                                <Header.Link
+                                  key={jj.id}
+                                  label={createLabel(jj.id)}
+                                  href={createHref(jj.id)}
+                                  onClick={(event) => {
+                                    onClickHandler(event);
+                                  }}
+                                />
+                              ))
+                            : undefined
+                        }
+                      />
+                    ))
+                  : undefined
+              }
+            />
+          );
+        })}
+      </Header.NavigationMenu>
+    </Header>
+  );
+};
+
+const renderHeader = (): TestTools => {
+  const result = render(HeaderWithMenus());
+  const { container, getByText, getAllByText } = result;
+
+  const getNavSections: TestTools['getNavSections'] = () => container.querySelectorAll('section > nav');
+  const isElementAriaHidden = (el: Element) => el.getAttribute('aria-hidden') === 'true';
+
+  const isElementAriaVisible = (el: Element) => !isElementAriaHidden(el);
+  const getDropdownButtonForLink = (el: Element) => el.parentElement?.querySelector('button') as HTMLButtonElement;
+  const getVisibleNav = () => {
+    return Array.from(getNavSections()).find((el) =>
+      isElementAriaVisible(el.parentElement as HTMLElement),
+    ) as HTMLElement;
+  };
+  const toggleMobileMenu = async (shouldBeOpen: boolean) => {
+    const menuButton = getByText('Menu') as HTMLButtonElement;
+    fireEvent.click(menuButton);
+    await waitFor(() => {
+      const isClosed = getNavSections().length === 0;
+      if (isClosed === shouldBeOpen) {
+        throw new Error('Navigation element mismatch');
+      }
+    });
+  };
+
+  const openMobileMenu: TestTools['openMobileMenu'] = async () => {
+    await toggleMobileMenu(true);
+  };
+
+  const closeMobileMenu: TestTools['closeMobileMenu'] = async () => {
+    await toggleMobileMenu(false);
+  };
+
+  const findVisibleSectionLinksByMenuIds: TestTools['findVisibleSectionLinksByMenuIds'] = async (menuIds) => {
+    const visibleNav = getVisibleNav();
+    // ignore links listed in activeListItem. They are invisible.
+    const activeListItem = visibleNav.querySelector('li.activeListItem');
+    return waitFor(() => {
+      return menuIds.map((id) => {
+        const hits = getAllByText(createLabel(id)).filter(
+          (el) => visibleNav.contains(el) && (!activeListItem || !activeListItem.contains(el)),
+        );
+        if (hits.length !== 1) {
+          throw new Error(`Label ${createLabel(id)} is found in ${hits.length} elements`);
+        }
+        return hits[0];
+      });
+    });
+  };
+
+  const getActiveLink: TestTools['getActiveLink'] = () => {
+    const visibleNav = getVisibleNav();
+    return visibleNav.querySelector('a.activeMobileLink') as HTMLAnchorElement;
+  };
+
+  const getPreviousLink: TestTools['getPreviousLink'] = () => {
+    const visibleNav = getVisibleNav();
+    return visibleNav.querySelector('span.previousMobileLink') as HTMLAnchorElement;
+  };
+
+  const selectMenuItem: TestTools['selectMenuItem'] = async (item) => {
+    if (!item.submenus) {
+      return Promise.reject(new Error('Menu item has no submenus'));
+    }
+    const links = await findVisibleSectionLinksByMenuIds([item.id]);
+    if (links.length !== 1) {
+      return Promise.reject(new Error(`Menu item ${item.id} not found`));
+    }
+    const getCurrentNavIndex = () => {
+      const currentNav = getVisibleNav();
+      const index = Array.from(getNavSections()).indexOf(currentNav);
+      if (index === -1) {
+        throw new Error('getCurrentNavIndex is -1');
+      }
+      return index;
+    };
+    const currentIndex = getCurrentNavIndex();
+    fireEvent.click(getDropdownButtonForLink(links[0]));
+    await waitFor(() => {
+      if (getCurrentNavIndex() === currentIndex) {
+        throw new Error('Current nav not changed.');
+      }
+    });
+    return findVisibleSectionLinksByMenuIds(item.submenus.map((subItem) => subItem.id));
+  };
+
+  const verifyActiveItem: TestTools['verifyActiveItem'] = (itemOrString) => {
+    const activeLink = getActiveLink();
+    const comparison = typeof itemOrString === 'string' ? itemOrString : createLabel(itemOrString.id);
+    // console.log('vai', activeLink.innerHTML, comparison);
+    return activeLink.innerHTML === comparison;
+  };
+
+  const verifyPreviousItem: TestTools['verifyPreviousItem'] = (itemOrString) => {
+    const previousLink = getPreviousLink();
+    if (!itemOrString) {
+      return !previousLink;
+    }
+    const comparison = typeof itemOrString === 'string' ? itemOrString : createLabel(itemOrString.id);
+    return !!previousLink && previousLink.innerHTML === comparison;
+  };
+
+  const getFocusedElement: TestTools['getFocusedElement'] = () => {
+    return getActiveElement(container);
+  };
+
+  const triggerAnimationEnd: TestTools['triggerAnimationEnd'] = (focusedItemOrString) => {
+    const getFocusedElementContents = () => {
+      const el = getFocusedElement();
+      return el ? el.innerHTML : '';
+    };
+    const expectedFocusedElementContents =
+      typeof focusedItemOrString === 'string' ? focusedItemOrString : createLabel(focusedItemOrString.id);
+    const animatedElement = (container.querySelector('section') as HTMLElement).parentElement as HTMLElement;
+    // For some reasong event will not be triggered without bubbles
+    const ev = new Event('transitionend', { bubbles: true });
+    // "propertyName" will not end up to the component in any other way than setting it to the object
+    // @ts-ignore
+    ev.propertyName = 'transform';
+    fireEvent(animatedElement, ev);
+    return waitFor(() => {
+      if (getFocusedElementContents() !== expectedFocusedElementContents) {
+        throw new Error('Focus is not in correct element');
+      }
+    });
+  };
+
+  const navigateTo: TestTools['navigateTo'] = async (item) => {
+    await selectMenuItem(item);
+    await triggerAnimationEnd(item);
+    if (verifyActiveItem(item) !== true) {
+      throw new Error('Active item is not set');
+    }
+  };
+
+  const navigateBack: TestTools['navigateBack'] = async (waitForParentItemOrString) => {
+    const previousLink = getPreviousLink() as HTMLElement;
+    fireEvent.click(previousLink);
+    await triggerAnimationEnd(waitForParentItemOrString);
+  };
+
+  return {
+    ...result,
+    openMobileMenu,
+    closeMobileMenu,
+    findVisibleSectionLinksByMenuIds,
+    getNavSections,
+    getActiveLink,
+    selectMenuItem,
+    verifyActiveItem,
+    triggerAnimationEnd,
+    getFocusedElement,
+    getPreviousLink,
+    verifyPreviousItem,
+    navigateTo,
+    navigateBack,
+  };
+};
+
+afterEach(async () => {
+  mockedWindowControls.reset();
+  jest.resetAllMocks();
+});
+
+afterAll(() => {
+  mockedWindowControls.restore();
+});
+
+describe('<HeaderActionBarNavigationMenu /> spec', () => {
+  it('renders the component and menu can be opened', async () => {
+    const { openMobileMenu, asFragment } = renderHeader();
+    await openMobileMenu();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should not have basic accessibility issues when menu is open', async () => {
+    const { container, openMobileMenu } = renderHeader();
+    await openMobileMenu();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should not have basic accessibility issues when user has navigated to the deepest level is open', async () => {
+    const { container, openMobileMenu, navigateTo } = renderHeader();
+    await openMobileMenu();
+    await navigateTo(getMenuItem([0]));
+    await navigateTo(getMenuItem([0, 2]));
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+    // this can take a long time so increased timeout
+  }, 10000);
+
+  it('When mobile menu is opened, first level links are shown', async () => {
+    const { openMobileMenu, findVisibleSectionLinksByMenuIds, getNavSections } = renderHeader();
+    await openMobileMenu();
+    await findVisibleSectionLinksByMenuIds(menus.map((item) => item.id));
+    expect(getNavSections()).toHaveLength(1);
+  });
+  it('Nav sections are rendered only when needed and removed when not needed', async () => {
+    const { openMobileMenu, navigateTo, getNavSections, navigateBack, closeMobileMenu } = renderHeader();
+    expect(getNavSections()).toHaveLength(0);
+    await openMobileMenu();
+    expect(getNavSections()).toHaveLength(1);
+    await navigateTo(getMenuItem([0]));
+    expect(getNavSections()).toHaveLength(2);
+    await navigateTo(getMenuItem([0, 2]));
+    expect(getNavSections()).toHaveLength(3);
+    await navigateBack(getMenuItem([0]));
+    expect(getNavSections()).toHaveLength(2);
+    await navigateBack(frontPageLabel);
+    expect(getNavSections()).toHaveLength(1);
+    await closeMobileMenu();
+    expect(getNavSections()).toHaveLength(0);
+  });
+  it('Previous and active links change while navigating', async () => {
+    const {
+      openMobileMenu,
+      navigateTo,
+      getNavSections,
+      navigateBack,
+      verifyActiveItem,
+      verifyPreviousItem,
+    } = renderHeader();
+    const menu3 = getMenuItem([3]);
+    const menu31 = getMenuItem([3, 1]);
+    const menu32 = getMenuItem([3, 2]);
+    const menu0 = getMenuItem([0]);
+    const menu02 = getMenuItem([0, 2]);
+    expect(getNavSections()).toHaveLength(0);
+    await openMobileMenu();
+    expect(verifyActiveItem(frontPageLabel)).toBeTruthy();
+    expect(verifyPreviousItem(null)).toBeTruthy();
+
+    await navigateTo(menu3);
+    expect(verifyActiveItem(menu3)).toBeTruthy();
+    expect(verifyPreviousItem(frontPageLabel)).toBeTruthy();
+
+    await navigateTo(menu31);
+    expect(verifyActiveItem(menu31)).toBeTruthy();
+    expect(verifyPreviousItem(menu3)).toBeTruthy();
+
+    await navigateBack(menu3);
+    expect(verifyActiveItem(menu3)).toBeTruthy();
+    expect(verifyPreviousItem(frontPageLabel)).toBeTruthy();
+
+    await navigateTo(menu32);
+    expect(verifyActiveItem(menu32)).toBeTruthy();
+    expect(verifyPreviousItem(menu3)).toBeTruthy();
+
+    await navigateBack(menu3);
+    await navigateBack(frontPageLabel);
+    expect(verifyActiveItem(frontPageLabel)).toBeTruthy();
+    expect(verifyPreviousItem(null)).toBeTruthy();
+
+    await navigateTo(menu0);
+    expect(verifyActiveItem(menu0)).toBeTruthy();
+    expect(verifyPreviousItem(frontPageLabel)).toBeTruthy();
+
+    await navigateTo(menu02);
+    expect(verifyActiveItem(menu02)).toBeTruthy();
+    expect(verifyPreviousItem(menu0)).toBeTruthy();
+
+    await navigateBack(menu0);
+    await navigateBack(frontPageLabel);
+    expect(verifyActiveItem(frontPageLabel)).toBeTruthy();
+    expect(verifyPreviousItem(null)).toBeTruthy();
+  });
+  it('If the top level active link is clicked, menu is closed.', async () => {
+    const { openMobileMenu, getNavSections, getActiveLink } = renderHeader();
+    expect(getNavSections()).toHaveLength(0);
+    await openMobileMenu();
+
+    const activeLinkToFrontpage = getActiveLink();
+    // suppress jsdom "navigation not implemented" error
+    activeLinkToFrontpage.setAttribute('href', '');
+    fireEvent.click(activeLinkToFrontpage);
+    await waitFor(() => {
+      expect(getNavSections()).toHaveLength(0);
+    });
+  });
+  it('If a lower level active link is clicked, menu is closed and onClick handler is called.', async () => {
+    const { openMobileMenu, getNavSections, getActiveLink, selectMenuItem } = renderHeader();
+    expect(getNavSections()).toHaveLength(0);
+    await openMobileMenu();
+    await selectMenuItem(getMenuItem([0]));
+
+    const activeLinkToFrontpage = getActiveLink();
+    fireEvent.click(activeLinkToFrontpage);
+    await waitFor(() => {
+      expect(onClickTracker).toHaveBeenCalledTimes(1);
+      expect(getNavSections()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -423,11 +423,15 @@ export const HeaderActionBarNavigationMenu = ({
           const { links, previousLink, activeLink, key } = getMenuContents(i);
           const isCurrentMenu = isMenuCurrent(i);
           const isCurrentlyAnimating = isAnimating();
+          const distanceToLast = selectedMenuLevels.length - 1 - i;
+          // Maximum of 2 menus can be seen at the same time and only when animating.
+          // Otherwise only one. If there are 3 menus, then root should not be shown.
+          const shouldBeVisible = (isCurrentlyAnimating && distanceToLast < 2) || isCurrentMenu;
           return (
             <RenderNavigationSection
               activeLink={activeLink}
               ariaHidden={!isCurrentMenu}
-              className={isCurrentMenu || isCurrentlyAnimating ? styles.visible : styles.hidden}
+              className={shouldBeVisible ? styles.visible : styles.hidden}
               key={key}
               links={links}
               previousLink={previousLink}

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -1,12 +1,4 @@
-import React, {
-  cloneElement,
-  isValidElement,
-  MouseEventHandler,
-  TransitionEvent,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { cloneElement, isValidElement, MouseEventHandler, TransitionEvent, useRef, useState } from 'react';
 
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
@@ -191,8 +183,6 @@ export const HeaderActionBarNavigationMenu = ({
   const { navigationContent, mobileMenuOpen, hasUniversalContent, universalContent } = useHeaderContext();
   const { setMobileMenuOpen } = useSetHeaderContext();
   // State for which link menu is open but not necessarily active. Needed for browsing the menu.
-  // State for the wide wrapping element's position. Value is also used as a class for animation.
-  const [position, setPosition] = useState<Position>('left0');
   const navContainerRef = useRef<HTMLDivElement>();
   const currentActiveLinkId = 'current-active-link';
 
@@ -210,6 +200,11 @@ export const HeaderActionBarNavigationMenu = ({
   };
 
   const getActiveMenus = () => selectedMenuLevels.filter((level) => level.active);
+
+  const getMenuPositionStyle = () => {
+    const activeMenuIndex = getActiveMenus().length - 1;
+    return styles[menuPositions[activeMenuIndex]];
+  };
 
   const isMenuActive = (index: number) => {
     const menuItem = selectedMenuLevels[index];
@@ -321,20 +316,7 @@ export const HeaderActionBarNavigationMenu = ({
     };
   };
 
-  /* Start animation when active menu has changed */
-  const activeMenuIndex = getActiveMenus().length - 1;
-  useEffect(() => {
-    setPosition(menuPositions[activeMenuIndex]);
-  }, [activeMenuIndex]);
-
-  useEffect(() => {
-    if (mobileMenuOpen && navContainerRef?.current) {
-      // Set the height of the menu container
-      const renderedChildIndex = Math.abs(navContainerRef.current.getBoundingClientRect().left / window.innerWidth);
-      const currentTargetHeight = navContainerRef.current.children[renderedChildIndex].clientHeight;
-      navContainerRef.current.style.height = `${currentTargetHeight}px`;
-    }
-  }, [mobileMenuOpen]);
+  if (!mobileMenuOpen) return null;
 
   const goDeeper = (link: React.ReactElement) => {
     if (isAnimating()) {
@@ -417,7 +399,7 @@ export const HeaderActionBarNavigationMenu = ({
   return (
     <div className={classNames(styles.headerNavigationMenu, mobileMenuOpen && styles.mobileMenuOpen)}>
       <div
-        className={classNames(styles.navigationWrapper, styles[position])}
+        className={classNames(styles.navigationWrapper, getMenuPositionStyle())}
         onTransitionEnd={menuSectionsAnimationDone}
         ref={navContainerRef}
       >

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -308,7 +308,6 @@ export const HeaderActionBarNavigationMenu = ({
     if (level === 1) {
       return undefined;
     }
-
     return findParentElement(selectedMenuLevels.slice(0, level));
   };
 
@@ -413,7 +412,10 @@ export const HeaderActionBarNavigationMenu = ({
   };
 
   return (
-    <div className={classNames(styles.headerNavigationMenu, mobileMenuOpen && styles.mobileMenuOpen)}>
+    <div
+      className={classNames(styles.headerNavigationMenu, mobileMenuOpen && styles.mobileMenuOpen)}
+      id="hds-mobile-menu"
+    >
       <div
         className={classNames(styles.navigationWrapper, getMenuPositionStyle())}
         onTransitionEnd={menuSectionsAnimationDone}

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -325,6 +325,52 @@ export const HeaderActionBarNavigationMenu = ({
     setMobileMenuOpen(false);
   };
 
+  const RenderNavigationSection = ({
+    links,
+    activeLink,
+    activeLinkId,
+    ariaHidden,
+    previousLink,
+    showPreviousLink,
+    className,
+  }: {
+    links: React.ReactNode[];
+    activeLink: React.ReactElement;
+    activeLinkId?: string;
+    previousLink?: React.ReactElement;
+    showPreviousLink?: boolean;
+    ariaHidden: boolean;
+    className: string;
+  }) => {
+    // PreviousDropdownLink defaults to titleHref if link is undefined
+    return (
+      <NavigationSection
+        universalLinks={universalLinks}
+        aria-hidden={ariaHidden}
+        className={className}
+        logo={<Logo logo={logo} logoProps={{ ...logoProps }} />}
+      >
+        {showPreviousLink && (
+          <PreviousDropdownLink
+            link={previousLink}
+            frontPageLabel={frontPageLabel}
+            titleHref={titleHref}
+            onClick={goBack}
+            openFrontPageLinksAriaLabel={openFrontPageLinksAriaLabel}
+          />
+        )}
+        <ActiveDropdownLink
+          id={activeLinkId}
+          link={activeLink}
+          frontPageLabel={frontPageLabel}
+          titleHref={titleHref}
+          onLinkClick={handleLinkClick}
+        />
+        <MenuLinks links={links} onDropdownButtonClick={goDeeper} onLinkClick={handleLinkClick} />
+      </NavigationSection>
+    );
+  };
+
   return (
     <div className={classNames(styles.headerNavigationMenu, mobileMenuOpen && styles.mobileMenuOpen)}>
       <div
@@ -332,100 +378,51 @@ export const HeaderActionBarNavigationMenu = ({
         onTransitionEnd={menuSectionsAnimationDone}
         ref={navContainerRef}
       >
-        {navigationContent && (
-          <>
-            {/* Previous menu links */}
-            {openMainLinks.length >= 1 && (
-              <NavigationSection
-                universalLinks={universalLinks}
-                aria-hidden
-                logo={<Logo logo={logo} logoProps={{ ...logoProps }} />}
-              >
-                <ActiveDropdownLink
-                  link={previousDropdownLink}
-                  frontPageLabel={frontPageLabel}
-                  titleHref={titleHref}
-                  onLinkClick={handleLinkClick}
-                />
-                <MenuLinks links={previousMenuLinks} onDropdownButtonClick={goDeeper} onLinkClick={handleLinkClick} />
-              </NavigationSection>
-            )}
-            {/* Currently open links */}
-            <NavigationSection
-              universalLinks={universalLinks}
-              aria-hidden={isRenderingDeepestMenu}
-              logo={<Logo logo={logo} logoProps={{ ...logoProps }} />}
-            >
-              {openMainLinks.length > 0 && (
-                <PreviousDropdownLink
-                  link={!isRenderingDeepestMenu ? previousDropdownLink : previousDropdownLink}
-                  frontPageLabel={frontPageLabel}
-                  titleHref={titleHref}
-                  onClick={goBack}
-                  openFrontPageLinksAriaLabel={openFrontPageLinksAriaLabel}
-                />
-              )}
-              <ActiveDropdownLink
-                id={!isRenderingDeepestMenu && !isAnimating ? currentActiveLinkId : undefined}
-                link={!isRenderingDeepestMenu ? currentlyActiveMainLink : previousDropdownLink}
-                frontPageLabel={frontPageLabel}
-                titleHref={titleHref}
-                onLinkClick={handleLinkClick}
-              />
-              <MenuLinks links={menuLinks} onDropdownButtonClick={goDeeper} onLinkClick={handleLinkClick} />
-            </NavigationSection>
-            {/* Next links. Rendered at the deepest level. */}
-            {!openingLink && (
-              <NavigationSection
-                universalLinks={universalLinks}
-                aria-hidden={!isRenderingDeepestMenu}
-                logo={<Logo logo={logo} logoProps={{ ...logoProps }} />}
-              >
-                <PreviousDropdownLink
-                  link={previousDropdownLink}
-                  frontPageLabel={frontPageLabel}
-                  titleHref={titleHref}
-                  onClick={goBack}
-                  openFrontPageLinksAriaLabel={openFrontPageLinksAriaLabel}
-                />
-                <ActiveDropdownLink
-                  id={isRenderingDeepestMenu ? currentActiveLinkId : undefined}
-                  link={currentlyActiveMainLink}
-                  frontPageLabel={frontPageLabel}
-                  titleHref={titleHref}
-                  onLinkClick={handleLinkClick}
-                />
-                <MenuLinks links={menuLinks} onDropdownButtonClick={goDeeper} onLinkClick={handleLinkClick} />
-              </NavigationSection>
-            )}
-            {/* Render the menu animating into view for better UX. */}
-            {openingLink && typeof openingLink !== 'string' && (
-              <NavigationSection
-                universalLinks={universalLinks}
-                aria-hidden={!openingLink}
-                logo={<Logo logo={logo} logoProps={{ ...logoProps }} />}
-              >
-                <PreviousDropdownLink
-                  link={currentlyActiveMainLink}
-                  frontPageLabel={frontPageLabel}
-                  titleHref={titleHref}
-                  onClick={goBack}
-                  openFrontPageLinksAriaLabel={openFrontPageLinksAriaLabel}
-                />
-                <ActiveDropdownLink
-                  link={openingLink}
-                  frontPageLabel={frontPageLabel}
-                  titleHref={titleHref}
-                  onLinkClick={handleLinkClick}
-                />
-                <MenuLinks
-                  links={openingLink.props.dropdownLinks}
-                  onDropdownButtonClick={goDeeper}
-                  onLinkClick={handleLinkClick}
-                />
-              </NavigationSection>
-            )}
-          </>
+        {/* Previous menu links */}
+        {openMainLinks.length >= 1 && (
+          <RenderNavigationSection
+            activeLink={previousDropdownLink}
+            ariaHidden
+            className={isAnimating ? styles.visible : styles.hidden}
+            links={previousMenuLinks}
+            showPreviousLink={false}
+          />
+        )}
+
+        {/* Currently open links */}
+        <RenderNavigationSection
+          activeLink={!isRenderingDeepestMenu ? currentlyActiveMainLink : previousDropdownLink}
+          activeLinkId={!isRenderingDeepestMenu && !isAnimating ? currentActiveLinkId : undefined}
+          ariaHidden={isRenderingDeepestMenu}
+          className={!isRenderingDeepestMenu ? styles.visible : styles.hidden}
+          links={menuLinks}
+          previousLink={openMainLinks.length > 0 ? previousDropdownLink : undefined}
+          showPreviousLink={openMainLinks.length > 0}
+        />
+
+        {/* Next links. Rendered at the deepest level. */}
+        {!openingLink && (
+          <RenderNavigationSection
+            activeLink={currentlyActiveMainLink}
+            activeLinkId={isRenderingDeepestMenu ? currentActiveLinkId : undefined}
+            ariaHidden={!isRenderingDeepestMenu}
+            className={isAnimating || isRenderingDeepestMenu ? styles.visible : styles.hidden}
+            links={menuLinks}
+            previousLink={previousDropdownLink}
+            showPreviousLink
+          />
+        )}
+
+        {/* Render the menu animating into view for better UX. */}
+        {openingLink && typeof openingLink !== 'string' && (
+          <RenderNavigationSection
+            activeLink={openingLink}
+            ariaHidden={!openingLink}
+            className={isAnimating ? styles.visible : styles.hidden}
+            links={openingLink.props.dropdownLinks}
+            previousLink={currentlyActiveMainLink}
+            showPreviousLink
+          />
         )}
       </div>
     </div>

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
@@ -1,0 +1,695 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu can be opened 1`] = `
+<DocumentFragment>
+  <header
+    class="hds-header header isNotLargeScreen"
+  >
+    <div
+      class="headerBackgroundWrapper"
+    >
+      <div
+        aria-hidden="true"
+        tabindex="0"
+      />
+      <div
+        class="headerActionBarContainer mobileMenuContainer"
+      >
+        <div
+          class="headerActionBar"
+        >
+          <a
+            aria-label="logoAriaLabel"
+            class="titleAndLogoContainer logo"
+            href="https://hel.fi"
+          >
+            <span
+              class="logoWrapper"
+            >
+              <span />
+            </span>
+          </a>
+          <a
+            aria-label="titleAriaLabel"
+            class="titleAndLogoContainer title normal"
+            href="https://domain.fi"
+          >
+            <span
+              class="title"
+            >
+              title
+            </span>
+          </a>
+          <div
+            class="headerActions"
+          >
+            ActionBar
+            <button
+              aria-controls="hds-mobile-menu"
+              aria-expanded="true"
+              aria-label="menuButtonAriaLabel"
+              class="actionBarItem undefined"
+              type="button"
+            >
+              <span
+                class="actionBarItemIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-label="cross"
+                  class="icon s"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M18 7.5L13.5 12L18 16.5L16.5 18L12 13.5L7.5 18L6 16.5L10.5 12L6 7.5L7.5 6L12 10.5L16.5 6L18 7.5Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="actionBarItemLabel"
+              >
+                Menu
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="headerNavigationMenu mobileMenuOpen"
+          id="hds-mobile-menu"
+        >
+          <div
+            class="navigationWrapper left0"
+          >
+            <section
+              aria-hidden="false"
+              class="navSection visible"
+            >
+              <nav
+                class="navigation"
+              >
+                <ul
+                  class="menu"
+                >
+                  <li
+                    class="activeListItem"
+                  >
+                    <span
+                      class="activeLinkWrapper"
+                    >
+                      <span
+                        class="isNotLargeScreen navigationLinkWrapper depth-0"
+                      >
+                        <a
+                          class="link linkM headerLink depth-0 activeMobileLink isNotLargeScreen"
+                          href="https://domain.fi"
+                        >
+                          frontPageLabel
+                        </a>
+                      </span>
+                    </span>
+                  </li>
+                  <li>
+                    <span
+                      class="mobileNavigationLink"
+                    >
+                      <span
+                        class="isNotLargeScreen navigationLinkWrapper depth-0 mobileLinkWrapper"
+                      >
+                        <a
+                          class="link linkM headerLink depth-0 mobileLink isNotLargeScreen"
+                          href="http://test-link-0.com"
+                        >
+                          TestLabel_0
+                        </a>
+                        <button
+                          aria-expanded="false"
+                          aria-label="Avaa alasvetovalikko."
+                          class="button isNotLargeScreen depth-0 mobileLinkDropdownButton"
+                          data-testid="dropdown-button-0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-label="angle-down"
+                            class="icon s chevron"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </button>
+                        <ul
+                          class="dropdownMenu isNotLargeScreen mobileLinkDropdown"
+                          data-testid="dropdown-menu-0"
+                          style="display: none;"
+                        >
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-0_0.com"
+                              >
+                                TestLabel_0_0
+                              </a>
+                              <button
+                                aria-expanded="false"
+                                aria-label="Avaa alasvetovalikko."
+                                class="button isNotLargeScreen depth-1 mobileLinkDropdownButton"
+                                data-testid="dropdown-button-0"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="angle-right"
+                                  class="icon s chevron"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </button>
+                              <ul
+                                class="dropdownMenu right isNotLargeScreen mobileLinkDropdown"
+                                data-testid="dropdown-menu-0"
+                                style="display: none;"
+                              >
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-0_0_0.com"
+                                    >
+                                      TestLabel_0_0_0
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-0_0_1.com"
+                                    >
+                                      TestLabel_0_0_1
+                                    </a>
+                                  </span>
+                                </li>
+                              </ul>
+                            </span>
+                          </li>
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-0_1.com"
+                              >
+                                TestLabel_0_1
+                              </a>
+                            </span>
+                          </li>
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-0_2.com"
+                              >
+                                TestLabel_0_2
+                              </a>
+                              <button
+                                aria-expanded="false"
+                                aria-label="Avaa alasvetovalikko."
+                                class="button isNotLargeScreen depth-1 mobileLinkDropdownButton"
+                                data-testid="dropdown-button-2"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="angle-right"
+                                  class="icon s chevron"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </button>
+                              <ul
+                                class="dropdownMenu right isNotLargeScreen mobileLinkDropdown"
+                                data-testid="dropdown-menu-2"
+                                style="display: none;"
+                              >
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-0_2_0.com"
+                                    >
+                                      TestLabel_0_2_0
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-0_2_1.com"
+                                    >
+                                      TestLabel_0_2_1
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-0_2_2.com"
+                                    >
+                                      TestLabel_0_2_2
+                                    </a>
+                                  </span>
+                                </li>
+                              </ul>
+                            </span>
+                          </li>
+                        </ul>
+                      </span>
+                    </span>
+                  </li>
+                  <li>
+                    <span
+                      class="mobileNavigationLink"
+                    >
+                      <span
+                        class="isNotLargeScreen navigationLinkWrapper depth-0 mobileLinkWrapper"
+                      >
+                        <a
+                          class="link linkM headerLink depth-0 mobileLink isNotLargeScreen"
+                          href="http://test-link-1.com"
+                        >
+                          TestLabel_1
+                        </a>
+                        <button
+                          aria-expanded="false"
+                          aria-label="Avaa alasvetovalikko."
+                          class="button isNotLargeScreen depth-0 mobileLinkDropdownButton"
+                          data-testid="dropdown-button-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-label="angle-down"
+                            class="icon s chevron"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </button>
+                        <ul
+                          class="dropdownMenu isNotLargeScreen mobileLinkDropdown"
+                          data-testid="dropdown-menu-1"
+                          style="display: none;"
+                        >
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-1_0.com"
+                              >
+                                TestLabel_1_0
+                              </a>
+                              <button
+                                aria-expanded="false"
+                                aria-label="Avaa alasvetovalikko."
+                                class="button isNotLargeScreen depth-1 mobileLinkDropdownButton"
+                                data-testid="dropdown-button-0"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="angle-right"
+                                  class="icon s chevron"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </button>
+                              <ul
+                                class="dropdownMenu right isNotLargeScreen mobileLinkDropdown"
+                                data-testid="dropdown-menu-0"
+                                style="display: none;"
+                              >
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-1_0_0.com"
+                                    >
+                                      TestLabel_1_0_0
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-1_0_1.com"
+                                    >
+                                      TestLabel_1_0_1
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-1_0_2.com"
+                                    >
+                                      TestLabel_1_0_2
+                                    </a>
+                                  </span>
+                                </li>
+                              </ul>
+                            </span>
+                          </li>
+                        </ul>
+                      </span>
+                    </span>
+                  </li>
+                  <li>
+                    <span
+                      class="mobileNavigationLink"
+                    >
+                      <span
+                        class="isNotLargeScreen navigationLinkWrapper depth-0 mobileLinkWrapper"
+                      >
+                        <a
+                          class="link linkM headerLink depth-0 mobileLink isNotLargeScreen"
+                          href="http://test-link-2.com"
+                        >
+                          TestLabel_2
+                        </a>
+                      </span>
+                    </span>
+                  </li>
+                  <li>
+                    <span
+                      class="mobileNavigationLink"
+                    >
+                      <span
+                        class="isNotLargeScreen navigationLinkWrapper depth-0 mobileLinkWrapper"
+                      >
+                        <a
+                          class="link linkM headerLink depth-0 mobileLink isNotLargeScreen"
+                          href="http://test-link-3.com"
+                        >
+                          TestLabel_3
+                        </a>
+                        <button
+                          aria-expanded="false"
+                          aria-label="Avaa alasvetovalikko."
+                          class="button isNotLargeScreen depth-0 mobileLinkDropdownButton"
+                          data-testid="dropdown-button-3"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-label="angle-down"
+                            class="icon s chevron"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </button>
+                        <ul
+                          class="dropdownMenu isNotLargeScreen mobileLinkDropdown"
+                          data-testid="dropdown-menu-3"
+                          style="display: none;"
+                        >
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-3_0.com"
+                              >
+                                TestLabel_3_0
+                              </a>
+                            </span>
+                          </li>
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-3_1.com"
+                              >
+                                TestLabel_3_1
+                              </a>
+                              <button
+                                aria-expanded="false"
+                                aria-label="Avaa alasvetovalikko."
+                                class="button isNotLargeScreen depth-1 mobileLinkDropdownButton"
+                                data-testid="dropdown-button-1"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="angle-right"
+                                  class="icon s chevron"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </button>
+                              <ul
+                                class="dropdownMenu right isNotLargeScreen mobileLinkDropdown"
+                                data-testid="dropdown-menu-1"
+                                style="display: none;"
+                              >
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-3_1_0.com"
+                                    >
+                                      TestLabel_3_1_0
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-3_1_1.com"
+                                    >
+                                      TestLabel_3_1_1
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-3_1_2.com"
+                                    >
+                                      TestLabel_3_1_2
+                                    </a>
+                                  </span>
+                                </li>
+                              </ul>
+                            </span>
+                          </li>
+                          <li>
+                            <span
+                              class="isNotLargeScreen navigationLinkWrapper depth-1 mobileLinkWrapper"
+                            >
+                              <a
+                                class="link linkM headerLink depth-1 dropdownLink isNotLargeScreen"
+                                href="http://test-link-3_2.com"
+                              >
+                                TestLabel_3_2
+                              </a>
+                              <button
+                                aria-expanded="false"
+                                aria-label="Avaa alasvetovalikko."
+                                class="button isNotLargeScreen depth-1 mobileLinkDropdownButton"
+                                data-testid="dropdown-button-2"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="angle-right"
+                                  class="icon s chevron"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </button>
+                              <ul
+                                class="dropdownMenu right isNotLargeScreen mobileLinkDropdown"
+                                data-testid="dropdown-menu-2"
+                                style="display: none;"
+                              >
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-3_2_0.com"
+                                    >
+                                      TestLabel_3_2_0
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-3_2_1.com"
+                                    >
+                                      TestLabel_3_2_1
+                                    </a>
+                                  </span>
+                                </li>
+                                <li>
+                                  <span
+                                    class="isNotLargeScreen navigationLinkWrapper depth-2 mobileLinkWrapper"
+                                  >
+                                    <a
+                                      class="link linkM headerLink depth-2 dropdownLink isNotLargeScreen"
+                                      href="http://test-link-3_2_2.com"
+                                    >
+                                      TestLabel_3_2_2
+                                    </a>
+                                  </span>
+                                </li>
+                              </ul>
+                            </span>
+                          </li>
+                        </ul>
+                      </span>
+                    </span>
+                  </li>
+                </ul>
+              </nav>
+              <div
+                class="mobileMenuBottom"
+              >
+                <ul
+                  class="universalList"
+                />
+                <a
+                  aria-label="logoAriaLabel"
+                  class="titleAndLogoContainer logo logoLink"
+                  href="https://hel.fi"
+                >
+                  <span
+                    class="logoWrapper"
+                  >
+                    <span />
+                  </span>
+                </a>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        tabindex="0"
+      />
+    </div>
+  </header>
+</DocumentFragment>
+`;

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
         >
           <div
             class="navigationWrapper left0"
+            style="height: 0px;"
           >
             <section
               aria-hidden="false"

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
@@ -214,11 +214,7 @@ export const HeaderLink = <T extends React.ElementType = 'a'>({
   });
 
   return (
-    <span
-      className={navigationWrapperLinkClassName}
-      ref={containerRef}
-      {...(Boolean(dropdownLinks) && { 'aria-expanded': isDropdownOpen })}
-    >
+    <span className={navigationWrapperLinkClassName} ref={containerRef}>
       <Item className={navigationLinkClassName} href={href} {...rest}>
         {label}
       </Item>

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.tsx
@@ -135,6 +135,7 @@ export const HeaderLinkDropdown = ({
         onClick={handleMenuButtonClick}
         data-testid={`dropdown-button-${index}`}
         aria-label={getDefaultButtonAriaLabel()}
+        aria-expanded={open}
       >
         {renderIcon()}
       </button>

--- a/packages/react/src/hooks/useForceRender.ts
+++ b/packages/react/src/hooks/useForceRender.ts
@@ -1,0 +1,13 @@
+import { useState, useCallback } from 'react';
+/*
+  Simple hook that re-renders component via useState
+*/
+function useForceRender() {
+  const [, forceUpdate] = useState<number>(0);
+  const reRender = useCallback(() => {
+    forceUpdate((p) => p + 1);
+  }, [forceUpdate]);
+
+  return reRender;
+}
+export default useForceRender;


### PR DESCRIPTION
## Description

Mobile menu had a few issues:
- when navigating back the active links were first old and then updated after animation
- unused menus were rendered
- unnecessary re-renders
- axe errors

The `useState` based rendering system was replaced with an index based system, where each selected menu is stored only as an array of data. Previously whole menu contents were stored and therefore updates were not in sync and updated too late.

With index based data the rendering does not depend on data in state, and is always up to date. And the code is simpler.

Note: vertical animation came after this PR was initially done and made the animation handling more complicated. This PR is now fixed to handle both animated transforms.

## Related Issue

Closes [HDS-1975](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1975)

## How Has This Been Tested?

Added missing unit tests. Tested locally.

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1975-mobile-menu/iframe.html?id=components-header--with-full-features&viewMode=story)

See related[ PR ](https://github.com/City-of-Helsinki/helsinki-design-system/pull/1176)

[HDS-1975]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ