### PR TITLE
HDS-1968: fix extra p tags on docs site

### DIFF
--- a/site/src/components/AnchorLink.js
+++ b/site/src/components/AnchorLink.js
@@ -3,6 +3,8 @@ import InternalLink from './InternalLink';
 import PropTypes from 'prop-types';
 import { useLocation } from '@reach/router';
 
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
 export const AnchorLink = ({ anchor, children, path }) => {
   const location = useLocation();
   const parsedPath = path || location.path;
@@ -10,7 +12,9 @@ export const AnchorLink = ({ anchor, children, path }) => {
     .toLowerCase()
     .replace(/ /g, '-')
     .replace(/[^\w-]/g, '');
-  return <InternalLink href={`${parsedPath || ''}#${parsedAnchor}`}>{children}</InternalLink>;
+  return (
+    <InternalLink href={`${parsedPath || ''}#${parsedAnchor}`}>{stripParagraphAsFirstChild(children)}</InternalLink>
+  );
 };
 
 AnchorLink.propTypes = {

--- a/site/src/components/ExternalLink.js
+++ b/site/src/components/ExternalLink.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'hds-react';
 import PropTypes from 'prop-types';
 
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
 const ExternalLink = ({ href, children, openInNewTab, openInNewTabAriaLabel, openInExternalDomainAriaLabel, size }) => {
   const openInNewTabProps = openInNewTab
     ? { openInNewTab, openInNewTabAriaLabel: openInNewTabAriaLabel || 'Opens in a new tab.' }
@@ -15,7 +17,7 @@ const ExternalLink = ({ href, children, openInNewTab, openInNewTabAriaLabel, ope
       {...openInNewTabProps}
       size={size}
     >
-      {children}
+      {stripParagraphAsFirstChild(children)}
     </Link>
   );
 };

--- a/site/src/components/InternalLink.js
+++ b/site/src/components/InternalLink.js
@@ -3,6 +3,8 @@ import { Link } from 'hds-react';
 import PropTypes from 'prop-types';
 import { navigate, withPrefix } from 'gatsby';
 
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
 const InternalLink = ({ href, children, openInNewTab, openInNewTabAriaLabel, size }) => {
   const openInNewTabProps = openInNewTab
     ? { openInNewTab, openInNewTabAriaLabel: openInNewTabAriaLabel || 'Opens in a new tab.' }
@@ -18,7 +20,7 @@ const InternalLink = ({ href, children, openInNewTab, openInNewTabAriaLabel, siz
         navigate(href);
       }}
     >
-      {children}
+      {stripParagraphAsFirstChild(children)}
     </Link>
   );
 };

--- a/site/src/components/LeadParagraph.js
+++ b/site/src/components/LeadParagraph.js
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const LeadParagraph = ({
-  color = 'var(--color-black-90)',
-  size = 'var(--fontsize-body-xl)',
-  style = {},
-  children,
-}) => (
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
+const LeadParagraph = ({ color = 'var(--color-black-90)', size = 'var(--fontsize-body-xl)', style = {}, children }) => (
   <p
     style={{
       fontSize: size,
@@ -15,7 +12,7 @@ const LeadParagraph = ({
       ...style,
     }}
   >
-    {children}
+    {stripParagraphAsFirstChild(children)}
   </p>
 );
 

--- a/site/src/components/Notification.js
+++ b/site/src/components/Notification.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Notification as HDSNotification } from 'hds-react';
+import PropTypes from 'prop-types';
+
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
+const Notification = ({ children, ...props }) => {
+  return <HDSNotification {...props}>{stripParagraphAsFirstChild(children)}</HDSNotification>;
+};
+
+// listed only used props
+Notification.propTypes = {
+  type: PropTypes.string,
+  label: PropTypes.string,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  size: PropTypes.oneOf(['default', 'small' , 'large']),
+};
+
+export default Notification;

--- a/site/src/components/PageTabs.js
+++ b/site/src/components/PageTabs.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { navigate } from 'gatsby';
 import { Tabs } from 'hds-react';
 
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
 import './PageTabs.scss';
 
 const resolvePathFromSubSlug = (slug) => {
@@ -22,8 +24,12 @@ const PageTabs = ({ pageContext, children }) => {
 
   const mdxChildren = Array.isArray(children) ? children : [children];
 
-  const tabList = mdxChildren.find((reactChild) => isValidElement(reactChild) && reactChild.type.componentName === pageTabListComponentName);
-  const tabPanel = mdxChildren.find((reactChild) => isValidElement(reactChild) && reactChild.type.componentName === pageTabPanelComponentName);
+  const tabList = mdxChildren.find(
+    (reactChild) => isValidElement(reactChild) && reactChild.type.componentName === pageTabListComponentName,
+  );
+  const tabPanel = mdxChildren.find(
+    (reactChild) => isValidElement(reactChild) && reactChild.type.componentName === pageTabPanelComponentName,
+  );
   const tabs = tabList.props?.children.filter((reactChild) => reactChild.type.componentName === pageTabComponentName);
   const tabActiveIndex = tabs.findIndex((tab) => slug.endsWith(tab.props.href));
   const activeIndex = tabActiveIndex === -1 ? 0 : tabActiveIndex;
@@ -37,7 +43,7 @@ const PageTabs = ({ pageContext, children }) => {
             key={tab.props.href}
             onClick={() => navigate(`${tab.props.href === '/' ? rootPath : rootPath + tab.props.href}`)}
           >
-            {tab.props.children}
+            {stripParagraphAsFirstChild(tab.props.children)}
           </Tabs.Tab>
         ))}
       </Tabs.TabList>
@@ -63,7 +69,7 @@ TabList.componentName = pageTabListComponentName;
 TabList.propTypes = {
   children: PropTypes.node.isRequired,
 };
-const Tab = ({ href, slug, children }) => <Tabs.Tab>{children}</Tabs.Tab>;
+const Tab = ({ href, slug, children }) => <Tabs.Tab> {children}</Tabs.Tab>;
 Tab.componentName = pageTabComponentName;
 Tab.propTypes = {
   slug: PropTypes.string,

--- a/site/src/components/StatusLabel.js
+++ b/site/src/components/StatusLabel.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StatusLabel as HDSStatusLabel } from 'hds-react';
+import PropTypes from 'prop-types';
+
+import { stripParagraphAsFirstChild } from './stripParagraphAsFirstChild';
+
+const StatusLabel = ({ children, ...props }) => {
+  return <HDSStatusLabel {...props}>{stripParagraphAsFirstChild(children)}</HDSStatusLabel>;
+};
+
+StatusLabel.propTypes = {
+  className: PropTypes.string,
+  dataTestId: PropTypes.string,
+  type: PropTypes.oneOf(['neutral', 'info', 'success', 'alert', 'error']),
+  iconLeft: PropTypes.node,
+};
+
+export default StatusLabel;

--- a/site/src/components/stripParagraphAsFirstChild.js
+++ b/site/src/components/stripParagraphAsFirstChild.js
@@ -1,0 +1,6 @@
+export function stripParagraphAsFirstChild(children) {
+  if (children && children.type === 'p' && children.props && children.props.children) {
+    return children.props.children;
+  }
+  return children;
+}

--- a/site/src/docs/about/accessibility/hds-accessibility.mdx
+++ b/site/src/docs/about/accessibility/hds-accessibility.mdx
@@ -3,11 +3,11 @@ slug: '/about/accessibility/hds-accessibility'
 title: 'HDS Accessibility'
 navTitle: 'HDS Accessibility'
 ---
-import { StatusLabel } from 'hds-react';
 
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import InternalLink from '../../../components/InternalLink';
+import StatusLabel from '../../../components/StatusLabel';
 
 # HDS Accessibility
 

--- a/site/src/docs/components/accordion/tabs.mdx
+++ b/site/src/docs/components/accordion/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/accordion/tabs'
 title: 'Accordion'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
-import Layout from '../../../components/layout'
+import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Accordion
 

--- a/site/src/docs/components/breadcrumb/tabs.mdx
+++ b/site/src/docs/components/breadcrumb/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/breadcrumb/tabs'
 title: 'Breadcrumb'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Breadcrumb
 

--- a/site/src/docs/components/breadcrumb/tabs.mdx
+++ b/site/src/docs/components/breadcrumb/tabs.mdx
@@ -3,10 +3,10 @@ slug: '/components/breadcrumb/tabs'
 title: 'Breadcrumb'
 ---
 
+import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
-import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import StatusLabel from '../../../components/StatusLabel';
 
 # Breadcrumb

--- a/site/src/docs/components/buttons/tabs.mdx
+++ b/site/src/docs/components/buttons/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/buttons/tabs'
 title: 'Button'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
-import Layout from '../../../components/layout'
+import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Button
 

--- a/site/src/docs/components/card/tabs.mdx
+++ b/site/src/docs/components/card/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/card/tabs'
 title: 'Card'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Card
 
@@ -18,7 +17,10 @@ import PageTabs from '../../../components/PageTabs';
 <StatusLabelTooltip/>
 </div>
 
-<LeadParagraph>Cards can be used to divide and organise interface content for better understandability and readability. When used correctly, Cards can help your users to scan through vast amounts of information quicker.</LeadParagraph>
+<LeadParagraph>
+  Cards can be used to divide and organise interface content for better understandability and readability. When used
+  correctly, Cards can help your users to scan through vast amounts of information quicker.
+</LeadParagraph>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/checkbox/customisation.mdx
+++ b/site/src/docs/components/checkbox/customisation.mdx
@@ -1,9 +1,11 @@
 ---
 slug: '/components/checkbox/customisation'
+title: 'Checkbox - Customisation'
 ---
 
-import { Checkbox, Notification } from 'hds-react';
+import { Checkbox } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import Notification from '../../../components/Notification';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -37,10 +39,10 @@ See all available theme variables in the table below.
 
 ### Customisation example
 
-<Playground scope={{ Checkbox, Notification }}>
+<Playground scope={{ Checkbox }}>
 
 ```jsx
-import { Checkbox, Notification } from 'hds-react';
+import { Checkbox } from 'hds-react';
 
 () => {
   const [checked, setChecked] = React.useState(false);

--- a/site/src/docs/components/checkbox/tabs.mdx
+++ b/site/src/docs/components/checkbox/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/checkbox/tabs'
 title: 'Checkbox'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Checkbox
 

--- a/site/src/docs/components/cookie-consent/tabs.mdx
+++ b/site/src/docs/components/cookie-consent/tabs.mdx
@@ -2,13 +2,11 @@
 slug: '/components/cookie-consent/tabs'
 title: 'CookieConsent'
 ---
-
-import { StatusLabel, Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # CookieConsent
 
@@ -18,8 +16,10 @@ import PageTabs from '../../../components/PageTabs';
   <StatusLabelTooltip/>
 </div>
 
-<LeadParagraph>The cookie compliance component informs users about cookie usage. This banner is shown when they visit a website or an
-  application for the first time.</LeadParagraph>
+<LeadParagraph>
+  The cookie compliance component informs users about cookie usage. This banner is shown when they visit a website or an
+  application for the first time.
+</LeadParagraph>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/date-input/tabs.mdx
+++ b/site/src/docs/components/date-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/date-input/tabs'
 title: 'DateInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # DateInput
 

--- a/site/src/docs/components/dialog/tabs.mdx
+++ b/site/src/docs/components/dialog/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/dialog/tabs'
 title: 'Dialog'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Dialog
 

--- a/site/src/docs/components/dropdown/tabs.mdx
+++ b/site/src/docs/components/dropdown/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/dropdown/tabs'
 title: 'Dropdown'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Dropdown
 

--- a/site/src/docs/components/fieldset/tabs.mdx
+++ b/site/src/docs/components/fieldset/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/fieldset/tabs'
 title: 'Fieldset'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Fieldset
 

--- a/site/src/docs/components/file-input/tabs.mdx
+++ b/site/src/docs/components/file-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/file-input/tabs'
 title: 'FileInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # FileInput
 

--- a/site/src/docs/components/footer/tabs.mdx
+++ b/site/src/docs/components/footer/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/footer/tabs'
 title: 'Footer'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Footer
 

--- a/site/src/docs/components/header/index.mdx
+++ b/site/src/docs/components/header/index.mdx
@@ -4,8 +4,10 @@ title: 'Header'
 navTitle: 'Header'
 ---
 
-import { Header, IconBell, IconSearch, Notification, Logo, logoFi, logoFiDark } from 'hds-react';
+import { Header, IconBell, IconSearch, Logo, logoFi, logoFiDark } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+
+import Notification from '../../../components/Notification';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 

--- a/site/src/docs/components/header/tabs.mdx
+++ b/site/src/docs/components/header/tabs.mdx
@@ -3,13 +3,12 @@ slug: '/components/header/tabs'
 title: 'Header'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import Notification from '../../../components/Notification';
 
 # Header
 

--- a/site/src/docs/components/header/tabs.mdx
+++ b/site/src/docs/components/header/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/header/tabs'
 title: 'Header'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Header
 

--- a/site/src/docs/components/hero/tabs.mdx
+++ b/site/src/docs/components/hero/tabs.mdx
@@ -3,19 +3,17 @@ slug: '/components/hero/tabs'
 title: 'Hero'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Hero
 
-
 <div className="status-label-description">
-  <StatusLabel variant="rounded" type="info">Stable</StatusLabel>
-  <StatusLabel variant="rounded" type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+  <StatusLabel type="info">Stable</StatusLabel>
+  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
   <StatusLabelTooltip/>
 </div>
 

--- a/site/src/docs/components/hero/tabs.mdx
+++ b/site/src/docs/components/hero/tabs.mdx
@@ -3,10 +3,10 @@ slug: '/components/hero/tabs'
 title: 'Hero'
 ---
 
+import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
-import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import StatusLabel from '../../../components/StatusLabel';
 
 # Hero

--- a/site/src/docs/components/highlight/tabs.mdx
+++ b/site/src/docs/components/highlight/tabs.mdx
@@ -3,18 +3,17 @@ slug: '/components/highlight/tabs'
 title: 'Highlight'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Highlight
 
 <div className="status-label-description">
-  <StatusLabel type="alert" variant="rounded">Beta</StatusLabel>
-  <StatusLabel variant="rounded" type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+  <StatusLabel type="alert">Beta</StatusLabel>
+  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
   <StatusLabelTooltip/>
 </div>
 

--- a/site/src/docs/components/icon/tabs.mdx
+++ b/site/src/docs/components/icon/tabs.mdx
@@ -3,13 +3,11 @@ slug: '/components/icon/tabs'
 title: 'Icon'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
-
 import LeadParagraph from '../../../components/LeadParagraph';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Icon
 

--- a/site/src/docs/components/koros/customisation.mdx
+++ b/site/src/docs/components/koros/customisation.mdx
@@ -3,9 +3,10 @@ slug: '/components/koros/customisation'
 title: 'Koros - Customisation'
 ---
 
-import { Koros, Notification } from 'hds-react';
+import { Koros } from 'hds-react';
 
 import TabsLayout from './tabs.mdx';
+import Notification from '../../../components/Notification';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 

--- a/site/src/docs/components/koros/tabs.mdx
+++ b/site/src/docs/components/koros/tabs.mdx
@@ -3,11 +3,10 @@ slug: '/components/koros/tabs'
 title: 'Koros'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Koros
 

--- a/site/src/docs/components/link/tabs.mdx
+++ b/site/src/docs/components/link/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/link/tabs'
 title: 'Link'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Link
 

--- a/site/src/docs/components/linkbox/tabs.mdx
+++ b/site/src/docs/components/linkbox/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/linkbox/tabs'
 title: 'Linkbox'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Linkbox
 

--- a/site/src/docs/components/loading-spinner/tabs.mdx
+++ b/site/src/docs/components/loading-spinner/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/loading-spinner/tabs'
 title: 'LoadingSpinner'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # LoadingSpinner
 

--- a/site/src/docs/components/login/tabs.mdx
+++ b/site/src/docs/components/login/tabs.mdx
@@ -3,17 +3,17 @@ slug: '/components/login/tabs'
 title: 'Login'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
+import Notification from '../../../components/Notification';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Login
 
 <div className="status-label-description">
   <StatusLabel type="error">Draft</StatusLabel>
-  <StatusLabel variant="rounded" type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
   <StatusLabelTooltip />
 </div>
 

--- a/site/src/docs/components/logo/customisation.mdx
+++ b/site/src/docs/components/logo/customisation.mdx
@@ -3,8 +3,9 @@ slug: '/components/logo/customisation'
 title: 'Logo - Customisation'
 ---
 
-import { Logo, Notification, logoFi } from 'hds-react';
+import { Logo, logoFi } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import Notification from '../../../components/Notification';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 

--- a/site/src/docs/components/logo/tabs.mdx
+++ b/site/src/docs/components/logo/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/logo/tabs'
 title: 'Logo'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Logo
 

--- a/site/src/docs/components/notification/tabs.mdx
+++ b/site/src/docs/components/notification/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/notification/tabs'
 title: 'Notification'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Notification
 

--- a/site/src/docs/components/number-input/tabs.mdx
+++ b/site/src/docs/components/number-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/number/tabs'
 title: 'NumberInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # NumberInput
 

--- a/site/src/docs/components/pagination/tabs.mdx
+++ b/site/src/docs/components/pagination/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/pagination/tabs'
 title: 'Pagination'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Pagination
 

--- a/site/src/docs/components/pagination/tabs.mdx
+++ b/site/src/docs/components/pagination/tabs.mdx
@@ -3,8 +3,6 @@ slug: '/components/pagination/tabs'
 title: 'Pagination'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';

--- a/site/src/docs/components/password-input/tabs.mdx
+++ b/site/src/docs/components/password-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/password-input/tabs'
 title: 'PasswordInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # PasswordInput
 

--- a/site/src/docs/components/phone-input/tabs.mdx
+++ b/site/src/docs/components/phone-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/phone-input/tabs'
 title: 'PhoneInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # PhoneInput
 

--- a/site/src/docs/components/radio-button/customisation.mdx
+++ b/site/src/docs/components/radio-button/customisation.mdx
@@ -3,9 +3,10 @@ slug: '/components/radio-button/customisation'
 title: 'RadioButton - Customisation'
 ---
 
-import { RadioButton, Notification } from 'hds-react';
+import { RadioButton } from 'hds-react';
 import { useState } from 'react';
 import TabsLayout from './tabs.mdx';
+import Notification from '../../../components/Notification';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 

--- a/site/src/docs/components/radio-button/tabs.mdx
+++ b/site/src/docs/components/radio-button/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/radio-button/tabs'
 title: 'RadioButton'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # RadioButton
 

--- a/site/src/docs/components/search-input/tabs.mdx
+++ b/site/src/docs/components/search-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/search-input/tabs'
 title: 'SearchInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # SearchInput
 

--- a/site/src/docs/components/selection-group/tabs.mdx
+++ b/site/src/docs/components/selection-group/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/selection-group/tabs'
 title: 'SelectionGroup'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # SelectionGroup
 

--- a/site/src/docs/components/side-navigation/tabs.mdx
+++ b/site/src/docs/components/side-navigation/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/side-navigation/tabs'
 title: 'SideNavigation'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # SideNavigation
 

--- a/site/src/docs/components/side-navigation/tabs.mdx
+++ b/site/src/docs/components/side-navigation/tabs.mdx
@@ -3,13 +3,12 @@ slug: '/components/side-navigation/tabs'
 title: 'SideNavigation'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import Notification from '../../../components/Notification';
 
 # SideNavigation
 

--- a/site/src/docs/components/status-label/tabs.mdx
+++ b/site/src/docs/components/status-label/tabs.mdx
@@ -3,8 +3,6 @@ slug: '/components/status-label/tabs'
 title: 'StatusLabel'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';

--- a/site/src/docs/components/status-label/tabs.mdx
+++ b/site/src/docs/components/status-label/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/status-label/tabs'
 title: 'StatusLabel'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # StatusLabel
 

--- a/site/src/docs/components/step-by-step/tabs.mdx
+++ b/site/src/docs/components/step-by-step/tabs.mdx
@@ -3,11 +3,10 @@ slug: '/components/step-by-step/tabs'
 title: 'StepByStep'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # StepByStep
 

--- a/site/src/docs/components/stepper/tabs.mdx
+++ b/site/src/docs/components/stepper/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/stepper/tabs'
 title: 'Stepper'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Stepper
 

--- a/site/src/docs/components/stepper/tabs.mdx
+++ b/site/src/docs/components/stepper/tabs.mdx
@@ -3,13 +3,12 @@ slug: '/components/stepper/tabs'
 title: 'Stepper'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import Notification from '../../../components/Notification';
 
 # Stepper
 

--- a/site/src/docs/components/table/tabs.mdx
+++ b/site/src/docs/components/table/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/table/tabs'
 title: 'Table'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Table
 

--- a/site/src/docs/components/table/tabs.mdx
+++ b/site/src/docs/components/table/tabs.mdx
@@ -3,13 +3,12 @@ slug: '/components/table/tabs'
 title: 'Table'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import Notification from '../../../components/Notification';
 
 # Table
 

--- a/site/src/docs/components/tabs/tabs.mdx
+++ b/site/src/docs/components/tabs/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/tabs/tabs'
 title: 'Tabs'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Tabs
 

--- a/site/src/docs/components/tag/index.mdx
+++ b/site/src/docs/components/tag/index.mdx
@@ -4,7 +4,7 @@ title: 'Tag'
 navTitle: 'Tag'
 ---
 
-import { Tag, StatusLabel  } from 'hds-react';
+import { Tag } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;

--- a/site/src/docs/components/tag/tabs.mdx
+++ b/site/src/docs/components/tag/tabs.mdx
@@ -3,12 +3,13 @@ slug: '/components/tag/tabs'
 title: 'Tag'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
+import { Notification } from 'hds-react';
 
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Tag
 

--- a/site/src/docs/components/tag/tabs.mdx
+++ b/site/src/docs/components/tag/tabs.mdx
@@ -3,8 +3,6 @@ slug: '/components/tag/tabs'
 title: 'Tag'
 ---
 
-import { Notification } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';

--- a/site/src/docs/components/text-area/tabs.mdx
+++ b/site/src/docs/components/text-area/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/text-area/tabs'
 title: 'TextArea'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # TextArea
 

--- a/site/src/docs/components/text-input/tabs.mdx
+++ b/site/src/docs/components/text-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/text-input/tabs'
 title: 'TextInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # TextInput
 

--- a/site/src/docs/components/time-input/tabs.mdx
+++ b/site/src/docs/components/time-input/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/time-input/tabs'
 title: 'TimeInput'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # TimeInput
 

--- a/site/src/docs/components/toggle-button/tabs.mdx
+++ b/site/src/docs/components/toggle-button/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/toggle-button/tabs'
 title: 'ToggleButton'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # ToggleButton
 

--- a/site/src/docs/components/tooltip/tabs.mdx
+++ b/site/src/docs/components/tooltip/tabs.mdx
@@ -3,12 +3,11 @@ slug: '/components/tooltip/tabs'
 title: 'Tooltip'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Tooltip
 

--- a/site/src/docs/foundation/design-tokens/breakpoints/tabs.mdx
+++ b/site/src/docs/foundation/design-tokens/breakpoints/tabs.mdx
@@ -3,11 +3,10 @@ slug: '/foundation/design-tokens/breakpoints/tabs'
 title: 'Breakpoint tokens'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Layout from '../../../../components/layout'
+import Layout from '../../../../components/layout';
 import PageTabs from '../../../../components/PageTabs';
+import StatusLabel from '../../../../components/StatusLabel';
 
 # Breakpoints
 

--- a/site/src/docs/foundation/design-tokens/breakpoints/tokens.mdx
+++ b/site/src/docs/foundation/design-tokens/breakpoints/tokens.mdx
@@ -3,7 +3,7 @@ slug: '/foundation/design-tokens/breakpoints/tokens'
 title: 'Breakpoints tokens - Tokens'
 ---
 
-import { Notification } from 'hds-react';
+import Notification from '../../../../components/Notification';
 
 import TabsLayout from './tabs.mdx';
 

--- a/site/src/docs/foundation/design-tokens/colour/tabs.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/tabs.mdx
@@ -3,11 +3,10 @@ slug: '/foundation/design-tokens/tabs'
 title: 'Colour tokens'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Layout from '../../../../components/layout'
+import Layout from '../../../../components/layout';
 import PageTabs from '../../../../components/PageTabs';
+import StatusLabel from '../../../../components/StatusLabel';
 
 # Colour
 

--- a/site/src/docs/foundation/design-tokens/spacing/tabs.mdx
+++ b/site/src/docs/foundation/design-tokens/spacing/tabs.mdx
@@ -3,11 +3,10 @@ slug: '/foundation/design-tokens/tabs'
 title: 'Spacing tokens'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Layout from '../../../../components/layout'
+import Layout from '../../../../components/layout';
 import PageTabs from '../../../../components/PageTabs';
+import StatusLabel from '../../../../components/StatusLabel';
 
 # Spacing
 

--- a/site/src/docs/foundation/design-tokens/typography/tabs.mdx
+++ b/site/src/docs/foundation/design-tokens/typography/tabs.mdx
@@ -3,11 +3,10 @@ slug: '/foundation/design-tokens/tabs'
 title: 'Typography tokens'
 ---
 
-import { StatusLabel } from 'hds-react';
-
 import LeadParagraph from '../../../../components/LeadParagraph';
-import Layout from '../../../../components/layout'
+import Layout from '../../../../components/layout';
 import PageTabs from '../../../../components/PageTabs';
+import StatusLabel from '../../../../components/StatusLabel';
 
 # Typography
 

--- a/site/src/docs/foundation/design-tokens/typography/tokens.mdx
+++ b/site/src/docs/foundation/design-tokens/typography/tokens.mdx
@@ -3,11 +3,10 @@ slug: '/foundation/design-tokens/typography/tokens'
 title: 'Typography tokens - Tokens'
 ---
 
-import { Notification } from "hds-react";
-
 import ExternalLink from '../../../../components/ExternalLink'
 import Playground from '../../../../components/Playground';
 import TextExample from '../../../../components/examples/TextExample';
+import Notification from '../../../../components/Notification';
 
 import TabsLayout from './tabs.mdx';
 

--- a/site/src/docs/foundation/guidelines/checkbox-radiobutton-toggle.mdx
+++ b/site/src/docs/foundation/guidelines/checkbox-radiobutton-toggle.mdx
@@ -4,11 +4,12 @@ title: "Checkboxes, radio buttons, or toggles?"
 navTitle: 'Checkboxes, radio buttons, or toggles?'
 ---
 
-import { Notification, Checkbox, RadioButton, ToggleButton, SelectionGroup, Link } from "hds-react";
+import { Checkbox, RadioButton, ToggleButton, SelectionGroup, Link } from "hds-react";
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PlaygroundPreview from '../../../components/Playground';
 import InternalLink from '../../../components/InternalLink';
+import Notification from '../../../components/Notification';
 
 # Checkboxes, radio buttons, or toggles?
 

--- a/site/src/docs/foundation/guidelines/grid.mdx
+++ b/site/src/docs/foundation/guidelines/grid.mdx
@@ -4,10 +4,10 @@ title: 'Grid'
 navTitle: 'Grid'
 ---
 
-import { Notification } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import InternalLink from '../../../components/InternalLink';
+import Notification from '../../../components/Notification';
 
 # Grid
 

--- a/site/src/docs/foundation/guidelines/inclusivity.mdx
+++ b/site/src/docs/foundation/guidelines/inclusivity.mdx
@@ -4,11 +4,11 @@ title: 'Inclusivity'
 navTitle: 'Inclusivity'
 ---
 
-import { StatusLabel } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/LeadParagraph';
 import InternalLink from '../../../components/InternalLink';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Inclusivity
 

--- a/site/src/docs/foundation/guidelines/server-side-rendering.mdx
+++ b/site/src/docs/foundation/guidelines/server-side-rendering.mdx
@@ -3,8 +3,9 @@ slug: "/foundation/guidelines/server-side-rendering"
 title: "Server-side rendering"
 navTitle: 'Server-side rendering'
 ---
-import { Accordion, Notification } from 'hds-react';
+import { Accordion } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
+import Notification from '../../../components/Notification';
 
 # Server-side rendering
 

--- a/site/src/docs/getting-started/contributing/design.mdx
+++ b/site/src/docs/getting-started/contributing/design.mdx
@@ -4,10 +4,10 @@ title: 'Design'
 navTitle: 'Design'
 ---
 
-import { Notification } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
+import Notification from '../../../components/Notification';
 
 # Contributing to the design
 

--- a/site/src/docs/getting-started/contributing/how-to-contribute.mdx
+++ b/site/src/docs/getting-started/contributing/how-to-contribute.mdx
@@ -4,11 +4,11 @@ title: 'How to contribute'
 navTitle: 'How to contribute'
 ---
 
-import { Notification } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import InternalLink from '../../../components/InternalLink';
+import Notification from '../../../components/Notification';
 
 # How to contribute
 

--- a/site/src/docs/patterns/cookies/basics.mdx
+++ b/site/src/docs/patterns/cookies/basics.mdx
@@ -4,11 +4,12 @@ title: 'Basics'
 navTitle: 'Basics'
 ---
 
-import { StatusLabel, Notification } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import ExternalLink from '../../../components/ExternalLink';
 import InternalLink from '../../../components/InternalLink';
+import Notification from '../../../components/Notification';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Basics
 

--- a/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
+++ b/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
@@ -4,9 +4,9 @@ title: 'Common Helsinki cookies'
 navTitle: 'Common Helsinki cookies'
 ---
 
-import { StatusLabel } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import ExternalLink from '../../../components/ExternalLink';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Common Helsinki cookies
 

--- a/site/src/docs/patterns/cookies/using-the-cookieconsent.mdx
+++ b/site/src/docs/patterns/cookies/using-the-cookieconsent.mdx
@@ -4,10 +4,11 @@ title: 'Using the CookieConsent'
 navTitle: 'Using the CookieConsent'
 ---
 
-import { StatusLabel, IconCheck, IconError } from 'hds-react';
+import { IconCheck, IconError } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import InternalLink from '../../../components/InternalLink';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Using the CookieConsent
 

--- a/site/src/docs/patterns/forms/form-building.mdx
+++ b/site/src/docs/patterns/forms/form-building.mdx
@@ -4,7 +4,7 @@ title: 'Building forms'
 navTitle: 'Building forms'
 ---
 
-import { Link, IconCheck, IconError, StatusLabel } from 'hds-react';
+import { Link, IconCheck, IconError } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -10,12 +10,12 @@ import {
   ErrorSummary,
   IconCheck,
   IconError,
-  Notification,
   TextInput,
   StatusLabel,
 } from 'hds-react';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
+import Notification from '../../../components/Notification';
 
 # Form validation
 

--- a/site/src/docs/patterns/navigation/building-navigation.mdx
+++ b/site/src/docs/patterns/navigation/building-navigation.mdx
@@ -6,6 +6,7 @@ navTitle: 'Building navigation'
 
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
+import StatusLabel from '../../../components/StatusLabel';
 import {
   Breadcrumb,
   Button,
@@ -13,7 +14,6 @@ import {
   Hero,
   Navigation,
   SideNavigation,
-  StatusLabel,
   Tabs,
   Footer,
   IconCheck,
@@ -30,7 +30,7 @@ import {
 
 # Building navigation
 
-<StatusLabel variant="rounded" type="error">Draft</StatusLabel>
+<StatusLabel type="error">Draft</StatusLabel>
 
 <LeadParagraph>
   Navigation components are crucial as they help users navigate through an application or website seamlessly.

--- a/site/src/docs/patterns/navigation/examples.mdx
+++ b/site/src/docs/patterns/navigation/examples.mdx
@@ -4,15 +4,16 @@ title: 'Examples'
 navTitle: 'Examples'
 ---
 
-import { Link, StatusLabel } from 'hds-react';
+import { Link } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import LeadParagraph from '../../../components/LeadParagraph';
 import Image from '../../../components/Image';
 import InternalLink from '../../../components/InternalLink';
+import StatusLabel from '../../../components/StatusLabel';
 
 # Examples
 
-<StatusLabel variant="rounded" type="error">Draft</StatusLabel>
+<StatusLabel type="error">Draft</StatusLabel>
 
 <LeadParagraph>
   Explore our collection of navigation patterns from the City of Helsinki's digital services. These examples demonstrate the effective implementation of user-centric design principles, resulting in accessible and efficient navigation experiences.


### PR DESCRIPTION
## Description

Whenever there is new line in a .mdx file, a `<p>` is added there.

There is no way to prevent that, so ended up filtering out useless p-tags in our components on the docs site.

Added a helper function to check, if component's child is a `<p>` and if it is, its children are hoisted and the `<p>` is stripped.

Another solution would have been a Gatsby plugin, but that would have been a lot more complex. Also targeting places where a `<p>` would have been needed and where not, would required a lot more work as a plugin processes all contents on the page.

Now only the components that clearly should not have p-tags are checked.

Because almost all pages use the Tabs-component, the list of changed files is a long one.

Closes [HDS-1968](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1968)

## How Has This Been Tested?

Locally browsing through built docs.

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1968-p-tags)

## Add to changelog
No additions to changelog. Contents or components not changed.



[HDS-1968]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ