### PR TITLE
HDS-2070 hide native password icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [TextInput] Hide native password reveal icon (Edge browser)
 
 ### Core
 
@@ -44,6 +45,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Text input] Hide native password reveal icon (Edge browser)
 
 ### Documentation
 

--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -152,6 +152,10 @@
   resize: vertical;
 }
 
+.hds-text-input .hds-text-input__input::-ms-reveal {
+  display: none;
+}
+
 .hds-text-input .hds-text-input__input::placeholder {
   color: var(--placeholder-color);
   opacity: 1;


### PR DESCRIPTION
## Description

Hide native reveal-icon in password input when using Edge browser

## Related Issue

[HDS-2070](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2070)

## How Has This Been Tested?

- local machine
- The working demo is [here](https://city-of-helsinki.github.io/hds-demo/password-reveal/?path=/story/components-passwordinput--auto-complete-on). Confirmed by me to work on MacOS & Windows 11 ARM with Edge browser.

## Add to changelog
- [x] Added needed line to changelog 


[HDS-2070]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ