### PR TITLE
HDS-2034: Fix bug with session poller

### DIFF
--- a/packages/react/src/components/login/sessionPoller/sessionPoller.test.ts
+++ b/packages/react/src/components/login/sessionPoller/sessionPoller.test.ts
@@ -491,6 +491,7 @@ describe(`sessionPoller`, () => {
       payload: { type: oidcClientEvents.USER_UPDATED, data: createUser() },
     });
     expect(getHttpPollerStartCalls()).toHaveLength(2);
+    expect(getHttpPollerStopCalls()).toHaveLength(1);
   });
   it('Polling is not started again if renewal fails. No need to poll with old tokens', async () => {
     initTests({ setValidSession: true, responses: [successfulResponse, successfulResponse, successfulResponse] });

--- a/packages/react/src/components/login/sessionPoller/sessionPoller.ts
+++ b/packages/react/src/components/login/sessionPoller/sessionPoller.ts
@@ -129,20 +129,18 @@ export function createSessionPoller(options: SessionPollerOptions = { pollInterv
     const stateChanged = storeStateChangeFromSignal(signal);
     const eventPayload = getEventSignalPayload(signal);
     if (eventPayload) {
-      if (eventPayload.type === oidcClientEvents.USER_RENEWAL_STARTED) {
-        stop();
-      }
       if (
+        eventPayload.type === oidcClientEvents.USER_RENEWAL_STARTED ||
+        eventPayload.type === oidcClientEvents.USER_REMOVED
+      ) {
+        stop();
+      } else if (
         eventPayload.type === oidcClientEvents.USER_UPDATED &&
         eventPayload.data &&
         currentState === oidcClientStates.VALID_SESSION
       ) {
         start();
       }
-    }
-    if (eventPayload && eventPayload.type === oidcClientEvents.USER_UPDATED) {
-      stop();
-      return;
     }
     if (stateChanged && currentState === oidcClientStates.VALID_SESSION) {
       start();

--- a/packages/react/src/components/login/whole.setup.test.ts
+++ b/packages/react/src/components/login/whole.setup.test.ts
@@ -405,11 +405,9 @@ describe('Test all modules together', () => {
       ]);
       // api tokens are fetched. Oidc client requests are mock in the the client itself.
       expect(getRequestCount()).toBe(1);
-      expect(getReceivedSignalTypes(sessionPollerNamespace)).toEqual([
-        initSignalType,
-        sessionPollerEvents.SESSION_POLLING_STOPPED,
-      ]);
-      expect(getReceivedSignalTypes(LISTEN_TO_ALL_MARKER)).toHaveLength(12);
+      // session poller will not emit signals until polling interval is reached.
+      expect(getReceivedSignalTypes(sessionPollerNamespace)).toEqual([initSignalType]);
+      expect(getReceivedSignalTypes(LISTEN_TO_ALL_MARKER)).toHaveLength(11);
     });
     it("When user and user's tokens are already stored in sessionStorage, only polling starts", async () => {
       const { getReceivedSignalTypes } = await initAll({
@@ -507,7 +505,7 @@ describe('Test all modules together', () => {
       await renewPromise;
 
       expect(mockMapForSessionHttpPoller.getCalls('start')).toHaveLength(2);
-      expect(mockMapForSessionHttpPoller.getCalls('stop')).toHaveLength(2);
+      expect(mockMapForSessionHttpPoller.getCalls('stop')).toHaveLength(1);
     });
     it('When user is logs out, api tokens are removed and session polling is stopped.', async () => {
       const { getReceivedSignalTypes } = await initAll({
@@ -526,7 +524,7 @@ describe('Test all modules together', () => {
         oidcClientStates.LOGGING_OUT,
         oidcClientEvents.USER_REMOVED,
       ]);
-      expect(mockMapForSessionHttpPoller.getCalls('stop')).toHaveLength(2);
+
       expect(getReceivedSignalTypes(apiTokensClientNamespace)).toEqual([
         apiTokensClientEvents.API_TOKENS_UPDATED,
         initSignalType,
@@ -538,7 +536,8 @@ describe('Test all modules together', () => {
       ]);
 
       expect(mockMapForSessionHttpPoller.getCalls('start')).toHaveLength(1);
-      expect(mockMapForSessionHttpPoller.getCalls('stop')).toHaveLength(2);
+      // 3 calls caused by LOGGING_OUT, USER_REMOVED and VALID_SESSION changed to invalid.
+      expect(mockMapForSessionHttpPoller.getCalls('stop')).toHaveLength(3);
     });
   });
 });


### PR DESCRIPTION
## Description

The poller was unintentionally stopped when "USER_UPDATED" signal was received.

It should have been USER_REMOVED

## Related Issue

Closes [HDS-2034](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2034)

## How Has This Been Tested?

Fixed tests

## Screenshots (if appropriate):

## Add to changelog
No need for changelog. This is internal operation


[HDS-2034]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ