### PR TITLE
HDS-2102: login data to cookie docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- [Component] What is added?
+- [CookieConsent] Data stored by the HDS login component is now in the common cookies.
 - [Login] Added a utility function to detect login callback error that could be ignored.
 - [DateInput] Added example how to handle date ranges.
 
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - [Login] Login system is good enough to start using in production as well. We still welcome feedback and improve the component.
+- [CookieConsent] Data stored by the HDS login component added to common cookie list.
 
 #### Fixed
 

--- a/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
+++ b/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
@@ -1057,8 +1057,28 @@ export const TunnistamoLoginCookies = (args) => {
     currentLanguage: language,
     requiredCookies: {
       groups: [
-        { commonGroup: 'tunnistamoLogin' },
-        { commonGroup: 'loadBalancing', cookies: [{ commonCookie: 'tunnistamo-login-loadbalancer' }] },
+        {
+          commonGroup: 'tunnistamoLogin',
+          cookies: [
+            {
+              commonCookie: 'oidc-ts-storage',
+            },
+            {
+              commonCookie: 'hds-api-token-storage',
+            },
+            {
+              commonCookie: 'hds-api-token-user-reference',
+            },
+          ],
+        },
+        {
+          commonGroup: 'loadBalancing',
+          cookies: [
+            {
+              commonCookie: 'tunnistamo-login-loadbalancer',
+            },
+          ],
+        },
         {
           commonGroup: 'informationSecurity',
           cookies: [{ commonCookie: 'tunnistamo-csrftoken' }],

--- a/packages/react/src/components/cookieConsent/getContent.ts
+++ b/packages/react/src/components/cookieConsent/getContent.ts
@@ -92,6 +92,11 @@ export function getCookieContent() {
   const tunnistamoUrl = 'api.hel.fi';
   const keycloakUrl = 'tunnistus.hel.fi';
   const suomiFiUrl = 'suomi.fi';
+  const currentSiteTranslations = {
+    fi: 'Tämä sivusto',
+    sv: 'Denna webbsida',
+    en: 'Current domain',
+  };
 
   return {
     texts: {
@@ -610,6 +615,20 @@ export function getCookieContent() {
           },
         ],
       },
+      hdsLoginComponent: {
+        ...commonLoginGroupTranslations,
+        cookies: [
+          {
+            commonCookie: 'oidc-ts-storage',
+          },
+          {
+            commonCookie: 'hds-api-token-storage',
+          },
+          {
+            commonCookie: 'hds-api-token-user-reference',
+          },
+        ],
+      },
     },
     commonCookies: {
       helConsentCookie: {
@@ -832,6 +851,67 @@ export function getCookieContent() {
         name: 'E-Identification-Lang',
         hostName: suomiFiUrl,
         ...commonLanguageTranslations,
+      },
+      'oidc-ts-storage': {
+        id: 'oidc-ts-storage',
+        name: 'oidc.user:*',
+        fi: {
+          hostName: currentSiteTranslations.fi,
+          description: 'Käyttäjän kirjautumistiedot tallennetaan selaimen muistiin (session storage).',
+          expiration: 'Istunto',
+        },
+        sv: {
+          hostName: currentSiteTranslations.sv,
+          description: 'Användarens inloggningsuppgifter lagras i webbläsarens minne (session storage).',
+          expiration: 'Session',
+        },
+        en: {
+          hostName: currentSiteTranslations.en,
+          description: "Authentication information of the user is saved to browser's memory (session storage).",
+          expiration: 'Session',
+        },
+      },
+      'hds-api-token-storage': {
+        id: 'hds_login_api_token_storage_key',
+        name: 'hds_login_api_token_storage_key',
+        fi: {
+          hostName: currentSiteTranslations.fi,
+          description:
+            'Kirjautuneen käyttäjän rajanpinta-avaimet (api tokens) tallennetaan selaimen muistiin (session storage).',
+          expiration: 'Istunto',
+        },
+        sv: {
+          hostName: currentSiteTranslations.sv,
+          description: 'Api-token för en autentiserad användare sparas i webbläsarens minne (session storage).',
+          expiration: 'Session',
+        },
+        en: {
+          hostName: currentSiteTranslations.en,
+          description: "Api tokens of an authenticated user is saved to browser's memory (session storage).",
+          expiration: 'Session',
+        },
+      },
+      'hds-api-token-user-reference': {
+        id: 'hds_login_api_token_user_reference',
+        name: 'hds_login_api_token_user_reference',
+        fi: {
+          hostName: currentSiteTranslations.fi,
+          description:
+            'Kirjautuneen käyttäjän pääsyoikeudet tallennetaan selaimen muistiin, jotta tunnistetaan kenen rajapinta-avaimet on tallessa.',
+          expiration: 'Istunto',
+        },
+        sv: {
+          hostName: currentSiteTranslations.sv,
+          description:
+            'Den inloggade användarens åtkomsträttigheter lagras i webbläsarens minne för att identifiera vems token som lagras.',
+          expiration: 'Session',
+        },
+        en: {
+          hostName: currentSiteTranslations.en,
+          description:
+            "Access token of an authenticated user is saved to browser's memory (session storage) to identify whose api tokens are stored.",
+          expiration: 'Session',
+        },
       },
     },
   };

--- a/site/src/docs/components/login/index.mdx
+++ b/site/src/docs/components/login/index.mdx
@@ -56,6 +56,11 @@ HDS Login components cannot support SSR at the moment because of the session sto
 
 Silent session renewal requires a <UsagePageAnchorLink anchor="silent-renewal">dedicated HTML file</UsagePageAnchorLink> that redirects to the OIDC provider "silently" in an iframe.
 
+### Consents for storing data
+
+The data of the authenticated user is stored in the session storage. Users must give consent to storing data in the session storage, just like cookie consents.
+You can use the ready-made consents in the <InternalLink href="/patterns/cookies/common-helsinki-cookies/#hds-login-component">common Helsinki cookies</InternalLink>.
+
 ### Example Usage
 
 <PlaygroundPreview>

--- a/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
+++ b/site/src/docs/patterns/cookies/common-helsinki-cookies.mdx
@@ -48,35 +48,44 @@ The following is a list of approved common cookies for common services like Mato
 
 ### Login
 
-| Cookie name                                                          | Cookie set by    | Purpose of use                     | Period of validity |
-| -------------------------------------------------------------------- | ---------------- | ---------------------------------- | ------------------ |
-| `sso-sessionid`                                                      | api.hel.fi       | Persist the authentication session | Session            |
-| `tunnistamo_prod-sessionid`                                          | api.hel.fi       | Persist the authentication session | Session            |
-| `profiili-prod-csrftoken`                                            | api.hel.fi       | A security control                 | 365 days           |
-| `AUTH_SESSION_ID`                                                    | tunnistus.hel.fi | Persist the authentication session | Session            |
-| `AUTH_SESSION_ID_LEGACY`                                             | tunnistus.hel.fi | Persist the authentication session | Session            |
-| `KC_*`                                                               | tunnistus.hel.fi | Persist the authentication session | Session            |
-| `JSESSIONID`                                                         | suomi.fi         | Persist the authentication session | Session            |
-| `E-Identification-LogTag`                                            | suomi.fi         | Persist the authentication session | Session            |
-| `_opensaml_req_cookie*`                                              | suomi.fi         | Persist the authentication session | Session            |
-| `_shibstate_*`                                                       | suomi.fi         | Persist the authentication session | Session            |
-| `_shibsession_*`                                                     | suomi.fi         | Persist the authentication session | Session            |
-| `shib_idp_session`                                                   | suomi.fi         | Persist the authentication session | Session            |
-| [Table 3:Common Tunnistamo cookies between *.hel.fi domain services] |
+| Cookie name                                                                       | Cookie set by    | Purpose of use                     | Period of validity |
+| --------------------------------------------------------------------------------- | ---------------- | ---------------------------------- | ------------------ |
+| `sso-sessionid`                                                                   | api.hel.fi       | Persist the authentication session | Session            |
+| `tunnistamo_prod-sessionid`                                                       | api.hel.fi       | Persist the authentication session | Session            |
+| `profiili-prod-csrftoken`                                                         | api.hel.fi       | A security control                 | 365 days           |
+| `AUTH_SESSION_ID`                                                                 | tunnistus.hel.fi | Persist the authentication session | Session            |
+| `AUTH_SESSION_ID_LEGACY`                                                          | tunnistus.hel.fi | Persist the authentication session | Session            |
+| `KC_*`                                                                            | tunnistus.hel.fi | Persist the authentication session | Session            |
+| `JSESSIONID`                                                                      | suomi.fi         | Persist the authentication session | Session            |
+| `E-Identification-LogTag`                                                         | suomi.fi         | Persist the authentication session | Session            |
+| `_opensaml_req_cookie*`                                                           | suomi.fi         | Persist the authentication session | Session            |
+| `_shibstate_*`                                                                    | suomi.fi         | Persist the authentication session | Session            |
+| `_shibsession_*`                                                                  | suomi.fi         | Persist the authentication session | Session            |
+| `shib_idp_session`                                                                | suomi.fi         | Persist the authentication session | Session            |
+| [Table 3:Common Tunnistamo and Keycloak cookies between *.hel.fi domain services] |
+
+### HDS Login component
+
+| Session storage key                                      | Data set by    | Purpose of use                                | Period of validity |
+| -------------------------------------------------------- | -------------- | --------------------------------------------- | ------------------ |
+| `oidc.user:*`                                            | Current domain | Store authentication data                     | Session            |
+| `hds_login_api_token_storage_key`                        | Current domain | Store api tokens of an authenticated user     | Session            |
+| `hds_login_api_token_user_reference`                     | Current domain | Identify the user whose api tokens are stored | Session            |
+| [Table 4:Common user data stored by the login component] |
 
 ### Load balancing
 
 | Cookie name                                                                                       | Cookie set by                | Purpose of use                | Period of validity |
 | ------------------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------- | ------------------ |
 | `A random 32-character long string`                                                               | api.hel.fi, tunnistus.hel.fi | Technical routing of requests | Session            |
-| [Table 4:Load-balancing cookies ensure that the service loads and works quickly and efficiently.] |
+| [Table 5:Load-balancing cookies ensure that the service loads and works quickly and efficiently.] |
 
 ### Information security
 
 | Cookie name                                                                              | Cookie set by | Purpose of use     | Period of validity |
 | ---------------------------------------------------------------------------------------- | ------------- | ------------------ | ------------------ |
 | `tunnistamo_prod-csrftoken`                                                              | api.hel.fi    | A security control | 365 days           |
-| [Table 5:Security cookies enable secure data transfer between the user and the service.] |
+| [Table 6:Security cookies enable secure data transfer between the user and the service.] |
 
 ### Language settings
 
@@ -84,7 +93,7 @@ The following is a list of approved common cookies for common services like Mato
 | -------------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------- | ------------------ |
 | `KEYCLOAK_LOCALE`                                                                                        | tunnistus.hel.fi | Persist the user's chosen language | Session            |
 | `E-Identification-Lang`                                                                                  | suomi.fi         | Persist the user's chosen language | Session            |
-| [Table 6:Language cookies store the language selections by the user to remember the preferred language.] |
+| [Table 7:Language cookies store the language selections by the user to remember the preferred language.] |
 
 ### Cookie consent
 
@@ -92,4 +101,4 @@ The following is a list of approved common cookies for common services like Mato
 | ---------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `city-of-helsinki-cookie-consents` | \<subdomain\>.hel.fi | Used by hel.fi to store information about whether visitors have given or declined the use of cookie categories used on the hel.fi site. | 1 year             |
 | `city-of-helsinki-consent-version` | \<subdomain\>.hel.fi | Used by hel.fi to store information about what version of the cookie consent the user has agreed to.                                    | 1 year             |
-| [Table 7:Cookie consents.]         |
+| [Table 8:Cookie consents.]         |


### PR DESCRIPTION
**No code changes, reviewable by anyone!**

## Description

The login component stores data to session storage. That data should also be listed in the common cookie consents.

Added information about the stored data common cookies and to the docs.

## Related Issue

Closes [HDS-2102](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2102)

## How Has This Been Tested?

Storybook and docs site tested locally.

[Docs demo](https://city-of-helsinki.github.io/hds-demo/hds-2102-docs/components/login/#consents-for-storing-data) of the part added to the login component docs.

[Docs demo](https://city-of-helsinki.github.io/hds-demo/hds-2102-docs/components/login/#consents-for-storing-data) of the cookie pattern where Login component data is listed with other cookie consents.

[Storybook demo ](https://city-of-helsinki.github.io/hds-demo/hds-2102-storybook/?path=/story/components-cookieconsent--tunnistamo-login-cookies) how consents are listed. Open the "Necessary cookies" > "Login"

## Screenshots (if appropriate):

How the new data is shown in the modal:

![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/2639230/d73013b1-a682-4d3a-8820-0a6fe25a0c28)


## Add to changelog
- [x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2102]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ