### PR TITLE
release-4.0.0 (HDS-2069) data provider for complex components

### DIFF
--- a/packages/react/src/components/dataProvider/DataContext.tsx
+++ b/packages/react/src/components/dataProvider/DataContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, SyntheticEvent } from 'react';
+
+import { createStorage, Storage, StorageData } from './storage';
+
+export type ChangeEventPayload = { value?: unknown; originalEvent?: SyntheticEvent };
+export type ChangeEvent = { id: string; type?: string; payload?: ChangeEventPayload };
+export type ChangeHandler<D = StorageData, M = StorageData> = (
+  event: ChangeEvent,
+  dataHandlers: DataHandlers<D, M>,
+) => boolean;
+export type ChangeTrigger = (event: ChangeEvent) => void;
+
+export type DataContextProps<D = StorageData, M = StorageData> = {
+  dataStorage: Storage<D>;
+  metaDataStorage: Storage<M>;
+};
+
+export type DataHandlers<D = StorageData, M = StorageData> = {
+  getData: () => D;
+  updateData: (newData: Partial<D>) => D;
+  getMetaData: () => M;
+  updateMetaData: (newData: Partial<M>) => M;
+  asyncRequestWithTrigger: (promise: Promise<ChangeEvent>) => void;
+  trigger: ChangeTrigger;
+};
+
+export type DataContextContent<D = StorageData, M = StorageData> = DataContextProps<D, M> & {
+  dataHandlers: DataHandlers<D, M>;
+};
+
+const defaultStorage = createStorage({});
+
+export const createDataHandlers = (dataStorage: Storage, metaDataStorage: Storage): DataHandlers => {
+  return {
+    getData: () => dataStorage.get(),
+    updateData: (newData: StorageData) => dataStorage.set(newData),
+    getMetaData: () => metaDataStorage.get(),
+    updateMetaData: (newData: StorageData) => metaDataStorage.set(newData),
+    asyncRequestWithTrigger: () => ({}),
+    trigger: () => ({}),
+  };
+};
+
+export const DataContext = createContext<DataContextContent>({
+  dataStorage: defaultStorage,
+  metaDataStorage: defaultStorage,
+  dataHandlers: createDataHandlers(defaultStorage, defaultStorage),
+});

--- a/packages/react/src/components/dataProvider/DataProvider.stories.tsx
+++ b/packages/react/src/components/dataProvider/DataProvider.stories.tsx
@@ -1,0 +1,385 @@
+import React, { ChangeEventHandler, MouseEventHandler, PropsWithChildren } from 'react';
+
+import { TextInput } from '../textInput/TextInput';
+import { Button } from '../button/Button';
+import { DataProvider, DataProviderProps } from './DataProvider';
+import { useContextDataHandlers } from './hooks';
+import { StorageData } from './storage';
+import { RadioButton } from '../radioButton/RadioButton';
+import { ErrorSummary } from '../errorSummary/ErrorSummary';
+import { Notification } from '../notification/Notification';
+import { Checkbox } from '../checkbox';
+import { Fieldset } from '../fieldset';
+
+export default {
+  component: DataProvider,
+  title: 'Components/DataProvider',
+};
+
+type NumericStepperData = {
+  value: number;
+  max: number;
+  min: number;
+  error: string;
+};
+
+export const NumericStepper = () => {
+  const props: DataProviderProps<NumericStepperData, StorageData> = {
+    initialData: { value: 1, max: 500, min: -5, error: '' },
+    metaData: {},
+    onChange: (event, { getData, updateData }) => {
+      const { payload, id, type } = event;
+      const { value, min, max } = getData();
+      const resolveNewValue = () => {
+        if (type !== 'click') {
+          return parseInt(String((payload && payload.value) || '0'), 10);
+        }
+        const diff = id === 'increment' ? 1 : -1;
+        return value + diff;
+      };
+      const resolveErrorMessage = (newValue) => {
+        if (newValue > max) {
+          return `Max is ${max}`;
+        }
+        if (newValue < min) {
+          return `Min is ${min}`;
+        }
+        return ``;
+      };
+
+      const newValue = resolveNewValue();
+
+      updateData({
+        error: resolveErrorMessage(newValue),
+        value: Math.max(Math.min(newValue, max), min),
+      });
+      return true;
+    },
+  };
+
+  const Input = () => {
+    const id = 'value';
+    const handlers = useContextDataHandlers<NumericStepperData>();
+    const { value } = handlers.getData();
+    const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      handlers.trigger({
+        id,
+        type: 'change',
+        payload: { value: e.currentTarget.value, originalEvent: e },
+      });
+    };
+    return <TextInput id={id} onChange={onChange} value={String(value)} />;
+  };
+
+  const Action = (buttonProps: PropsWithChildren<{ id: string }>) => {
+    const { id, children } = buttonProps;
+    const { trigger } = useContextDataHandlers();
+    const onClick: MouseEventHandler<HTMLButtonElement> = () => {
+      trigger({
+        id,
+        type: 'click',
+      });
+    };
+    return <Button onClick={onClick}>{children}</Button>;
+  };
+
+  const Error = () => {
+    const handlers = useContextDataHandlers<NumericStepperData>();
+    const { error } = handlers.getData();
+    return error ? <p>{error}</p> : null;
+  };
+
+  return (
+    <DataProvider {...props}>
+      <Input />
+      <Action id="decrement">-</Action>
+      <Action id="increment">+</Action>
+      <Error />
+    </DataProvider>
+  );
+};
+
+NumericStepper.parameters = {
+  loki: { skip: true },
+};
+
+type FormData = {
+  firstName: string;
+  lastName: string;
+  selectedAgeRange: string;
+  ageRanges: string[];
+};
+
+type FormMetaData = {
+  hasBeenSubmitted: boolean;
+  finished: boolean;
+  errors: string[];
+};
+
+export const Form = () => {
+  const validate = (data: FormData): FormMetaData['errors'] => {
+    const errors: FormMetaData['errors'] = [];
+    if (!data.firstName) {
+      errors.push('Firstname is required');
+    }
+    if (!data.lastName) {
+      errors.push('Lastname is required');
+    }
+    if (!data.selectedAgeRange) {
+      errors.push('Pick an age range');
+    }
+    return errors;
+  };
+  const props: DataProviderProps<FormData, FormMetaData> = {
+    initialData: {
+      firstName: '',
+      lastName: '',
+      ageRanges: ['0-17', '18-40', '41-65', '66+'],
+      selectedAgeRange: '',
+    },
+    metaData: { hasBeenSubmitted: false, errors: [], finished: false },
+
+    onChange: (event, { getData, updateData, updateMetaData, getMetaData }) => {
+      const { payload, id } = event;
+      const value = String(payload && payload.value);
+      const isSubmit = id === 'submit';
+      if (isSubmit) {
+        const errors = validate(getData());
+        updateMetaData({
+          errors,
+          hasBeenSubmitted: true,
+          finished: errors.length === 0,
+        });
+        return true;
+      }
+      const isAgeRange = id === 'ageRanges';
+      const newData = isAgeRange
+        ? {
+            selectedAgeRange: value,
+          }
+        : {
+            [id]: value,
+          };
+
+      updateData({
+        ...newData,
+      });
+      if (getMetaData().hasBeenSubmitted) {
+        updateMetaData({
+          errors: validate(getData()),
+        });
+      }
+      return true;
+    },
+  };
+
+  const Input = ({ id }: { id: keyof FormData }) => {
+    const handlers = useContextDataHandlers<FormData, FormMetaData>();
+    const value = handlers.getData()[id];
+    const { trigger } = useContextDataHandlers();
+    const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      trigger({
+        id,
+        type: 'change',
+        payload: { value: e.currentTarget.value, originalEvent: e },
+      });
+    };
+    const idToLabel = (idStr: string) => {
+      const splitPos = idStr.indexOf('N');
+      const split = `${idStr.substring(0, splitPos)} ${idStr.substring(splitPos).toLowerCase()}`;
+      return split.substring(0, 1).toUpperCase() + split.substring(1);
+    };
+    return <TextInput id={id} onChange={onChange} value={String(value)} label={`${idToLabel(id)}:`} />;
+  };
+
+  const AgeRanges = ({ id }: { id: keyof FormData }) => {
+    const handlers = useContextDataHandlers<FormData, FormMetaData>();
+    const { ageRanges, selectedAgeRange } = handlers.getData();
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      handlers.trigger({
+        id,
+        type: 'change',
+        payload: { value: e.currentTarget.value, originalEvent: e },
+      });
+    };
+    return (
+      <div>
+        <p>
+          <strong>Age:</strong>
+        </p>
+        {ageRanges.map((value, i) => {
+          return (
+            <RadioButton
+              id={`radio${i}`}
+              label={value}
+              key={value} // eslint-disable-line react/no-array-index-key
+              value={value}
+              name="radio"
+              checked={selectedAgeRange === value}
+              onChange={handleChange}
+            />
+          );
+        })}
+        <p>&nbsp;</p>
+      </div>
+    );
+  };
+
+  const Action = (buttonProps: PropsWithChildren<{ id: string }>) => {
+    const { id, children } = buttonProps;
+    const { trigger } = useContextDataHandlers();
+    const onClick: MouseEventHandler<HTMLButtonElement> = () => {
+      trigger({
+        id,
+        type: 'click',
+      });
+    };
+    return <Button onClick={onClick}>{children}</Button>;
+  };
+
+  const Errors = () => {
+    const handlers = useContextDataHandlers<FormData, FormMetaData>();
+    const { errors } = handlers.getMetaData();
+    return errors.length ? (
+      <ErrorSummary label="Please fix these errors">
+        <ul>
+          {errors.map((error, i) => {
+            return (
+              <li>
+                Error {i + 1}: {error}
+              </li>
+            );
+          })}
+        </ul>
+      </ErrorSummary>
+    ) : null;
+  };
+
+  const Note = () => {
+    const handlers = useContextDataHandlers<FormData, FormMetaData>();
+    const { finished } = handlers.getMetaData();
+    return finished ? <Notification type="success">Form sent!</Notification> : null;
+  };
+  const FormElements = () => {
+    const handlers = useContextDataHandlers<FormData, FormMetaData>();
+    const { finished } = handlers.getMetaData();
+    return finished ? null : (
+      <>
+        <Errors />
+        <Input id="firstName" />
+        <Input id="lastName" />
+        <AgeRanges id="ageRanges" />
+        <Action id="submit">Submit</Action>
+      </>
+    );
+  };
+  return (
+    <DataProvider {...props}>
+      <FormElements />
+      <Note />
+    </DataProvider>
+  );
+};
+
+Form.parameters = {
+  loki: { skip: true },
+};
+
+type SelectionGroupWithParentData = {
+  options: string[];
+  selectedValues: Set<string>;
+};
+
+type SelectionGroupWithParentMetaData = {
+  selectPercentage: number;
+};
+
+// this is a simpler way to create SelectionGroup/WithParent example
+export const GroupedCheckBoxes = () => {
+  const props: DataProviderProps<SelectionGroupWithParentData, SelectionGroupWithParentMetaData> = {
+    initialData: {
+      options: [1, 2, 3, 4, 5, 6, 7].map((num) => `Option ${num}`),
+      selectedValues: new Set(),
+    },
+    metaData: { selectPercentage: 0 },
+
+    onChange: (event, { getData, updateData, updateMetaData, getMetaData }) => {
+      const { payload } = event;
+      const value = String(payload && payload.value);
+      const { selectedValues, options } = getData();
+      const { selectPercentage } = getMetaData();
+      if (value === 'all') {
+        const shouldSelectAll = selectPercentage === 1;
+        selectedValues.clear();
+        if (!shouldSelectAll) {
+          options.forEach((v) => selectedValues.add(v));
+        }
+      } else {
+        const isSelected = selectedValues.has(value);
+        if (isSelected) {
+          selectedValues.delete(value);
+        } else {
+          selectedValues.add(value);
+        }
+      }
+      updateData({
+        selectedValues,
+      });
+      updateMetaData({
+        selectPercentage: selectedValues.size / options.length,
+      });
+
+      return true;
+    },
+  };
+
+  const Group = () => {
+    const handlers = useContextDataHandlers<SelectionGroupWithParentData, SelectionGroupWithParentMetaData>();
+    const { selectedValues, options } = handlers.getData();
+    const { selectPercentage } = handlers.getMetaData();
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      handlers.trigger({
+        id: 'unknown',
+        type: 'change',
+        payload: { value: e.currentTarget.value, originalEvent: e },
+      });
+    };
+    return (
+      <Fieldset heading="Group label *">
+        <Checkbox
+          id="parent"
+          label="Select all"
+          key="parent" // eslint-disable-line react/no-array-index-key
+          value="all"
+          name="parent"
+          checked={selectPercentage === 1}
+          indeterminate={selectPercentage !== 1 && selectPercentage !== 0}
+          onChange={handleChange}
+        />
+
+        {options.map((value, i) => {
+          return (
+            <Checkbox
+              id={`option${i}`}
+              label={value}
+              key={value} // eslint-disable-line react/no-array-index-key
+              value={value}
+              checked={selectedValues.has(value)}
+              onChange={handleChange}
+            />
+          );
+        })}
+      </Fieldset>
+    );
+  };
+
+  return (
+    <DataProvider {...props}>
+      <Group />
+    </DataProvider>
+  );
+};
+
+GroupedCheckBoxes.parameters = {
+  loki: { skip: true },
+};

--- a/packages/react/src/components/dataProvider/DataProvider.stories.tsx
+++ b/packages/react/src/components/dataProvider/DataProvider.stories.tsx
@@ -32,7 +32,7 @@ export const NumericStepper = () => {
       const { value, min, max } = getData();
       const resolveNewValue = () => {
         if (type !== 'click') {
-          return parseInt(String((payload && payload.value) || '0'), 10);
+          return parseInt(String((payload && payload.value) || '0').replace(/[^0-9]/g, ''), 10);
         }
         const diff = id === 'increment' ? 1 : -1;
         return value + diff;
@@ -212,7 +212,7 @@ export const Form = () => {
             <RadioButton
               id={`radio${i}`}
               label={value}
-              key={value} // eslint-disable-line react/no-array-index-key
+              key={value}
               value={value}
               name="radio"
               checked={selectedAgeRange === value}
@@ -349,7 +349,7 @@ export const GroupedCheckBoxes = () => {
         <Checkbox
           id="parent"
           label="Select all"
-          key="parent" // eslint-disable-line react/no-array-index-key
+          key="parent"
           value="all"
           name="parent"
           checked={selectPercentage === 1}
@@ -362,7 +362,7 @@ export const GroupedCheckBoxes = () => {
             <Checkbox
               id={`option${i}`}
               label={value}
-              key={value} // eslint-disable-line react/no-array-index-key
+              key={value}
               value={value}
               checked={selectedValues.has(value)}
               onChange={handleChange}

--- a/packages/react/src/components/dataProvider/DataProvider.test.tsx
+++ b/packages/react/src/components/dataProvider/DataProvider.test.tsx
@@ -1,0 +1,767 @@
+import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { render, waitFor, fireEvent, act, cleanup } from '@testing-library/react';
+import { v4 as uuidv4 } from 'uuid';
+
+import useForceRender from '../../hooks/useForceRender';
+import { getAllMockCallArgs } from '../../utils/testHelpers';
+import { Button } from '../button';
+import { ChangeEvent, DataHandlers } from './DataContext';
+import { DataProviderProps, DataProvider } from './DataProvider';
+import {
+  useDataStorage,
+  useMetaDataStorage,
+  useChangeTrigger,
+  useContextDataHandlers,
+  useDataContext,
+  useAsyncChangeTrigger,
+} from './hooks';
+import { Storage, StorageData } from './storage';
+
+type DomEventData = { rendered: number; mounted: number; unmounted: number; updateTime: number };
+type DataPerId = DomEventData & {
+  instanceId: string;
+  instanceRenderCount: number;
+  value: unknown;
+  id: string;
+};
+
+type TestComponentProps = {
+  id: string;
+};
+
+type TestData = {
+  time: number;
+  list: Array<string>;
+  componentData: StorageData;
+  keys?: StorageData;
+  uuid: string;
+};
+
+describe('DataContext', () => {
+  // this tracks how many times context's children are rendered and (un/)mounted
+  const domEventsPerId = new Map<string, DomEventData>();
+  const initialDomEventData: DomEventData = { rendered: 0, mounted: 0, unmounted: 0, updateTime: 0 };
+  const contextTracker = jest.fn();
+  const asyncTracker = jest.fn();
+  const getDomEventDataPerId = (id: string) => {
+    return domEventsPerId.get(id) || { ...initialDomEventData };
+  };
+
+  // get the time a component was rendered.
+  const getDomUpdateTime = (id: string) => {
+    const current = getDomEventDataPerId(id);
+    return current.updateTime;
+  };
+
+  // upadates domEvents of given id. Called in useEffect.
+  const updateDomEventsPerId = (id: string, targetProp: keyof DomEventData) => {
+    const current = getDomEventDataPerId(id);
+    current[targetProp] += 1;
+    current.updateTime = Date.now();
+    domEventsPerId.set(id, current);
+  };
+
+  const useDomEventCountHook = (id: string) => {
+    // when component is mounted, these refs are initialized or reset.
+    // domEventsPerId tracks all renders, this ref tracks only renders of this instance.
+    const instanceRenderCountRef = useRef(1);
+    // instanceIdRef changes when new instance is created.
+    const instanceIdRef = useRef(uuidv4());
+    useEffect(() => {
+      updateDomEventsPerId(id, 'mounted');
+      return () => {
+        updateDomEventsPerId(id, 'unmounted');
+      };
+    }, []);
+    useEffect(() => {
+      updateDomEventsPerId(id, 'rendered');
+      instanceRenderCountRef.current += 1;
+    });
+    return { instanceRenderCount: instanceRenderCountRef.current, instanceId: instanceIdRef.current };
+  };
+
+  const getOnClickUpdaterProps = (id: string) => {
+    const trigger = useChangeTrigger();
+    return {
+      onClick: () => {
+        trigger({ id, type: 'click' });
+      },
+    };
+  };
+
+  const getComponentKey = (metaData: TestData, componentProps: unknown) => {
+    const keys = metaData.keys || {};
+    const { id } = (componentProps as unknown) as { id: string };
+    return String(keys[id] || id) || undefined;
+  };
+
+  const updateComponentKeyInMetaData = (id: string, metaData: TestData) => {
+    const keys = metaData.keys || {};
+    keys[id] = uuidv4();
+    return {
+      ...metaData,
+      keys,
+    };
+  };
+
+  const TestComponent = (componentProps: TestComponentProps) => {
+    const { id } = componentProps;
+    const data = useDataStorage<TestData>().get();
+    contextTracker(useContextDataHandlers(), useDataStorage(), useMetaDataStorage());
+    const value = String(data.componentData[id]);
+    const { instanceRenderCount, instanceId } = useDomEventCountHook(id);
+    const asyncTrigger = useAsyncChangeTrigger();
+    const onClick = (success: boolean) => {
+      const promise: Promise<ChangeEvent> = new Promise((resolve, reject) => {
+        const resolver = () => {
+          success ? resolve({ id, type: 'async', payload: { value: '4000' } }) : reject(new Error('Failed async call'));
+        };
+        setTimeout(resolver, 500);
+      });
+      success ? promise.then(asyncTracker) : promise.catch(asyncTracker);
+      asyncTrigger(promise);
+    };
+    return (
+      <div id={`${id}`}>
+        <Button id={`button-${id}`} {...getOnClickUpdaterProps(id)}>
+          Click me!
+        </Button>
+        <Button id={`button-${id}-async`} onClick={() => onClick(true)}>
+          Successful Async test
+        </Button>
+        <Button id={`button-${id}-failed-async`} onClick={() => onClick(false)}>
+          Failing Async test
+        </Button>
+        <span id={`render-count-${id}`}>{instanceRenderCount}</span>
+        <span id={`instance-uuid-${id}`}>{instanceId}</span>
+        <span id={`value-${id}`}>{value as string}</span>
+      </div>
+    );
+  };
+  // components that does not use context are not re-rendered when context changes.
+  // calling useDataContext() to force re-render
+  function ForceDataContextChildToUpdate<T = PropsWithChildren<unknown>>(f: React.FC<T>) {
+    return (props: T) => {
+      useDataContext();
+      return f(props);
+    };
+  }
+
+  // When key changes, the component is re-mounted
+  function DataContextChildWithKeyTracking<T = PropsWithChildren<unknown>>(Comp: React.FC<T>) {
+    return (props: T) => {
+      const componentKey = getComponentKey(useMetaDataStorage<TestData>().get(), props);
+      return <Comp {...{ ...props, key: componentKey }} />;
+    };
+  }
+
+  const TestComponentWithKeyTracking = DataContextChildWithKeyTracking<TestComponentProps>(TestComponent);
+
+  // tracks only whole data container's re-rendering process
+  const DataContextRenderCounter = ForceDataContextChildToUpdate((props: PropsWithChildren<{ id: string }>) => {
+    const { instanceRenderCount } = useDomEventCountHook(props.id);
+    return <span id="render-count-context">{instanceRenderCount}</span>;
+  });
+
+  // renders dom
+  const renderComponent = ({ initialData, metaData }: { initialData: TestData; metaData: TestData }) => {
+    const onChange: DataProviderProps<TestData, TestData>['onChange'] = (event, dataHandlers) => {
+      if (event.type === 'click') {
+        const data = dataHandlers.getData();
+        const currentValue = data.componentData[event.id] as number;
+        const newComponentData = {
+          ...data.componentData,
+          [event.id]: currentValue + 1,
+        };
+        dataHandlers.updateData({ ...data, componentData: newComponentData });
+        if (event.id === 'test3') {
+          dataHandlers.updateMetaData(updateComponentKeyInMetaData(event.id, dataHandlers.getMetaData()));
+        }
+      }
+      if (event.type === 'async') {
+        const data = dataHandlers.getData();
+        const newComponentData = {
+          ...data.componentData,
+          [event.id]: event.payload?.value,
+        };
+        dataHandlers.updateData({ ...data, componentData: newComponentData });
+      }
+      return true;
+    };
+
+    const Root = () => {
+      const [renderContext, toggleRenderContext] = useState(true);
+      const rerender = useForceRender();
+      const onClick = () => {
+        rerender();
+      };
+      const toggleContext = () => {
+        toggleRenderContext((current) => !current);
+      };
+      // store data so it can be changed later to force a new Context instance.
+      const dataRefs = useRef({ initialData, metaData, onChange });
+      const updateData = () => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const { initialData, metaData, onChange } = dataRefs.current;
+        dataRefs.current = {
+          initialData: {
+            ...initialData,
+            componentData: {
+              test1: -100,
+              test2: -200,
+              test3: -300,
+            },
+            time: Date.now(),
+          },
+          metaData,
+          onChange,
+        };
+        rerender();
+      };
+      const updateMetaData = () => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const { initialData, metaData, onChange } = dataRefs.current;
+        dataRefs.current = {
+          initialData,
+          onChange,
+          metaData: {
+            ...metaData,
+            componentData: {
+              test1: -1000,
+              test2: -2000,
+              test3: -3000,
+            },
+            time: Date.now(),
+          },
+        };
+        rerender();
+      };
+      const updateOnChange = () => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const { initialData, metaData } = dataRefs.current;
+        dataRefs.current = {
+          initialData,
+          onChange: () => {
+            throw new Error('This should not happen');
+          },
+          metaData,
+        };
+        rerender();
+      };
+      return (
+        <div>
+          <Button id="button-re-render" onClick={onClick}>
+            Re-render
+          </Button>
+          <Button id="button-toggle-context" onClick={toggleContext}>
+            Show/hide context
+          </Button>
+          <Button id="button-update-data" onClick={updateData}>
+            Update data
+          </Button>
+          <Button id="button-update-metadata" onClick={updateMetaData}>
+            Update metadata
+          </Button>
+          <Button id="button-update-onChange" onClick={updateOnChange}>
+            Update onChange
+          </Button>
+          {renderContext && (
+            <div id="container-wrapper">
+              <DataProvider
+                initialData={dataRefs.current.initialData}
+                metaData={dataRefs.current.metaData}
+                onChange={dataRefs.current.onChange}
+              >
+                <TestComponent id="test1" key="key1" />
+                <TestComponent id="test2" key="key2" />
+                <TestComponentWithKeyTracking id="test3" key="key3" />
+                <TestComponent id="test4" key="key4" />
+                <DataContextRenderCounter id="context-counter" key="counter" />
+              </DataProvider>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const result = render(<Root />);
+
+    const getElementById = (id: string) => {
+      return result.container.querySelector(`#${id}`) as HTMLElement;
+    };
+
+    const getInstanceRenderCount = (id: string) => {
+      return parseInt(getElementById(`render-count-${id}`).innerHTML, 10);
+    };
+    const getInstanceId = (id: string) => {
+      return getElementById(`instance-uuid-${id}`).innerHTML;
+    };
+
+    const getValue = (id: string) => {
+      return getElementById(`value-${id}`).innerHTML;
+    };
+
+    const clickButton = (id: string) => {
+      const el = getElementById(`button-${id}`);
+      fireEvent.click(el);
+    };
+
+    const executeAndWaitForUpdate = async (executor: () => void) => {
+      await act(async () => {
+        const lastUpdateTime = getDomUpdateTime('context-counter');
+        executor();
+        await waitFor(() => {
+          if (getDomUpdateTime('context-counter') === lastUpdateTime) {
+            throw new Error('Context not updated');
+          }
+        });
+      });
+    };
+
+    const rerenderAll = async () => {
+      await executeAndWaitForUpdate(() => clickButton('re-render'));
+    };
+
+    const toggleContext = async () => {
+      await act(async () => {
+        const isVisible = !!getElementById('container-wrapper');
+        clickButton('toggle-context');
+        await waitFor(() => {
+          if (!!getElementById('container-wrapper') === isVisible) {
+            throw new Error('Context not toggled');
+          }
+        });
+      });
+    };
+
+    const collectAllDataPerId = (id: string): DataPerId => {
+      const domEvents = getDomEventDataPerId(id);
+      const instanceId = getInstanceId(id);
+      const instanceRenderCount = getInstanceRenderCount(id);
+      const value = getValue(id);
+      return {
+        ...domEvents,
+        instanceId,
+        instanceRenderCount,
+        value,
+        id,
+      };
+    };
+
+    // return initial render data of a component when it has been mounted once.
+    const getRenderedComponentDataPerId = (
+      id: string,
+      testData: TestData,
+    ): Omit<DataPerId, 'updateTime' | 'instanceId'> => {
+      return {
+        id,
+        instanceRenderCount: 1,
+        rendered: 1,
+        mounted: 1,
+        unmounted: 0,
+        // getValue() returns element's innerHTML which is a string
+        // so data[id] must also be a string to use expect.toBe()
+        value: String(testData.componentData[id]),
+      };
+    };
+
+    // store dom data into arrays for easy comparisons after re-renders
+    const createComponentDataStorage = (id: string, testData: TestData) => {
+      const storage = [getRenderedComponentDataPerId(id, testData)] as Array<Partial<DataPerId>>;
+      const get = (index = -1): DataPerId => {
+        const arrIndex = index < 0 ? storage.length + index : index;
+        return storage[arrIndex] as DataPerId;
+      };
+      return {
+        appendData: (partial: Partial<DataPerId>) => {
+          const last = get();
+          storage.push({ ...last, ...partial });
+        },
+        get,
+      };
+    };
+
+    return {
+      ...result,
+      getInstanceRenderCount,
+      getElementById,
+      getValue,
+      clickButton,
+      executeAndWaitForUpdate,
+      rerenderAll,
+      toggleContext,
+      getInstanceId,
+      collectAllDataPerId,
+      createComponentDataStorage,
+    };
+  };
+
+  // contextTracker stores last context props used in components.
+  const getLastContextTrackerCall = (): DataHandlers => {
+    const calls = getAllMockCallArgs(contextTracker);
+    return calls[calls.length - 1];
+  };
+
+  const getDataHandlersFromUseContextDataHandlersCalls = (): DataHandlers => {
+    return getLastContextTrackerCall()[0];
+  };
+
+  const getDataStorageFromUseContextDataHandlersCalls = (): Storage => {
+    return getLastContextTrackerCall()[1];
+  };
+
+  const getMetaDataStorageFromUseContextDataHandlersCalls = (): Storage => {
+    return getLastContextTrackerCall()[2];
+  };
+
+  const getUsedContextInstances = () => {
+    const dataHandlers = getDataHandlersFromUseContextDataHandlersCalls();
+    return [
+      dataHandlers,
+      dataHandlers.getData(),
+      dataHandlers.getMetaData(),
+      getDataStorageFromUseContextDataHandlersCalls(),
+      getMetaDataStorageFromUseContextDataHandlersCalls(),
+    ];
+  };
+
+  const increaseValueByOne = (value?: number) => {
+    return typeof value !== 'number' ? 0 : value + 1;
+  };
+
+  // increase tracked values by one after remount
+  const updateComponentDataAfterReMount = (previousData: Partial<DataPerId>): Partial<DataPerId> => {
+    return {
+      ...previousData,
+      mounted: increaseValueByOne(previousData.mounted),
+      rendered: increaseValueByOne(previousData.rendered),
+      unmounted: increaseValueByOne(previousData.unmounted),
+      instanceRenderCount: 1,
+    };
+  };
+
+  // increase tracked values by one after re-render
+  const updateComponentDataAfterInstanceRender = (previousData: Partial<DataPerId>): Partial<DataPerId> => {
+    return {
+      ...previousData,
+      rendered: increaseValueByOne(previousData.rendered),
+      instanceRenderCount: increaseValueByOne(previousData.instanceRenderCount),
+    };
+  };
+
+  const getDataById = (testData: TestData, id: string): number => {
+    return Reflect.get(testData.componentData, id);
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+    domEventsPerId.clear();
+  });
+
+  const initialData: TestData = {
+    time: Date.now(),
+    list: [],
+    componentData: { test1: 100, test2: 200, test3: 300, test4: 0 },
+    uuid: uuidv4(),
+  };
+  const metaData: TestData = {
+    time: Date.now(),
+    list: [],
+    componentData: { test1: 1000, test2: 2000, test3: 3000, test4: 0 },
+    uuid: uuidv4(),
+  };
+  it('Data is passed to components and all components are rendered with proper data.', async () => {
+    const { collectAllDataPerId, createComponentDataStorage, getValue } = renderComponent({
+      initialData,
+      metaData,
+    });
+    const test1Storage = createComponentDataStorage('test1', initialData);
+    // automatic data comparision
+    expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+    // manual data comparision
+    expect(collectAllDataPerId('test2')).toMatchObject({
+      id: 'test2',
+      rendered: 1,
+      mounted: 1,
+      unmounted: 0,
+      value: getValue('test2'),
+    });
+  });
+  it('Component is not re-mounted even if whole context is re-rendered', async () => {
+    const { rerenderAll, getInstanceId, collectAllDataPerId, createComponentDataStorage } = renderComponent({
+      initialData,
+      metaData,
+    });
+    const test1Storage = createComponentDataStorage('test1', initialData);
+    const test2Storage = createComponentDataStorage('test2', initialData);
+
+    // store instaceIds so those can be compared.
+    test1Storage.appendData({ instanceId: getInstanceId('test1') });
+    test2Storage.appendData({ instanceId: getInstanceId('test2') });
+
+    expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+    expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+
+    await rerenderAll();
+    test1Storage.appendData(updateComponentDataAfterInstanceRender(test1Storage.get()));
+    test2Storage.appendData(updateComponentDataAfterInstanceRender(test2Storage.get()));
+    expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+    expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+    await rerenderAll();
+    test1Storage.appendData(updateComponentDataAfterInstanceRender(test1Storage.get()));
+    test2Storage.appendData(updateComponentDataAfterInstanceRender(test2Storage.get()));
+    expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+    expect(collectAllDataPerId('test2')).toMatchObject(test2Storage.get());
+
+    // manual data comparision to make sure automation works
+    expect(collectAllDataPerId('test2')).toMatchObject({
+      id: 'test2',
+      rendered: 3,
+      unmounted: 0,
+      mounted: 1,
+      instanceRenderCount: 3,
+    });
+
+    // verify instanceIds did not change
+    expect(test1Storage.get(-1).instanceId).toBe(test1Storage.get(-2).instanceId);
+    expect(test1Storage.get(-2).instanceId).toBe(test1Storage.get(-3).instanceId);
+
+    // verify instanceIds did not change
+    expect(test2Storage.get(-1).instanceId).toBe(test2Storage.get(-2).instanceId);
+    expect(test2Storage.get(-2).instanceId).toBe(test2Storage.get(-3).instanceId);
+  });
+
+  it('Component whose data changed, but key did not, is not re-mounted', async () => {
+    const {
+      clickButton,
+      executeAndWaitForUpdate,
+      getInstanceId,
+      createComponentDataStorage,
+      collectAllDataPerId,
+    } = renderComponent({ initialData, metaData });
+    const test1Storage = createComponentDataStorage('test1', initialData);
+    test1Storage.appendData({ instanceId: getInstanceId('test1') });
+
+    await executeAndWaitForUpdate(() => {
+      clickButton('test1');
+    });
+
+    test1Storage.appendData({
+      ...updateComponentDataAfterInstanceRender(test1Storage.get()),
+      instanceId: test1Storage.get().instanceId,
+      value: String(getDataById(initialData, 'test1') + 1),
+    });
+
+    expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
+  });
+  it('Component whose key changes, is re-mounted', async () => {
+    const {
+      clickButton,
+      executeAndWaitForUpdate,
+      getInstanceId,
+      createComponentDataStorage,
+      collectAllDataPerId,
+    } = renderComponent({ initialData, metaData });
+    const test3Storage = createComponentDataStorage('test3', initialData);
+    test3Storage.appendData({ instanceId: getInstanceId('test1') });
+
+    await executeAndWaitForUpdate(() => {
+      clickButton('test3');
+    });
+
+    test3Storage.appendData({
+      ...updateComponentDataAfterReMount(test3Storage.get()),
+      instanceId: getInstanceId('test3'),
+      value: String(getDataById(initialData, 'test3') + 1),
+    });
+    expect(collectAllDataPerId('test3')).toMatchObject(test3Storage.get());
+  });
+  it('Data instances does not change when Context or parent re-renders, if props remains the same', async () => {
+    const { executeAndWaitForUpdate, rerenderAll, clickButton } = renderComponent({
+      initialData,
+      metaData,
+    });
+
+    const [dataHandlersV1, dataV1, metaDataV1, dataStorageV1, metaDataStorageV1] = getUsedContextInstances();
+    await rerenderAll();
+
+    const [dataHandlersV2, dataV2, metaDataV2] = getUsedContextInstances();
+    expect(dataHandlersV2).toBe(dataHandlersV1);
+    expect(dataV2).toBe(dataV1);
+    expect(metaDataV2).toBe(metaDataV1);
+
+    await executeAndWaitForUpdate(() => {
+      clickButton('test1');
+    });
+    const [dataHandlersV3, dataV3, metaDataV3] = getUsedContextInstances();
+    expect(dataHandlersV3).toBe(dataHandlersV2);
+    expect(dataV3).not.toBe(dataV2);
+    expect(metaDataV3).toBe(metaDataV2);
+    await rerenderAll();
+    await executeAndWaitForUpdate(() => {
+      // this will update metaData:
+      clickButton('test3');
+    });
+    const [dataHandlersV4, dataV4, metaDataV4, dataStorageV4, metaDataStorageV4] = getUsedContextInstances();
+    expect(dataHandlersV4).toBe(dataHandlersV3);
+    expect(dataV4).not.toBe(dataV3);
+    expect(metaDataV4).not.toBe(metaDataV3);
+    expect(dataStorageV4).toBe(dataStorageV1);
+    expect(metaDataStorageV4).toBe(metaDataStorageV1);
+  });
+  it('Data and dataHandlers instances change when initialData is changed. MetaData is not changed.', async () => {
+    const { executeAndWaitForUpdate, clickButton, collectAllDataPerId } = renderComponent({
+      initialData,
+      metaData,
+    });
+    const [dataHandlersV1, dataV1, metaDataV1, dataStorageV1, metaDataStorageV1] = getUsedContextInstances();
+    await executeAndWaitForUpdate(() => {
+      clickButton('update-data');
+    });
+    const [dataHandlersV2, dataV2, metaDataV2, dataStorageV2, metaDataStorageV2] = getUsedContextInstances();
+    expect(dataHandlersV2).not.toBe(dataHandlersV1);
+    expect(dataV2).not.toBe(dataV1);
+    expect(metaDataV2).toBe(metaDataV1);
+    expect(dataStorageV2).not.toBe(dataStorageV1);
+    expect(metaDataStorageV2).toBe(metaDataStorageV1);
+    expect(collectAllDataPerId('test1')).toMatchObject({
+      id: 'test1',
+      instanceRenderCount: 2,
+      mounted: 1,
+      rendered: 2,
+      unmounted: 0,
+      value: '-100',
+    });
+    expect(collectAllDataPerId('test2')).toMatchObject({
+      id: 'test2',
+      instanceRenderCount: 2,
+      mounted: 1,
+      rendered: 2,
+      unmounted: 0,
+      value: '-200',
+    });
+  });
+  it('MetaData and dataHandlers instances change when metaData is changed. Data is not changed.', async () => {
+    const { executeAndWaitForUpdate, clickButton, collectAllDataPerId } = renderComponent({
+      initialData,
+      metaData,
+    });
+    await executeAndWaitForUpdate(() => {
+      clickButton('test1');
+      clickButton('test2');
+    });
+
+    const [dataHandlersV1, dataV1, metaDataV1, dataStorageV1, metaDataStorageV1] = getUsedContextInstances();
+    await executeAndWaitForUpdate(() => {
+      clickButton('update-metadata');
+    });
+    const [dataHandlersV2, dataV2, metaDataV2, dataStorageV2, metaDataStorageV2] = getUsedContextInstances();
+    expect(dataHandlersV2).not.toBe(dataHandlersV1);
+    expect(dataV2).toBe(dataV1);
+    expect(metaDataV2).not.toBe(metaDataV1);
+    expect(dataStorageV2).toBe(dataStorageV1);
+    expect(metaDataStorageV2).not.toBe(metaDataStorageV1);
+    expect(collectAllDataPerId('test1')).toMatchObject({
+      id: 'test1',
+      mounted: 1,
+      rendered: 3,
+      unmounted: 0,
+      value: '101',
+    });
+    expect(collectAllDataPerId('test2')).toMatchObject({
+      id: 'test2',
+      mounted: 1,
+      rendered: 3,
+      unmounted: 0,
+      value: '201',
+    });
+  });
+  it('The onChange callback is memoized.', async () => {
+    const { executeAndWaitForUpdate, clickButton, collectAllDataPerId } = renderComponent({
+      initialData,
+      metaData,
+    });
+    await executeAndWaitForUpdate(() => {
+      clickButton('test2');
+    });
+    expect(collectAllDataPerId('test2')).toMatchObject({
+      id: 'test2',
+      mounted: 1,
+      rendered: 2,
+      unmounted: 0,
+      value: '201',
+    });
+    await executeAndWaitForUpdate(() => {
+      clickButton('update-onChange');
+    });
+    await executeAndWaitForUpdate(() => {
+      clickButton('test2');
+    });
+    expect(collectAllDataPerId('test2')).toMatchObject({
+      id: 'test2',
+      mounted: 1,
+      rendered: 4,
+      unmounted: 0,
+      value: '202',
+    });
+  });
+  it('asyncRequestWithTrigger accepts a promise and triggers the result as an event', async () => {
+    const { executeAndWaitForUpdate, clickButton, collectAllDataPerId } = renderComponent({
+      initialData,
+      metaData,
+    });
+    const dataHandlers = getDataHandlersFromUseContextDataHandlersCalls();
+    const triggerSpy = jest.spyOn(dataHandlers, 'trigger');
+    expect(collectAllDataPerId('test4')).toMatchObject({
+      id: 'test4',
+      mounted: 1,
+      rendered: 1,
+      unmounted: 0,
+      value: '0',
+    });
+    await executeAndWaitForUpdate(() => {
+      clickButton('test4-async');
+    });
+    await waitFor(() => {
+      expect(asyncTracker).toHaveBeenCalledTimes(1);
+      expect(triggerSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(collectAllDataPerId('test4')).toMatchObject({
+      id: 'test4',
+      mounted: 1,
+      rendered: 2,
+      unmounted: 0,
+      value: '4000',
+    });
+  });
+  it('asyncRequestWithTrigger ignores failed promises.', async () => {
+    const { clickButton } = renderComponent({
+      initialData,
+      metaData,
+    });
+    const dataHandlers = getDataHandlersFromUseContextDataHandlersCalls();
+    const triggerSpy = jest.spyOn(dataHandlers, 'trigger');
+    clickButton('test4-failed-async');
+    await waitFor(() => {
+      expect(asyncTracker).toHaveBeenCalledTimes(1);
+      expect(triggerSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+  it('async triggers are properly handled also after component teardown', async () => {
+    // without the unmount check with isComponentUnmounted
+    // console.error would be called with "Can't perform a React state update on an unmounted component"
+    const logSpy = jest.spyOn(global.console, 'error');
+    const { clickButton, toggleContext } = renderComponent({
+      initialData,
+      metaData,
+    });
+    clickButton('test4-async');
+    expect(asyncTracker).toHaveBeenCalledTimes(0);
+    await toggleContext();
+    await waitFor(() => {
+      expect(asyncTracker).toHaveBeenCalledTimes(1);
+    });
+    expect(logSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/react/src/components/dataProvider/DataProvider.test.tsx
+++ b/packages/react/src/components/dataProvider/DataProvider.test.tsx
@@ -91,7 +91,7 @@ describe('DataContext', () => {
 
   const getComponentKey = (metaData: TestData, componentProps: unknown) => {
     const keys = metaData.keys || {};
-    const { id } = (componentProps as unknown) as { id: string };
+    const { id } = componentProps as unknown as { id: string };
     return String(keys[id] || id) || undefined;
   };
 
@@ -533,13 +533,8 @@ describe('DataContext', () => {
   });
 
   it('Component whose data changed, but key did not, is not re-mounted', async () => {
-    const {
-      clickButton,
-      executeAndWaitForUpdate,
-      getInstanceId,
-      createComponentDataStorage,
-      collectAllDataPerId,
-    } = renderComponent({ initialData, metaData });
+    const { clickButton, executeAndWaitForUpdate, getInstanceId, createComponentDataStorage, collectAllDataPerId } =
+      renderComponent({ initialData, metaData });
     const test1Storage = createComponentDataStorage('test1', initialData);
     test1Storage.appendData({ instanceId: getInstanceId('test1') });
 
@@ -556,13 +551,8 @@ describe('DataContext', () => {
     expect(collectAllDataPerId('test1')).toMatchObject(test1Storage.get());
   });
   it('Component whose key changes, is re-mounted', async () => {
-    const {
-      clickButton,
-      executeAndWaitForUpdate,
-      getInstanceId,
-      createComponentDataStorage,
-      collectAllDataPerId,
-    } = renderComponent({ initialData, metaData });
+    const { clickButton, executeAndWaitForUpdate, getInstanceId, createComponentDataStorage, collectAllDataPerId } =
+      renderComponent({ initialData, metaData });
     const test3Storage = createComponentDataStorage('test3', initialData);
     test3Storage.appendData({ instanceId: getInstanceId('test1') });
 

--- a/packages/react/src/components/dataProvider/DataProvider.tsx
+++ b/packages/react/src/components/dataProvider/DataProvider.tsx
@@ -1,0 +1,62 @@
+import to from 'await-to-js';
+import React, { PropsWithChildren, useEffect, useMemo, useRef } from 'react';
+
+import useForceRender from '../../hooks/useForceRender';
+import { DataHandlers, DataContext, createDataHandlers, ChangeEvent } from './DataContext';
+import { StorageData, createStorage } from './storage';
+
+export type DataProviderProps<D extends StorageData, M extends StorageData> = {
+  initialData: D;
+  metaData: M;
+  onChange: (changeEvent: ChangeEvent, dataHandlers: DataHandlers<D, M>) => boolean;
+};
+
+export function DataProvider<D extends StorageData, M extends StorageData>({
+  children,
+  ...rest
+}: PropsWithChildren<DataProviderProps<D, M>>) {
+  const { initialData, metaData, onChange } = rest;
+  const memoizedOnChange: DataProviderProps<D, M>['onChange'] = useMemo(() => onChange, []);
+  const dataStorage = useMemo(() => createStorage(initialData), [initialData]);
+  const metaDataStorage = useMemo(() => createStorage(metaData), [metaData]);
+  const rerender = useForceRender();
+  const isComponentUnmounted = useRef(false);
+  const dataHandlers = useMemo(() => {
+    const handlers = createDataHandlers(dataStorage, metaDataStorage);
+    const asyncRequestWithTrigger: DataHandlers['asyncRequestWithTrigger'] = async (promise) => {
+      const [err, result] = await to(promise);
+      if (err) {
+        return;
+      }
+      if (isComponentUnmounted.current) {
+        return;
+      }
+      handlers.trigger(result);
+    };
+    handlers.trigger = (e) => {
+      if (memoizedOnChange(e, handlers as DataHandlers<D, M>)) {
+        rerender();
+      }
+    };
+    handlers.asyncRequestWithTrigger = asyncRequestWithTrigger;
+    return handlers;
+  }, [dataStorage, metaDataStorage, rerender, memoizedOnChange]);
+
+  useEffect(() => {
+    return () => {
+      isComponentUnmounted.current = true;
+    };
+  }, []);
+
+  return (
+    <DataContext.Provider
+      value={{
+        dataStorage,
+        metaDataStorage,
+        dataHandlers,
+      }}
+    >
+      {children}
+    </DataContext.Provider>
+  );
+}

--- a/packages/react/src/components/dataProvider/README.md
+++ b/packages/react/src/components/dataProvider/README.md
@@ -1,0 +1,2 @@
+DataProvider has not been created via `yarn scaffold`, because it might be only for internal use.
+So it does not show on docs site.

--- a/packages/react/src/components/dataProvider/hooks.test.tsx
+++ b/packages/react/src/components/dataProvider/hooks.test.tsx
@@ -1,0 +1,421 @@
+import React, { useEffect, useRef } from 'react';
+import { render, waitFor, fireEvent, act, cleanup } from '@testing-library/react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { getAllMockCallArgs } from '../../utils/testHelpers';
+import { Button } from '../button';
+import { ChangeEvent, DataContextContent, DataHandlers } from './DataContext';
+import { DataProviderProps, DataProvider } from './DataProvider';
+import {
+  useAsyncChangeTrigger,
+  useChangeTrigger,
+  useContextDataHandlers,
+  useDataContext,
+  useDataStorage,
+  useMetaDataStorage,
+} from './hooks';
+import useForceRender from '../../hooks/useForceRender';
+import { Storage } from './storage';
+
+type TestData = {
+  time: number;
+  uuid: string;
+};
+
+describe('DataContext hooks', () => {
+  const hookReturnValueTester = jest.fn();
+  const onChangeTracker = jest.fn();
+  const updateTracker = jest.fn();
+  const asyncTracker = jest.fn();
+  const getNewTestData = (): TestData => {
+    const newData: TestData = {
+      time: Date.now(),
+      uuid: uuidv4(),
+    };
+    updateTracker(newData);
+    return newData;
+  };
+
+  const ids = {
+    dataContextHook: 'data-context-hook',
+    dataStorageHook: 'data-storage-hook',
+    metaDataStorageHook: 'metadata-storage-hook',
+    handlersHook: 'handlers-hook',
+    rerenderHook: 're-render-hook',
+    triggerHook: 'trigger-hook',
+    asyncTriggerHook: 'async-trigger-hook',
+  };
+
+  const DataContextHookTest = () => {
+    const id = ids.dataContextHook;
+    const context = useDataContext();
+    hookReturnValueTester(id, context);
+    return (
+      <div>
+        <Button id={`button-${id}`} onClick={() => context.dataHandlers.trigger({ id: 'foo' })}>
+          Re-render
+        </Button>
+      </div>
+    );
+  };
+
+  const ContextDataStorageHookTest = () => {
+    const id = ids.dataStorageHook;
+    const storage = useDataStorage();
+    hookReturnValueTester(id, storage);
+    const updateData = () => {
+      storage.set(getNewTestData());
+    };
+    return (
+      <div>
+        <Button id={`button-${id}`} onClick={updateData}>
+          Update
+        </Button>
+      </div>
+    );
+  };
+
+  const ContextMetaDataStorageHookTest = () => {
+    const id = ids.metaDataStorageHook;
+    const storage = useMetaDataStorage();
+    hookReturnValueTester(id, storage);
+    const updateMetaData = () => {
+      storage.set(getNewTestData());
+    };
+    return (
+      <div>
+        <Button id={`button-${id}`} onClick={updateMetaData}>
+          Update
+        </Button>
+      </div>
+    );
+  };
+
+  const ContextDataHandlersHookTest = () => {
+    const id = ids.handlersHook;
+    const handlers = useContextDataHandlers();
+    hookReturnValueTester(id, handlers);
+    const trigger = () => handlers.trigger({ id: 'handler' });
+    return (
+      <div>
+        <Button id={`button-${id}`} onClick={trigger}>
+          Trigger
+        </Button>
+      </div>
+    );
+  };
+
+  const ContextTriggerHookTest = () => {
+    const id = ids.triggerHook;
+    const trigger = useChangeTrigger();
+    hookReturnValueTester(id, trigger);
+    const triggerOnClick = () => {
+      trigger({ id: 'updateMetaData', payload: { value: getNewTestData() } });
+    };
+    return (
+      <div>
+        <Button id={`button-${id}`} onClick={triggerOnClick}>
+          Trigger
+        </Button>
+      </div>
+    );
+  };
+
+  const ContextAsyncTriggerHookTest = () => {
+    const id = ids.asyncTriggerHook;
+    const asyncTrigger = useAsyncChangeTrigger();
+    hookReturnValueTester(id, asyncTrigger);
+    const triggerOnClick = () => {
+      const promise: Promise<ChangeEvent> = new Promise((resolve) => {
+        const resolver = () => {
+          const event = { id: 'updateMetaData', payload: { value: getNewTestData() } };
+          resolve(event);
+        };
+        setTimeout(resolver, 300);
+      });
+      promise.finally(asyncTracker);
+      asyncTrigger(promise);
+    };
+    return (
+      <div>
+        <Button id={`button-${id}`} onClick={triggerOnClick}>
+          Trigger
+        </Button>
+      </div>
+    );
+  };
+
+  const useRenderCountHook = () => {
+    const instanceRenderCountRef = useRef(1);
+
+    useEffect(() => {
+      instanceRenderCountRef.current += 1;
+    });
+    return instanceRenderCountRef.current;
+  };
+
+  // tracks only whole data container's re-rendering process
+  const DataContextRenderCounter = () => {
+    // components that does not use context are not re-rendered when context changes.
+    // calling useDataContext() to force re-render
+    useDataContext();
+    const count = useRenderCountHook();
+    return <span id="render-time-context">{count}</span>;
+  };
+
+  const initialData: TestData = {
+    time: Date.now(),
+    uuid: uuidv4(),
+  };
+
+  const metaData: TestData = {
+    time: Date.now(),
+    uuid: uuidv4(),
+  };
+
+  // renders dom
+  const renderComponent = () => {
+    const onChange: DataProviderProps<TestData, TestData>['onChange'] = (event, dataHandlers) => {
+      onChangeTracker(event, dataHandlers);
+      const { id, payload } = event;
+      const data = payload && (payload.value as TestData);
+      if (id === 'updateData' && data) {
+        dataHandlers.updateData(data);
+      }
+      if (id === 'updateMetaData' && data) {
+        dataHandlers.updateMetaData(data);
+      }
+      return true;
+    };
+
+    const Root = () => {
+      const forceRender = useForceRender();
+      const onClick = () => {
+        forceRender();
+      };
+
+      return (
+        <div>
+          <Button id="button-re-render" onClick={onClick}>
+            Re-render
+          </Button>
+          <DataProvider initialData={initialData} metaData={metaData} onChange={onChange}>
+            <DataContextHookTest key="key1" />
+            <ContextDataHandlersHookTest key="key2" />
+            <ContextDataStorageHookTest key="key3" />
+            <ContextMetaDataStorageHookTest key="key4" />
+            <ContextTriggerHookTest key="key5" />
+            <ContextAsyncTriggerHookTest key="key6" />
+            <DataContextRenderCounter key="counter" />
+          </DataProvider>
+        </div>
+      );
+    };
+
+    const result = render(<Root />);
+
+    const getElementById = (id: string) => {
+      return result.container.querySelector(`#${id}`) as HTMLElement;
+    };
+
+    const getInstanceRenderTime = (id: string) => {
+      return parseInt(getElementById(`render-time-${id}`).innerHTML, 10);
+    };
+
+    const clickButton = (id: string) => {
+      const el = getElementById(`button-${id}`);
+      fireEvent.click(el);
+    };
+
+    const executeAndWaitForUpdate = async (executor: () => void) => {
+      await act(async () => {
+        const lastUpdateTime = getInstanceRenderTime('context');
+        executor();
+        await waitFor(() => {
+          if (getInstanceRenderTime('context') === lastUpdateTime) {
+            throw new Error('Context not updated');
+          }
+        });
+      });
+    };
+
+    const rerenderAll = async () => {
+      await executeAndWaitForUpdate(() => clickButton('re-render'));
+    };
+
+    return {
+      ...result,
+      getElementById,
+      clickButton,
+      executeAndWaitForUpdate,
+      rerenderAll,
+    };
+  };
+
+  const getLastContextTrackerCallPerId = (id: string): unknown[] => {
+    const calls = getAllMockCallArgs(hookReturnValueTester).filter((call) => call[0] === id);
+    return calls[calls.length - 1];
+  };
+
+  const getLastUpdateTrackerCall = (): unknown[] => {
+    const calls = getAllMockCallArgs(updateTracker);
+    return calls[calls.length - 1];
+  };
+
+  const getContextFromTracker = () => {
+    return getLastContextTrackerCallPerId(ids.dataContextHook)[1] as DataContextContent;
+  };
+
+  const getDataStorageFromTracker = () => {
+    return getLastContextTrackerCallPerId(ids.dataStorageHook)[1] as Storage<TestData>;
+  };
+
+  const getMetaDataStorageFromTracker = () => {
+    return getLastContextTrackerCallPerId(ids.metaDataStorageHook)[1] as Storage<TestData>;
+  };
+
+  const getHandlersFromTracker = () => {
+    return getLastContextTrackerCallPerId(ids.handlersHook)[1] as DataHandlers;
+  };
+
+  const getTriggerFunctionFromTracker = () => {
+    return getLastContextTrackerCallPerId(ids.triggerHook)[1] as DataHandlers['trigger'];
+  };
+
+  const getAsyncTriggerFunctionFromTracker = () => {
+    return getLastContextTrackerCallPerId(ids.asyncTriggerHook)[1] as DataHandlers['asyncRequestWithTrigger'];
+  };
+
+  const getUpdatedData = () => {
+    return getLastUpdateTrackerCall()[0] as Storage<TestData>;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  it('useDataContext hook returns the whole context object', async () => {
+    const { clickButton, executeAndWaitForUpdate, rerenderAll } = renderComponent();
+
+    const context = getContextFromTracker();
+    expect(context.dataStorage).toBeDefined();
+    expect(context.metaDataStorage).toBeDefined();
+    expect(context.dataHandlers).toBeDefined();
+    await executeAndWaitForUpdate(() => {
+      clickButton(ids.dataContextHook);
+    });
+    await executeAndWaitForUpdate(() => {
+      clickButton(ids.dataContextHook);
+    });
+    await rerenderAll();
+    const context2 = getContextFromTracker();
+    expect(context.dataStorage).toBe(context2.dataStorage);
+    expect(context.metaDataStorage).toBe(context2.metaDataStorage);
+    expect(context.dataHandlers).toBe(context2.dataHandlers);
+  });
+
+  it('useDataStorage hook returns the data storage object.', async () => {
+    const { clickButton, rerenderAll } = renderComponent();
+
+    const storage = getDataStorageFromTracker();
+    expect(storage.get).toBeDefined();
+    expect(storage.set).toBeDefined();
+    expect(storage.get()).toMatchObject(initialData);
+
+    clickButton(ids.dataStorageHook);
+    await rerenderAll();
+
+    const newData = getUpdatedData();
+    const storage2 = getDataStorageFromTracker();
+    expect(storage).toBe(storage2);
+    expect(storage2.get()).toMatchObject(newData);
+    expect(storage2.get()).not.toMatchObject(initialData);
+  });
+
+  it('useMetaDataStorage hook returns the data storage object.', async () => {
+    const { clickButton, rerenderAll } = renderComponent();
+
+    const metaDataStorage = getMetaDataStorageFromTracker();
+    expect(metaDataStorage.get).toBeDefined();
+    expect(metaDataStorage.set).toBeDefined();
+    expect(metaDataStorage.get()).toMatchObject(metaData);
+
+    clickButton(ids.metaDataStorageHook);
+    await rerenderAll();
+
+    const newMetaData = getUpdatedData();
+    const metaDataStorage2 = getMetaDataStorageFromTracker();
+    expect(metaDataStorage).toBe(metaDataStorage2);
+    expect(metaDataStorage2.get()).toMatchObject(newMetaData);
+    expect(metaDataStorage2.get()).not.toMatchObject(metaData);
+  });
+
+  it('useContextDataHandlers hook returns the dataHandlers object.', async () => {
+    const { rerenderAll } = renderComponent();
+
+    const handlers = getHandlersFromTracker();
+    expect(handlers.updateData).toBeDefined();
+    expect(handlers.updateMetaData).toBeDefined();
+    expect(handlers.getData()).toMatchObject(initialData);
+    expect(handlers.getMetaData()).toMatchObject(metaData);
+    expect(handlers.asyncRequestWithTrigger).toBeDefined();
+    expect(handlers.trigger).toBeDefined();
+
+    const triggeredData = getNewTestData();
+    act(() => {
+      handlers.trigger({ id: 'updateData', payload: { value: triggeredData } });
+    });
+    await rerenderAll();
+    const handlers2 = getHandlersFromTracker();
+    expect(handlers2).toBe(handlers);
+    expect(handlers2.getData()).toMatchObject(triggeredData);
+  });
+
+  it('useTrigger hook returns a function to trigger a change', async () => {
+    const { executeAndWaitForUpdate, clickButton } = renderComponent();
+
+    const trigger = getTriggerFunctionFromTracker();
+    const metadataStorage = getMetaDataStorageFromTracker();
+    const currentData = metadataStorage.get();
+
+    expect(currentData).toMatchObject(metaData);
+    expect(trigger).toBeDefined();
+
+    await executeAndWaitForUpdate(() => {
+      clickButton(ids.triggerHook);
+    });
+
+    const newData = getUpdatedData();
+    const metadataStorage2 = getMetaDataStorageFromTracker();
+    expect(metadataStorage2.get()).toMatchObject(newData);
+  });
+  it('useAsyncChangeTrigger hook returns a function to trigger a change after a promise is fulfilled.', async () => {
+    const { executeAndWaitForUpdate, clickButton } = renderComponent();
+
+    const asyncTrigger = getAsyncTriggerFunctionFromTracker();
+    const metadataStorage = getMetaDataStorageFromTracker();
+    const currentData = metadataStorage.get();
+
+    expect(currentData).toMatchObject(metaData);
+    expect(asyncTrigger).toBeDefined();
+
+    await executeAndWaitForUpdate(() => {
+      clickButton(ids.asyncTriggerHook);
+    });
+
+    await waitFor(() => {
+      expect(asyncTracker).toHaveBeenCalledTimes(1);
+    });
+
+    const newData = getUpdatedData();
+    expect(metadataStorage.get()).toMatchObject(newData);
+
+    await executeAndWaitForUpdate(() => {
+      clickButton(ids.asyncTriggerHook);
+    });
+
+    const newestData = getUpdatedData();
+    expect(metadataStorage.get()).toMatchObject(newestData);
+  });
+});

--- a/packages/react/src/components/dataProvider/hooks.ts
+++ b/packages/react/src/components/dataProvider/hooks.ts
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+
+import { DataContext, ChangeTrigger, DataContextContent, DataHandlers } from './DataContext';
+import { StorageData } from './storage';
+
+export function useDataContext<D = StorageData, M = StorageData>() {
+  return (useContext(DataContext) as unknown) as DataContextContent<D, M>;
+}
+
+export function useContextDataHandlers<D = StorageData, M = StorageData>() {
+  return useDataContext<D, M>().dataHandlers;
+}
+
+export function useDataStorage<D = StorageData>() {
+  return useDataContext<D>().dataStorage;
+}
+
+export function useMetaDataStorage<M = StorageData>() {
+  return useDataContext<M, M>().metaDataStorage;
+}
+
+export function useChangeTrigger(): ChangeTrigger {
+  const { dataHandlers } = useDataContext();
+  return dataHandlers.trigger;
+}
+
+export function useAsyncChangeTrigger(): DataHandlers['asyncRequestWithTrigger'] {
+  const { dataHandlers } = useDataContext();
+  return (promise) => dataHandlers.asyncRequestWithTrigger(promise);
+}

--- a/packages/react/src/components/dataProvider/hooks.ts
+++ b/packages/react/src/components/dataProvider/hooks.ts
@@ -4,7 +4,7 @@ import { DataContext, ChangeTrigger, DataContextContent, DataHandlers } from './
 import { StorageData } from './storage';
 
 export function useDataContext<D = StorageData, M = StorageData>() {
-  return (useContext(DataContext) as unknown) as DataContextContent<D, M>;
+  return useContext(DataContext) as unknown as DataContextContent<D, M>;
 }
 
 export function useContextDataHandlers<D = StorageData, M = StorageData>() {

--- a/packages/react/src/components/dataProvider/index.ts
+++ b/packages/react/src/components/dataProvider/index.ts
@@ -1,0 +1,2 @@
+export * from './DataProvider';
+export * from './hooks';

--- a/packages/react/src/components/dataProvider/storage.test.ts
+++ b/packages/react/src/components/dataProvider/storage.test.ts
@@ -1,0 +1,94 @@
+import { createStorage } from './storage';
+
+describe(`storage`, () => {
+  type ResultObject = typeof data & typeof newValues & typeof partialNewValues;
+  const data = {
+    strProp: 'prop',
+    dataProp: {
+      hello: 'there',
+    },
+    numProp: 1,
+    objProp: {
+      childProp: {
+        value: '1',
+      },
+    },
+    arrProp: [{ prop: 'arrProp' }],
+  };
+  const newValues = {
+    strProp: 'newprop',
+    numProp: -1,
+    newValuesProp: {
+      foo: 'bar',
+    },
+    objProp: {
+      newChildProp: {
+        newValue: '1',
+      },
+    },
+    arrProp: [{ newProp: 'newArrProp' }],
+    arrProp2: [{ newProp: 'newArrProp2' }],
+  };
+  const partialNewValues = {
+    objProp: {
+      newObjProp: {
+        newValue: '100',
+      },
+    },
+    arrProp: [{ newProp: 'partialArrProp' }],
+    arrProp2: [{ newProp: 'partialArrProp2' }],
+    arrProp3: [{ newProp: 'partialProp3' }],
+  };
+  it(`stores initial data as a shallow copy. Get() returns data.`, async () => {
+    const storage = createStorage(data);
+    expect(storage.get()).toMatchObject(data);
+    expect(storage.get()).not.toBe(data);
+    expect((storage.get() as ResultObject).objProp).toBe(data.objProp);
+  });
+  it(`get() returns given data[id]`, async () => {
+    const storage = createStorage(data);
+    expect(storage.get()).toMatchObject(data);
+  });
+  it(`set(data) updates data by merging old and new`, async () => {
+    const storage = createStorage(data);
+    const originalData = storage.get();
+    storage.set(newValues);
+    expect(storage.get()).not.toBe(originalData);
+    expect(storage.get()).toMatchObject({ ...data, ...newValues });
+
+    storage.set(partialNewValues);
+    const current = storage.get() as ResultObject;
+    expect(current).toMatchObject({ ...data, ...newValues, ...partialNewValues });
+    // original data props still exist
+    expect(current.dataProp).toMatchObject(data.dataProp);
+    expect(current.newValuesProp).toMatchObject(newValues.newValuesProp);
+
+    // merge affects all matching props
+    expect(current.objProp).toMatchObject(partialNewValues.objProp);
+
+    expect(current.objProp.newObjProp).toBe(partialNewValues.objProp.newObjProp);
+
+    // overwritten objects lose props
+    expect(current.objProp.newChildProp).toBeUndefined();
+    expect(current.arrProp).toMatchObject(partialNewValues.arrProp);
+    expect(current.arrProp2).toMatchObject(partialNewValues.arrProp2);
+    expect(current.arrProp3).toMatchObject(partialNewValues.arrProp3);
+  });
+  it(`updating does not affect original data`, async () => {
+    const source = {
+      a: {
+        b: {
+          c: 'c',
+        },
+      },
+      aa: { bb: 'bb' },
+    };
+    const clone = JSON.parse(JSON.stringify(source));
+    const storage = createStorage(data);
+    storage.set({ a: { b: { c: null } } });
+    expect(source).toMatchObject(clone);
+    storage.set({ a: null });
+    storage.set({ aa: null });
+    expect(source).toMatchObject(clone);
+  });
+});

--- a/packages/react/src/components/dataProvider/storage.ts
+++ b/packages/react/src/components/dataProvider/storage.ts
@@ -1,0 +1,30 @@
+/**
+ *
+ *  Simple storage for getting/setting data.
+ *  Data is not mutated, a new object is always created.
+ *
+ * */
+
+export type StorageData = Record<string, unknown>;
+export type Storage<D = StorageData> = {
+  set: (newData: D) => D;
+  get: () => D;
+};
+
+export function createStorage(initialData: StorageData): Storage {
+  let data = { ...initialData };
+  const setter: Storage['set'] = (newData) => {
+    data = {
+      ...data,
+      ...newData,
+    };
+    return data;
+  };
+  const getter: Storage['get'] = () => {
+    return data;
+  };
+  return {
+    get: getter,
+    set: setter,
+  };
+}


### PR DESCRIPTION
**Note: Target branch is Select component's feature branch**

## Description

First commit for Select/Multiselect. Their data structure is complicated and multiple components should update the data. Also all components must be able to read and render/react to data changes.

Instead of multiple states, all data should be stored to one place: DataProvider. It is a React context with hooks.

Benefits:
- data is updated in sync, so all states stay in sync. For example select options can be deleted via the list, clear button, tags, clear all button.
- all data is accessible to all components
- public data (passed by users) is stored in one place and may be passed to onChange-callbacks.
- private/inner data (created by components) is stored to one place. Private data can be elements, element refs, click locations, on-going requests, element/test ids, etc.
- changes are triggered with events and a simple pure function handles data updates

### Example of simplification
Current [story of grouped checkboxes](https://github.com/City-of-Helsinki/helsinki-design-system/blob/52a3bd878932beb1daf1ff044e69f09396616491/packages/react/src/components/selectionGroup/SelectionGroup.stories.tsx#L187) is a quite complex and has 100 lines of data handling
New version in this PR has 30 lines.

### In action

The context is used in [this PR](https://github.com/City-of-Helsinki/helsinki-design-system/pull/1240).

[The full version of Select ](https://github.com/City-of-Helsinki/helsinki-design-system/blob/hds-2069-select-base/packages/react/src/components/select/Select.tsx) (WIP) also uses it to simplify data flow

## Motivation and Context

Complex data structures can be simple with one data provider as a single source of truth and one update function.

## How Has This Been Tested?

Jest tests.

## Demo

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-2069-data-provider/?path=/story/components-dataprovider--form)

## Add to changelog
- Component is not public yet, so no CHANGELOG.
