### PR TITLE
HDS-1685 Fix wave motifs links to external pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- Fixed Wave motifs links to Helsinki Brand pages 
 
 ### Figma
 

--- a/site/src/docs/foundation/visual-assets/wave-motifs.mdx
+++ b/site/src/docs/foundation/visual-assets/wave-motifs.mdx
@@ -92,12 +92,11 @@ HDS includes a few components that have wave motif support built into them:
 - <InternalLink href="/components/footer">Footer</InternalLink>
 
 ## Animation
-<p>It is allowed to animate wave motifs. While this is not directly supported in the HDS Koro component, you can find more info and downloadable wave motif animation from the <ExternalLink href="https://brand.hel.fi/en/downloadable-animations/">Helsinki Brand website - Downloadable animations section</ExternalLink>.</p>
+<p>It is allowed to animate wave motifs. While this is not directly supported in the HDS Koro component, you can find downloadable wave motif animation from the <ExternalLink href="https://www.hel.fi/en/decision-making/information-on-helsinki/design-and-digitalisation/helsinki-brand-and-visual-identity/visual-identity-guidelines/download-elements#wave-motifs">Helsinki Brand website - Downloadable Wave motifs section</ExternalLink>.</p>
 
 ## Further reading
 Please refer to the Helsinki Brand website to learn more about wave motifs and their usage:
-- <ExternalLink href="https://brand.hel.fi/en/wave-motifs/">Helsinki Brand - Wave motifs</ExternalLink>
-- <ExternalLink href="https://brand.hel.fi/en/surface-division/">Helsinki Brand - Surface division</ExternalLink>
-- <ExternalLink href="https://brand.hel.fi/en/downloadable-animations/">Helsinki Brand - Downloadable animations</ExternalLink>
+- <ExternalLink href="https://www.hel.fi/en/decision-making/information-on-helsinki/design-and-digitalisation/helsinki-brand-and-visual-identity/visual-identity-guidelines/use-basic-elements#wave-motifs">Helsinki Brand - Wave motifs</ExternalLink>
+- <ExternalLink href="https://www.hel.fi/en/decision-making/information-on-helsinki/design-and-digitalisation/helsinki-brand-and-visual-identity/visual-identity-guidelines/download-elements#wave-motifs">Helsinki Brand - Downloadable animations</ExternalLink>
 
 


### PR DESCRIPTION
## Description

Further reading links about wave motifs (Koros) do not point to correct section in Helsinki Brand pages.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1685

## How Has This Been Tested?
Localhost
[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1685-fix-wave-motif-links/foundation/visual-assets/wave-motifs/#further-reading)

## Add to changelog
- [x] Added needed line to changelog 