### PR TITLE
HDS-2192: Hide footer separators from screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Link] Possibility to style a Link as button with `useButtonStyles` prop.
 - [CookieConsent] Consent cookie's default domain was changed to window.location.hostname.
 - [Combobox] Marked the component as deprecated
+- [Footer.Base] Added `aria-hidden` to separators
 
 #### Fixed
 

--- a/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
+++ b/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
@@ -110,7 +110,9 @@ export const FooterBase = ({
                 return (
                   // eslint-disable-next-line react/no-array-index-key
                   <Fragment key={index}>
-                    <span className={styles.separator}>|</span>
+                    <span className={styles.separator} aria-hidden>
+                      |
+                    </span>
                     {cloneElement(child as React.ReactElement, {
                       variant: FooterVariant.Base,
                     })}

--- a/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`<Footer.Base /> spec renders the component 1`] = `
               class="links"
             >
               <span
+                aria-hidden="true"
                 class="separator"
               >
                 |
@@ -88,6 +89,7 @@ exports[`<Footer.Base /> spec renders the component 1`] = `
                 </span>
               </a>
               <span
+                aria-hidden="true"
                 class="separator"
               >
                 |
@@ -100,6 +102,7 @@ exports[`<Footer.Base /> spec renders the component 1`] = `
                 </span>
               </a>
               <span
+                aria-hidden="true"
                 class="separator"
               >
                 |


### PR DESCRIPTION
## Description

Separators did not have aria-hidden. Did the same fix as was done to header: https://github.com/City-of-Helsinki/helsinki-design-system/pull/1178

## Related Issue

Closes [HDS-2192](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2192)

## How Has This Been Tested?

Cannot produce with VoiceOver. It did not pause like described in the ticket.

[Demo](https://city-of-helsinki.github.io/hds-demo/hds-2192-footer-separators/?path=/story/components-footer--custom-section)

## Add to changelog
- [x] Added needed line to changelog 



[HDS-2192]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ