### PR TITLE
fix: don't override default class names with Table className prop

### DIFF
--- a/packages/react/src/components/cookieConsent/consentGroupDataTable/ConsentGroupDataTable.tsx
+++ b/packages/react/src/components/cookieConsent/consentGroupDataTable/ConsentGroupDataTable.tsx
@@ -30,16 +30,7 @@ export function ConsentGroupDataTable(props: { consents: CookieGroup['cookies'];
 
   return (
     <div className={classNames(styles.dataTableContainer)}>
-      <Table
-        id={id}
-        data-testid={id}
-        cols={cols}
-        rows={rows}
-        indexKey="id"
-        renderIndexCol={false}
-        theme={theme}
-        dense
-      />
+      <Table id={id} dataTestId={id} cols={cols} rows={rows} indexKey="id" renderIndexCol={false} theme={theme} dense />
     </div>
   );
 }

--- a/packages/react/src/components/table/components/TableContainer/TableContainer.tsx
+++ b/packages/react/src/components/table/components/TableContainer/TableContainer.tsx
@@ -18,6 +18,7 @@ export type TableContainerProps = {
 
 export const TableContainer = ({
   children,
+  className,
   dataTestId,
   variant = 'dark',
   id,
@@ -32,6 +33,7 @@ export const TableContainer = ({
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     <div tabIndex={0} className={styles.container}>
       <table
+        {...rest}
         className={classNames(
           styles.table,
           variant === 'dark' ? styles.dark : styles.light,
@@ -39,11 +41,11 @@ export const TableContainer = ({
           zebra && styles.zebra,
           verticalLines && styles.verticalLines,
           customThemeClass,
+          className,
         )}
         aria-labelledby={headingId}
         data-testid={dataTestId}
         id={id}
-        {...rest}
       >
         {children}
       </table>


### PR DESCRIPTION
## Description
At the moment all default class names are overridden when using Table component `className` prop. The reason for this is the` {...rest}` statement after all the props in the TableContainer component. The `className` prop is added to the class names to solve this issue. `{...rest}` is also moved before other props to avoid other default props to be overridden as well.

## Motivation and Context

Motivation for this PR is to support className prop in the Table component. This can be used to add some minor tweaks for the default styles. Other reason for this PR is to avoid unexpected behaviour when using className prop.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Add to changelog
- [ ] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->
