### PR TITLE
fix: Add onblur event for Tooltip parent

### DIFF
--- a/packages/react/src/components/tooltip/Tooltip.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.tsx
@@ -127,6 +127,7 @@ export const Tooltip = ({
         aria-label={buttonLabel}
         aria-expanded={isTooltipOpen}
         onClick={onButtonClick}
+        onBlur={() => setIsTooltipOpen(false)}
       >
         <span aria-hidden="true">
           <IconQuestionCircle />


### PR DESCRIPTION
## Description

Tooltip parent didn't have an on blur event. Now it has. [JIRA HDS-2196](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2196)

## How Has This Been Tested?

Open Tooltip component in Storybooks -> click on (?) -button -> Tooltip comes visible -> press Tab -key -> Tooltip disappers
