### PR TITLE
HDS-2065: change default cookie domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- [Component] What is added?
+- [CookieConsent] A new cookie is set containing version number of consents.
 
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 - [Link] Possibility to style a Link as button with `useButtonStyles` prop.
+- [CookieConsent] Consent cookie's default domain was changed to window.location.hostname.
 
 #### Fixed
 
@@ -40,6 +42,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 - [Link] Possibility to style a Link as button.
 
@@ -80,6 +83,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -99,6 +103,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -118,6 +123,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -137,6 +143,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed

--- a/packages/react/src/components/cookieConsent/contexts/ContentContext.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/ContentContext.tsx
@@ -97,10 +97,10 @@ export const forceFocusToElement = (elementSelector: string): void => {
   }
 };
 
-export const Provider = ({ children, contentSource }: ConsentContextProps): React.ReactElement => {
+export const Provider = ({ children, contentSource, cookieDomain }: ConsentContextProps): React.ReactElement => {
   const language = contentSource.currentLanguage;
   const contextData: ContentContextType = useMemo(() => {
-    const content = createContent(contentSource);
+    const content = createContent(contentSource, cookieDomain);
     const callbacks = {
       onAllConsentsGiven: contentSource.onAllConsentsGiven,
       onConsentsParsed: contentSource.onConsentsParsed,

--- a/packages/react/src/components/cookieConsent/contexts/ContextComponent.test.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/ContextComponent.test.tsx
@@ -255,7 +255,7 @@ describe('ContextComponent', () => {
         ...allApprovedConsentData.consents,
         ...unknownConsents,
       });
-      expect(getSetCookieArguments().options.domain).toEqual('hel.fi');
+      expect(getSetCookieArguments().options.domain).toEqual('subdomain.hel.fi');
     });
 
     it('sets the domain of the cookie to given cookieDomain', () => {

--- a/packages/react/src/components/cookieConsent/cookieConsentController.test.ts
+++ b/packages/react/src/components/cookieConsent/cookieConsentController.test.ts
@@ -321,16 +321,16 @@ describe(`cookieConsentController.ts`, () => {
         });
       });
 
-      it('the domain of the cookie is set to <domain>.<suffix> so it is readable from *.hel.fi and *.hel.ninja', () => {
+      it('by default, the domain of the cookie is set to window.location.hostname so it is only readable from that exact domain and not other subdomains.', () => {
         mockedWindowControls.setUrl('https://subdomain.hel.fi');
         createControllerAndInitCookie(defaultControllerTestData);
         controller.save();
-        expect(getSetCookieArguments().options.domain).toEqual('hel.fi');
+        expect(getSetCookieArguments().options.domain).toEqual('subdomain.hel.fi');
 
         mockedWindowControls.setUrl('http://profiili.hel.ninja:3000?foo=bar');
         createControllerAndInitCookie(defaultControllerTestData);
         controller.save();
-        expect(getSetCookieArguments().options.domain).toEqual('hel.ninja');
+        expect(getSetCookieArguments().options.domain).toEqual('profiili.hel.ninja');
       });
 
       it('if "cookieDomain" property is passed in the props, it is set as the domain of the cookie', () => {

--- a/packages/react/src/components/cookieConsent/cookieConsentController.test.ts
+++ b/packages/react/src/components/cookieConsent/cookieConsentController.test.ts
@@ -10,6 +10,7 @@ import createConsentController, {
 } from './cookieConsentController';
 import mockDocumentCookie from './__mocks__/mockDocumentCookie';
 import { extractSetCookieArguments } from './test.util';
+import { VERSION_COOKIE_NAME } from './cookieStorageProxy';
 
 describe(`cookieConsentController.ts`, () => {
   let controller: ConsentController;
@@ -25,6 +26,7 @@ describe(`cookieConsentController.ts`, () => {
   });
 
   const getSetCookieArguments = (index = -1) => extractSetCookieArguments(mockedCookieControls, index);
+  const versionCookie = { [VERSION_COOKIE_NAME]: '1' };
 
   const defaultControllerTestData = {
     requiredConsents: ['requiredConsent1', 'requiredConsent2'],
@@ -42,7 +44,7 @@ describe(`cookieConsentController.ts`, () => {
     cookie?: ConsentObject;
     cookieDomain?: string;
   }) => {
-    mockedCookieControls.init({ [COOKIE_NAME]: JSON.stringify(cookie) });
+    mockedCookieControls.init({ [COOKIE_NAME]: JSON.stringify(cookie), ...versionCookie });
     controller = createConsentController({
       requiredConsents,
       optionalConsents,
@@ -128,7 +130,8 @@ describe(`cookieConsentController.ts`, () => {
 
       it('cookie is only read on init', () => {
         createControllerAndInitCookie({});
-        expect(mockedCookieControls.mockGet).toHaveBeenCalledTimes(1);
+        // cookieStorageProxy reads cookies (x2) first and then cookieController
+        expect(mockedCookieControls.mockGet).toHaveBeenCalledTimes(3);
         expect(mockedCookieControls.mockSet).toHaveBeenCalledTimes(0);
       });
     });

--- a/packages/react/src/components/cookieConsent/cookieConsentController.ts
+++ b/packages/react/src/components/cookieConsent/cookieConsentController.ts
@@ -1,6 +1,5 @@
 import { pick, isObject, isUndefined } from 'lodash';
 
-import { createCookieController } from './cookieController';
 import { createCookieStorageProxy } from './cookieStorageProxy';
 
 export type ConsentList = string[];
@@ -223,14 +222,4 @@ export default function createConsentController(props: ConsentControllerProps): 
     },
     save,
   };
-}
-
-export function getConsentsFromCookie(cookieDomain?: string): ConsentObject {
-  const cookieController = createCookieController(
-    {
-      domain: cookieDomain || getCookieDomainFromUrl(),
-    },
-    COOKIE_NAME,
-  );
-  return parseConsents(cookieController.get());
 }

--- a/packages/react/src/components/cookieConsent/cookieConsentController.ts
+++ b/packages/react/src/components/cookieConsent/cookieConsentController.ts
@@ -1,6 +1,6 @@
 import { pick, isObject, isUndefined } from 'lodash';
 
-import { createCookieStorageProxy } from './cookieStorageProxy';
+import { createCookieStorageProxy, getCookieDomainForSubDomainAccess } from './cookieStorageProxy';
 
 export type ConsentList = string[];
 
@@ -75,11 +75,7 @@ export function parseConsents(jsonString: string | undefined): ConsentObject {
 }
 
 export const getCookieDomainFromUrl = (): string => {
-  if (typeof window === 'undefined') {
-    return '';
-  }
-
-  return window.location.hostname.split('.').slice(-2).join('.');
+  return getCookieDomainForSubDomainAccess();
 };
 
 export function createStorage(initialValues: ConsentStorage): {

--- a/packages/react/src/components/cookieConsent/cookieConsentController.ts
+++ b/packages/react/src/components/cookieConsent/cookieConsentController.ts
@@ -1,6 +1,7 @@
 import { pick, isObject, isUndefined } from 'lodash';
 
 import { createCookieController } from './cookieController';
+import { createCookieStorageProxy } from './cookieStorageProxy';
 
 export type ConsentList = string[];
 
@@ -153,7 +154,7 @@ export default function createConsentController(props: ConsentControllerProps): 
   verifyConsentProps(props);
   const { optionalConsents = [], requiredConsents = [] } = props;
   const allConsents = [...optionalConsents, ...requiredConsents];
-  const cookieController = createCookieController(
+  const cookieController = createCookieStorageProxy(
     {
       maxAge: COOKIE_EXPIRATION_TIME,
       domain: props.cookieDomain || getCookieDomainFromUrl(),

--- a/packages/react/src/components/cookieConsent/cookieController.test.ts
+++ b/packages/react/src/components/cookieConsent/cookieController.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable jest/no-mocks-import */
+import cookie from 'cookie';
+
 import mockDocumentCookie from './__mocks__/mockDocumentCookie';
 import { getAll, setNamedCookie, getNamedCookie, createCookieController, CookieSetOptions } from './cookieController';
 
@@ -59,7 +61,7 @@ describe(`cookieController.ts`, () => {
 
       const cookiesAsString = mockedCookieControls.getCookie();
       Object.entries(allCookies).forEach(([key, value]) => {
-        expect(cookiesAsString.includes(`${key} = ${value};`)).toBeTruthy();
+        expect(cookiesAsString.includes(cookie.serialize(key, value))).toBeTruthy();
       });
     });
 
@@ -78,7 +80,7 @@ describe(`cookieController.ts`, () => {
       setNamedCookie(target, newValue);
       expect(getNamedCookie(target)).toEqual(newValue);
       const cookiesAsString = mockedCookieControls.getCookie();
-      expect(cookiesAsString).toEqual(`${target} = ${encodeURIComponent(newValue)};`);
+      expect(cookiesAsString).toEqual(`${target}=${encodeURIComponent(newValue)}`);
     });
 
     it('passes also options to document.cookie', () => {
@@ -92,17 +94,18 @@ describe(`cookieController.ts`, () => {
         maxAge: 100,
       };
       setNamedCookie(dummyKey, dummyValue, options);
-      const optionsFromCookie = mockedCookieControls.getCookieOptions(dummyKey);
+      const optionsFromCookie = mockedCookieControls.getCookieOptions(dummyKey, options);
       expect(optionsFromCookie).toEqual(options);
     });
 
     it('passes also partial options to document.cookie', () => {
+      const activeCookieOptions = mockedCookieControls.getSerializeOptions();
       const options: CookieSetOptions = {
         domain: 'domain.com',
         sameSite: 'none',
       };
       setNamedCookie(dummyKey, dummyValue, options);
-      const optionsFromCookie = mockedCookieControls.getCookieOptions(dummyKey);
+      const optionsFromCookie = mockedCookieControls.getCookieOptions(dummyKey, { ...activeCookieOptions, ...options });
       expect(optionsFromCookie).toEqual(options);
     });
     it('throws when setting invalid options', () => {
@@ -133,7 +136,7 @@ describe(`cookieController.ts`, () => {
 
       controller.set(cookieValue);
       expect(getNamedCookie(cookieName)).toEqual(cookieValue);
-      const passedOptions = mockedCookieControls.getCookieOptions(cookieName);
+      const passedOptions = mockedCookieControls.getCookieOptions(cookieName, options);
       expect(passedOptions).toEqual(options);
     });
     it('createCookieController.get gets a cookie with name passed to the controller on initialization', () => {

--- a/packages/react/src/components/cookieConsent/cookieController.ts
+++ b/packages/react/src/components/cookieConsent/cookieController.ts
@@ -2,6 +2,13 @@ import cookie, { CookieSerializeOptions } from 'cookie';
 
 export type CookieSetOptions = CookieSerializeOptions;
 
+export const defaultCookieSetOptions: CookieSetOptions = {
+  path: '/',
+  secure: false,
+  sameSite: 'strict',
+  maxAge: undefined,
+};
+
 function getAll() {
   return cookie.parse(document.cookie);
 }
@@ -22,13 +29,6 @@ function createCookieController(
   get: () => string;
   set: (data: string) => void;
 } {
-  const defaultCookieSetOptions: CookieSetOptions = {
-    path: '/',
-    secure: false,
-    sameSite: 'strict',
-    maxAge: undefined,
-  };
-
   const cookieOptions: CookieSetOptions = {
     ...defaultCookieSetOptions,
     ...options,

--- a/packages/react/src/components/cookieConsent/cookieModal/CookieModal.test.tsx
+++ b/packages/react/src/components/cookieConsent/cookieModal/CookieModal.test.tsx
@@ -27,7 +27,7 @@ import { Content } from '../contexts/ContentContext';
 
 const { defaultConsentData, unknownConsents, dataTestIds } = commonTestProps;
 
-const mockedCookieControls = mockDocumentCookie();
+const mockedCookieControls = mockDocumentCookie({ domain: 'localhost' });
 
 let content: Content;
 

--- a/packages/react/src/components/cookieConsent/cookiePage/CookiePage.test.tsx
+++ b/packages/react/src/components/cookieConsent/cookiePage/CookiePage.test.tsx
@@ -21,6 +21,7 @@ import {
 } from '../test.util';
 import { createContent } from '../content.builder';
 import { CookiePage } from './CookiePage';
+import { VERSION_COOKIE_NAME } from '../cookieStorageProxy';
 
 const { requiredGroupParent, optionalGroupParent, defaultConsentData, unknownConsents, dataTestIds } = commonTestProps;
 
@@ -40,8 +41,9 @@ const renderCookieConsent = ({
     ...unknownConsents,
   };
   const contentSource = getContentSource(requiredConsents, optionalConsents);
+  const versionCookie = { [VERSION_COOKIE_NAME]: '1' };
   content = createContent(contentSource);
-  mockedCookieControls.init({ [COOKIE_NAME]: JSON.stringify(cookieWithInjectedUnknowns) });
+  mockedCookieControls.init({ [COOKIE_NAME]: JSON.stringify(cookieWithInjectedUnknowns), ...versionCookie });
   const result = render(<CookiePage contentSource={contentSource} />);
 
   return result;

--- a/packages/react/src/components/cookieConsent/cookieStorageProxy.test.ts
+++ b/packages/react/src/components/cookieConsent/cookieStorageProxy.test.ts
@@ -2,7 +2,7 @@
 import { CookieSerializeOptions } from 'cookie';
 
 import mockDocumentCookie from './__mocks__/mockDocumentCookie';
-import mockWindowLocation from './__mocks__/mockWindowLocation';
+import mockWindowLocation from '../../utils/mockWindowLocation';
 import { CookieSetOptions, defaultCookieSetOptions, getAll } from './cookieController';
 import { VERSION_COOKIE_NAME, createCookieStorageProxy } from './cookieStorageProxy';
 import { COOKIE_NAME } from './cookieConsentController';

--- a/packages/react/src/components/cookieConsent/cookieStorageProxy.test.ts
+++ b/packages/react/src/components/cookieConsent/cookieStorageProxy.test.ts
@@ -1,0 +1,236 @@
+/* eslint-disable jest/no-mocks-import */
+import { CookieSerializeOptions } from 'cookie';
+
+import mockDocumentCookie from './__mocks__/mockDocumentCookie';
+import mockWindowLocation from './__mocks__/mockWindowLocation';
+import { CookieSetOptions, defaultCookieSetOptions, getAll } from './cookieController';
+import { VERSION_COOKIE_NAME, createCookieStorageProxy } from './cookieStorageProxy';
+import { COOKIE_NAME } from './cookieConsentController';
+import { getMockCalls } from '../../utils/testHelpers';
+
+describe(`cookieStorageProxy.ts`, () => {
+  const mockedCookieControls = mockDocumentCookie();
+  const mockedWindowControls = mockWindowLocation();
+
+  afterEach(() => {
+    mockedCookieControls.clear();
+  });
+  afterAll(() => {
+    mockedCookieControls.restore();
+    mockedWindowControls.restore();
+  });
+
+  const otherCookiesList = {
+    cookieKey: COOKIE_NAME,
+    jsonCookie: JSON.stringify({ json: true }),
+    objectStringCookie: '{ obj: true }',
+    emptyCookie: '',
+  };
+
+  const windowDomain = 'subdomain.hel.fi';
+
+  mockedWindowControls.setUrl(`https://${windowDomain}`);
+
+  const cookieOptionsForMultiDomain: CookieSerializeOptions = {
+    domain: 'hel.fi',
+    path: '/',
+  };
+
+  const cookieOptionsForSubDomain: CookieSerializeOptions = {
+    ...cookieOptionsForMultiDomain,
+    domain: windowDomain,
+  };
+
+  const baseConsentData = {
+    'consent-name': false,
+    'another-consent-name': true,
+    consentX: false,
+    consentY: true,
+    [COOKIE_NAME]: true,
+  };
+  const versionCookie = { [VERSION_COOKIE_NAME]: '1' };
+  describe('createcookieStorageProxy creates a proxy for cookieController', () => {
+    const consentCookie = {
+      [COOKIE_NAME as string]: JSON.stringify(baseConsentData),
+    };
+
+    const multipleCookiesWithConsentCookie = {
+      ...otherCookiesList,
+      ...consentCookie,
+    };
+
+    const getNumberOfStoredConsentCookies = () => document.cookie.split(`${COOKIE_NAME}=`).length - 1;
+    const getCookieWriteCount = () => getMockCalls(mockedCookieControls.mockSet).length;
+    const getCookieReadCount = () => getMockCalls(mockedCookieControls.mockGet).length;
+    const storeCookieVersion = () => mockedCookieControls.add(versionCookie);
+    const removeCookieVersion = (cookies: string) => {
+      return cookies.replace(`; ${VERSION_COOKIE_NAME}=1`, '');
+    };
+
+    const getCookieOptionsDomain = (cookieName: string, writeOptions: CookieSetOptions, wasDeleted: boolean) => {
+      return mockedCookieControls.getCookieOptions(cookieName, writeOptions, wasDeleted).domain;
+    };
+    const getAddedCookieOptionsDomain = (cookieName: string, writeOptions: CookieSetOptions) => {
+      return getCookieOptionsDomain(cookieName, writeOptions, false);
+    };
+    const getDeletedCookieOptionsDomain = (cookieName: string, writeOptions: CookieSetOptions) => {
+      return getCookieOptionsDomain(cookieName, writeOptions, true);
+    };
+
+    const initTests = (extraOptions: CookieSetOptions = {}) => {
+      const options: CookieSetOptions = {
+        ...defaultCookieSetOptions,
+        ...extraOptions,
+      };
+      return createCookieStorageProxy(options, COOKIE_NAME);
+    };
+
+    it('Does not add or convert cookies, if no old nor new consents are found.', () => {
+      mockedCookieControls.add(otherCookiesList);
+      const cookiesBefore = document.cookie;
+      const writeCountBeforeInit = getCookieWriteCount();
+      const readCountBeforeInit = getCookieReadCount();
+      const proxy = initTests();
+      // consent cookie and version cookie are read
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 2);
+      expect(getNumberOfStoredConsentCookies()).toBe(0);
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 3);
+
+      const consents = proxy.get();
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 4);
+
+      const result = getAll();
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 5);
+
+      expect(consents).toEqual('');
+      expect(result).toMatchObject(otherCookiesList);
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit);
+      expect(document.cookie).toBe(cookiesBefore);
+    });
+
+    it('Does not add or convert cookies, if there is a single consent cookie and version is stored.', () => {
+      storeCookieVersion();
+      mockedCookieControls.add(multipleCookiesWithConsentCookie);
+      const cookiesBefore = document.cookie;
+      expect(getNumberOfStoredConsentCookies()).toBe(1);
+      const writeCountBeforeInit = getCookieWriteCount();
+      const readCountBeforeInit = getCookieReadCount();
+      const proxy = initTests();
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 2);
+      const consents = proxy.get();
+      expect(consents).toEqual(multipleCookiesWithConsentCookie[COOKIE_NAME]);
+      const result = getAll();
+      expect(result).toMatchObject(multipleCookiesWithConsentCookie);
+      expect(result[COOKIE_NAME]).toEqual(multipleCookiesWithConsentCookie[COOKIE_NAME]);
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit);
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 4);
+      expect(document.cookie).toBe(cookiesBefore);
+    });
+
+    it('Stores also a version cookie when consents are stored for the first time.', () => {
+      mockedCookieControls.add(otherCookiesList);
+      const writeCountBeforeInit = getCookieWriteCount();
+      const cookieData = consentCookie[COOKIE_NAME];
+      const proxy = initTests();
+      // consent cookie and version cookie are read
+      expect(getNumberOfStoredConsentCookies()).toBe(0);
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit);
+
+      proxy.set(cookieData);
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit + 2);
+      const consents = proxy.get();
+
+      expect(consents).toEqual(cookieData);
+      const result = getAll();
+      expect(result).toMatchObject({ ...otherCookiesList, ...consentCookie, ...versionCookie });
+    });
+
+    it('Moves old cookie to a new domain, if version is not found. New cookies have same domain. Version cookie is not set.', () => {
+      mockedCookieControls.add(multipleCookiesWithConsentCookie, cookieOptionsForMultiDomain);
+      const cookiesBefore = document.cookie;
+      expect(getNumberOfStoredConsentCookies()).toBe(1);
+      const writeCountBeforeInit = getCookieWriteCount();
+      const readCountBeforeInit = getCookieReadCount();
+      const proxy = initTests();
+      const consents = proxy.get();
+      expect(consents).toEqual(multipleCookiesWithConsentCookie[COOKIE_NAME]);
+      const result = getAll();
+      expect(result).toMatchObject(multipleCookiesWithConsentCookie);
+      expect(result[COOKIE_NAME]).toEqual(multipleCookiesWithConsentCookie[COOKIE_NAME]);
+      // one write for removing old cookie, one write for adding new
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit + 2);
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 4);
+      expect(removeCookieVersion(document.cookie)).toBe(cookiesBefore);
+
+      expect(getDeletedCookieOptionsDomain(COOKIE_NAME, cookieOptionsForMultiDomain)).toBe(
+        cookieOptionsForMultiDomain.domain,
+      );
+      expect(getAddedCookieOptionsDomain(COOKIE_NAME, cookieOptionsForSubDomain)).toBe(
+        cookieOptionsForSubDomain.domain,
+      );
+
+      expect(() => getAddedCookieOptionsDomain(VERSION_COOKIE_NAME, cookieOptionsForSubDomain)).toThrow();
+    });
+
+    it('If a custom domain is set, the consent cookie is moved, if the version cookie is not found. Version cookie is not set.', () => {
+      const cookieOptions = cookieOptionsForMultiDomain;
+      const commonDomainForAllCookies = cookieOptions.domain;
+      mockedCookieControls.add(multipleCookiesWithConsentCookie, cookieOptions);
+      const cookiesBefore = document.cookie;
+      const writeCountBeforeInit = getCookieWriteCount();
+      const proxy = initTests({ domain: commonDomainForAllCookies });
+      expect(proxy.get()).toEqual(multipleCookiesWithConsentCookie[COOKIE_NAME]);
+      expect(removeCookieVersion(document.cookie)).toBe(cookiesBefore);
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit + 2);
+
+      expect(getDeletedCookieOptionsDomain(COOKIE_NAME, cookieOptions)).toBe(commonDomainForAllCookies);
+      expect(getAddedCookieOptionsDomain(COOKIE_NAME, cookieOptions)).toBe(commonDomainForAllCookies);
+      expect(() => getAddedCookieOptionsDomain(VERSION_COOKIE_NAME, cookieOptionsForSubDomain)).toThrow();
+    });
+    it('Removes all consent cookies, if there are multiple consent cookies. Empty consent cookie is added.', () => {
+      mockedCookieControls.add(multipleCookiesWithConsentCookie, cookieOptionsForMultiDomain);
+      mockedCookieControls.add(multipleCookiesWithConsentCookie, cookieOptionsForSubDomain);
+      const writeCountBeforeInit = getCookieWriteCount();
+      expect(getNumberOfStoredConsentCookies()).toBe(2);
+      const proxy = initTests();
+      // empty consent cookie was added
+      expect(getNumberOfStoredConsentCookies()).toBe(1);
+      const consents = proxy.get();
+      expect(consents).toEqual('{}');
+      const result = getAll();
+
+      expect(result).toMatchObject(otherCookiesList);
+      // two writes for removing old cookies, one write for adding empty one
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit + 3);
+    });
+
+    it('Does not add or convert cookies, if there are no consents, but version is stored.', () => {
+      mockedCookieControls.add(otherCookiesList, cookieOptionsForMultiDomain);
+      storeCookieVersion();
+      const cookiesBefore = document.cookie;
+      expect(getNumberOfStoredConsentCookies()).toBe(0);
+      const writeCountBeforeInit = getCookieWriteCount();
+      const readCountBeforeInit = getCookieReadCount();
+      const proxy = initTests();
+      expect(getCookieReadCount()).toBe(readCountBeforeInit + 2);
+      const consents = proxy.get();
+      expect(consents).toEqual('');
+      const result = getAll();
+      expect(result).toMatchObject(otherCookiesList);
+      expect(getCookieWriteCount()).toBe(writeCountBeforeInit);
+      expect(document.cookie).toBe(cookiesBefore);
+    });
+
+    it('When a cookie is removed both "maxAge" and "expires" should not be set. "expires" is set to year 1970.', () => {
+      mockedCookieControls.add(multipleCookiesWithConsentCookie, cookieOptionsForMultiDomain);
+      initTests();
+      const multiDomainDeleteOptions = mockedCookieControls.getCookieOptions(
+        COOKIE_NAME,
+        cookieOptionsForMultiDomain,
+        true,
+      );
+      expect(multiDomainDeleteOptions.maxAge).toBeUndefined();
+      expect((multiDomainDeleteOptions.expires as Date).getFullYear()).toBe(1970);
+    });
+  });
+});

--- a/packages/react/src/components/cookieConsent/cookieStorageProxy.ts
+++ b/packages/react/src/components/cookieConsent/cookieStorageProxy.ts
@@ -1,0 +1,134 @@
+import { CookieSerializeOptions, parse } from 'cookie';
+
+import { createCookieController, setNamedCookie, defaultCookieSetOptions, getAll } from './cookieController';
+
+export type CookieSetOptions = CookieSerializeOptions;
+
+const COOKIE_DELIMETER = ';';
+const CURRENT_VERSION = 1;
+export const VERSION_COOKIE_NAME = 'city-of-helsinki-consent-version';
+
+// the old version how default cookie domain was picked
+function getCookieDomainForMultiDomainAccess(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.location.hostname.split('.').slice(-2).join('.');
+}
+
+// the new version how to pick default cookie domain
+export function getCookieDomainForSubDomainAccess(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.location.hostname;
+}
+
+function getVersionNumber(cookies?: ReturnType<typeof parse>): number {
+  const data = cookies || getAll();
+  const version = data ? parseInt(data[VERSION_COOKIE_NAME], 10) : 0;
+  return Number.isNaN(version) ? 0 : version;
+}
+
+/**
+ * This is a proxy between 'cookieConsentController' and 'cookieController'. It mimics the 'cookieController'.
+ * The purpose of this controller is to convert old cookie consents to the new version after the cookie consent default domain has changed.
+ * This handles the uncontrollable scenario where old users have consents stored to '*.hel.fi' and new version stores them to '<subdomain>.hel.fi'.
+ * The 'document.cookie' would contain both versions in uncertain order. The 'cookie.parse()' returns only the first, which can be either.
+ * This proxy should fix all overlaps, because it moves old versions to new domain.
+ */
+
+export function createCookieStorageProxy(
+  ...args: Parameters<typeof createCookieController>
+): ReturnType<typeof createCookieController> {
+  const [options, cookieName] = args;
+  const domain = options.domain || getCookieDomainForSubDomainAccess();
+  const controllerOptions = { ...options, domain };
+  const cookieController = createCookieController(controllerOptions, cookieName);
+
+  const isConsentCookie = (cookieData: unknown) => {
+    return String(cookieData).trim().startsWith(cookieName);
+  };
+
+  const getConsentCookies = (): string[] => {
+    const cookies = document.cookie || '';
+    if (!cookies || cookies.indexOf('=') < 0) {
+      return [];
+    }
+    return cookies.split(COOKIE_DELIMETER).filter((cookieData) => isConsentCookie(cookieData));
+  };
+
+  const getConsentData = (consentCookieList: string[]): string => {
+    const consentData = consentCookieList[0];
+    const data = consentData ? parse(`${consentData}${COOKIE_DELIMETER}`.trim()) : {};
+    return data[cookieName] || '';
+  };
+
+  let hasVersionNumber = getVersionNumber() === CURRENT_VERSION;
+  const storeVersionNumberIfNotSet = () => {
+    if (hasVersionNumber) {
+      return;
+    }
+    setNamedCookie(VERSION_COOKIE_NAME, String(CURRENT_VERSION), { ...defaultCookieSetOptions, ...controllerOptions });
+    hasVersionNumber = true;
+  };
+
+  const clearedDomains = new Set();
+
+  const clearCookie = (cookieDomain: string) => {
+    if (clearedDomains.has(cookieDomain)) {
+      return;
+    }
+    clearedDomains.add(cookieDomain);
+    setNamedCookie(cookieName, '', {
+      ...defaultCookieSetOptions,
+      ...options,
+      domain: cookieDomain,
+      expires: new Date(0),
+      maxAge: undefined,
+    });
+  };
+
+  const clearAllConsentCookieDomains = () => {
+    clearCookie(getCookieDomainForMultiDomainAccess());
+    clearCookie(getCookieDomainForSubDomainAccess());
+    if (options.domain) {
+      clearCookie(options.domain);
+    }
+  };
+
+  // Logic of the cookie filtering:
+  // The old domain was by default *.hel.fi
+  // If a custom domain has been used, it can only be <subdomain>.hel.fi or still *.hel.fi
+  // If a custom domain has been added/removed after cookies with old default domain are set, there might be two existing versions returned already; before even the new default was added.
+  // If this is the case there are two cookies with consents.
+  // As a fail-safe, if multiple consents are found they are all removed, because there is no way knowing which consents are latest.
+  // In this case cookie consents are asked again.
+
+  const consentCookies = getConsentCookies();
+  const hasStoredConsents = consentCookies.length > 0;
+  const hasMultipleVersions = consentCookies.length > 1;
+
+  if (hasMultipleVersions) {
+    clearAllConsentCookieDomains();
+    cookieController.set('{}');
+  } else if (!hasVersionNumber && hasStoredConsents) {
+    clearCookie(getCookieDomainForMultiDomainAccess());
+    if (hasStoredConsents) {
+      const current = getConsentData(consentCookies);
+      if (current) {
+        cookieController.set(current);
+      }
+    }
+  }
+
+  return {
+    get: () => cookieController.get(),
+    set: (data: string) => {
+      storeVersionNumberIfNotSet();
+      cookieController.set(data);
+    },
+  };
+}

--- a/packages/react/src/components/cookieConsent/getContent.ts
+++ b/packages/react/src/components/cookieConsent/getContent.ts
@@ -614,24 +614,41 @@ export function getCookieContent() {
     commonCookies: {
       helConsentCookie: {
         id: 'SET_IN_CODE',
-        hostName: '*.hel.fi',
+        hostName: 'SET_IN_CODE',
         commonGroup: 'SET_IN_CODE',
+        name: 'SET_IN_CODE',
         fi: {
-          name: 'Evästesuostumukset',
           description:
             'Sivusto käyttää tätä evästettä tietojen tallentamiseen siitä, ovatko kävijät antaneet hyväksyntänsä tai kieltäytyneet evästeiden käytöstä.',
           expiration: '1 vuosi',
         },
         sv: {
-          name: 'Samtycken till kakor',
           description:
             'Webbplatsen använder denna kaka för att lagra information om huruvida besökare har godkänt användningen av kakor eller inte.',
           expiration: 'Ett år',
         },
         en: {
-          name: 'Cookie consents',
           description:
             'Used by hel.fi to store information about whether visitors have given or declined the use of cookie categories used on the hel.fi site.',
+          expiration: '1 year',
+        },
+      },
+      helConsentCookieVersion: {
+        id: 'SET_IN_CODE',
+        hostName: 'SET_IN_CODE',
+        commonGroup: 'SET_IN_CODE',
+        name: 'SET_IN_CODE',
+        fi: {
+          description: 'Tähän evästeeseen tallennetaan käyttäjän hyväksymän evästeselosteen versio.',
+          expiration: '1 vuosi',
+        },
+        sv: {
+          description: 'Används för att lagra information om versionen av cookies samtycke som användaren har godkänt.',
+          expiration: 'Ett år',
+        },
+        en: {
+          description:
+            'Used by hel.fi to store information about what version of the cookie consent the user has agreed to.',
           expiration: '1 year',
         },
       },


### PR DESCRIPTION
## Description

Cookie consents were stored with domain set as `.hel.fi`. Now for security reasons the domain is by default `<subdomain>.hel.fi`.

Could not just store the cookie to a new domain, because there would be cases where `document.cookie` contains data from both domains. And the order in not guaranteed to be same in all browsers - or servers. 

So old stored cookie should be removed and new stored. A version numbering was added to detect, if the cookie is stored the new way or old. `document.cookie` does not return domain or any other data, so no other way to know.

**The version is stored to a new cookie and cookies require consents, so the new version will ask consents again.**

This PR has no documentation updates, there is another [ticket](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2015) for those.



## Related Issue

Closes [HDS-2065](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2065)

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-2065-cookies/?path=/story/components-cookieconsent--simple-modal-version)

## How Has This Been Tested?

Unit tests, local tests, demo testing.

How to test on the demo site:
- goto [this demo](https://city-of-helsinki.github.io/hds-demo/hds-2065-old-cookie-version/?path=/story/components-cookieconsent--simple-modal-version) with old cookie consent system. 
- it will write cookies the old way.  Note: `github.io` is a public suffix domain. Cookies with domain set to top level (`.github.io`) are not allowed on public suffix sites.
- you can check the stored cookies in the console ("application" tab in Chrome, "cookies" are in the sidebar)
- next goto [demo of this PR](https://city-of-helsinki.github.io/hds-demo/hds-2065-cookies/?path=/story/components-cookieconsent--simple-modal-version). Because of new version cookie, consents are asked again. Before user gives consents, the old ones are converted to new domain and there is now a version cookie. Cookies are also moved to new domain, except that is not possible to test in `github.io`, because all cookie domains must be `subdomain.github.io` (public suffix issue).

You can test cookie fully in localhost, if you add a longer domain for localhost in the [hosts file](https://www.hostinger.com/tutorials/how-to-edit-hosts-file-macos).

Add
`127.0.0.1 local.hds.hel.ninja  `

Then start Storybook and goto http://local.hds.hel.ninja:6006/ and add or modify cookies from the console.

## Add to changelog
- [x] Added needed line to changelog 


[HDS-2065]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ