### PR TITLE
Hds 1696 Values in disabled dropdowns shouldn't be clearable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Dropdown] Clearing values from disabled Dropdowns is prohibited
 
 ### Core
 

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -526,6 +526,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
             selectedItemsContainerRef={selectedItemsContainerRef}
             setActiveIndex={setActiveIndex}
             toggleButtonHidden={!showToggleButton}
+            disabled={disabled}
           />
         )}
         {props.multiselect === false && props.icon && (
@@ -569,6 +570,7 @@ export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
               toggleButtonRef.current.focus();
             }}
             clearButtonAriaLabel={props.clearButtonAriaLabel}
+            disabled={disabled}
           />
         )}
         {/* MENU */}

--- a/packages/react/src/components/dropdown/select/Select.tsx
+++ b/packages/react/src/components/dropdown/select/Select.tsx
@@ -550,6 +550,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
             selectedItemSrLabel={props.selectedItemSrLabel}
             selectedItemsContainerRef={selectedItemsContainerRef}
             setActiveIndex={setActiveIndex}
+            disabled={disabled}
           />
         )}
         {/* TOGGLE BUTTON */}
@@ -581,6 +582,7 @@ export const Select = <OptionType,>(props: SelectProps<OptionType>) => {
               toggleButtonRef.current.focus();
             }}
             clearButtonAriaLabel={props.clearButtonAriaLabel}
+            disabled={disabled}
           />
         )}
         {/* MENU */}

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -27,6 +27,10 @@ type SelectedItemsProps<OptionType> = {
    */
   clearButtonAriaLabel?: string;
   /**
+   * Boolean to set for disabled state
+   */
+  disabled: boolean;
+  /**
    * Dropdown ID
    */
   dropdownId: string;
@@ -171,9 +175,16 @@ type ClearButtonProps = {
   clearButtonAriaLabel: string;
   toggleButtonHidden?: boolean;
   onFocus?: () => void;
+  disabled?: boolean;
 };
 
-export const ClearButton = ({ toggleButtonHidden, onClear, clearButtonAriaLabel, onFocus }: ClearButtonProps) => {
+export const ClearButton = ({
+  toggleButtonHidden,
+  onClear,
+  clearButtonAriaLabel,
+  onFocus,
+  disabled,
+}: ClearButtonProps) => {
   return (
     <button
       type="button"
@@ -181,6 +192,7 @@ export const ClearButton = ({ toggleButtonHidden, onClear, clearButtonAriaLabel,
       onClick={onClear}
       aria-label={clearButtonAriaLabel}
       onFocus={onFocus && onFocus}
+      disabled={disabled}
     >
       <IconCrossCircle />
     </button>
@@ -193,6 +205,7 @@ export const SelectedItems = <OptionType,>({
   clearable = true,
   clearButtonAriaLabel,
   dropdownId,
+  disabled,
   getSelectedItemProps,
   hideItems = false,
   onClear,
@@ -309,6 +322,7 @@ export const SelectedItems = <OptionType,>({
               (containerEl?.childNodes[0] as HTMLDivElement).setAttribute('tabindex', '0');
             }
           }}
+          disabled={disabled}
         />
       )}
     </>

--- a/packages/react/src/internal/selectedItems/SelectedItems.tsx
+++ b/packages/react/src/internal/selectedItems/SelectedItems.tsx
@@ -29,7 +29,7 @@ type SelectedItemsProps<OptionType> = {
   /**
    * Boolean to set for disabled state
    */
-  disabled: boolean;
+  disabled?: boolean;
   /**
    * Dropdown ID
    */
@@ -279,7 +279,7 @@ export const SelectedItems = <OptionType,>({
               }}
               onDelete={(e) => {
                 e.stopPropagation();
-                onRemove(_selectedItem);
+                if (!disabled) onRemove(_selectedItem);
               }}
               srOnlyLabel={replaceTokenWithValue(selectedItemSrLabel, selectedItemLabel)}
               {...getSelectedItemProps({


### PR DESCRIPTION
## Description

If disabled Dropdown (Select/Combobox) has values, they shouldn't be clearable. Clear all button is now disabled and trying to remove a selected value from multi-select dropdown does nothing. I didn't touch removing single values from multi-selects because the UI and UX should be thought out properly and that's a story for another PR.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-1696

## How Has This Been Tested?
Localhost
[Combobox with clear button](https://city-of-helsinki.github.io/hds-demo/hds-1696-disabled-combobox/?path=/story/components-dropdowns-combobox--with-clear-button)
[Combobox multi-select](https://city-of-helsinki.github.io/hds-demo/hds-1696-disabled-combobox/?path=/story/components-dropdowns-combobox--multi-select-example) (select values and set disabled: true)
[Select with clear button](https://city-of-helsinki.github.io/hds-demo/hds-1696-disabled-combobox/?path=/story/components-dropdowns-select--with-clear-button)
[Multi-select](http://localhost:6006/?path=/story/components-dropdowns-select--multiselect&args=disabled:false) (select values and set disabled: true)

## Add to changelog
- [x] Added needed line to changelog 
