### PR TITLE
HDS-2063-remove-unused-props

### DIFF
--- a/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, cloneElement, useCallback, useEffect, useRef, useState } from 'react';
+import React, { cloneElement, useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 // import base styles
@@ -12,42 +12,6 @@ import { MergeElementProps } from '../../../../common/types';
 import useIsomorphicLayoutEffect from '../../../../hooks/useIsomorphicLayoutEffect';
 
 const classNames = styleBoundClassNames(styles);
-
-export type LinkProps = {
-  /**
-   * Indicator for active link. This is used in HeaderNavigationMenu.
-   */
-  active?: boolean;
-  /**
-   * Additional class names to apply to the link.
-   */
-  className?: string;
-  /**
-   * Boolean for indicating whether the link has a dropdown menu.
-   */
-  hasDropdownLinks?: boolean;
-  /**
-   * Hypertext Reference of the link.
-   */
-  href: string;
-  /**
-   * Boolean for indicating whether the link's dropdown menu is open.
-   */
-  isDropdownOpen?: boolean;
-  /**
-   * Label for link.
-   */
-  label: string;
-  /**
-   * Optional event handler for onMouseEnter.
-   */
-  onMouseEnter?: MouseEventHandler;
-  /**
-   * Depth in nested dropdowns.
-   * @internal
-   */
-  depth: number;
-};
 
 export type NavigationLinkProps<ReactElement> = {
   /**


### PR DESCRIPTION
## Description

There were unused props in Header.Link but after having a closer look, the whole Header LinkProps was useless.

## Related Issue

[HDS-2063](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2063)

## How Has This Been Tested?

- ran local tests

## Add to changelog
- I guess CHANGELOG doesn't need any additions since this change didn't affect anything, just removal of the unused typing. So not used, nowhere seen 🤷‍♂️ 


[HDS-2063]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ