### PR TITLE
Hds 2218 fix file input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [FileInput] FileInput accepts capitalized extensions (.png vs .PNG)
 
 ### Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes that are not related to specific components
 
 - [Component] What bugs/typos are fixed?
 - [FileInput] FileInput accepts capitalized extensions (.png vs .PNG)
+- [TextInput] Fix info, success and error icon shrinking when the description was long.
 
 ### Core
 
@@ -50,6 +51,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [TextInput] Fix info, success and error icon shrinking when the description was long.
 
 ### Documentation
 

--- a/packages/core/src/components/text-input/text-input.css
+++ b/packages/core/src/components/text-input/text-input.css
@@ -194,6 +194,7 @@
   background: var(--color-error);
   content: '';
   display: inline-block;
+  flex-shrink: 0;
   height: var(--icon-size);
   margin-right: var(--spacing-2-xs);
   -webkit-mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E %3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M11.175 3.45608C11.5239 2.86969 12.3977 2.84875 12.7842 3.39325L12.825 3.45608L21.8771 18.6666C22.2202 19.2432 21.8055 19.951 21.1235 19.9976L21.052 20H2.94799C2.24813 20 1.7987 19.3114 2.09013 18.7267L2.12295 18.6666L11.175 3.45608ZM13 16V18H11V16H13ZM13 8.5V14.5H11V8.5H13Z' fill='currentColor'%3E%3C/path%3E %3C/svg%3E");
@@ -224,6 +225,7 @@
   background: var(--color-success);
   content: '';
   display: inline-block;
+  flex-shrink: 0;
   height: var(--icon-size);
   margin-right: var(--spacing-2-xs);
   -webkit-mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E %3Cg fill='none' fill-rule='evenodd'%3E %3Crect width='24' height='24'/%3E %3Cpath fill='currentColor' d='M12,3 C7.02943725,3 3,7.02943725 3,12 C3,16.9705627 7.02943725,21 12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3 Z M16.5,8 L18,9.5 L10.5,17 L6,12.5 L7.5,11 L10.5,14 L16.5,8 Z'/%3E %3C/g%3E %3C/svg%3E");
@@ -254,6 +256,7 @@
   background: var(--color-info);
   content: '';
   display: inline-block;
+  flex-shrink: 0;
   height: var(--icon-size);
   margin-right: var(--spacing-2-xs);
   -webkit-mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E %3Cg fill='none' fill-rule='evenodd'%3E %3Crect width='24' height='24'/%3E %3Cpath fill='currentColor' d='M12,3 C16.9705627,3 21,7.02943725 21,12 C21,16.9705627 16.9705627,21 12,21 C7.02943725,21 3,16.9705627 3,12 C3,7.02943725 7.02943725,3 12,3 Z M13,16 L13,18 L11,18 L11,16 L13,16 Z M13,6 L13,14 L11,14 L11,6 L13,6 Z'/%3E %3C/g%3E %3C/svg%3E");

--- a/packages/react/src/components/fileInput/FileInput.test.tsx
+++ b/packages/react/src/components/fileInput/FileInput.test.tsx
@@ -173,6 +173,8 @@ describe('<FileInput /> spec', () => {
     const firstFile = new File(['test-jpg'], firstFileName, { type: 'image/jpeg' });
     const secondFileName = 'test-file-b.json';
     const secondFile = new File(['test-json'], secondFileName, { type: 'application/json' });
+    const thirdFileName = 'test-file-c.JPG';
+    const thirdFile = new File(['test-JPG'], thirdFileName, { type: 'image/jpeg' });
     render(
       <FileInput
         id="test-file-input"
@@ -185,10 +187,10 @@ describe('<FileInput /> spec', () => {
       />,
     );
     const fileUpload = screen.getByLabelText(inputLabel);
-    userEvent.upload(fileUpload, [firstFile, secondFile]);
+    userEvent.upload(fileUpload, [firstFile, secondFile, thirdFile]);
     expect(screen.getByText(firstFileName)).toBeInTheDocument();
-    expect(screen.getByText('1/2 file(s) added', { exact: false })).toBeInTheDocument();
-    expect(screen.getByText('File processing failed for 1/2 files:', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('2/3 file(s) added', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('File processing failed for 1/3 files:', { exact: false })).toBeInTheDocument();
     expect(
       screen.getByText(`The file type, ${secondFileName}, is not supported. Only .jpg and .png files.`, {
         exact: false,

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -300,9 +300,9 @@ const getExtension = (path: string): string => {
 const validateAccept =
   (language: Language, accept: string) =>
   (file: File): true | ValidationError => {
-    const extension: string = getExtension(file.name);
+    const extension: string = getExtension(file.name).toLocaleLowerCase();
     const fileType: string = file.type;
-    const acceptedExtensions = accept.split(',').map((str) => str.trim());
+    const acceptedExtensions = accept.split(',').map((str) => str.trim().toLocaleLowerCase());
     const isMatchingType = !!acceptedExtensions.find(
       (acceptExtension) =>
         acceptExtension.includes(fileType) || acceptExtension.includes(`${fileType.split('/')[0]}/*`),


### PR DESCRIPTION
## Description

Convert both the filter and the filename to lowercase before comparing to make the validation case-insensitive. Also fixes the Error icon sizing issue (or all text-input related icon issues to be exact, the icon resized itself when the description text was long enough to push it smaller -> added flex-shrink: 0; to counter this.)

## Related Issue

[HDS-2218](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2218)

## Motivation and Context

Currently, the FileInput component doesn't accept capitalized versions of filenames when an extension is specified. So if you accept ".png", "image.PNG" is not accepted.

## How Has This Been Tested?

- local machine

## Add to changelog
- [X] Added needed line to changelog 


[HDS-2218]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ