### PR TITLE
HDS-2218: Make FileInput case-insensitive towards file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [FileInput] FileInput accepts capitalized extensions (.png vs .PNG)
 
 ### Core
 

--- a/packages/react/src/components/fileInput/FileInput.test.tsx
+++ b/packages/react/src/components/fileInput/FileInput.test.tsx
@@ -173,6 +173,8 @@ describe('<FileInput /> spec', () => {
     const firstFile = new File(['test-jpg'], firstFileName, { type: 'image/jpeg' });
     const secondFileName = 'test-file-b.json';
     const secondFile = new File(['test-json'], secondFileName, { type: 'application/json' });
+    const thirdFileName = 'test-file-c.JPG';
+    const thirdFile = new File(['test-JPG'], thirdFileName, { type: 'image/jpeg' });
     render(
       <FileInput
         id="test-file-input"
@@ -185,10 +187,10 @@ describe('<FileInput /> spec', () => {
       />,
     );
     const fileUpload = screen.getByLabelText(inputLabel);
-    userEvent.upload(fileUpload, [firstFile, secondFile]);
+    userEvent.upload(fileUpload, [firstFile, secondFile, thirdFile]);
     expect(screen.getByText(firstFileName)).toBeInTheDocument();
-    expect(screen.getByText('1/2 file(s) added', { exact: false })).toBeInTheDocument();
-    expect(screen.getByText('File processing failed for 1/2 files:', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('2/3 file(s) added', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('File processing failed for 1/3 files:', { exact: false })).toBeInTheDocument();
     expect(
       screen.getByText(`The file type, ${secondFileName}, is not supported. Only .jpg and .png files.`, {
         exact: false,

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -300,9 +300,9 @@ const getExtension = (path: string): string => {
 const validateAccept =
   (language: Language, accept: string) =>
   (file: File): true | ValidationError => {
-    const extension: string = getExtension(file.name);
+    const extension: string = getExtension(file.name).toLocaleLowerCase();
     const fileType: string = file.type;
-    const acceptedExtensions = accept.split(',').map((str) => str.trim());
+    const acceptedExtensions = accept.split(',').map((str) => str.trim().toLocaleLowerCase());
     const isMatchingType = !!acceptedExtensions.find(
       (acceptExtension) =>
         acceptExtension.includes(fileType) || acceptExtension.includes(`${fileType.split('/')[0]}/*`),


### PR DESCRIPTION
## Description

Convert both the filter and the filename to lowercase before comparing to make the validation case-insensitive.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-2218
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #

## Motivation and Context

Currently, the FileInput component doesn't accept capitalized versions of filenames when an extension is specified. So if you accept ".png", "image.PNG" is not accepted.

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

## Add to changelog
- [X] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->
