### PR TITLE
HDS-1950 Add missing Next.js & Gatsby snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- Add missing Next.js and Gatsby code snippets to foundations / server side rendering
 
 ### Figma
 

--- a/site/src/docs/foundation/guidelines/server-side-rendering.mdx
+++ b/site/src/docs/foundation/guidelines/server-side-rendering.mdx
@@ -86,6 +86,37 @@ See below for more complete examples:
 >
   In the Next.js framework, create a file called _document.js in folder pages, and add this code to it:
 
+  ```js
+  // pages/_document.js - tested with next.js version: 10.0.5
+  import Document, { Html, Head, Main, NextScript } from 'next/document'
+  import { getCriticalHdsRules, hdsStyles } from 'hds-react';
+
+  class MyDocument extends Document {
+    static async getInitialProps(ctx) {
+      const initialProps = await Document.getInitialProps(ctx)
+      const hdsCriticalRules = await getCriticalHdsRules(initialProps.html, hdsStyles);
+
+      return {...initialProps, hdsCriticalRules}
+    }
+
+    render() {
+      return (
+        <Html>
+          <Head>
+            <style data-used-styles dangerouslySetInnerHTML={{ __html: this.props.hdsCriticalRules }} />
+          </Head>
+          <body>
+            <Main />
+            <NextScript />
+          </body>
+        </Html>
+      )
+    }
+  }
+
+  export default MyDocument
+  ```
+
 </Accordion>
 
 <Accordion
@@ -98,6 +129,28 @@ See below for more complete examples:
   }}
 >
   In the Gatsby framework, create a file called gatsby-ssr.js at the root of the project, and add this code to it:
+
+  ```js
+  // gatsby-ssr.js - tested with gatsby version 4.17.0
+  import React from 'react';
+  import { getCriticalHdsRules, hdsStyles } from 'hds-react';
+  import { renderToString } from 'react-dom/server';
+
+  export const replaceRenderer = async ({ bodyComponent, setHeadComponents }) => {
+    const bodyHTML = renderToString(bodyComponent);
+
+    if (hdsStyles && hdsStyles.length > 0 && bodyHTML && bodyHTML.length > 0) {
+      const cssRules = await getCriticalHdsRules(bodyHTML, hdsStyles);
+      const HeadComponents = [
+        <style data-used-styles dangerouslySetInnerHTML={{ __html: cssRules }} />
+      ];
+
+      return setHeadComponents(HeadComponents);
+    }
+
+    return;
+  }
+  ```
 
 </Accordion>
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Add missing  Next.js and Gatsby code snippets back to the documentation. 
They should be in here https://hds.hel.fi/foundation/guidelines/server-side-rendering/
but were accidentally(?) removed in this commit https://github.com/City-of-Helsinki/helsinki-design-system/commit/9f691db72a9582d60030d362d67f33b6e8adca9c

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1950


## How Has This Been Tested?
On local build

## Screenshots (if appropriate):
**Before:**
<img width="810" alt="Screenshot 2023-12-08 at 12 12 20" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/14258876/78a99182-bd04-47aa-8e94-88e87b9531bd">

**After:**
<img width="716" alt="Screenshot 2023-12-08 at 12 13 23" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/14258876/a325d4d5-fcd6-4a9c-83ff-f65598707379">


## Add to changelog
- [x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->
