### PR TITLE
HDS-2069 first steps to new Select, Group component

### DIFF
--- a/packages/react/src/components/group/Group.stories.tsx
+++ b/packages/react/src/components/group/Group.stories.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+
+import { TextInput } from '../textInput/TextInput';
+import { Button } from '../button/Button';
+import { ChangeHandlerProps, Controller, GroupChild, GroupChildFunction, GroupProps } from './utils';
+import { Group, RenderWithController } from './Group';
+import { createOnClickListener, createInputOnChangeListener } from './utils/propSetterHelpers';
+import { IconArrowDown, IconArrowUp } from '../../icons';
+import { ForwardController } from './utils/forwardController';
+
+export default {
+  component: Group,
+  title: 'Components/Group',
+};
+
+export const Example = () => {
+  const pickData = (id: keyof typeof props.initialData, controller: Controller) => {
+    const data = controller.getData() as typeof props.initialData;
+    return data[id];
+  };
+  const props: GroupProps = {
+    initialData: { text: 'initial text', reverse: 'reverse', otherProp: 'hello world' },
+    onChange: (change: ChangeHandlerProps) => {
+      const { controller, id, payload } = change;
+      controller.updateData({ data: { [id]: String(payload && payload.value) || '' } });
+    },
+    propSetter: (propSetterProps) => {
+      const { id, controller } = propSetterProps;
+
+      return id === 'reverse'
+        ? {
+            value: String(pickData('text', controller) || '')
+              .split('')
+              .reverse()
+              .join(''),
+          }
+        : {
+            ...createInputOnChangeListener(propSetterProps),
+            value: String(pickData(id, controller)) || '',
+          };
+    },
+  };
+
+  const JoinedValues: GroupChildFunction = ({ controller }: { controller: Controller }) => {
+    const allProps = Object.values(controller.getData() as Record<string, string>).join('+');
+    return <p>All data joined: {allProps}</p>;
+  };
+
+  return (
+    <Group {...props}>
+      <TextInput id="text" key="text" label="Input" />
+      <TextInput label="Reversed input:" disabled id="reverse" data-hds-group-id="reverse" key="rev" />
+      {({ controller }) => {
+        return <JoinedValues controller={controller} />;
+      }}
+    </Group>
+  );
+};
+
+Example.parameters = {
+  loki: { skip: true },
+};
+
+export const NumericStepper = () => {
+  const pickData = (id: keyof typeof props.initialData, controller: Controller) => {
+    const data = controller.getData() as typeof props.initialData;
+    return data[id];
+  };
+  const props: GroupProps = {
+    initialData: { value: 1, max: 500, min: -5, error: '' },
+
+    onChange: (change: ChangeHandlerProps) => {
+      const { controller, payload, id, type } = change;
+      const { value, min, max } = controller.getData() as { value: string; min: number; max: number; error: string };
+      const resolveNewValue = () => {
+        if (type !== 'click') {
+          return parseInt(String((payload && payload.value) || '0'), 10);
+        }
+        const diff = id === 'increment' ? 1 : -1;
+        return parseInt(value, 10) + diff;
+      };
+      const resolveErrorMessage = (newValue) => {
+        if (newValue > max) {
+          return `Max is ${max}`;
+        }
+        if (newValue < min) {
+          return `Min is ${min}`;
+        }
+        return ``;
+      };
+      const newValue = resolveNewValue();
+
+      controller.updateData({
+        data: {
+          error: resolveErrorMessage(newValue),
+          value: Math.max(Math.min(newValue, max), min),
+        },
+        updateKeys: [],
+      });
+    },
+
+    propSetter: (propSetterProps) => {
+      const { id, controller, elementProps } = propSetterProps;
+      if (id === 'value') {
+        return {
+          ...createInputOnChangeListener(propSetterProps),
+          value: String(pickData(id, controller)) || '',
+        };
+      }
+      if (id === 'error') {
+        return { children: pickData(id, controller) || '' };
+      }
+      return {
+        ...elementProps,
+        ...createOnClickListener(propSetterProps),
+      };
+    },
+  };
+
+  const Error: GroupChild = ({ children }) => {
+    return <p>{children}</p>;
+  };
+  return (
+    <Group {...props}>
+      <TextInput id="value" />
+      <Button id="decrement">-</Button>
+      <Button id="increment">+</Button>
+      <Error id="error" />
+    </Group>
+  );
+};
+
+NumericStepper.parameters = {
+  loki: { skip: true },
+};
+
+export const Accordion = () => {
+  const props: GroupProps = {
+    initialData: { open: false, title: 'Accordion title' },
+
+    onChange: (change: ChangeHandlerProps) => {
+      const { controller, payload, type, id } = change;
+      if (type === 'toggle-open') {
+        controller.updateData({ data: { open: payload && payload.value } });
+      }
+      if (id === 'inner-close-button') {
+        controller.updateData({ data: { open: false } });
+      }
+    },
+
+    propSetter: (propSetterProps) => {
+      const { id } = propSetterProps;
+      if (id === 'title' || id === 'inner-close-button') {
+        return createOnClickListener(propSetterProps);
+      }
+      return {};
+    },
+  };
+
+  const Title = ForwardController((titleProps, forwardedController) => {
+    const data = forwardedController.getData() as Record<string, unknown>;
+    const title = data[titleProps.id as string] as string;
+    const onClick = () => {
+      forwardedController.triggerChange({ id: 'title-button', type: 'toggle-open', payload: { value: !data.open } });
+    };
+    const Icon = data.open ? IconArrowUp : IconArrowDown;
+    return (
+      <div>
+        <Button variant="supplementary" iconRight={<Icon />} onClick={onClick}>
+          {title}
+        </Button>
+      </div>
+    );
+  });
+
+  const ToggledContent = ForwardController((titleProps, forwardedController) => {
+    const data = forwardedController.getData() as Record<string, unknown>;
+    const isOpen = !!data.open as boolean;
+    if (!isOpen) {
+      return null;
+    }
+    return (
+      <div>
+        {titleProps.children}
+        <RenderWithController controller={forwardedController}>
+          <Button variant="secondary" id="inner-close-button">
+            Close
+          </Button>
+        </RenderWithController>
+      </div>
+    );
+  });
+
+  return (
+    <Group {...props}>
+      <Title id="title" />
+      <ToggledContent>
+        <p>Content</p>
+      </ToggledContent>
+    </Group>
+  );
+};
+
+Accordion.parameters = {
+  loki: { skip: true },
+};

--- a/packages/react/src/components/group/Group.test.tsx
+++ b/packages/react/src/components/group/Group.test.tsx
@@ -1,0 +1,758 @@
+import React, { createRef, useEffect, useRef, useState } from 'react';
+import { render, waitFor, fireEvent, act, cleanup } from '@testing-library/react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Group, RenderWithController } from './Group';
+import { GroupChild, GroupProps, PropSetter } from './utils';
+import { Button } from '../button';
+import { TextInput } from '../textInput';
+import useForceRender from '../../hooks/useForceRender';
+import { getAllMockCallArgs } from '../../utils/testHelpers';
+import { StorageData } from './utils/storage';
+import { ForwardController } from './utils/forwardController';
+
+type DomEventData = { rendered: number; mounted: number; unmounted: number; updateTime: number };
+type DataPerId = DomEventData & {
+  instanceId: string;
+  instanceRenderCount: number;
+  value: unknown;
+  id: string;
+};
+
+/* eslint-disable react/no-unused-prop-types */
+type TestComponentProps = {
+  id?: string;
+  value?: string;
+  key?: string;
+  onButtonClick?: () => void;
+  onTextInputChange?: () => void;
+};
+/* eslint-enable react/no-unused-prop-types */
+
+type ControllerData = Record<string, number | string>;
+
+describe('Group', () => {
+  // track how many times group's children are rendered and (un/)mounted
+  const domEventsPerId = new Map<string, DomEventData>();
+  const initialDomEventData: DomEventData = { rendered: 0, mounted: 0, unmounted: 0, updateTime: 0 };
+  const propSetterTracker = jest.fn();
+
+  const getCurrentDomEventData = (id: string) => {
+    return domEventsPerId.get(id) || { ...initialDomEventData };
+  };
+
+  const getDomUpdateTime = (id: string) => {
+    const current = getCurrentDomEventData(id);
+    return current.updateTime;
+  };
+
+  const updateDomEventsPerId = (id: string, targetProp: keyof DomEventData) => {
+    const current = getCurrentDomEventData(id);
+    current[targetProp] += 1;
+    current.updateTime = Date.now();
+    domEventsPerId.set(id, current);
+  };
+
+  const domEventCountHook = (id: string) => {
+    // when component is mounted, these refs are initialized or reset.
+    // domEventsPerId tracks all renders, this ref only renders of this instance.
+    const instanceRenderCountRef = useRef(1);
+    // instanceIdRef changes when new instance is created.
+    const instanceIdRef = useRef(uuidv4());
+    useEffect(() => {
+      updateDomEventsPerId(id, 'mounted');
+      return () => {
+        updateDomEventsPerId(id, 'unmounted');
+      };
+    }, []);
+    useEffect(() => {
+      updateDomEventsPerId(id, 'rendered');
+      instanceRenderCountRef.current += 1;
+    });
+    return { instanceRenderCount: instanceRenderCountRef.current, instanceId: instanceIdRef.current };
+  };
+
+  // return initial render data of a component when it has been mounted once.
+  const getRenderedComponentDataPerId = (
+    id: string,
+    data: StorageData,
+  ): Omit<DataPerId, 'updateTime' | 'instanceId'> => {
+    return {
+      id,
+      instanceRenderCount: 1,
+      rendered: 1,
+      mounted: 1,
+      unmounted: 0,
+      // getValue() returns element's innerHTML which is a string
+      // so data[id] must also be a string to use expect.toBe()
+      value: String(data[id]),
+    };
+  };
+
+  const TestComponent = React.forwardRef<HTMLDivElement, TestComponentProps>((componentProps, ref) => {
+    const { id, value, onButtonClick, onTextInputChange } = componentProps;
+    const { instanceRenderCount, instanceId } = domEventCountHook(id || 'no-id');
+    return (
+      <div id={`${id}`} ref={ref}>
+        <Button id={`button-${id}`} onClick={onButtonClick}>
+          Click me!
+        </Button>
+        <TextInput id={`input-${id}`} value={value} onChange={onTextInputChange} />
+        <span id={`render-count-${id}`}>{instanceRenderCount}</span>
+        <span id={`instance-uuid-${id}`}>{instanceId}</span>
+        <span id={`value-${id}`}>{value as string}</span>
+      </div>
+    );
+  });
+
+  // tracks only whole group's re-rendering process
+  const GroupRenderCounter: GroupChild = () => {
+    const id = 'group';
+    const { instanceRenderCount } = domEventCountHook(id);
+    return <span id="render-count-group">{instanceRenderCount}</span>;
+  };
+
+  const ForwardedController = ForwardController<{ childId?: string }>((props, controller) => {
+    const id = String(props.id);
+    const { childId } = props;
+    const value = (controller.getData() as ControllerData)[id];
+    const { instanceRenderCount, instanceId } = domEventCountHook(id);
+    const onButtonClick = () => {
+      controller.triggerChange({ id, type: 'click' });
+    };
+    return (
+      <>
+        <Button id={`button-${id}`} onClick={onButtonClick}>
+          Click me!
+        </Button>
+        <span id={`render-count-${id}`}>{instanceRenderCount}</span>
+        <span id={`instance-uuid-${id}`}>{instanceId}</span>
+        <span id={`value-${id}`}>{value as string}</span>
+        {childId && (
+          <RenderWithController controller={controller}>
+            <TestComponent id={childId} key={childId} />
+          </RenderWithController>
+        )}
+      </>
+    );
+  });
+
+  const renderComponent = ({
+    initialData,
+    dataSets,
+    componentIds,
+    updateKeys,
+  }: {
+    initialData: StorageData;
+    dataSets?: Array<StorageData>;
+    componentIds: string[];
+    updateKeys?: boolean;
+  }) => {
+    const propSetter: PropSetter = ({ id, controller, elementProps }) => {
+      propSetterTracker(id, controller, elementProps);
+      return {
+        id,
+        value: (controller.getData() as ControllerData)[id],
+        onButtonClick: () => {
+          controller.triggerChange({ id, type: 'click' });
+        },
+        onTextInputChange: (e: React.KeyboardEvent<HTMLInputElement>) => {
+          controller.triggerChange({ id, type: 'change', payload: { value: e.currentTarget.value } });
+        },
+      };
+    };
+
+    const onChange: GroupProps['onChange'] = (changeProps) => {
+      const { controller, id } = changeProps;
+      const currentData = (controller.getData() as ControllerData)[id];
+      controller.updateData({
+        data: { [id as string]: Number(currentData) + 1 },
+        updateKeys: [updateKeys !== false ? id : ''],
+      });
+    };
+
+    // multiple dataSets are used for controller re-initialization
+    // when initialData changes.
+    const getGroupInitialData = (): StorageData => {
+      if (dataSets) {
+        return dataSets.shift() as StorageData;
+      }
+      return initialData;
+    };
+
+    const GroupWrapper = () => {
+      const [renderGroup, toggleRenderGroup] = useState(true);
+      const rerender = useForceRender();
+      const onClick = () => {
+        rerender();
+      };
+      const toggleGroup = () => {
+        toggleRenderGroup((current) => !current);
+      };
+      return (
+        <div>
+          <Button id="button-wrapper" onClick={onClick}>
+            Re-render
+          </Button>
+          <Button id="button-toggleGroup" onClick={toggleGroup}>
+            Show/hide group
+          </Button>
+          {renderGroup && (
+            <div id="group-wrapper">
+              <Group propSetter={propSetter} initialData={getGroupInitialData()} onChange={onChange}>
+                {componentIds.includes('test1') && <TestComponent id="test1" key="key1" />}
+                {componentIds.includes('test2') && <TestComponent id="test2" key="key2" />}
+                {componentIds.includes('test3') && <ForwardedController id="test3" key="key3" />}
+                {componentIds.includes('test4') && <ForwardedController id="test4" key="key4" childId="test4_0" />}
+                {componentIds.includes('test5') &&
+                  (({ controller }) => {
+                    return (
+                      <RenderWithController controller={controller} key="renderWithController">
+                        <TestComponent id="test5" key="key5" />
+                      </RenderWithController>
+                    );
+                  })}
+                <p key="p">I am just a child</p>
+                <GroupRenderCounter key="counter" />
+              </Group>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const result = render(<GroupWrapper />);
+
+    const getElementById = (id: string) => {
+      return result.container.querySelector(`#${id}`) as HTMLElement;
+    };
+
+    const getInstanceRenderCount = (id: string) => {
+      return parseInt(getElementById(`render-count-${id}`).innerHTML, 10);
+    };
+    const getInstanceId = (id: string) => {
+      return getElementById(`instance-uuid-${id}`).innerHTML;
+    };
+
+    const getValue = (id: string) => {
+      return getElementById(`value-${id}`).innerHTML;
+    };
+
+    const clickButton = (id: string) => {
+      const el = getElementById(`button-${id}`);
+      fireEvent.click(el);
+    };
+
+    const executeAndWaitForUpdate = async (executor: () => void) => {
+      await act(async () => {
+        const lastUpdateTime = getDomUpdateTime('group');
+        executor();
+        await waitFor(() => {
+          if (getDomUpdateTime('group') === lastUpdateTime) {
+            throw new Error('Group not updated');
+          }
+        });
+      });
+    };
+
+    const rerenderAll = async () => {
+      await act(async () => {
+        const lastUpdateTime = getDomUpdateTime('group');
+        clickButton('wrapper');
+        await waitFor(() => {
+          if (getDomUpdateTime('wrapper') === lastUpdateTime) {
+            throw new Error('Wrapper not updated');
+          }
+        });
+      });
+    };
+
+    const toggleGroup = async () => {
+      await act(async () => {
+        const isVisible = !!getElementById('group-wrapper');
+        clickButton('toggleGroup');
+        await waitFor(() => {
+          if (!!getElementById('group-wrapper') === isVisible) {
+            throw new Error('Group not toggled');
+          }
+        });
+      });
+    };
+
+    const collectAllDataPerId = (id: string): DataPerId => {
+      const domEvents = getCurrentDomEventData(id);
+      const instanceId = getInstanceId(id);
+      const instanceRenderCount = getInstanceRenderCount(id);
+      const value = getValue(id);
+      return {
+        ...domEvents,
+        instanceId,
+        instanceRenderCount,
+        value,
+        id,
+      };
+    };
+
+    // store component's data for easy comparisons after re-renders
+    const createComponentDataStorage = (id: string, groupData: StorageData) => {
+      const storage = [getRenderedComponentDataPerId(id, groupData)] as Array<Partial<DataPerId>>;
+      const get = (index = -1): DataPerId => {
+        const arrIndex = index < 0 ? storage.length + index : index;
+        return storage[arrIndex] as DataPerId;
+      };
+      return {
+        add: (data: Partial<DataPerId>) => {
+          storage.push(data);
+        },
+        addWithMerge: (partial: Partial<DataPerId>) => {
+          const last = get();
+          storage.push({ ...last, ...partial });
+        },
+        get,
+      };
+    };
+
+    return {
+      ...result,
+      getInstanceRenderCount,
+      getElementById,
+      getValue,
+      clickButton,
+      executeAndWaitForUpdate,
+      rerenderAll,
+      toggleGroup,
+      getInstanceId,
+      collectAllDataPerId,
+      createComponentDataStorage,
+    };
+  };
+
+  const getControllerFromPropSetterCalls = () => {
+    const calls = getAllMockCallArgs(propSetterTracker);
+    return calls[calls.length - 1][1];
+  };
+
+  const getControllerByIdFromPropSetterCalls = (id: string) => {
+    const calls = getAllMockCallArgs(propSetterTracker).filter((call) => call[0] === id);
+    return calls[calls.length - 1][1];
+  };
+
+  const increaseValueByOne = (value?: number) => {
+    return typeof value !== 'number' ? 0 : value + 1;
+  };
+
+  const updateComponentDataAfterReMount = (previousData: Partial<DataPerId>): Partial<DataPerId> => {
+    return {
+      ...previousData,
+      mounted: increaseValueByOne(previousData.mounted),
+      rendered: increaseValueByOne(previousData.rendered),
+      unmounted: increaseValueByOne(previousData.unmounted),
+      instanceRenderCount: 1,
+    };
+  };
+
+  const updateComponentDataAfterInstanceRender = (previousData: Partial<DataPerId>): Partial<DataPerId> => {
+    return {
+      ...previousData,
+      rendered: increaseValueByOne(previousData.rendered),
+      instanceRenderCount: increaseValueByOne(previousData.instanceRenderCount),
+    };
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+    domEventsPerId.clear();
+  });
+
+  describe('Basic components are rendered with propSetter and given data', () => {
+    const initialData = {
+      test1: 100,
+      test2: 2000,
+    };
+    const componentIds = ['test1', 'test2'];
+    it('Data is passed to components and all components are rendered with proper data.', async () => {
+      const { collectAllDataPerId, createComponentDataStorage, getValue } = renderComponent({
+        initialData,
+        componentIds,
+      });
+      const test1Storage = createComponentDataStorage('test1', initialData);
+      // automatic data comparision
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      // manual data comparision
+      expect(collectAllDataPerId('test2')).toMatchObject({
+        id: 'test2',
+        rendered: 1,
+        mounted: 1,
+        unmounted: 0,
+        value: getValue('test2'),
+      });
+    });
+    it('Component is not re-mounted even if whole group is re-rendered', async () => {
+      const { rerenderAll, getInstanceId, collectAllDataPerId, createComponentDataStorage } = renderComponent({
+        initialData,
+        componentIds,
+      });
+      const test1Storage = createComponentDataStorage('test1', initialData);
+      const test2Storage = createComponentDataStorage('test2', initialData);
+
+      // store instaceIds so those can be compared.
+      test1Storage.addWithMerge({ instanceId: getInstanceId('test1') });
+      test2Storage.addWithMerge({ instanceId: getInstanceId('test2') });
+
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+
+      await rerenderAll();
+      test1Storage.addWithMerge(updateComponentDataAfterInstanceRender(test1Storage.get()));
+      test2Storage.addWithMerge(updateComponentDataAfterInstanceRender(test2Storage.get()));
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+      await rerenderAll();
+      test1Storage.addWithMerge(updateComponentDataAfterInstanceRender(test1Storage.get()));
+      test2Storage.addWithMerge(updateComponentDataAfterInstanceRender(test2Storage.get()));
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+
+      // manual data comparision to make sure automation works
+      expect(collectAllDataPerId('test2')).toMatchObject({
+        id: 'test2',
+        rendered: 3,
+        unmounted: 0,
+        mounted: 1,
+        instanceRenderCount: 3,
+      });
+
+      // verify instanceIds did not change
+      expect(test1Storage.get(-1).instanceId).toBe(test1Storage.get(-2).instanceId);
+      expect(test1Storage.get(-2).instanceId).toBe(test1Storage.get(-3).instanceId);
+
+      // verify instanceIds did not change
+      expect(test2Storage.get(-1).instanceId).toBe(test2Storage.get(-2).instanceId);
+      expect(test2Storage.get(-2).instanceId).toBe(test2Storage.get(-3).instanceId);
+    });
+    it('Only the component whose data and key changes is re-mounted', async () => {
+      const {
+        rerenderAll,
+        clickButton,
+        executeAndWaitForUpdate,
+        getInstanceId,
+        createComponentDataStorage,
+        collectAllDataPerId,
+      } = renderComponent({ initialData, componentIds });
+      const test1Storage = createComponentDataStorage('test1', initialData);
+      const test2Storage = createComponentDataStorage('test2', initialData);
+      test1Storage.addWithMerge({ instanceId: getInstanceId('test1') });
+      test2Storage.addWithMerge({ instanceId: getInstanceId('test2') });
+
+      // one call for each group component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(2);
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+
+      test1Storage.addWithMerge({
+        ...updateComponentDataAfterReMount(test1Storage.get()),
+        instanceId: getInstanceId('test1'),
+        value: String(initialData.test1 + 1),
+      });
+      test2Storage.addWithMerge(updateComponentDataAfterInstanceRender(test2Storage.get()));
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(4);
+      await executeAndWaitForUpdate(() => {
+        clickButton('test2');
+      });
+
+      test1Storage.addWithMerge(updateComponentDataAfterInstanceRender(test1Storage.get()));
+      test2Storage.addWithMerge({
+        ...updateComponentDataAfterReMount(test2Storage.get()),
+        instanceId: getInstanceId('test2'),
+        value: String(initialData.test2 + 1),
+      });
+
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+      expect(test1Storage.get().rendered).toBe(3);
+      expect(test2Storage.get().rendered).toBe(3);
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(6);
+      await rerenderAll();
+      test1Storage.addWithMerge(updateComponentDataAfterInstanceRender(test1Storage.get()));
+      test2Storage.addWithMerge(updateComponentDataAfterInstanceRender(test2Storage.get()));
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+      expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+
+      expect(collectAllDataPerId('test2')).toMatchObject({
+        id: 'test2',
+        rendered: 4,
+        unmounted: 1,
+        mounted: 2,
+        instanceRenderCount: 2,
+      });
+
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(8);
+    });
+    it('Component whose data changed, but key did not, is not re-mounted', async () => {
+      const {
+        clickButton,
+        executeAndWaitForUpdate,
+        getInstanceId,
+        createComponentDataStorage,
+        collectAllDataPerId,
+      } = renderComponent({ initialData, componentIds, updateKeys: false });
+      const test1Storage = createComponentDataStorage('test1', initialData);
+      test1Storage.addWithMerge({ instanceId: getInstanceId('test1') });
+
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+
+      test1Storage.addWithMerge({
+        ...updateComponentDataAfterInstanceRender(test1Storage.get()),
+        instanceId: test1Storage.get().instanceId,
+        value: String(initialData.test1 + 1),
+      });
+
+      expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+    });
+    it('Controller instance does not change when Group or parent re-renders, if initialData remains the same', async () => {
+      const { executeAndWaitForUpdate, rerenderAll, clickButton, collectAllDataPerId } = renderComponent({
+        initialData,
+        componentIds,
+      });
+      const controller = getControllerFromPropSetterCalls();
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+      expect(getControllerFromPropSetterCalls()).toBe(controller);
+      await rerenderAll();
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+      expect(getControllerFromPropSetterCalls()).toBe(controller);
+      await rerenderAll();
+      expect(getControllerFromPropSetterCalls()).toBe(controller);
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+      expect(collectAllDataPerId('test1')).toMatchObject({
+        id: 'test1',
+        rendered: 6,
+        unmounted: 3,
+        mounted: 4,
+        instanceRenderCount: 1,
+        value: String(initialData.test1 + 3),
+      });
+      expect(collectAllDataPerId('test2')).toMatchObject({
+        id: 'test2',
+        rendered: 6,
+        unmounted: 0,
+        mounted: 1,
+        instanceRenderCount: 6,
+        value: String(initialData.test2),
+      });
+    });
+    it('Controller instance changes when initialData is changed. Component values is updated to the new value from the initialData.', async () => {
+      const dataSets = [
+        { ...initialData, test1: 400000, test2: 7000, key: 1 },
+        { ...initialData, test1: 500000, test2: 8000, key: 2 },
+        { ...initialData, test1: 600000, test2: 9000, key: 3 },
+      ];
+      const { executeAndWaitForUpdate, rerenderAll, clickButton, collectAllDataPerId, getValue } = renderComponent({
+        dataSets: [...dataSets],
+        initialData: {},
+        componentIds,
+      });
+      const controller = getControllerFromPropSetterCalls();
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+      expect(getControllerFromPropSetterCalls()).toBe(controller);
+      expect(getValue('test1')).toBe(String(dataSets[0].test1 + 1));
+
+      await rerenderAll();
+      const newController = getControllerFromPropSetterCalls();
+      expect(newController).not.toBe(controller);
+      expect(getValue('test1')).toBe(String(dataSets[1].test1));
+      expect(getValue('test2')).toBe(String(dataSets[1].test2));
+
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+      expect(getControllerFromPropSetterCalls()).toBe(newController);
+
+      await rerenderAll();
+      const newestController = getControllerFromPropSetterCalls();
+      expect(newestController).not.toBe(newController);
+      expect(getValue('test1')).toBe(String(dataSets[2].test1));
+      expect(getValue('test2')).toBe(String(dataSets[2].test2));
+
+      await executeAndWaitForUpdate(() => {
+        clickButton('test1');
+      });
+      expect(getControllerFromPropSetterCalls()).toBe(newestController);
+      expect(collectAllDataPerId('test1')).toMatchObject({
+        id: 'test1',
+        rendered: 6,
+        unmounted: 5,
+        mounted: 6,
+        instanceRenderCount: 1,
+        value: String(dataSets[2].test1 + 1),
+      });
+      expect(collectAllDataPerId('test2')).toMatchObject({
+        id: 'test2',
+        rendered: 6,
+        unmounted: 0,
+        mounted: 1,
+        instanceRenderCount: 6,
+        value: String(dataSets[2].test2),
+      });
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(12);
+    });
+  });
+  describe('ForwardController and plain function', () => {
+    const initialData = {
+      test3: 300,
+      test4: 400,
+      test4_0: 4000,
+      test5: 500,
+    };
+    const componentIds = ['test3', 'test4', 'test5'];
+    it('Receives controller as a function argument and uses it with children.', async () => {
+      const { collectAllDataPerId, createComponentDataStorage } = renderComponent({
+        initialData,
+        componentIds,
+      });
+      const test3Storage = createComponentDataStorage('test3', initialData);
+      const test4Storage = createComponentDataStorage('test4', initialData);
+      const test40Storage = createComponentDataStorage('test4_0', initialData);
+      const test5Storage = createComponentDataStorage('test5', initialData);
+      expect(collectAllDataPerId('test3')).toMatchObject(test3Storage.get());
+      expect(collectAllDataPerId('test4')).toMatchObject(test4Storage.get());
+      expect(collectAllDataPerId('test4_0')).toMatchObject(test40Storage.get());
+      expect(collectAllDataPerId('test5')).toMatchObject(test5Storage.get());
+    });
+    it('Only the component whose data and key changes is re-mounted', async () => {
+      const {
+        rerenderAll,
+        clickButton,
+        executeAndWaitForUpdate,
+        getInstanceId,
+        createComponentDataStorage,
+        collectAllDataPerId,
+      } = renderComponent({ initialData, componentIds });
+      const test3Storage = createComponentDataStorage('test3', initialData);
+      const test4Storage = createComponentDataStorage('test4', initialData);
+      const test40Storage = createComponentDataStorage('test4_0', initialData);
+      const test5Storage = createComponentDataStorage('test5', initialData);
+      test3Storage.addWithMerge({ instanceId: getInstanceId('test3') });
+      test4Storage.addWithMerge({ instanceId: getInstanceId('test4') });
+      test40Storage.addWithMerge({ instanceId: getInstanceId('test4_0') });
+      test5Storage.addWithMerge({ instanceId: getInstanceId('test5') });
+
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(4);
+      await executeAndWaitForUpdate(() => {
+        clickButton('test3');
+      });
+
+      test3Storage.addWithMerge({
+        ...updateComponentDataAfterReMount(test3Storage.get()),
+        instanceId: getInstanceId('test3'),
+        value: String(initialData.test3 + 1),
+      });
+      test4Storage.addWithMerge(updateComponentDataAfterInstanceRender(test4Storage.get()));
+      test40Storage.addWithMerge(updateComponentDataAfterInstanceRender(test40Storage.get()));
+      test5Storage.addWithMerge(updateComponentDataAfterInstanceRender(test5Storage.get()));
+      expect(collectAllDataPerId('test3')).toMatchObject(test3Storage.get());
+      expect(collectAllDataPerId('test4')).toMatchObject(test4Storage.get());
+      expect(collectAllDataPerId('test4_0')).toMatchObject(test40Storage.get());
+      expect(collectAllDataPerId('test5')).toMatchObject(test5Storage.get());
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(8);
+      await executeAndWaitForUpdate(() => {
+        clickButton('test4');
+      });
+
+      test3Storage.addWithMerge(updateComponentDataAfterInstanceRender(test3Storage.get()));
+      test4Storage.addWithMerge({
+        ...updateComponentDataAfterReMount(test4Storage.get()),
+        instanceId: getInstanceId('test4'),
+        value: String(initialData.test4 + 1),
+      });
+      test40Storage.addWithMerge({
+        ...updateComponentDataAfterReMount(test40Storage.get()),
+        instanceId: getInstanceId('test4_0'),
+        value: String(initialData.test4_0),
+      });
+      test5Storage.addWithMerge(updateComponentDataAfterInstanceRender(test5Storage.get()));
+
+      expect(collectAllDataPerId('test3')).toMatchObject(test3Storage.get());
+      expect(collectAllDataPerId('test4')).toMatchObject(test4Storage.get());
+      expect(collectAllDataPerId('test4_0')).toMatchObject(test40Storage.get());
+      expect(collectAllDataPerId('test5')).toMatchObject(test5Storage.get());
+      expect(test3Storage.get().rendered).toBe(3);
+      expect(test4Storage.get().rendered).toBe(3);
+      expect(test40Storage.get().rendered).toBe(3);
+      expect(test5Storage.get().rendered).toBe(3);
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(12);
+      await rerenderAll();
+      test3Storage.addWithMerge(updateComponentDataAfterInstanceRender(test3Storage.get()));
+      test4Storage.addWithMerge(updateComponentDataAfterInstanceRender(test4Storage.get()));
+      test40Storage.addWithMerge(updateComponentDataAfterInstanceRender(test40Storage.get()));
+      test5Storage.addWithMerge(updateComponentDataAfterInstanceRender(test5Storage.get()));
+      expect(collectAllDataPerId('test3')).toMatchObject(test3Storage.get());
+      expect(collectAllDataPerId('test4')).toMatchObject(test4Storage.get());
+      expect(collectAllDataPerId('test4_0')).toMatchObject(test40Storage.get());
+      expect(collectAllDataPerId('test5')).toMatchObject(test5Storage.get());
+
+      expect(collectAllDataPerId('test5')).toMatchObject({
+        id: 'test5',
+        rendered: 4,
+        unmounted: 0,
+        mounted: 1,
+        instanceRenderCount: 4,
+      });
+
+      // one call for each component * render times
+      expect(propSetterTracker).toHaveBeenCalledTimes(16);
+    });
+    it('Same controller instance is passed to all components. Also after update.', async () => {
+      const dataSets = [
+        { ...initialData, test3: 400000, test4: 7000, test4_0: 10000, test5: 3000, key: 1 },
+        { ...initialData, test3: 400001, test4: 7001, test4_0: 10001, test5: 3001, key: 2 },
+      ];
+      const { rerenderAll, getValue } = renderComponent({
+        dataSets: [...dataSets],
+        initialData: {},
+        componentIds,
+      });
+      const test3Controller = getControllerByIdFromPropSetterCalls('test3');
+      expect(test3Controller).toBe(getControllerByIdFromPropSetterCalls('test4'));
+      expect(test3Controller).toBe(getControllerByIdFromPropSetterCalls('test4_0'));
+      expect(test3Controller).toBe(getControllerByIdFromPropSetterCalls('test5'));
+
+      expect(getValue('test3')).toBe(String(dataSets[0].test3));
+      expect(getValue('test4')).toBe(String(dataSets[0].test4));
+      expect(getValue('test4_0')).toBe(String(dataSets[0].test4_0));
+      expect(getValue('test5')).toBe(String(dataSets[0].test5));
+
+      await rerenderAll();
+      const newTest3Controller = getControllerByIdFromPropSetterCalls('test3');
+      expect(newTest3Controller).not.toBe(test3Controller);
+      expect(newTest3Controller).toBe(getControllerByIdFromPropSetterCalls('test4'));
+      expect(newTest3Controller).toBe(getControllerByIdFromPropSetterCalls('test4_0'));
+      expect(newTest3Controller).toBe(getControllerByIdFromPropSetterCalls('test5'));
+
+      expect(getValue('test3')).toBe(String(dataSets[1].test3));
+      expect(getValue('test4')).toBe(String(dataSets[1].test4));
+      expect(getValue('test4_0')).toBe(String(dataSets[1].test4_0));
+      expect(getValue('test5')).toBe(String(dataSets[1].test5));
+    });
+  });
+});

--- a/packages/react/src/components/group/Group.tsx
+++ b/packages/react/src/components/group/Group.tsx
@@ -1,0 +1,66 @@
+import React, { isValidElement, useMemo } from 'react';
+
+import { getChildrenAsArray } from '../../utils/getChildren';
+import useForceRender from '../../hooks/useForceRender';
+import { createController } from './utils/controller';
+import { Controller, GroupChild, GroupProps } from './utils';
+import { isForwardController } from './utils/forwardController';
+
+export function pickGroupId(props: React.HtmlHTMLAttributes<HTMLElement>) {
+  return props['data-hds-group-id'] || props.id;
+}
+
+export const renderGroupChild = (
+  child: React.FunctionComponentElement<GroupChild> | React.ReactElement,
+  controller: Controller,
+) => {
+  const groupId = pickGroupId(child.props);
+  const props = groupId ? controller.getProps({ id: groupId, elementProps: child.props }) : {};
+  if (isForwardController(child)) {
+    props.forwardedController = controller;
+  }
+  return React.cloneElement(child, props);
+};
+
+export function renderGroupChildren(children: React.ReactNode | null, controller: Controller): React.ReactNode[] {
+  return getChildrenAsArray(children).map((child) => {
+    if (!child) {
+      return null;
+    }
+    const childType = typeof child;
+    if (childType === 'string' || childType === 'number') {
+      return child;
+    }
+    // in this case the child is a plain function accepting controller in argument object
+    if (childType === 'function') {
+      const renderResult = React.cloneElement(
+        (child as React.FC<{ controller: Controller }>)({ controller }) as React.ReactElement,
+      );
+      return renderGroupChild(renderResult, controller);
+    }
+    if (!isValidElement(child)) {
+      return null;
+    }
+    return renderGroupChild(child as React.ReactElement, controller);
+  });
+}
+
+export const RenderWithController = ({ children, controller }: React.PropsWithChildren<{ controller: Controller }>) => {
+  return <>{renderGroupChildren(children, controller)}</>;
+};
+
+export function Group({ children, propSetter, initialData, metaData, onChange = () => undefined }: GroupProps) {
+  const reRenderer = useForceRender();
+  const controller = useMemo(
+    () =>
+      createController({
+        reRenderer,
+        propSetter,
+        initialData,
+        metaData,
+        onChange,
+      }),
+    [initialData],
+  );
+  return <>{renderGroupChildren(children, controller)}</>;
+}

--- a/packages/react/src/components/group/utils/controller.test.ts
+++ b/packages/react/src/components/group/utils/controller.test.ts
@@ -1,0 +1,154 @@
+import { sleep } from '../../../utils/testHelpers';
+import { createController } from './controller';
+
+describe(`controller`, () => {
+  const initialData = { key: 'value' };
+  const metaData = { meta: 'value' };
+  const elementProps = { id: 'element-id', class: 'style' };
+  const mockedProps = { prop: 'value', key: 'key', ref: { current: {} } };
+  const defaultId = 'id';
+  const onChange = jest.fn();
+  const reRenderer = jest.fn();
+  const propSetter = jest.fn().mockReturnValue(mockedProps);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe(`getData() `, () => {
+    it(`returns initial data until updated`, () => {
+      const controller = createController({ initialData, reRenderer, propSetter, onChange });
+      expect(controller.getData()).toMatchObject(initialData);
+    });
+  });
+  describe(`getProps() `, () => {
+    it(`calls the passed propSetter with id and original props passed to the element.`, () => {
+      const controller = createController({ initialData, reRenderer, propSetter, onChange });
+      expect(controller.getProps({ id: defaultId, elementProps })).toBe(mockedProps);
+      expect(propSetter).toHaveBeenCalledWith({ id: defaultId, controller, key: '', elementProps });
+      expect(onChange).toHaveBeenCalledTimes(0);
+      expect(reRenderer).toHaveBeenCalledTimes(0);
+    });
+  });
+  describe(`triggerChange() `, () => {
+    it(`calls the onChange-function with id, payload and controller instance`, () => {
+      const controller = createController({ initialData, reRenderer, propSetter, onChange });
+      const payload = { value: 'value' };
+      controller.triggerChange({ id: defaultId, payload });
+      expect(onChange).toHaveBeenCalledWith({ id: defaultId, payload, controller });
+      expect(propSetter).toHaveBeenCalledTimes(0);
+      expect(reRenderer).toHaveBeenCalledTimes(0);
+    });
+  });
+  describe(`updateData() updates stored data and calls reRender(). Original data is not mutated.`, () => {
+    const multiData = {
+      key1: 'key1',
+      key2: ['key2'],
+      key3: {
+        key: '3',
+      },
+      someKey: null,
+      someOtherKey: 'hello',
+    };
+    const clone = JSON.parse(JSON.stringify(multiData));
+    it(`updates only given part of data`, () => {
+      const controller = createController({ initialData: multiData, metaData, reRenderer, propSetter, onChange });
+      const newKey1 = 'newKey1';
+      expect(controller.getData()).toMatchObject(multiData);
+      controller.updateData({ data: { key1: newKey1 } });
+      expect(controller.getData()).toMatchObject({ ...multiData, key1: newKey1 });
+
+      const newKey2 = ['newKey2'];
+      controller.updateData({ data: { key2: newKey2 } });
+      expect(controller.getData()).toMatchObject({ ...multiData, key1: newKey1, key2: newKey2 });
+
+      const newKey3 = undefined;
+      controller.updateData({ data: { key3: newKey3 } });
+      expect(controller.getData()).toMatchObject({ ...multiData, key1: newKey1, key2: newKey2, key3: newKey3 });
+
+      expect(onChange).toHaveBeenCalledTimes(0);
+      expect(propSetter).toHaveBeenCalledTimes(0);
+      expect(reRenderer).toHaveBeenCalledTimes(3);
+      expect(multiData).toMatchObject(clone);
+      expect(controller.getMetaData()).toMatchObject(metaData);
+    });
+    it(`the third argument (updateKeys) resets stored keys for given ids which forces component to re-mount.`, async () => {
+      const propSetterWithoutKeys = () => {
+        return { prop: 'values' };
+      };
+      const controller = createController({
+        initialData: multiData,
+        reRenderer,
+        propSetter: propSetterWithoutKeys,
+        onChange,
+      });
+      expect(controller.getProps({ id: 'key1', elementProps: {} }).key).toBe('key1');
+
+      controller.updateData({ data: { key1: 'anyvValue' }, updateKeys: ['key1'] });
+      const newProps = [
+        controller.getProps({ id: 'key1', elementProps: {} }),
+        controller.getProps({ id: 'key2', elementProps: {} }),
+        controller.getProps({ id: 'key3', elementProps: {} }),
+      ];
+      expect(newProps[0].key).not.toBe('key1');
+      expect(newProps[1].key).toBe('key2');
+      expect(newProps[2].key).toBe('key3');
+
+      // New keys are timestamped.
+      // Sleep a while to make sure timestamp changes on fast machines
+      await sleep(20);
+
+      controller.updateData({ data: { key1: 'anyvValue' }, updateKeys: ['key1', 'key2'] });
+      const updatedProps = [
+        controller.getProps({ id: 'key1', elementProps: {} }),
+        controller.getProps({ id: 'key2', elementProps: {} }),
+        controller.getProps({ id: 'key3', elementProps: {} }),
+      ];
+      expect(updatedProps[0].key).not.toBe(newProps[0].key);
+      expect(updatedProps[1].key).not.toBe(newProps[1].key);
+      expect(updatedProps[2].key).toBe(newProps[2].key);
+
+      await sleep(20);
+
+      controller.updateData({ data: { key1: 'value' }, updateKeys: ['key3'] });
+      const lastProps = [
+        controller.getProps({ id: 'key1', elementProps: {} }),
+        controller.getProps({ id: 'key2', elementProps: {} }),
+        controller.getProps({ id: 'key3', elementProps: {} }),
+      ];
+      expect(lastProps[0].key).toBe(updatedProps[0].key);
+      expect(lastProps[1].key).toBe(updatedProps[1].key);
+      expect(lastProps[2].key).not.toBe(updatedProps[2].key);
+
+      await sleep(20);
+    });
+  });
+  describe(`getMetaData() `, () => {
+    it(`returns initial metadata until updated`, () => {
+      const controller = createController({ initialData, reRenderer, propSetter, onChange, metaData });
+      expect(controller.getMetaData()).toMatchObject(metaData);
+    });
+  });
+  describe(`updateMetaData() updates only metadata and does not call reRender(). Original data is not mutated.`, () => {
+    const newMetaData = {
+      metaProp: { foo: 'bar' },
+      deepObj: {
+        deepValue: 1,
+      },
+    };
+    const clone = JSON.parse(JSON.stringify(newMetaData));
+    it(`updates only given part of data`, () => {
+      const controller = createController({ initialData, metaData: newMetaData, reRenderer, propSetter, onChange });
+      expect(controller.getMetaData()).toMatchObject(newMetaData);
+
+      controller.updateMetaData({ deepObj: 2 });
+      expect(controller.getMetaData()).toMatchObject({ ...newMetaData, deepObj: 2 });
+      controller.updateMetaData({ metaProp: null });
+      expect(controller.getMetaData()).toMatchObject({ deepObj: 2, metaProp: null });
+
+      expect(onChange).toHaveBeenCalledTimes(0);
+      expect(propSetter).toHaveBeenCalledTimes(0);
+      expect(reRenderer).toHaveBeenCalledTimes(0);
+      expect(newMetaData).toMatchObject(clone);
+      expect(controller.getData()).toMatchObject(initialData);
+    });
+  });
+});

--- a/packages/react/src/components/group/utils/controller.ts
+++ b/packages/react/src/components/group/utils/controller.ts
@@ -1,0 +1,47 @@
+import { Controller, ControllerProps } from '.';
+import { createPropHandler } from './propHandler';
+import { createStorage, StorageData } from './storage';
+
+/**
+ *
+ * Controller for all Group's data and events.
+ *
+ */
+
+export function createController({
+  reRenderer,
+  propSetter,
+  initialData,
+  onChange,
+  metaData,
+}: ControllerProps): Controller {
+  const storage = createStorage(initialData);
+  const meta = createStorage(metaData || {});
+  const propHandler = createPropHandler(propSetter);
+  return {
+    getProps(props) {
+      return propHandler.getProps({ ...props, controller: this });
+    },
+    getData() {
+      return storage.get();
+    },
+    updateData({ data, updateKeys }) {
+      storage.set(data);
+      if (updateKeys && updateKeys.length) {
+        updateKeys.forEach((id) => {
+          propHandler.updateKey(id);
+        });
+      }
+      reRenderer();
+    },
+    triggerChange(props) {
+      return onChange({ ...props, controller: this });
+    },
+    getMetaData() {
+      return meta.get() as StorageData;
+    },
+    updateMetaData(newData: StorageData) {
+      return meta.set(newData);
+    },
+  };
+}

--- a/packages/react/src/components/group/utils/forwardController.ts
+++ b/packages/react/src/components/group/utils/forwardController.ts
@@ -1,0 +1,40 @@
+import React, { FC } from 'react';
+
+import { Controller, HTMLElementAttributesWithChildren } from '.';
+
+const HDSForwardController = Symbol('HDSForwardController');
+
+/**
+ *
+ * Basically cloned how React.ForwardRef works.
+ * Sometimes it is convenient to pass controller to a React.JSX/FC component.
+ * If a React.JSX/FC component has HDSForwardController as a prop,
+ * then the controller should be passed as a second argument.
+ *
+ */
+
+export function ForwardController<P extends HTMLElementAttributesWithChildren & Record<string, unknown>>(
+  component: (props: HTMLElementAttributesWithChildren & P, controller: Controller) => React.ReactElement | null,
+): FC<HTMLElementAttributesWithChildren & P> {
+  const renderFunc = (componentProps: P & { forwardedController?: Controller }) => {
+    const { forwardedController, ...rest } = componentProps;
+    if (!forwardedController) {
+      throw new Error('forwardedController not passed to ForwardController');
+    }
+    return component((rest as unknown) as P, forwardedController);
+  };
+  Object.defineProperty(renderFunc, HDSForwardController, {
+    value: true,
+  });
+  return renderFunc;
+}
+
+export function isForwardController(component: unknown) {
+  const isFunctionOrObject = (checkTarget: unknown) => {
+    // typeof null === object, so checking that too.
+    const typeOfTarget = checkTarget ? typeof checkTarget : '';
+    return typeOfTarget === 'object' || typeOfTarget === 'function';
+  };
+  const reactObjectType = isFunctionOrObject(component) && Reflect.get(component as React.ComponentType, 'type');
+  return isFunctionOrObject(reactObjectType) && Reflect.get(reactObjectType, HDSForwardController) === true;
+}

--- a/packages/react/src/components/group/utils/index.ts
+++ b/packages/react/src/components/group/utils/index.ts
@@ -1,0 +1,67 @@
+import {
+  SyntheticEvent,
+  FunctionComponent,
+  HtmlHTMLAttributes,
+  PropsWithChildren,
+  ComponentType,
+  MutableRefObject,
+} from 'react';
+
+import { StorageData, Storage } from './storage';
+
+export type ChangeEventPayload = { value?: unknown; originalEvent?: SyntheticEvent };
+export type ChangeEvent = { id: string; type?: string; payload?: ChangeEventPayload };
+export type ChangeHandlerProps = ChangeEvent & { controller: Controller };
+export type ChangeHandler = (props: ChangeHandlerProps) => unknown;
+export type HTMLElementAttributesWithChildren = PropsWithChildren<HtmlHTMLAttributes<HTMLElement>>;
+export type DefaultGroupElementProps = Record<string, unknown> & {
+  key?: string;
+  forwardedController?: Controller;
+  'data-hds-group-id'?: string;
+};
+
+export type ElementRef = MutableRefObject<HTMLElement | null>;
+
+export type Controller = {
+  getProps: ({ id: string, elementProps: DefaultGroupElementProps }) => ReturnType<PropSetter>;
+  updateData: (props: { data: StorageData; updateKeys?: string[] }) => void;
+  getData: Storage['get'];
+  getMetaData: () => StorageData;
+  updateMetaData: (appended: StorageData) => StorageData;
+  triggerChange: (change: ChangeEvent) => unknown;
+};
+
+export type ControllerProps = {
+  reRenderer: () => void;
+  propSetter: PropSetter;
+  initialData: StorageData;
+  metaData?: StorageData;
+  onChange: ChangeHandler;
+};
+
+export type PropSetter<T = DefaultGroupElementProps> = (props: {
+  id: string;
+  controller: Controller;
+  key: string;
+  elementProps: DefaultGroupElementProps;
+}) => T;
+
+export type PropHandler = {
+  getProps: (props: {
+    id: string;
+    controller: Controller;
+    elementProps: DefaultGroupElementProps;
+  }) => DefaultGroupElementProps;
+  updateKey: (id: string) => void;
+};
+
+export type GroupChildFunction = FunctionComponent<{ controller: Controller }>;
+
+export type GroupChild<P = DefaultGroupElementProps> = ComponentType<HTMLElementAttributesWithChildren & P>;
+
+export type GroupProps = PropsWithChildren<unknown> & {
+  propSetter: PropSetter;
+  initialData: StorageData;
+  metaData?: StorageData;
+  onChange?: ChangeHandler;
+};

--- a/packages/react/src/components/group/utils/propHandler.test.ts
+++ b/packages/react/src/components/group/utils/propHandler.test.ts
@@ -1,0 +1,99 @@
+import { Controller, PropSetter } from '.';
+import { createPropHandler } from './propHandler';
+
+describe(`propHandler handles component props, keys and refs`, () => {
+  let nextKey: string | undefined;
+  let nextRef: { current: string } | undefined;
+  let currentProps: Record<string, unknown> = {};
+  const fakeController = ({} as unknown) as Controller;
+  const defaultProps = { id: 'primary_id', controller: fakeController, elementProps: { attributeY: 'value' } };
+  const secondaryProps = { id: 'second_id', controller: fakeController, elementProps: { attributeX: 'value' } };
+  const propSetterTracker = jest.fn();
+  const propSetter: PropSetter = ({ id, controller, elementProps }) => {
+    propSetterTracker(id, controller, elementProps);
+    const props: Record<string, unknown> = { id, controller, elementProps, ...currentProps };
+    if (nextKey) {
+      props.key = nextKey;
+    }
+    if (nextRef) {
+      props.ref = nextRef;
+    }
+    return props;
+  };
+  const createRef = (id: string) => {
+    return { current: `ref_for_${id}` };
+  };
+  afterEach(() => {
+    jest.clearAllMocks();
+    nextKey = undefined;
+    nextRef = undefined;
+    currentProps = {};
+  });
+  describe(`getProps`, () => {
+    it(`Calls the given propSetter with controller, given id and props passed to the component.`, () => {
+      const propHandler = createPropHandler(propSetter);
+      propHandler.getProps(defaultProps);
+      expect(propSetterTracker).toHaveBeenCalledTimes(1);
+      expect(propSetterTracker).toHaveBeenCalledWith(defaultProps.id, fakeController, defaultProps.elementProps);
+      propHandler.getProps({ ...defaultProps, id: secondaryProps.id });
+      expect(propSetterTracker).toHaveBeenCalledTimes(2);
+      expect(propSetterTracker).toHaveBeenCalledWith(secondaryProps.id, fakeController, defaultProps.elementProps);
+      propHandler.getProps({ ...defaultProps, id: 'id3' });
+      expect(propSetterTracker).toHaveBeenCalledTimes(3);
+      expect(propSetterTracker).toHaveBeenCalledWith('id3', fakeController, defaultProps.elementProps);
+    });
+    it(`Returns all given props`, () => {
+      const propHandler = createPropHandler(propSetter);
+      currentProps = { ariaLabel: 'label', class: 'class' };
+      nextKey = 'newKey';
+      nextRef = createRef('any');
+      expect(propHandler.getProps(defaultProps)).toMatchObject({
+        ...defaultProps,
+        ...currentProps,
+        key: nextKey,
+        ref: nextRef,
+      });
+    });
+    it(`A key is always added to the props. It is the given id by default`, () => {
+      const propHandler = createPropHandler(propSetter);
+      expect(propHandler.getProps(defaultProps).key).toBe(defaultProps.id);
+      expect(propHandler.getProps({ ...defaultProps, id: secondaryProps.id }).key).toBe(secondaryProps.id);
+    });
+    it(`If the propSetter returns a key, then it is used as a key for that single time.`, () => {
+      const propHandler = createPropHandler(propSetter);
+      nextKey = 'testKey';
+      expect(propHandler.getProps(defaultProps)).toMatchObject({
+        ...defaultProps,
+        key: nextKey,
+      });
+      nextKey = undefined;
+      expect(propHandler.getProps(defaultProps)).toMatchObject({
+        ...defaultProps,
+        key: defaultProps.id,
+      });
+    });
+  });
+  describe(`updateKey`, () => {
+    it(`Updates a key by id, so the component is re-rendered when group updates. New key is the id with a timestamp`, () => {
+      const propHandler = createPropHandler(propSetter);
+      propHandler.getProps(defaultProps);
+      const firstProps = propHandler.getProps(defaultProps);
+      expect(firstProps.key).toBe(defaultProps.id);
+      propHandler.updateKey(defaultProps.id);
+      const secondProps = propHandler.getProps(defaultProps);
+      expect(secondProps.key).not.toBe(defaultProps.id);
+      expect(secondProps.key?.startsWith(`${defaultProps.id}_`)).toBeTruthy();
+    });
+    it(`Once given, the given key is used until updated again unless propSetter returns another one.`, () => {
+      const propHandler = createPropHandler(propSetter);
+      propHandler.updateKey(defaultProps.id);
+      const { key } = propHandler.getProps(defaultProps);
+      expect(key).not.toBe(defaultProps.id);
+      expect(propHandler.getProps(defaultProps).key).toBe(key);
+      nextKey = 'key2';
+      expect(propHandler.getProps(defaultProps).key).toBe(nextKey);
+      nextKey = undefined;
+      expect(propHandler.getProps(defaultProps).key).toBe(key);
+    });
+  });
+});

--- a/packages/react/src/components/group/utils/propHandler.ts
+++ b/packages/react/src/components/group/utils/propHandler.ts
@@ -1,0 +1,29 @@
+import { PropSetter, PropHandler } from '.';
+
+/**
+ *
+ * propHandler calls the propSetter and also handles component.key and component.ref
+ * Refs are stored so they can be fetched from anywhere with controller access.
+ * Keys are used for remounting components when needed. It key changes, the component is remounted.
+ *
+ */
+
+export function createPropHandler(propSetter: PropSetter): PropHandler {
+  const elementKeys = new Map<string, string>();
+  return {
+    getProps: ({ id, controller, elementProps }) => {
+      const storedKey = elementKeys.get(id);
+      const props = propSetter({ id, controller, key: storedKey || '', elementProps }) || {};
+      if (!props.key) {
+        props.key = storedKey || id;
+      }
+      // Setting group/controller specific props to undefined will override the props given to the React component in JSX.
+      // React.cloneElement always passes JSX props, so this will prevent them from being set to the element.
+      Reflect.set(props, 'data-hds-group-id', undefined);
+      return props;
+    },
+    updateKey: (id) => {
+      elementKeys.set(id, `${id}_${Date.now()}`);
+    },
+  };
+}

--- a/packages/react/src/components/group/utils/propSetterHelpers.ts
+++ b/packages/react/src/components/group/utils/propSetterHelpers.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { ChangeHandlerProps } from '.';
+
+export function createOnClickListener(props: ChangeHandlerProps) {
+  const { id, controller } = props;
+  return {
+    onClick: (originalEvent: React.MouseEvent) => {
+      controller.triggerChange({ id, type: 'click', payload: { originalEvent } });
+    },
+  };
+}
+
+export function createInputOnChangeListener(props: ChangeHandlerProps) {
+  const { id, controller } = props;
+  return {
+    onChange: (originalEvent: React.KeyboardEvent<HTMLInputElement>) => {
+      controller.triggerChange({
+        id,
+        type: 'change',
+        payload: { value: originalEvent.currentTarget.value, originalEvent },
+      });
+    },
+  };
+}

--- a/packages/react/src/components/group/utils/storage.test.ts
+++ b/packages/react/src/components/group/utils/storage.test.ts
@@ -1,0 +1,94 @@
+import { createStorage } from './storage';
+
+describe(`storage`, () => {
+  type ResultObject = typeof data & typeof newValues & typeof partialNewValues;
+  const data = {
+    strProp: 'prop',
+    dataProp: {
+      hello: 'there',
+    },
+    numProp: 1,
+    objProp: {
+      childProp: {
+        value: '1',
+      },
+    },
+    arrProp: [{ prop: 'arrProp' }],
+  };
+  const newValues = {
+    strProp: 'newprop',
+    numProp: -1,
+    newValuesProp: {
+      foo: 'bar',
+    },
+    objProp: {
+      newChildProp: {
+        newValue: '1',
+      },
+    },
+    arrProp: [{ newProp: 'newArrProp' }],
+    arrProp2: [{ newProp: 'newArrProp2' }],
+  };
+  const partialNewValues = {
+    objProp: {
+      newObjProp: {
+        newValue: '100',
+      },
+    },
+    arrProp: [{ newProp: 'partialArrProp' }],
+    arrProp2: [{ newProp: 'partialArrProp2' }],
+    arrProp3: [{ newProp: 'partialProp3' }],
+  };
+  it(`stores initial data as a shallow copy. Get() returns data.`, async () => {
+    const storage = createStorage(data);
+    expect(storage.get()).toMatchObject(data);
+    expect(storage.get()).not.toBe(data);
+    expect((storage.get() as ResultObject).objProp).toBe(data.objProp);
+  });
+  it(`get() returns given data[id]`, async () => {
+    const storage = createStorage(data);
+    expect(storage.get()).toMatchObject(data);
+  });
+  it(`set(data) updates data by merging old and new`, async () => {
+    const storage = createStorage(data);
+    const originalData = storage.get();
+    storage.set(newValues);
+    expect(storage.get()).not.toBe(originalData);
+    expect(storage.get()).toMatchObject({ ...data, ...newValues });
+
+    storage.set(partialNewValues);
+    const current = storage.get() as ResultObject;
+    expect(current).toMatchObject({ ...data, ...newValues, ...partialNewValues });
+    // original data props still exist
+    expect(current.dataProp).toMatchObject(data.dataProp);
+    expect(current.newValuesProp).toMatchObject(newValues.newValuesProp);
+
+    // merge affects all matching props
+    expect(current.objProp).toMatchObject(partialNewValues.objProp);
+
+    expect(current.objProp.newObjProp).toBe(partialNewValues.objProp.newObjProp);
+
+    // overwritten objects lose props
+    expect(current.objProp.newChildProp).toBeUndefined();
+    expect(current.arrProp).toMatchObject(partialNewValues.arrProp);
+    expect(current.arrProp2).toMatchObject(partialNewValues.arrProp2);
+    expect(current.arrProp3).toMatchObject(partialNewValues.arrProp3);
+  });
+  it(`updating does not affect original data`, async () => {
+    const source = {
+      a: {
+        b: {
+          c: 'c',
+        },
+      },
+      aa: { bb: 'bb' },
+    };
+    const clone = JSON.parse(JSON.stringify(source));
+    const storage = createStorage(data);
+    storage.set({ a: { b: { c: null } } });
+    expect(source).toMatchObject(clone);
+    storage.set({ a: null });
+    storage.set({ aa: null });
+    expect(source).toMatchObject(clone);
+  });
+});

--- a/packages/react/src/components/group/utils/storage.ts
+++ b/packages/react/src/components/group/utils/storage.ts
@@ -1,0 +1,30 @@
+/**
+ *
+ *  Simple storage for getting/setting data.
+ *  Data is not mutated, a new object is always created.
+ *
+ * */
+
+export type StorageData = Record<string, unknown>;
+export type Storage = {
+  set: (newData: StorageData) => StorageData;
+  get: () => unknown;
+};
+
+export function createStorage(initialData: StorageData): Storage {
+  let data = { ...initialData };
+  const setter: Storage['set'] = (newData) => {
+    data = {
+      ...data,
+      ...newData,
+    };
+    return data;
+  };
+  const getter: Storage['get'] = () => {
+    return data;
+  };
+  return {
+    get: getter,
+    set: setter,
+  };
+}

--- a/packages/react/src/utils/testHelpers.ts
+++ b/packages/react/src/utils/testHelpers.ts
@@ -27,3 +27,11 @@ export function filterMockCallArgs(func: jest.Mock | jest.SpyInstance, filter: (
 export function hasListenerBeenCalled(listener: jest.Mock) {
   return listener && getMockCalls(listener).length > 0;
 }
+
+export function sleep(time: number) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(true);
+    }, time);
+  });
+}


### PR DESCRIPTION
## Description

**Target branch is the feature branch of new Select/MultiSelect**

The first step towards simpler code with complex components: `Group`-component and its `controller`.

The `Group` shares its data with its children. Data is stored to a `controller`. Controller also handles props of each  children in the `Group`. This way all changes happen in one place and all props are in same place and data is shared.

`Group` props include a `propSetter` and `onChange` functions. `PropSetter` returns props for each child component and `onChange` handles data changes.

React hooks and context is not used, so most of the code would work in vanilla js and web components.

This PR has only initial code and does not take into account all user scenarios or optimise anything - except DOM updates are tested well.

## Related Issue

[HDS-2069](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2069)

Closes nothing yet.

## Motivation and Context

Created to make complex components simpler. PropSetter has helpers for UI events and later on also aria-attributes can be added with common helpers. All components can basically access all data in a very simple way.

## How Has This Been Tested?

Added unit tests and basic stories.

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-2069-select/?path=/story/components-group--accordion)

## Add to changelog
No additions yet.


[HDS-2069]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ