### PR TITLE
(HDS-2160) change notification progressbar direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - [Component] What has been changed
+- [Notification] Change auto closing notification progressbar to decrease instead of increase.
 
 #### Fixed
 

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -164,8 +164,8 @@ const getCloseTransition = (duration: number) => ({
  * @param duration
  */
 const getAutoCloseTransition = (duration: number) => ({
-  from: { transform: 'translate3d(-100%, 0, 0)' },
-  to: { transform: 'translate3d(0%, 0, 0)' },
+  from: { transform: 'translate3d(0%, 0, 0)' },
+  to: { transform: 'translate3d(-100%, 0, 0)' },
   config: {
     duration,
   },


### PR DESCRIPTION
## Description

Change the direction of the Notification's progressbar to decrease instead of decrease when using auto-closing toast.

## Related Issue

[HDS-2160](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2160)

## How Has This Been Tested?

- running all tests locally

## Screenshots (if appropriate):

![Screen Recording 2024-04-16 at 10 07 43](https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/61544dbe-4bd0-4ae7-bae9-d2dfaf41ee11)

## Add to changelog
- [x] Added needed line to changelog 


[HDS-2160]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ