### PR TITLE
HDS-1727 Scaling notes to Hero with diagonal koros examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Changes that are not related to specific components
 
 #### Added
 
-- [Component] What is added?
+- [Hero] Note about scaling to diagonal koros examples
 
 #### Changed
 

--- a/site/src/docs/components/hero/code.mdx
+++ b/site/src/docs/components/hero/code.mdx
@@ -107,6 +107,8 @@ import { Fieldset, TextInput } from 'hds-react';
 
 </Playground>
 
+**Note:** Hero with diagonal Koros adjusts its contents based on browser width. Preview here might might not scale correcly. <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-hero--diagonal-koros">View Hero with diagonal Koros example in Storybook</Link>.
+
 ### Packages
 
 | Package       | Included                                                                                        | Storybook link                                                                                                                                                    | Source link                                                                                                                                                                                                                |

--- a/site/src/docs/components/hero/index.mdx
+++ b/site/src/docs/components/hero/index.mdx
@@ -144,6 +144,8 @@ Use when you want to create a dynamic Hero layout on your page. Ensure the image
   </Hero>
 </PlaygroundPreview>
 
+**Note:** Hero with diagonal Koros adjusts its contents based on browser width. Preview here might might not scale correcly. <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-hero--diagonal-koros">View Hero with diagonal Koros example in Storybook</Link>.
+
 #### Wide bottom image
 
 Use when you want to emphasize the title and introduction text content over the image. Ensure the image adapts to various screen sizes to prevent clipping, especially with faces in the picture. On desktop, it's on the right side, while on mobile, it's below. Validate this for all screen sizes.


### PR DESCRIPTION
## Description

Doc site examples of Hero with diagonal Koros don't adjust their content properly on medium sized screens. This happens because Hero uses CSS mediaqueries based on browser width but the component width is shrunk because of Playground component. Problem is similar to [Header scaling in doc site](https://github.com/City-of-Helsinki/helsinki-design-system/pull/1112) which couldn't be fixed and only notes were addes to the examples. I did the same here.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1727

## How Has This Been Tested?
Localhost
[Demo](https://city-of-helsinki.github.io/hds-demo/hds-1727-notes-to-hero-diag-koros/components/hero/#diagonal-koro-shape-and-image-as-a-background)

## Add to changelog
- [x] Added needed line to changelog 
