### PR TITLE
(HDS-2185) Add measure & outline addons to Storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- [Component] What is added?
+- Added measure and outline addons to Storybook
 
 #### Changed
 

--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -8,7 +8,9 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-backgrounds',
     '@storybook/addon-viewport',
-    '@storybook/addon-storysource'
+    '@storybook/addon-storysource',
+    '@storybook/addon-measure',
+    '@storybook/addon-outline',
   ],
   staticDirs: ['../src/fonts']
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,8 @@
     "@storybook/addon-a11y": "6.4.18",
     "@storybook/addon-backgrounds": "6.4.18",
     "@storybook/addon-docs": "6.4.18",
+    "@storybook/addon-measure": "6.4.22",
+    "@storybook/addon-outline": "6.4.22",
     "@storybook/addon-storysource": "^6.4.19",
     "@storybook/addon-viewport": "6.4.18",
     "@storybook/addons": "6.4.18",

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -17,6 +17,8 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-actions',
     '@storybook/addon-storysource',
+    '@storybook/addon-measure',
+    '@storybook/addon-outline',
   ],
   staticDirs: ['../src/fonts', { from: '../src/components/login/storybookStatic', to: '/static-login' }],
   webpack: async (config) => ({

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,6 +53,8 @@
     "@storybook/addon-controls": "6.4.22",
     "@storybook/addon-docs": "6.4.22",
     "@storybook/addon-links": "6.4.22",
+    "@storybook/addon-measure": "6.4.22",
+    "@storybook/addon-outline": "6.4.22",
     "@storybook/addon-storysource": "6.4.22",
     "@storybook/addon-viewport": "6.4.22",
     "@storybook/addons": "6.4.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4742,6 +4742,36 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
+"@storybook/addon-measure@6.4.22":
+  version "6.4.22"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-6.4.22.tgz#5e2daac4184a4870b6b38ff71536109b7811a12a"
+  integrity sha512-CjDXoCNIXxNfXfgyJXPc0McjCcwN1scVNtHa9Ckr+zMjiQ8pPHY7wDZCQsG69KTqcWHiVfxKilI82456bcHYhQ==
+  dependencies:
+    "@storybook/addons" "6.4.22"
+    "@storybook/api" "6.4.22"
+    "@storybook/client-logger" "6.4.22"
+    "@storybook/components" "6.4.22"
+    "@storybook/core-events" "6.4.22"
+    "@storybook/csf" "0.0.2--canary.87bc651.0"
+    core-js "^3.8.2"
+    global "^4.4.0"
+
+"@storybook/addon-outline@6.4.22":
+  version "6.4.22"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-6.4.22.tgz#7a2776344785f7deab83338fbefbefd5e6cfc8cf"
+  integrity sha512-VIMEzvBBRbNnupGU7NV0ahpFFb6nKVRGYWGREjtABdFn2fdKr1YicOHFe/3U7hRGjb5gd+VazSvyUvhaKX9T7Q==
+  dependencies:
+    "@storybook/addons" "6.4.22"
+    "@storybook/api" "6.4.22"
+    "@storybook/client-logger" "6.4.22"
+    "@storybook/components" "6.4.22"
+    "@storybook/core-events" "6.4.22"
+    "@storybook/csf" "0.0.2--canary.87bc651.0"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-storysource@6.4.22":
   version "6.4.22"
   resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-6.4.22.tgz#c2fc80e90476495ecacf74986e3cf81f25379f53"


### PR DESCRIPTION
## Description

Add measure & outline addons to Storybook (core and react)

## Related Issue
https://helsinkisolutionoffice.atlassian.net/browse/HDS-2185

## How Has This Been Tested?
Locally running storybook and tests

## Screenshots (if appropriate):

<img width="598" alt="Screenshot 2024-04-16 at 10 38 17" src="https://github.com/City-of-Helsinki/helsinki-design-system/assets/14258876/347fd851-fa8b-4f26-8d02-65a9a24b9376">

## Add to changelog
- [x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->
