### PR TITLE
Changelog-templater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,122 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.X.X] - Month, XX, 202X
+
+### React
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Core
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Documentation
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Figma
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Sketch/Abstract
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Hds-js
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
 ## [3.5.0] - February, 6, 2024
 
 ### React

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start:core": "lerna run --scope hds-core start",
     "start:react": "lerna run --scope hds-react start",
     "release": "lerna publish from-package --yes",
-    "update-versions": "lerna version --exact --no-git-tag-version --no-push --amend --yes"
+    "update-versions": "lerna version --exact --no-git-tag-version --no-push --amend --yes",
+    "update-changelog": "node ./scripts/changelog/update-changelog.js"
   },
   "devDependencies": {
     "lerna": "^7.0.1",

--- a/scripts/changelog/CHANGELOG.template.md
+++ b/scripts/changelog/CHANGELOG.template.md
@@ -1,0 +1,116 @@
+## [3.X.X] - Month, XX, 202X
+
+### React
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Core
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Documentation
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Figma
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Sketch/Abstract
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+
+### Hds-js
+
+#### Breaking
+
+- [Component] What are the breaking changes?
+
+#### Added
+
+- [Component] What is added?
+
+#### Changed
+
+Changes that are not related to specific components
+- [Component] What has been changed
+
+#### Fixed
+
+- [Component] What bugs/typos are fixed?
+

--- a/scripts/changelog/update-changelog.js
+++ b/scripts/changelog/update-changelog.js
@@ -1,0 +1,13 @@
+/**
+ * This takes the CHANGELOG.md and prepends the CHANGELOG.template.md to it.
+ */
+
+const fs = require('fs');
+const changeLogFile = './CHANGELOG.md';
+
+const old = fs.readFileSync(changeLogFile, 'utf8');
+const template = fs.readFileSync('./scripts/changelog/CHANGELOG.template.md', 'utf8');
+const latestVersionPosition = old.indexOf('## [');
+changeLogWithTemplate = old.substring(0, latestVersionPosition) + template + old.substring(latestVersionPosition);
+
+fs.writeFileSync(changeLogFile, changeLogWithTemplate);


### PR DESCRIPTION
## Description

This takes the `CHANGELOG.md` and prepends the `./changelog_templater/CHANGELOG.template.md` to it. Makes life easier when after release the empty template should be prepended to the existing Changelog.

## Motivation and Context

To make our lives easier.
