### PR TITLE
(HDS-2178) fix: Fixed typo in mobile heading example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.X.X] - Month, XX, 202X
+## [3.7.0] - Month, XX, 202X
 
 ### React
 
@@ -63,7 +63,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Typography] Fixed typo in Typography table, mobile heading title had extra x.
 
 ### Figma
 

--- a/site/src/docs/foundation/design-tokens/typography/index.mdx
+++ b/site/src/docs/foundation/design-tokens/typography/index.mdx
@@ -36,7 +36,7 @@ You can use <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-des
 | --------------------- | -------: | --------: | --------------------------------------------------------------------------------------------------------- |
 | **Heading XXL**       | 64px     | 4rem      | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL</div>                    |
 | **Heading XL**        | 48px     | 3rem      | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL</div>                       |
-| **Heading XL Mobile** | 40px     | 2.5rem    | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XXL Mobile</div> |
+| **Heading XL Mobile** | 40px     | 2.5rem    | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XL Mobile</div> |
 | **Heading L**         | 32px     | 2rem      | <div class="heading-l" aria-label="Visualised heading L example">Heading L</div>                          |
 | **Heading M**         | 24px     | 1.5rem    | <div class="heading-m" aria-label="Visualised heading M example">Heading M</div>                          |
 | **Heading S**         | 20px     | 1.25rem   | <div class="heading-s" aria-label="Visualised heading S example">Heading S</div>                          |


### PR DESCRIPTION
Fixed typo in mobile heading example

## Description

There was extra x in example, fixed the doc.

## Related Issue

[HDS-2178](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2178)

## Add to changelog
- [x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2178]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ