### PR TITLE
HDS-2112: Deprecate combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 Changes that are not related to specific components
-- [Component] What has been changed
+
+- [Combobox] Marked the component as deprecated
 - [Link] Possibility to style a Link as button with `useButtonStyles` prop.
 
 #### Fixed
@@ -40,6 +41,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 - [Link] Possibility to style a Link as button.
 
@@ -60,6 +62,7 @@ Changes that are not related to specific components
 #### Changed
 
 - [CookieConsent] Cookie guidelines recommend using subdomains
+- [Dropdown] Added notification about deprecated Combobox and deprecated Select props
 - Updated Getting started-section for designers from Sketch/Abstract guidelines to Figma guidelines
 - [Link] Added examples of styling Link as a button.
 
@@ -80,6 +83,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -99,6 +103,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -118,6 +123,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -137,6 +143,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed

--- a/packages/react/src/components/dropdown/combobox/Combobox.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.tsx
@@ -72,7 +72,9 @@ function getDefaultFilter<OptionType>(labelField: string): FilterFunction<Option
     });
   };
 }
-
+/**
+ * @deprecated Will be removed in the next major release.
+ */
 export const Combobox = <OptionType,>(props: ComboboxProps<OptionType>) => {
   // we can't destructure all the props. after destructuring, the link
   // between the multiselect prop and the value, onChange etc. props would vanish

--- a/site/src/docs/components/dropdown/tabs.mdx
+++ b/site/src/docs/components/dropdown/tabs.mdx
@@ -8,16 +8,27 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import Notification from '../../../components/Notification';
 
 # Dropdown
 
 <div class="status-label-description">
   <StatusLabel type="info">Stable</StatusLabel>
-  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
-  <StatusLabelTooltip/>
+  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
+    Accessible
+  </StatusLabel>
+  <StatusLabelTooltip />
 </div>
 
-<LeadParagraph>A dropdown offers a user a list of options, of which one or multiple can be selected. Dropdowns are often used as part of forms and filters. HDS offers two types of dropdowns, a Select and a Combobox component.</LeadParagraph>
+<LeadParagraph>
+  A dropdown offers a user a list of options, of which one or multiple can be selected. Dropdowns are often used as part
+  of forms and filters. HDS offers two types of dropdowns, a Select and a Combobox component.
+</LeadParagraph>
+
+<Notification type="alert" label="Dropdowns are deprecated" className="siteNotification">
+  <p>Combobox is deprecated and will be removed in the next major release.</p>
+  <p>Select is being redesigned and will have different props in the next major release.</p>
+</Notification>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>


### PR DESCRIPTION
## Description

Added notes about deprecation

## Related Issue

Closes [HDS-2112]( https://helsinkisolutionoffice.atlassian.net/browse/HDS-2112)

## How Has This Been Tested?

No code changes. Checked that VSCode identifies deprecation properly.



## Add to changelog
- [ x] Added needed line to changelog 

Visual presention on the docs change:

![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/2639230/5bed6cb5-d928-4a46-bbbf-91f3d39be71d)



[HDS-2112]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ