### PR TITLE
HDS-2141: remove api tokens when user is renewed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- [Component] What has been changed
+- [Login] API tokens are removed when user token renewal starts
 - [Notification] Change auto closing notification progressbar to decrease instead of increase.
 - [CookieConsent] Fixed SSR problem with "document not defined"
 
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+- [Login] Improved LoginProvider and api token client documentation.
 - Added measure and outline addons to Storybook
 - [DateInput] Added examples how to handle date ranges and validation.
 
@@ -112,6 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - [login] Added a utility function to detect login callback error that could be ignored.
+
+### Hds-js
+
+#### Changed
+
+- [Login] API tokens are removed when user token renewal starts
 
 ## [3.7.0] - April, 11, 2024
 

--- a/packages/react/src/components/login/apiTokensClient/hooks.test.tsx
+++ b/packages/react/src/components/login/apiTokensClient/hooks.test.tsx
@@ -293,12 +293,13 @@ describe('apiToken hooks testing', () => {
         expect(getInnerHtml(elementIds.lastSignal)).toBe(apiTokensClientEvents.API_TOKENS_UPDATED);
         expect(getInnerHtml(elementIds.error)).toBe('');
       });
-      it('Tracks renewal', async () => {
+      it('Tracks renewal and handles renewal errors.', async () => {
         const user = createUserAndPlaceUserToStorage(defaultOidcClientProps.userManagerSettings);
         setUserReferenceToStorage(user.access_token);
         setApiTokensToStorage(apiTokens);
         const { emit, getInnerHtml } = init({
           component: 'errorTracking',
+          // force renewal to fail
           responses: [{ returnedStatus: HttpStatusCode.OK, body: '"invalid{json' }],
         });
         act(() => {

--- a/packages/react/src/components/login/whole.setup.test.ts
+++ b/packages/react/src/components/login/whole.setup.test.ts
@@ -477,6 +477,7 @@ describe('Test all modules together', () => {
       expect(getReceivedSignalTypes(apiTokensClientNamespace)).toEqual([
         apiTokensClientEvents.API_TOKENS_UPDATED,
         initSignalType,
+        apiTokensClientEvents.API_TOKENS_REMOVED,
       ]);
       expect(getReceivedSignalTypes(sessionPollerNamespace)).toEqual([
         initSignalType,
@@ -498,6 +499,7 @@ describe('Test all modules together', () => {
       expect(getReceivedSignalTypes(apiTokensClientNamespace)).toEqual([
         apiTokensClientEvents.API_TOKENS_UPDATED,
         initSignalType,
+        apiTokensClientEvents.API_TOKENS_REMOVED,
         apiTokensClientEvents.API_TOKENS_RENEWAL_STARTED,
         apiTokensClientEvents.API_TOKENS_UPDATED,
       ]);

--- a/site/src/docs/components/login/api.mdx
+++ b/site/src/docs/components/login/api.mdx
@@ -78,7 +78,6 @@ export const CustomisationPageAnchorLink = ({ anchor, children }) => {
 
 - <AnchorLink>Beacon</AnchorLink>
 - <AnchorLink>Signals</AnchorLink>
-- <AnchorLink anchor="important-1">Important</AnchorLink>
 
 ### Components
 
@@ -670,7 +669,7 @@ Only custom modules can emit signals. See the <CustomisationPageAnchorLink ancho
 
 See also <CustomisationPageAnchorLink anchor="custom-namespaced-beacons-for-modules">custom namespaced beacons</CustomisationPageAnchorLink>.
 
-#### Important
+##### Important
 
 If a listener is added while signaling and it is triggered by the currently emitted signal, a loop could be created. This could occur when using hooks and not memoizing listeners. Avoid emitting signals inside listeners.
 

--- a/site/src/docs/components/login/api.mdx
+++ b/site/src/docs/components/login/api.mdx
@@ -333,6 +333,8 @@ Oidc client hooks are listed in the <AnchorLink anchor="oidc-client-hooks">hooks
 The `Api tokens client` listens to the `Oidc client` signals and waits until the user is authenticated and then fetches the API tokens. It retries if fetch fails and terminates when the maximum number of retries is reached.
 When the user is about to expire and renews, API tokens are also renewed automatically.
 
+When user renewal starts, API tokens are also removed to prevent usage of API tokens that are not possibly valid anymore. Use `isRenewing()` to check if API tokens are being renewed, and if it returns 'false', then use the API tokens returned by `getTokens()`.
+
 ##### Requirements
 
 URL where to get the tokens from. A user's access token is also required, so the user must be authenticated to fetch API tokens.
@@ -405,11 +407,11 @@ Returned errors are instances of the `ApiTokensClientError`. It is an extended E
 
 The `Api tokens client` also emits events when an action is complete or starting.
 
-| Event type                           | Description                                                                      | Utility function to check the signal      |
-| ------------------------------------ | -------------------------------------------------------------------------------- | ----------------------------------------- |
-| `API_TOKENS_UPDATED`                 | Tokens have changed. Includes also changes to `null`.                            | `isApiTokensUpdatedSignal(signal)`        |
-| `API_TOKENS_REMOVED`                 | Tokens have been removed. Happens usually when the user object has been removed. | `isApiTokensRemovedSignal(signal)`        |
-| `API_TOKENS_RENEWAL_STARTED`         | Api tokens are renewed. Happens usually right after user renewal.                | `isApiTokensRenewalStartedSignal(signal)` |
+| Event type                           | Description                                                                                    | Utility function to check the signal      |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `API_TOKENS_UPDATED`                 | Tokens have changed. Includes also changes to `null`.                                          | `isApiTokensUpdatedSignal(signal)`        |
+| `API_TOKENS_REMOVED`                 | Tokens have been removed. Happens usually when the user object has been removed or is renewed. | `isApiTokensRemovedSignal(signal)`        |
+| `API_TOKENS_RENEWAL_STARTED`         | Api tokens are renewed. Happens usually right after user renewal.                              | `isApiTokensRenewalStartedSignal(signal)` |
 | [Table 24: Api tokens client events] |
 
 ##### Dedicated signal triggers

--- a/site/src/docs/components/login/usage.mdx
+++ b/site/src/docs/components/login/usage.mdx
@@ -130,7 +130,13 @@ All component properties are listed on the <ApiPageAnchorLink anchor="logincallb
 #### LoginProvider
 
 This component creates a React context and initialises all modules. All components and hooks are required to render inside the LoginProvider or React Context will throw an error.
-Position the context in the component tree like any other React context. The context does not change and cause re-renders often, so it can be at the top level.
+Position the context in the component tree like any other React context.
+
+The value of context does not change every time one of its modules changes. Therefore, it does not cause re-renders, so it can be at the top level. For example, if user data or API tokens are renewed, the value of the context is not updated. Only its modules. This way, the application using the LoginProvider is not constantly re-rendered.
+
+Up-to-date user data or API tokens can be accessed from the modules with hooks.
+
+The <AnchorLink>useSignalListener</AnchorLink> can be used to update a component when a module of the LoginProvider changes.
 
 <PlaygroundPreview>
 


### PR DESCRIPTION
## Description

An issue was reported via Slack: when user is renewed, api tokens are not removed immediately. If browser is refreshed between user and api token renewal, the old ones are used because they are still in session storage.

(note: api tokens are bound to user's access token, so new user with a new access token, should not get the old api tokens. This has also been discussed in Slack. Link is in the ticket. So this may not fix the root cause, but there is no harm to remove old tokens.)

The api tokens are now removed when user renewal starts.

Also improved documentation and stories.


## Related Issue

Closes [HDS-2141](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2141)

## How Has This Been Tested?

Added unit tests for this scenario.

[Docs demo](https://city-of-helsinki.github.io/hds-demo/hds-2141-docs/components/login/)

[Storybook demo](https://city-of-helsinki.github.io/hds-demo/login/iframe.html?args=useKeycloak:false&id=components-login--example-application&viewMode=story)

## Add to changelog
- [x ] Added needed line to changelog 



[HDS-2141]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ