### PR TITLE
(HDS-2046) Fix notifications size texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Changes that are not related to specific components
 
 - Fixed Wave motifs links to Helsinki Brand pages 
 - [Header] Small fixes
+- [Notification] Fix size texts
 
 ### Figma
 

--- a/site/src/docs/components/notification/index.mdx
+++ b/site/src/docs/components/notification/index.mdx
@@ -113,7 +113,7 @@ export const ToastExample = () => {
 
 #### Notification sizes
 
-HDS Navigation component supports many commonly used features out of the box. The main navigation bar can be configured to include search, language selection and user profile actions. You may also easily customize the action row with your own actions.
+Notifications have three different sizes ranging from `small` to `large`, `default` being in the middle. The small sized doesn't display the `label`, although the screen-readers are able to read it.
 
 <PlaygroundPreview>
   <Notification size="large" label="New messages">


### PR DESCRIPTION
## Description

Fix falsy Notification texts that included some Navigation stuff instead.

## Related Issue

[HDS-2046](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2046)

## How Has This Been Tested?

- local machine

## Add to changelog
- [x] Added needed line to changelog 


[HDS-2046]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ