### PR TITLE
hds-2183: fix header ssr styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - [Link] Possibility to style a Link as button with `useButtonStyles` prop.
+- [Header] Fixed an issue with inconsistent css-class order in SSR.
 - [Select] Marked most props as deprecated. The redesigned next major version will have different props.
 - [CookieConsent] Consent cookie's default domain was changed to window.location.hostname.
 - [Combobox] Marked the component as deprecated

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -23,7 +23,7 @@
   "rules": {
     "no-use-before-define": "off",
     "default-param-last": "off",
-    "@typescript-eslint/no-use-before-define": ["error"],
+    "@typescript-eslint/no-use-before-define": "error",
     "no-shadow": "off", // replaced by ts-eslint rule below
     "@typescript-eslint/no-shadow": "error",
     "import/no-extraneous-dependencies": [
@@ -90,7 +90,7 @@
       }
     ],
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error"]
+    "@typescript-eslint/no-unused-vars": "error"
   },
   "settings": {
     "react": {

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -36,6 +36,14 @@
       "error",
       {
         "groups": ["builtin", "external", "internal", ["parent", "sibling", "index"]],
+        "pathGroups": [
+          {
+            "pattern": "./**/*.{css,scss}",
+            "group": "sibling",
+            "position": "before"
+          }
+        ],
+        "distinctGroup": false,
         "newlines-between": "always"
       }
     ],

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import '../../styles/base.module.css';
-import { LoadingSpinner } from '../loadingSpinner';
 import styles from './Button.module.scss';
+import { LoadingSpinner } from '../loadingSpinner';
 import classNames from '../../utils/classNames';
 
 export type ButtonSize = 'default' | 'small';

--- a/packages/react/src/components/cookieConsent/languageSwitcher/LanguageSwitcherItem/LanguageSwitcherItem.tsx
+++ b/packages/react/src/components/cookieConsent/languageSwitcher/LanguageSwitcherItem/LanguageSwitcherItem.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import styles from './LanguageSwitcherItem.module.scss';
 import classNames from '../../../../utils/classNames';
 import { MergeElementProps } from '../../../../common/types';
 import { useMobile } from '../../../../hooks/useMobile';
-import styles from './LanguageSwitcherItem.module.scss';
 
 type ItemProps = {
   /**

--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -1,11 +1,11 @@
 import { format, parse, isValid, subYears, addYears, startOfMonth, endOfMonth, max } from 'date-fns';
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 
+import styles from './DateInput.module.scss';
 import { IconCalendar } from '../../icons';
 import mergeRefWithInternalRef from '../../utils/mergeRefWithInternalRef';
 import { TextInput, TextInputProps } from '../textInput';
 import { DatePicker, LegendItem } from './components/datePicker';
-import styles from './DateInput.module.scss';
 
 export type DateInputProps = Omit<TextInputProps, 'onChange'> & {
   /**

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import finnish from 'date-fns/locale/fi';
 import swedish from 'date-fns/locale/sv';
 import { Modifier, usePopper } from 'react-popper';
 
+import styles from './DatePicker.module.scss';
 import { defaultProps } from './defaults/defaultProps';
 import { DatePickerContext } from '../../context/DatePickerContext';
 import { DayPickerProps } from './types';
@@ -20,7 +21,6 @@ import { MonthTable } from '../monthTable';
 import { Legend } from '../legend';
 import { Button } from '../../../button';
 import { IconCheck, IconCross } from '../../../../icons';
-import styles from './DatePicker.module.scss';
 import classNames from '../../../../utils/classNames';
 import { scrollIntoViewIfNeeded } from '../../../../utils/scrollIntoViewIfNeeded';
 

--- a/packages/react/src/components/dialog/dialogContent/DialogContent.tsx
+++ b/packages/react/src/components/dialog/dialogContent/DialogContent.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 
-import classNames from '../../../utils/classNames';
 import styles from './DialogContent.module.scss';
+import classNames from '../../../utils/classNames';
 import { DialogContext } from '../DialogContext';
 
 export type DialogContentProps = React.PropsWithChildren<{

--- a/packages/react/src/components/dialog/dialogHeader/DialogHeader.tsx
+++ b/packages/react/src/components/dialog/dialogHeader/DialogHeader.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject, useContext, useEffect } from 'react';
 
-import { IconCross } from '../../../icons';
 import styles from './DialogHeader.module.scss';
+import { IconCross } from '../../../icons';
 import { DialogContext } from '../DialogContext';
 
 export type DialogHeaderProps = {

--- a/packages/react/src/components/errorSummary/ErrorSummary.tsx
+++ b/packages/react/src/components/errorSummary/ErrorSummary.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect } from 'react';
 
 import '../../styles/base.module.css';
-import notificationStyles from '../notification/Notification.module.css';
 import errorSummaryStyles from './ErrorSummary.module.scss';
+import notificationStyles from '../notification/Notification.module.css';
 import { IconAlertCircleFill } from '../../icons';
 import classNames from '../../utils/classNames';
 

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -2,12 +2,12 @@ import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { uniqueId } from 'lodash';
 
 import '../../styles/base.module.css';
+import styles from './FileInput.module.scss';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 import classNames from '../../utils/classNames';
 import { Button } from '../button';
 import { IconPlus, IconPhoto, IconCross, IconDocument, IconUpload } from '../../icons';
 import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
-import styles from './FileInput.module.scss';
 
 type Language = 'en' | 'fi' | 'sv';
 

--- a/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.tsx
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.tsx
@@ -1,9 +1,9 @@
 import React, { cloneElement, Fragment, isValidElement } from 'react';
 
 import '../../../../styles/base.module.css';
+import styles from './FooterNavigationGroup.module.scss';
 import { FooterVariant } from '../../Footer.interface';
 import { useMediaQueryLessThan } from '../../../../hooks/useMediaQuery';
-import styles from './FooterNavigationGroup.module.scss';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 

--- a/packages/react/src/components/header/Header.tsx
+++ b/packages/react/src/components/header/Header.tsx
@@ -1,5 +1,7 @@
 import React, { ComponentType, FC } from 'react';
 
+import '../../styles/base.module.css';
+import styles from './Header.module.scss';
 import { styleBoundClassNames } from '../../utils/classNames';
 import { HeaderContextProvider, useHeaderContext } from './HeaderContext';
 import { HeaderUniversalBar } from './components/headerUniversalBar';
@@ -12,8 +14,6 @@ import { HeaderSearch } from './components/headerSearch';
 import { SkipLink } from '../../internal/skipLink';
 import { LanguageProvider, LanguageProviderProps } from './LanguageContext';
 import { HeaderTheme } from './Header.type';
-import '../../styles/base.module.css';
-import styles from './Header.module.scss';
 import { useTheme } from '../../hooks/useTheme';
 
 const classNames = styleBoundClassNames(styles);

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.module.scss
@@ -1,6 +1,5 @@
-@use "../../Header.module.scss";
-@use "../../../../styles/common.scss";
-@use "./_typography.scss";
+@use '../../../../styles/common.scss';
+@use './_typography.scss';
 @value medium-down from "../../../../styles/breakpoints.scss";
 
 .headerActionBar {

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren, MouseEventHandler, useEffect, useMemo, useRef } from 'react';
 
+import styles from './HeaderActionBar.module.scss';
 import { styleBoundClassNames } from '../../../../utils/classNames';
 import { Logo } from '../../../logo';
 import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
@@ -8,7 +9,6 @@ import { HeaderLanguageSelectorConsumer, getLanguageSelectorComponentProps } fro
 import { useCallbackIfDefined, useEnterOrSpacePressCallback } from '../../../../utils/useCallback';
 import { elementIsFocusable } from '../../../../utils/elementIsFocusable';
 import { HeaderActionBarMenuItem } from '../headerActionBarItem';
-import styles from './HeaderActionBar.module.scss';
 import HeaderActionBarLogo from './HeaderActionBarLogo';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 import { useHeaderContext } from '../../HeaderContext';

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarLogo.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarLogo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
 import styles from './HeaderActionBarLogo.module.scss';
+import { LinkItem, LinkProps } from '../../../../internal/LinkItem';
 
 type HeaderActionBarLogoProps = {
   /**

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -1,8 +1,8 @@
 import React, { cloneElement, isValidElement, MouseEventHandler, TransitionEvent, useEffect, useRef } from 'react';
 
+import styles from './HeaderActionBarNavigationMenu.module.scss';
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
-import styles from './HeaderActionBarNavigationMenu.module.scss';
 import { getChildrenAsArray } from '../../../../utils/getChildren';
 import { HeaderLink } from '../headerLink';
 import { IconAngleLeft } from '../../../../icons';

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.module.scss
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.module.scss
@@ -1,4 +1,3 @@
-@use '../../Header.module.scss';
 @use '../../../../styles/common.scss';
 
 button.actionBarItem {

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
@@ -1,7 +1,7 @@
 import React, { cloneElement, forwardRef, ReactNode } from 'react';
 
-import classNames from '../../../../utils/classNames';
 import classes from './HeaderActionBarItem.module.scss';
+import classNames from '../../../../utils/classNames';
 
 type ButtonAttributes = JSX.IntrinsicElements['button'];
 

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemWithDropdown.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemWithDropdown.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 
+import classes from './HeaderActionBarItemWithDropdown.module.scss';
 import { IconCross } from '../../../../icons';
 import { HeaderActionBarItem, HeaderActionBarItemProps } from './HeaderActionBarItem';
 import classNames from '../../../../utils/classNames';
-import classes from './HeaderActionBarItemWithDropdown.module.scss';
 
 type HeaderActionBarItemWithDropdownProps = React.PropsWithChildren<{
   /**

--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.module.scss
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.module.scss
@@ -1,4 +1,3 @@
-@use "../../Header.module.scss";
 @import '../../../../styles/common.scss';
 
 .languageSelector {

--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.tsx
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren } from 'react';
 
+import classes from './HeaderLanguageSelector.module.scss';
 import { LanguageOption, useActiveLanguage, useAvailableLanguages, useSetLanguage } from '../../LanguageContext';
 import classNames from '../../../../utils/classNames';
 import { withDefaultPrevented } from '../../../../utils/useCallback';
 import { HeaderActionBarItemWithDropdown } from '../headerActionBarItem';
 import { IconAngleDown, IconAngleUp, IconGlobe } from '../../../../icons';
-import classes from './HeaderLanguageSelector.module.scss';
 import { useHeaderContext } from '../../HeaderContext';
 import { getComponentFromChildren } from '../../../../utils/getChildren';
 

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.module.scss
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.module.scss
@@ -1,5 +1,4 @@
-@use "../../Header.module.scss";
-@import "../../../../styles/common.scss";
+@import '../../../../styles/common.scss';
 
 .headerLink.headerLink {
   --link-color: var(--color-black-90);
@@ -31,7 +30,6 @@
   padding-left: var(--header-focus-outline-width);
 }
 
-
 .navigationLinkWrapper {
   align-items: center;
   display: flex;
@@ -53,7 +51,7 @@
   }
 }
 
-.headerLink.isNotLargeScreen{
+.headerLink.isNotLargeScreen {
   align-self: center;
   border: none;
   box-sizing: border-box;
@@ -63,5 +61,7 @@
   padding: 0;
   word-wrap: break-word;
 
-  &:focus { border: none }
+  &:focus {
+    border: none;
+  }
 }

--- a/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.module.scss
+++ b/packages/react/src/components/header/components/headerLink/headerLinkDropdown/HeaderLinkDropdown.module.scss
@@ -1,5 +1,3 @@
-@use "../../../Header.module.scss";
-
 button.button {
   background-color: var(--nav-button-background-color);
   border: none;

--- a/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
@@ -1,10 +1,10 @@
 import React, { cloneElement, isValidElement, useEffect } from 'react';
 
 import '../../../../styles/base.module.css';
+import styles from './HeaderNavigationMenu.module.scss';
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween, getChildrenAsArray } from '../../../../utils/getChildren';
-import styles from './HeaderNavigationMenu.module.scss';
 
 export type HeaderNavigationMenuProps = React.PropsWithChildren<{
   /**

--- a/packages/react/src/components/highlight/Highlight.tsx
+++ b/packages/react/src/components/highlight/Highlight.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import '../../styles/base.module.css';
+import styles from './Highlight.module.scss';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
-import styles from './Highlight.module.scss';
 
 export interface HighlightTheme {
   '--accent-line-color'?: string;

--- a/packages/react/src/components/imageWithCard/ImageWithCard.tsx
+++ b/packages/react/src/components/imageWithCard/ImageWithCard.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import '../../styles/base.module.css';
-import classNames from '../../utils/classNames';
 import styles from './ImageWithCard.module.css';
+import classNames from '../../utils/classNames';
 
 export type ImageWithCardAlignment = 'left' | 'right';
 export type ImageWithCardLayout = 'hover' | 'split';

--- a/packages/react/src/components/koros/Koros.tsx
+++ b/packages/react/src/components/koros/Koros.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { uniqueId } from 'lodash';
 
 import '../../styles/base.module.css';
-import classNames from '../../utils/classNames';
 import styles from './Koros.module.css';
+import classNames from '../../utils/classNames';
 
 export type KorosType = 'basic' | 'beat' | 'pulse' | 'wave' | 'vibration' | 'calm';
 

--- a/packages/react/src/components/login/components/LoginButton.tsx
+++ b/packages/react/src/components/login/components/LoginButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import styles from './LoginButton.module.scss';
 import { useAuthenticatedUser, useOidcClient } from '../client/hooks';
 import { useSignalTrackingWithReturnValue } from '../beacon/hooks';
 import {
@@ -9,7 +10,6 @@ import {
 } from '../client/signals';
 import { Button, ButtonProps } from '../../button/Button';
 import { LoadingSpinner } from '../../loadingSpinner';
-import styles from './LoginButton.module.scss';
 import { IconAlertCircleFill } from '../../../icons';
 
 export type LoginButtonProps = { spinnerColor?: string; errorText: string } & ButtonProps;

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -3,8 +3,8 @@ import { animated, useSpring } from '@react-spring/web';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 
 import '../../styles/base.module.css';
-import classNames from '../../utils/classNames';
 import styles from './Notification.module.css';
+import classNames from '../../utils/classNames';
 import { IconInfoCircleFill, IconErrorFill, IconAlertCircleFill, IconCheckCircleFill, IconCross } from '../../icons';
 
 export type NotificationType = 'info' | 'error' | 'alert' | 'success';

--- a/packages/react/src/components/numberInput/NumberInput.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 
-import useThrottledWheel from '../../hooks/useThrottledWheel';
 import '../../styles/base.module.css';
 import styles from './NumberInput.module.scss';
+import useThrottledWheel from '../../hooks/useThrottledWheel';
 import { IconMinus, IconPlus } from '../../icons';
 import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
 import { TextInputProps } from '../textInput';

--- a/packages/react/src/components/section/Section.tsx
+++ b/packages/react/src/components/section/Section.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import '../../styles/base.module.css';
+import styles from './Section.module.css';
 import classNames from '../../utils/classNames';
 import { Koros, KorosType } from '../koros';
-import styles from './Section.module.css';
 
 export type SectionColor = 'primary' | 'secondary' | 'tertiary' | 'plain';
 

--- a/packages/react/src/components/sideNavigation/mainLevel/MainLevel.tsx
+++ b/packages/react/src/components/sideNavigation/mainLevel/MainLevel.tsx
@@ -1,7 +1,7 @@
 import React, { cloneElement, isValidElement, ReactNode, useContext, useEffect, useState } from 'react';
 
-import classNames from '../../../utils/classNames';
 import styles from './MainLevel.module.scss';
+import classNames from '../../../utils/classNames';
 import SideNavigationContext from '../SideNavigationContext';
 import { FCWithName } from '../../../common/types';
 import { IconAngleDown, IconAngleUp, IconLinkExternal } from '../../../icons';

--- a/packages/react/src/components/stepByStep/StepByStep.tsx
+++ b/packages/react/src/components/stepByStep/StepByStep.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
 
 import '../../styles/base.module.css';
+import styles from './StepByStep.module.scss';
 import { Button, ButtonProps } from '../button';
 import classNames from '../../utils/classNames';
 import { Link, LinkProps } from '../link';
-import styles from './StepByStep.module.scss';
 
 type StepType = {
   /**

--- a/packages/react/src/components/stepper/Step.tsx
+++ b/packages/react/src/components/stepper/Step.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import '../../styles/base.module.css';
-import { IconCheck, IconError, IconPlaybackPause } from '../../icons';
 import styles from './Stepper.module.scss';
+import { IconCheck, IconError, IconPlaybackPause } from '../../icons';
 import classNames from '../../utils/classNames';
 
 export enum StepState {

--- a/packages/react/src/components/stepper/Stepper.stories.tsx
+++ b/packages/react/src/components/stepper/Stepper.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useReducer, useRef } from 'react';
 
-import { Stepper } from './Stepper';
 import styles from './Stepper.module.scss';
+import { Stepper } from './Stepper';
 import { Step, StepState } from './Step';
 import { Button } from '../button';
 import { IconArrowLeft, IconArrowRight } from '../../icons';

--- a/packages/react/src/components/timeInput/TimeInput.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.tsx
@@ -1,10 +1,10 @@
 import React, { FocusEventHandler, useEffect, useRef, useState } from 'react';
 
 import '../../styles/base.module.css';
+import styles from './TimeInput.module.scss';
 import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
 import { TextInputProps } from '../textInput/TextInput';
 import textInputStyles from '../textInput/TextInput.module.css';
-import styles from './TimeInput.module.scss';
 import classNames from '../../utils/classNames';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 import mergeRefWithInternalRef from '../../utils/mergeRefWithInternalRef';

--- a/packages/react/src/icons/IconAlertCircle.tsx
+++ b/packages/react/src/icons/IconAlertCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAlertCircle = ({
   ariaLabel = 'alert-circle',

--- a/packages/react/src/icons/IconAlertCircleFill.tsx
+++ b/packages/react/src/icons/IconAlertCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAlertCircleFill = ({
   ariaLabel = 'alert-circle-fill',

--- a/packages/react/src/icons/IconAngleDown.tsx
+++ b/packages/react/src/icons/IconAngleDown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAngleDown = ({
   ariaLabel = 'angle-down',

--- a/packages/react/src/icons/IconAngleLeft.tsx
+++ b/packages/react/src/icons/IconAngleLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAngleLeft = ({
   ariaLabel = 'angle-left',

--- a/packages/react/src/icons/IconAngleRight.tsx
+++ b/packages/react/src/icons/IconAngleRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAngleRight = ({
   ariaLabel = 'angle-right',

--- a/packages/react/src/icons/IconAngleUp.tsx
+++ b/packages/react/src/icons/IconAngleUp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAngleUp = ({
   ariaLabel = 'angle-up',

--- a/packages/react/src/icons/IconArrowBottomLeft.tsx
+++ b/packages/react/src/icons/IconArrowBottomLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowBottomLeft = ({
   ariaLabel = 'arrow-bottom-left',

--- a/packages/react/src/icons/IconArrowBottomRight.tsx
+++ b/packages/react/src/icons/IconArrowBottomRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowBottomRight = ({
   ariaLabel = 'arrow-bottom-right',

--- a/packages/react/src/icons/IconArrowDown.tsx
+++ b/packages/react/src/icons/IconArrowDown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowDown = ({
   ariaLabel = 'arrow-down',

--- a/packages/react/src/icons/IconArrowLeft.tsx
+++ b/packages/react/src/icons/IconArrowLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowLeft = ({
   ariaLabel = 'arrow-left',

--- a/packages/react/src/icons/IconArrowRedo.tsx
+++ b/packages/react/src/icons/IconArrowRedo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowRedo = ({
   ariaLabel = 'arrow-redo',

--- a/packages/react/src/icons/IconArrowRight.tsx
+++ b/packages/react/src/icons/IconArrowRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowRight = ({
   ariaLabel = 'arrow-right',

--- a/packages/react/src/icons/IconArrowRightDashed.tsx
+++ b/packages/react/src/icons/IconArrowRightDashed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowRightDashed = ({
   ariaLabel = 'arrow-right-dashed',

--- a/packages/react/src/icons/IconArrowTopLeft.tsx
+++ b/packages/react/src/icons/IconArrowTopLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowTopLeft = ({
   ariaLabel = 'arrow-top-left',

--- a/packages/react/src/icons/IconArrowTopRight.tsx
+++ b/packages/react/src/icons/IconArrowTopRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowTopRight = ({
   ariaLabel = 'arrow-top-right',

--- a/packages/react/src/icons/IconArrowUndo.tsx
+++ b/packages/react/src/icons/IconArrowUndo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowUndo = ({
   ariaLabel = 'arrow-undo',

--- a/packages/react/src/icons/IconArrowUp.tsx
+++ b/packages/react/src/icons/IconArrowUp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconArrowUp = ({
   ariaLabel = 'arrow-up',

--- a/packages/react/src/icons/IconAtSign.tsx
+++ b/packages/react/src/icons/IconAtSign.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconAtSign = ({
   ariaLabel = 'at-sign',

--- a/packages/react/src/icons/IconBagCogwheel.tsx
+++ b/packages/react/src/icons/IconBagCogwheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconBagCogwheel = ({
   ariaLabel = 'bag-cogwheel',

--- a/packages/react/src/icons/IconBell.tsx
+++ b/packages/react/src/icons/IconBell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconBell = ({
   ariaLabel = 'bell',

--- a/packages/react/src/icons/IconBellCrossed.tsx
+++ b/packages/react/src/icons/IconBellCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconBellCrossed = ({
   ariaLabel = 'bell-crossed',

--- a/packages/react/src/icons/IconBinoculars.tsx
+++ b/packages/react/src/icons/IconBinoculars.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconBinoculars = ({
   ariaLabel = 'binoculars',

--- a/packages/react/src/icons/IconBox.tsx
+++ b/packages/react/src/icons/IconBox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconBox = ({
   ariaLabel = 'box',

--- a/packages/react/src/icons/IconCake.tsx
+++ b/packages/react/src/icons/IconCake.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCake = ({
   ariaLabel = 'cake',

--- a/packages/react/src/icons/IconCalendar.tsx
+++ b/packages/react/src/icons/IconCalendar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCalendar = ({
   ariaLabel = 'calendar',

--- a/packages/react/src/icons/IconCalendarClock.tsx
+++ b/packages/react/src/icons/IconCalendarClock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCalendarClock = ({
   ariaLabel = 'calendar-clock',

--- a/packages/react/src/icons/IconCalendarCross.tsx
+++ b/packages/react/src/icons/IconCalendarCross.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCalendarCross = ({
   ariaLabel = 'calendar-cross',

--- a/packages/react/src/icons/IconCalendarEvent.tsx
+++ b/packages/react/src/icons/IconCalendarEvent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCalendarEvent = ({
   ariaLabel = 'calendar-event',

--- a/packages/react/src/icons/IconCalendarPlus.tsx
+++ b/packages/react/src/icons/IconCalendarPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCalendarPlus = ({
   ariaLabel = 'calendar-plus',

--- a/packages/react/src/icons/IconCalendarRecurring.tsx
+++ b/packages/react/src/icons/IconCalendarRecurring.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCalendarRecurring = ({
   ariaLabel = 'calendar-recurring',

--- a/packages/react/src/icons/IconCamera.tsx
+++ b/packages/react/src/icons/IconCamera.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCamera = ({
   ariaLabel = 'camera',

--- a/packages/react/src/icons/IconCheck.tsx
+++ b/packages/react/src/icons/IconCheck.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCheck = ({
   ariaLabel = 'check',

--- a/packages/react/src/icons/IconCheckCircle.tsx
+++ b/packages/react/src/icons/IconCheckCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCheckCircle = ({
   ariaLabel = 'check-circle',

--- a/packages/react/src/icons/IconCheckCircleFill.tsx
+++ b/packages/react/src/icons/IconCheckCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCheckCircleFill = ({
   ariaLabel = 'check-circle-fill',

--- a/packages/react/src/icons/IconChildren.tsx
+++ b/packages/react/src/icons/IconChildren.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconChildren = ({
   ariaLabel = 'children',

--- a/packages/react/src/icons/IconClock.tsx
+++ b/packages/react/src/icons/IconClock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconClock = ({
   ariaLabel = 'clock',

--- a/packages/react/src/icons/IconClockCross.tsx
+++ b/packages/react/src/icons/IconClockCross.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconClockCross = ({
   ariaLabel = 'clock-cross',

--- a/packages/react/src/icons/IconClockPlus.tsx
+++ b/packages/react/src/icons/IconClockPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconClockPlus = ({
   ariaLabel = 'clock-plus',

--- a/packages/react/src/icons/IconCoffeeCupSaucer.tsx
+++ b/packages/react/src/icons/IconCoffeeCupSaucer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCoffeeCupSaucer = ({
   ariaLabel = 'coffee-cup-saucer',

--- a/packages/react/src/icons/IconCogwheel.tsx
+++ b/packages/react/src/icons/IconCogwheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCogwheel = ({
   ariaLabel = 'cogwheel',

--- a/packages/react/src/icons/IconCogwheels.tsx
+++ b/packages/react/src/icons/IconCogwheels.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCogwheels = ({
   ariaLabel = 'cogwheels',

--- a/packages/react/src/icons/IconCollapse.tsx
+++ b/packages/react/src/icons/IconCollapse.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCollapse = ({
   ariaLabel = 'collapse',

--- a/packages/react/src/icons/IconCompany.tsx
+++ b/packages/react/src/icons/IconCompany.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCompany = ({
   ariaLabel = 'company',

--- a/packages/react/src/icons/IconCopy.tsx
+++ b/packages/react/src/icons/IconCopy.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCopy = ({
   ariaLabel = 'copy',

--- a/packages/react/src/icons/IconCross.tsx
+++ b/packages/react/src/icons/IconCross.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCross = ({
   ariaLabel = 'cross',

--- a/packages/react/src/icons/IconCrossCircle.tsx
+++ b/packages/react/src/icons/IconCrossCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCrossCircle = ({
   ariaLabel = 'cross-circle',

--- a/packages/react/src/icons/IconCrossCircleFill.tsx
+++ b/packages/react/src/icons/IconCrossCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCrossCircleFill = ({
   ariaLabel = 'cross-circle-fill',

--- a/packages/react/src/icons/IconCustomerBotNegative.tsx
+++ b/packages/react/src/icons/IconCustomerBotNegative.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCustomerBotNegative = ({
   ariaLabel = 'customer-bot-negative',

--- a/packages/react/src/icons/IconCustomerBotNeutral.tsx
+++ b/packages/react/src/icons/IconCustomerBotNeutral.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCustomerBotNeutral = ({
   ariaLabel = 'customer-bot-neutral',

--- a/packages/react/src/icons/IconCustomerBotPositive.tsx
+++ b/packages/react/src/icons/IconCustomerBotPositive.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconCustomerBotPositive = ({
   ariaLabel = 'customer-bot-positive',

--- a/packages/react/src/icons/IconDiscord.tsx
+++ b/packages/react/src/icons/IconDiscord.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDiscord = ({
   ariaLabel = 'discord',

--- a/packages/react/src/icons/IconDisplay.tsx
+++ b/packages/react/src/icons/IconDisplay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDisplay = ({
   ariaLabel = 'display',

--- a/packages/react/src/icons/IconDocument.tsx
+++ b/packages/react/src/icons/IconDocument.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDocument = ({
   ariaLabel = 'document',

--- a/packages/react/src/icons/IconDocumentBlank.tsx
+++ b/packages/react/src/icons/IconDocumentBlank.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDocumentBlank = ({
   ariaLabel = 'document-blank',

--- a/packages/react/src/icons/IconDocumentBlankGroup.tsx
+++ b/packages/react/src/icons/IconDocumentBlankGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDocumentBlankGroup = ({
   ariaLabel = 'document-blank-group',

--- a/packages/react/src/icons/IconDocumentGroup.tsx
+++ b/packages/react/src/icons/IconDocumentGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDocumentGroup = ({
   ariaLabel = 'document-group',

--- a/packages/react/src/icons/IconDownload.tsx
+++ b/packages/react/src/icons/IconDownload.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDownload = ({
   ariaLabel = 'download',

--- a/packages/react/src/icons/IconDownloadCloud.tsx
+++ b/packages/react/src/icons/IconDownloadCloud.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDownloadCloud = ({
   ariaLabel = 'download-cloud',

--- a/packages/react/src/icons/IconDrag.tsx
+++ b/packages/react/src/icons/IconDrag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconDrag = ({
   ariaLabel = 'drag',

--- a/packages/react/src/icons/IconEntrepreneur.tsx
+++ b/packages/react/src/icons/IconEntrepreneur.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconEntrepreneur = ({
   ariaLabel = 'entrepreneur',

--- a/packages/react/src/icons/IconEnvelope.tsx
+++ b/packages/react/src/icons/IconEnvelope.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconEnvelope = ({
   ariaLabel = 'envelope',

--- a/packages/react/src/icons/IconError.tsx
+++ b/packages/react/src/icons/IconError.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconError = ({
   ariaLabel = 'error',

--- a/packages/react/src/icons/IconErrorFill.tsx
+++ b/packages/react/src/icons/IconErrorFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconErrorFill = ({
   ariaLabel = 'error-fill',

--- a/packages/react/src/icons/IconEuroSign.tsx
+++ b/packages/react/src/icons/IconEuroSign.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconEuroSign = ({
   ariaLabel = 'euro-sign',

--- a/packages/react/src/icons/IconEye.tsx
+++ b/packages/react/src/icons/IconEye.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconEye = ({
   ariaLabel = 'eye',

--- a/packages/react/src/icons/IconEyeCrossed.tsx
+++ b/packages/react/src/icons/IconEyeCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconEyeCrossed = ({
   ariaLabel = 'eye-crossed',

--- a/packages/react/src/icons/IconFaceNeutral.tsx
+++ b/packages/react/src/icons/IconFaceNeutral.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFaceNeutral = ({
   ariaLabel = 'face-neutral',

--- a/packages/react/src/icons/IconFaceSad.tsx
+++ b/packages/react/src/icons/IconFaceSad.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFaceSad = ({
   ariaLabel = 'face-sad',

--- a/packages/react/src/icons/IconFaceSmile.tsx
+++ b/packages/react/src/icons/IconFaceSmile.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFaceSmile = ({
   ariaLabel = 'face-smile',

--- a/packages/react/src/icons/IconFacebook.tsx
+++ b/packages/react/src/icons/IconFacebook.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFacebook = ({
   ariaLabel = 'facebook',

--- a/packages/react/src/icons/IconFamily.tsx
+++ b/packages/react/src/icons/IconFamily.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFamily = ({
   ariaLabel = 'family',

--- a/packages/react/src/icons/IconFolder.tsx
+++ b/packages/react/src/icons/IconFolder.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFolder = ({
   ariaLabel = 'folder',

--- a/packages/react/src/icons/IconFolderGroup.tsx
+++ b/packages/react/src/icons/IconFolderGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconFolderGroup = ({
   ariaLabel = 'folder-group',

--- a/packages/react/src/icons/IconGlobe.tsx
+++ b/packages/react/src/icons/IconGlobe.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconGlobe = ({
   ariaLabel = 'globe',

--- a/packages/react/src/icons/IconGoogle.tsx
+++ b/packages/react/src/icons/IconGoogle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconGoogle = ({
   ariaLabel = 'google',

--- a/packages/react/src/icons/IconGraphColumns.tsx
+++ b/packages/react/src/icons/IconGraphColumns.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconGraphColumns = ({
   ariaLabel = 'graph-columns',

--- a/packages/react/src/icons/IconGroup.tsx
+++ b/packages/react/src/icons/IconGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconGroup = ({
   ariaLabel = 'group',

--- a/packages/react/src/icons/IconHammers.tsx
+++ b/packages/react/src/icons/IconHammers.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHammers = ({
   ariaLabel = 'hammers',

--- a/packages/react/src/icons/IconHeadphones.tsx
+++ b/packages/react/src/icons/IconHeadphones.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHeadphones = ({
   ariaLabel = 'headphones',

--- a/packages/react/src/icons/IconHeart.tsx
+++ b/packages/react/src/icons/IconHeart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHeart = ({
   ariaLabel = 'heart',

--- a/packages/react/src/icons/IconHeartFill.tsx
+++ b/packages/react/src/icons/IconHeartFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHeartFill = ({
   ariaLabel = 'heart-fill',

--- a/packages/react/src/icons/IconHistory.tsx
+++ b/packages/react/src/icons/IconHistory.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHistory = ({
   ariaLabel = 'history',

--- a/packages/react/src/icons/IconHome.tsx
+++ b/packages/react/src/icons/IconHome.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHome = ({
   ariaLabel = 'home',

--- a/packages/react/src/icons/IconHomeSmoke.tsx
+++ b/packages/react/src/icons/IconHomeSmoke.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconHomeSmoke = ({
   ariaLabel = 'home-smoke',

--- a/packages/react/src/icons/IconInfoCircle.tsx
+++ b/packages/react/src/icons/IconInfoCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconInfoCircle = ({
   ariaLabel = 'info-circle',

--- a/packages/react/src/icons/IconInfoCircleFill.tsx
+++ b/packages/react/src/icons/IconInfoCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconInfoCircleFill = ({
   ariaLabel = 'info-circle-fill',

--- a/packages/react/src/icons/IconInstagram.tsx
+++ b/packages/react/src/icons/IconInstagram.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconInstagram = ({
   ariaLabel = 'instagram',

--- a/packages/react/src/icons/IconKey.tsx
+++ b/packages/react/src/icons/IconKey.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconKey = ({
   ariaLabel = 'key',

--- a/packages/react/src/icons/IconLayers.tsx
+++ b/packages/react/src/icons/IconLayers.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLayers = ({
   ariaLabel = 'layers',

--- a/packages/react/src/icons/IconLightbulb.tsx
+++ b/packages/react/src/icons/IconLightbulb.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLightbulb = ({
   ariaLabel = 'lightbulb',

--- a/packages/react/src/icons/IconLink.tsx
+++ b/packages/react/src/icons/IconLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLink = ({
   ariaLabel = 'link',

--- a/packages/react/src/icons/IconLinkExternal.tsx
+++ b/packages/react/src/icons/IconLinkExternal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLinkExternal = ({
   ariaLabel = 'link-external',

--- a/packages/react/src/icons/IconLinkedin.tsx
+++ b/packages/react/src/icons/IconLinkedin.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLinkedin = ({
   ariaLabel = 'linkedin',

--- a/packages/react/src/icons/IconLocate.tsx
+++ b/packages/react/src/icons/IconLocate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLocate = ({
   ariaLabel = 'locate',

--- a/packages/react/src/icons/IconLocation.tsx
+++ b/packages/react/src/icons/IconLocation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLocation = ({
   ariaLabel = 'location',

--- a/packages/react/src/icons/IconLock.tsx
+++ b/packages/react/src/icons/IconLock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLock = ({
   ariaLabel = 'lock',

--- a/packages/react/src/icons/IconLockOpen.tsx
+++ b/packages/react/src/icons/IconLockOpen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconLockOpen = ({
   ariaLabel = 'lock-open',

--- a/packages/react/src/icons/IconMap.tsx
+++ b/packages/react/src/icons/IconMap.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMap = ({
   ariaLabel = 'map',

--- a/packages/react/src/icons/IconMenuDots.tsx
+++ b/packages/react/src/icons/IconMenuDots.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMenuDots = ({
   ariaLabel = 'menu-dots',

--- a/packages/react/src/icons/IconMenuHamburger.tsx
+++ b/packages/react/src/icons/IconMenuHamburger.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMenuHamburger = ({
   ariaLabel = 'menu-hamburger',

--- a/packages/react/src/icons/IconMicrophone.tsx
+++ b/packages/react/src/icons/IconMicrophone.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMicrophone = ({
   ariaLabel = 'microphone',

--- a/packages/react/src/icons/IconMicrophoneCrossed.tsx
+++ b/packages/react/src/icons/IconMicrophoneCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMicrophoneCrossed = ({
   ariaLabel = 'microphone-crossed',

--- a/packages/react/src/icons/IconMinus.tsx
+++ b/packages/react/src/icons/IconMinus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMinus = ({
   ariaLabel = 'minus',

--- a/packages/react/src/icons/IconMinusCircle.tsx
+++ b/packages/react/src/icons/IconMinusCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMinusCircle = ({
   ariaLabel = 'minus-circle',

--- a/packages/react/src/icons/IconMinusCircleFill.tsx
+++ b/packages/react/src/icons/IconMinusCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMinusCircleFill = ({
   ariaLabel = 'minus-circle-fill',

--- a/packages/react/src/icons/IconMobile.tsx
+++ b/packages/react/src/icons/IconMobile.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMobile = ({
   ariaLabel = 'mobile',

--- a/packages/react/src/icons/IconMoneyBag.tsx
+++ b/packages/react/src/icons/IconMoneyBag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMoneyBag = ({
   ariaLabel = 'money-bag',

--- a/packages/react/src/icons/IconMoneyBagFill.tsx
+++ b/packages/react/src/icons/IconMoneyBagFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMoneyBagFill = ({
   ariaLabel = 'money-bag-fill',

--- a/packages/react/src/icons/IconMover.tsx
+++ b/packages/react/src/icons/IconMover.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconMover = ({
   ariaLabel = 'mover',

--- a/packages/react/src/icons/IconOccupation.tsx
+++ b/packages/react/src/icons/IconOccupation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconOccupation = ({
   ariaLabel = 'occupation',

--- a/packages/react/src/icons/IconPaperclip.tsx
+++ b/packages/react/src/icons/IconPaperclip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPaperclip = ({
   ariaLabel = 'paperclip',

--- a/packages/react/src/icons/IconPen.tsx
+++ b/packages/react/src/icons/IconPen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPen = ({
   ariaLabel = 'pen',

--- a/packages/react/src/icons/IconPenLine.tsx
+++ b/packages/react/src/icons/IconPenLine.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPenLine = ({
   ariaLabel = 'pen-line',

--- a/packages/react/src/icons/IconPersonFemale.tsx
+++ b/packages/react/src/icons/IconPersonFemale.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPersonFemale = ({
   ariaLabel = 'person-female',

--- a/packages/react/src/icons/IconPersonGenderless.tsx
+++ b/packages/react/src/icons/IconPersonGenderless.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPersonGenderless = ({
   ariaLabel = 'person-genderless',

--- a/packages/react/src/icons/IconPersonMale.tsx
+++ b/packages/react/src/icons/IconPersonMale.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPersonMale = ({
   ariaLabel = 'person-male',

--- a/packages/react/src/icons/IconPersonWheelchair.tsx
+++ b/packages/react/src/icons/IconPersonWheelchair.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPersonWheelchair = ({
   ariaLabel = 'person-wheelchair',

--- a/packages/react/src/icons/IconPhone.tsx
+++ b/packages/react/src/icons/IconPhone.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPhone = ({
   ariaLabel = 'phone',

--- a/packages/react/src/icons/IconPhoto.tsx
+++ b/packages/react/src/icons/IconPhoto.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPhoto = ({
   ariaLabel = 'photo',

--- a/packages/react/src/icons/IconPhotoPlus.tsx
+++ b/packages/react/src/icons/IconPhotoPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPhotoPlus = ({
   ariaLabel = 'photo-plus',

--- a/packages/react/src/icons/IconPlaybackFastforward.tsx
+++ b/packages/react/src/icons/IconPlaybackFastforward.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackFastforward = ({
   ariaLabel = 'playback-fastforward',

--- a/packages/react/src/icons/IconPlaybackNext.tsx
+++ b/packages/react/src/icons/IconPlaybackNext.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackNext = ({
   ariaLabel = 'playback-next',

--- a/packages/react/src/icons/IconPlaybackPause.tsx
+++ b/packages/react/src/icons/IconPlaybackPause.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackPause = ({
   ariaLabel = 'playback-pause',

--- a/packages/react/src/icons/IconPlaybackPlay.tsx
+++ b/packages/react/src/icons/IconPlaybackPlay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackPlay = ({
   ariaLabel = 'playback-play',

--- a/packages/react/src/icons/IconPlaybackPrevious.tsx
+++ b/packages/react/src/icons/IconPlaybackPrevious.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackPrevious = ({
   ariaLabel = 'playback-previous',

--- a/packages/react/src/icons/IconPlaybackRecord.tsx
+++ b/packages/react/src/icons/IconPlaybackRecord.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackRecord = ({
   ariaLabel = 'playback-record',

--- a/packages/react/src/icons/IconPlaybackRewind.tsx
+++ b/packages/react/src/icons/IconPlaybackRewind.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackRewind = ({
   ariaLabel = 'playback-rewind',

--- a/packages/react/src/icons/IconPlaybackStop.tsx
+++ b/packages/react/src/icons/IconPlaybackStop.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlaybackStop = ({
   ariaLabel = 'playback-stop',

--- a/packages/react/src/icons/IconPlus.tsx
+++ b/packages/react/src/icons/IconPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlus = ({
   ariaLabel = 'plus',

--- a/packages/react/src/icons/IconPlusCircle.tsx
+++ b/packages/react/src/icons/IconPlusCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlusCircle = ({
   ariaLabel = 'plus-circle',

--- a/packages/react/src/icons/IconPlusCircleFill.tsx
+++ b/packages/react/src/icons/IconPlusCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPlusCircleFill = ({
   ariaLabel = 'plus-circle-fill',

--- a/packages/react/src/icons/IconPodcast.tsx
+++ b/packages/react/src/icons/IconPodcast.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPodcast = ({
   ariaLabel = 'podcast',

--- a/packages/react/src/icons/IconPrinter.tsx
+++ b/packages/react/src/icons/IconPrinter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconPrinter = ({
   ariaLabel = 'printer',

--- a/packages/react/src/icons/IconQuestionCircle.tsx
+++ b/packages/react/src/icons/IconQuestionCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconQuestionCircle = ({
   ariaLabel = 'question-circle',

--- a/packages/react/src/icons/IconQuestionCircleFill.tsx
+++ b/packages/react/src/icons/IconQuestionCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconQuestionCircleFill = ({
   ariaLabel = 'question-circle-fill',

--- a/packages/react/src/icons/IconRefresh.tsx
+++ b/packages/react/src/icons/IconRefresh.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconRefresh = ({
   ariaLabel = 'refresh',

--- a/packages/react/src/icons/IconRestaurant.tsx
+++ b/packages/react/src/icons/IconRestaurant.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconRestaurant = ({
   ariaLabel = 'restaurant',

--- a/packages/react/src/icons/IconRss.tsx
+++ b/packages/react/src/icons/IconRss.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconRss = ({
   ariaLabel = 'rss',

--- a/packages/react/src/icons/IconSaveDiskette.tsx
+++ b/packages/react/src/icons/IconSaveDiskette.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSaveDiskette = ({
   ariaLabel = 'save-diskette',

--- a/packages/react/src/icons/IconSaveDisketteFill.tsx
+++ b/packages/react/src/icons/IconSaveDisketteFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSaveDisketteFill = ({
   ariaLabel = 'save-diskette-fill',

--- a/packages/react/src/icons/IconScroll.tsx
+++ b/packages/react/src/icons/IconScroll.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconScroll = ({
   ariaLabel = 'scroll',

--- a/packages/react/src/icons/IconScrollCogwheel.tsx
+++ b/packages/react/src/icons/IconScrollCogwheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconScrollCogwheel = ({
   ariaLabel = 'scroll-cogwheel',

--- a/packages/react/src/icons/IconScrollContent.tsx
+++ b/packages/react/src/icons/IconScrollContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconScrollContent = ({
   ariaLabel = 'scroll-content',

--- a/packages/react/src/icons/IconScrollGroup.tsx
+++ b/packages/react/src/icons/IconScrollGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconScrollGroup = ({
   ariaLabel = 'scroll-group',

--- a/packages/react/src/icons/IconSearch.tsx
+++ b/packages/react/src/icons/IconSearch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSearch = ({
   ariaLabel = 'search',

--- a/packages/react/src/icons/IconSenior.tsx
+++ b/packages/react/src/icons/IconSenior.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSenior = ({
   ariaLabel = 'senior',

--- a/packages/react/src/icons/IconShare.tsx
+++ b/packages/react/src/icons/IconShare.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconShare = ({
   ariaLabel = 'share',

--- a/packages/react/src/icons/IconShield.tsx
+++ b/packages/react/src/icons/IconShield.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconShield = ({
   ariaLabel = 'shield',

--- a/packages/react/src/icons/IconShoppingCart.tsx
+++ b/packages/react/src/icons/IconShoppingCart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconShoppingCart = ({
   ariaLabel = 'shopping-cart',

--- a/packages/react/src/icons/IconSignin.tsx
+++ b/packages/react/src/icons/IconSignin.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSignin = ({
   ariaLabel = 'signin',

--- a/packages/react/src/icons/IconSignout.tsx
+++ b/packages/react/src/icons/IconSignout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSignout = ({
   ariaLabel = 'signout',

--- a/packages/react/src/icons/IconSitemap.tsx
+++ b/packages/react/src/icons/IconSitemap.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSitemap = ({
   ariaLabel = 'sitemap',

--- a/packages/react/src/icons/IconSliders.tsx
+++ b/packages/react/src/icons/IconSliders.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSliders = ({
   ariaLabel = 'sliders',

--- a/packages/react/src/icons/IconSnapchat.tsx
+++ b/packages/react/src/icons/IconSnapchat.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSnapchat = ({
   ariaLabel = 'snapchat',

--- a/packages/react/src/icons/IconSort.tsx
+++ b/packages/react/src/icons/IconSort.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSort = ({
   ariaLabel = 'sort',

--- a/packages/react/src/icons/IconSortAlphabeticalAscending.tsx
+++ b/packages/react/src/icons/IconSortAlphabeticalAscending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSortAlphabeticalAscending = ({
   ariaLabel = 'sort-alphabetical-ascending',

--- a/packages/react/src/icons/IconSortAlphabeticalDescending.tsx
+++ b/packages/react/src/icons/IconSortAlphabeticalDescending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSortAlphabeticalDescending = ({
   ariaLabel = 'sort-alphabetical-descending',

--- a/packages/react/src/icons/IconSortAscending.tsx
+++ b/packages/react/src/icons/IconSortAscending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSortAscending = ({
   ariaLabel = 'sort-ascending',

--- a/packages/react/src/icons/IconSortDescending.tsx
+++ b/packages/react/src/icons/IconSortDescending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSortDescending = ({
   ariaLabel = 'sort-descending',

--- a/packages/react/src/icons/IconSpeechbubble.tsx
+++ b/packages/react/src/icons/IconSpeechbubble.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSpeechbubble = ({
   ariaLabel = 'speechbubble',

--- a/packages/react/src/icons/IconSpeechbubbleText.tsx
+++ b/packages/react/src/icons/IconSpeechbubbleText.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSpeechbubbleText = ({
   ariaLabel = 'speechbubble-text',

--- a/packages/react/src/icons/IconStar.tsx
+++ b/packages/react/src/icons/IconStar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconStar = ({
   ariaLabel = 'star',

--- a/packages/react/src/icons/IconStarFill.tsx
+++ b/packages/react/src/icons/IconStarFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconStarFill = ({
   ariaLabel = 'star-fill',

--- a/packages/react/src/icons/IconSwapUser.tsx
+++ b/packages/react/src/icons/IconSwapUser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconSwapUser = ({
   ariaLabel = 'swap-user',

--- a/packages/react/src/icons/IconTextBold.tsx
+++ b/packages/react/src/icons/IconTextBold.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTextBold = ({
   ariaLabel = 'text-bold',

--- a/packages/react/src/icons/IconTextItalic.tsx
+++ b/packages/react/src/icons/IconTextItalic.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTextItalic = ({
   ariaLabel = 'text-italic',

--- a/packages/react/src/icons/IconTextTool.tsx
+++ b/packages/react/src/icons/IconTextTool.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTextTool = ({
   ariaLabel = 'text-tool',

--- a/packages/react/src/icons/IconThumbsDown.tsx
+++ b/packages/react/src/icons/IconThumbsDown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconThumbsDown = ({
   ariaLabel = 'thumbs-down',

--- a/packages/react/src/icons/IconThumbsDownFill.tsx
+++ b/packages/react/src/icons/IconThumbsDownFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconThumbsDownFill = ({
   ariaLabel = 'thumbs-down-fill',

--- a/packages/react/src/icons/IconThumbsUp.tsx
+++ b/packages/react/src/icons/IconThumbsUp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconThumbsUp = ({
   ariaLabel = 'thumbs-up',

--- a/packages/react/src/icons/IconThumbsUpFill.tsx
+++ b/packages/react/src/icons/IconThumbsUpFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconThumbsUpFill = ({
   ariaLabel = 'thumbs-up-fill',

--- a/packages/react/src/icons/IconTicket.tsx
+++ b/packages/react/src/icons/IconTicket.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTicket = ({
   ariaLabel = 'ticket',

--- a/packages/react/src/icons/IconTiktok.tsx
+++ b/packages/react/src/icons/IconTiktok.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTiktok = ({
   ariaLabel = 'tiktok',

--- a/packages/react/src/icons/IconTrash.tsx
+++ b/packages/react/src/icons/IconTrash.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTrash = ({
   ariaLabel = 'trash',

--- a/packages/react/src/icons/IconTraveler.tsx
+++ b/packages/react/src/icons/IconTraveler.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTraveler = ({
   ariaLabel = 'traveler',

--- a/packages/react/src/icons/IconTwitch.tsx
+++ b/packages/react/src/icons/IconTwitch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTwitch = ({
   ariaLabel = 'twitch',

--- a/packages/react/src/icons/IconTwitter.tsx
+++ b/packages/react/src/icons/IconTwitter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTwitter = ({
   ariaLabel = 'twitter',

--- a/packages/react/src/icons/IconTwitterOld.tsx
+++ b/packages/react/src/icons/IconTwitterOld.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconTwitterOld = ({
   ariaLabel = 'twitter_old',

--- a/packages/react/src/icons/IconUpload.tsx
+++ b/packages/react/src/icons/IconUpload.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconUpload = ({
   ariaLabel = 'upload',

--- a/packages/react/src/icons/IconUploadCloud.tsx
+++ b/packages/react/src/icons/IconUploadCloud.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconUploadCloud = ({
   ariaLabel = 'upload-cloud',

--- a/packages/react/src/icons/IconUser.tsx
+++ b/packages/react/src/icons/IconUser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconUser = ({
   ariaLabel = 'user',

--- a/packages/react/src/icons/IconVaccine.tsx
+++ b/packages/react/src/icons/IconVaccine.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVaccine = ({
   ariaLabel = 'vaccine',

--- a/packages/react/src/icons/IconVideocamera.tsx
+++ b/packages/react/src/icons/IconVideocamera.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVideocamera = ({
   ariaLabel = 'videocamera',

--- a/packages/react/src/icons/IconVideocameraCrossed.tsx
+++ b/packages/react/src/icons/IconVideocameraCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVideocameraCrossed = ({
   ariaLabel = 'videocamera-crossed',

--- a/packages/react/src/icons/IconVimeo.tsx
+++ b/packages/react/src/icons/IconVimeo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVimeo = ({
   ariaLabel = 'vimeo',

--- a/packages/react/src/icons/IconVirus.tsx
+++ b/packages/react/src/icons/IconVirus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVirus = ({
   ariaLabel = 'virus',

--- a/packages/react/src/icons/IconVolumeHigh.tsx
+++ b/packages/react/src/icons/IconVolumeHigh.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVolumeHigh = ({
   ariaLabel = 'volume-high',

--- a/packages/react/src/icons/IconVolumeLow.tsx
+++ b/packages/react/src/icons/IconVolumeLow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVolumeLow = ({
   ariaLabel = 'volume-low',

--- a/packages/react/src/icons/IconVolumeMinus.tsx
+++ b/packages/react/src/icons/IconVolumeMinus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVolumeMinus = ({
   ariaLabel = 'volume-minus',

--- a/packages/react/src/icons/IconVolumeMute.tsx
+++ b/packages/react/src/icons/IconVolumeMute.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVolumeMute = ({
   ariaLabel = 'volume-mute',

--- a/packages/react/src/icons/IconVolumePlus.tsx
+++ b/packages/react/src/icons/IconVolumePlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconVolumePlus = ({
   ariaLabel = 'volume-plus',

--- a/packages/react/src/icons/IconWhatsapp.tsx
+++ b/packages/react/src/icons/IconWhatsapp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconWhatsapp = ({
   ariaLabel = 'whatsapp',

--- a/packages/react/src/icons/IconWifi.tsx
+++ b/packages/react/src/icons/IconWifi.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconWifi = ({
   ariaLabel = 'wifi',

--- a/packages/react/src/icons/IconWifiCrossed.tsx
+++ b/packages/react/src/icons/IconWifiCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconWifiCrossed = ({
   ariaLabel = 'wifi-crossed',

--- a/packages/react/src/icons/IconX.tsx
+++ b/packages/react/src/icons/IconX.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconX = ({
   ariaLabel = 'x',

--- a/packages/react/src/icons/IconYle.tsx
+++ b/packages/react/src/icons/IconYle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconYle = ({
   ariaLabel = 'yle',

--- a/packages/react/src/icons/IconYouth.tsx
+++ b/packages/react/src/icons/IconYouth.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconYouth = ({
   ariaLabel = 'youth',

--- a/packages/react/src/icons/IconYoutube.tsx
+++ b/packages/react/src/icons/IconYoutube.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconYoutube = ({
   ariaLabel = 'youtube',

--- a/packages/react/src/icons/IconZoomIn.tsx
+++ b/packages/react/src/icons/IconZoomIn.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconZoomIn = ({
   ariaLabel = 'zoom-in',

--- a/packages/react/src/icons/IconZoomOut.tsx
+++ b/packages/react/src/icons/IconZoomOut.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconZoomOut = ({
   ariaLabel = 'zoom-out',

--- a/packages/react/src/icons/IconZoomText.tsx
+++ b/packages/react/src/icons/IconZoomText.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const IconZoomText = ({
   ariaLabel = 'zoom-text',

--- a/packages/react/src/internal/menuButton/menu/Menu.tsx
+++ b/packages/react/src/internal/menuButton/menu/Menu.tsx
@@ -1,8 +1,8 @@
 import React, { cloneElement, isValidElement, useEffect, useRef, useState, MouseEvent } from 'react';
 import { RectReadOnly } from 'react-use-measure';
 
-import classNames from '../../../utils/classNames';
 import styles from './Menu.module.scss';
+import classNames from '../../../utils/classNames';
 
 type MenuStyles = {
   top?: number;

--- a/packages/react/src/internal/visible/Visible.tsx
+++ b/packages/react/src/internal/visible/Visible.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import classNames from '../../utils/classNames';
 import styles from './visible.module.scss';
+import classNames from '../../utils/classNames';
 
 type Breakpoint = 's' | 'm' | 'l' | 'xl';
 

--- a/release/icon-kit-template-react-tsx.eta
+++ b/release/icon-kit-template-react-tsx.eta
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { IconProps } from './Icon.interface';
 import styles from './Icon.module.css';
+import { IconProps } from './Icon.interface';
 
 export const <%= it.componentJSName %> = ({
   ariaLabel = '<%= it.iconName %>',


### PR DESCRIPTION
## Description

The order of css classes in SSR (next.js/Gatsby) was different than in "normal" React SPA.

The issue was fixed by re-ordering imports in Header.tsx. The components own style module should be imported before sub components to keep css classes in same order in React and SSR.

Added also an Eslint rule to force `./*.module.scss` to be imported before other internal imports. This caused 200+ changes in this PR when Eslint was run with `--fix`

There was also a weird way to use `Header.module.scss` in most of the sub components by using `@use`. This caused Header styles to be duplicated. Removing this resulted in 30kb smaller `index.css` file.

Built css-files are attached in "css-files.zip". The files are "beautified" with [css-beautifier](https://www.roxunlimited.com/css-beautifier) to make comparison easier.

## Related Issue

Closes [HDS-2183]( https://helsinkisolutionoffice.atlassian.net/browse/HDS-2183)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manually comparing built css files. See "css-files.zip".
- visual tests still pass
- error in current [docs site](https://hds.hel.fi/components/header/) is fixed in [demo](https://city-of-helsinki.github.io/hds-demo/hds-2183-header-ssr-docs/components/header/)
- next.js app (v 14.1.4). The app is attached as zip. See README to start it.
- [storybook demo](https://city-of-helsinki.github.io/hds-demo/hds-2183-header-ssr-storybook/?path=/story/components-header--with-full-features) and local versions work

[nextjs-hds-example.zip](https://github.com/City-of-Helsinki/helsinki-design-system/files/14863648/nextjs-hds-example.zip)
[css-files.zip](https://github.com/City-of-Helsinki/helsinki-design-system/files/14863638/css-files.zip)

## Add to changelog
- [ x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2183]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ