### PR TITLE
Fix rounded links buttons on iOS 15.5

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -12,7 +12,6 @@
   * Normalize.css rules
   * Correct the inability to style clickable types in iOS and Safari.
   */
-  -webkit-appearance: button;
   background-color: var(--background-color, transparent);
   border: var(--border-width) solid var(--border-color, transparent);
   border-radius: 0;
@@ -63,6 +62,7 @@
  * Normalize.css rules
  * Correct the inability to style clickable types in iOS and Safari.
  */
+button.hds-button,
 .hds-button[type="button"],
 .hds-button[type="reset"],
 .hds-button[type="submit"] {


### PR DESCRIPTION
## Description

Fix iOS 15.5 (and hopefully 15.8) rounded link buttons.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->
I do not have an issue yet, but I do have an slack message with a thread: https://helsinkicity.slack.com/archives/CHCV3KTHA/p1705669479076289


## Motivation and Context

It seems that at least iOS 15.5 and 15.8 render links in a weird way if `-webkit-appearance: button;` is set. They ignore border-radius and padding properties from css if it is set. More current iOS versions do not have this problem.

This problem comes probably from the original mindset of `.hds-button` only applying to `<button>` elements when the normalize.css code was being merged with the button code. Now that `.hds-button` is also used for `<a href="...`-elements, the assumption fails.

By modifying the button.css code we can get the original intent of normalize.css to work better in this case and exclude link buttons from the `-webkit-appearance: button` issue.

## How Has This Been Tested?

On an iOS simulator for iOS 15.5

## Screenshots (if appropriate):

Screenshot of a modified hds documentation page with `<button>` and two `<a href` links with similar styles but different rendering on iOS 15.5.

![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/fc69842c-1457-4a2a-8cb1-cf6f2716e90f)
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/22763037-32dc-4377-aaf5-2fad6f98cebf)

Screenshot of originating source for normalize.css
![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/1191667/7eb95050-f2f3-4817-98d3-32881e3f8a6f)


## Add to changelog
- [ ] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->
