### PR TITLE
(HDS-1967) Fix Koros heights in Footer by using the getShapeHeight fu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Footer] Fix Koros height issue (Calm type was of wrong height)
 
 ### Core
 

--- a/packages/react/src/components/footer/Footer.module.scss
+++ b/packages/react/src/components/footer/Footer.module.scss
@@ -1,13 +1,5 @@
 @value small-down, x-small-down, x-large-up from "../../styles/breakpoints.scss";
 
-$koros-heights: (
-  'basic': 15px,
-  'beat': 70px,
-  'pulse': 34px,
-  'wave': 35px,
-  'vibration': 54px,
-);
-
 .footer {
   --footer-background: var(--color-black-5);
   --footer-color: var(--color-black-90);
@@ -29,20 +21,6 @@ $koros-heights: (
 
 .koros {
   fill: var(--footer-background, transparent);
-  overflow: hidden;
-
-  svg {
-    left: 50%;
-    position: relative;
-    transform: translateX(-50%);
-    width: 4028px; /* can't use relative units here, as we want to have the koro waves always centered */
-  }
-
-  @each $type, $height in $koros-heights {
-    &.#{$type} {
-      height: #{$height};
-    }
-  }
 }
 
 .footerContent {

--- a/packages/react/src/components/footer/Footer.tsx
+++ b/packages/react/src/components/footer/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import '../../styles/base.module.css';
 import styles from './Footer.module.scss';
-import { Koros, KorosType } from '../koros';
+import { Koros, KorosType, getShapeHeight } from '../koros';
 import classNames from '../../utils/classNames';
 import { FooterNavigation } from './components/footerNavigation/FooterNavigation';
 import { FooterNavigationGroup } from './components/footerNavigationGroup/FooterNavigationGroup';
@@ -55,20 +55,20 @@ export const Footer = ({
 }: FooterProps) => {
   // custom theme class that is applied to the root element
   const customThemeClass = useTheme<FooterTheme>(styles.footer, theme);
+  const korosHeight = getShapeHeight({ type: korosType });
 
   return (
     <footer
       {...footerProps}
       className={classNames(
         styles.footer,
-        styles[`koros-${korosType}`],
         typeof theme === 'string' && styles[`theme-${theme}`],
         customThemeClass,
         className,
       )}
       aria-label={ariaLabel}
     >
-      <Koros className={classNames(styles.koros, styles[korosType])} type={korosType} />
+      <Koros className={classNames(styles.koros)} type={korosType} style={{ height: `${korosHeight}px` }} />
       <div className={styles.footerContent}>
         <div className={styles.footerSections}>
           {title && <h2 className={styles.title}>{title}</h2>}

--- a/packages/react/src/components/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/components/footer/__snapshots__/Footer.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.Base /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerCustom/__snapshots__/FooterCustom.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerCustom/__snapshots__/FooterCustom.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.Custom /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerGroupHeading/__snapshots__/FooterGroupHeading.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerGroupHeading/__snapshots__/FooterGroupHeading.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.FooterGroupHeading /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerLink/__snapshots__/FooterLink.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerLink/__snapshots__/FooterLink.test.tsx.snap
@@ -15,10 +15,11 @@ exports[`<Link /> spec renders the base variant 1`] = `
 exports[`<Link /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerNavigation/__snapshots__/FooterNavigation.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerNavigation/__snapshots__/FooterNavigation.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.Navigation /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerNavigationGroup/__snapshots__/FooterNavigationGroup.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/__snapshots__/FooterNavigationGroup.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.NavigationGroup /> spec renders the navigation groups 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerUtilities/__snapshots__/FooterUtilities.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerUtilities/__snapshots__/FooterUtilities.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.Utilities /> spec renders the component 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/packages/react/src/components/footer/components/footerUtilityGroup/__snapshots__/FooterUtilityGroup.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerUtilityGroup/__snapshots__/FooterUtilityGroup.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`<Footer.UtilityGroup /> spec renders the utility groups 1`] = `
 <DocumentFragment>
   <footer
-    class="footer koros-basic theme-light"
+    class="footer theme-light"
   >
     <div
-      class="koros basic koros basic"
+      class="koros basic koros"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"


### PR DESCRIPTION
## Description

Fix the Footer Calm variant Koros height-issue by using the same method as in Hero ->   using the getShapeHeight-method in Koros-component

## Related Issue

[HDS-1967](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1967)

## How Has This Been Tested?

- local machine tests

## Screenshots (if appropriate):

![image](https://github.com/City-of-Helsinki/helsinki-design-system/assets/8654955/a49b8b7b-e0c5-4f12-a929-a9de72ef6d04)


## Add to changelog
- [x] Added needed line to changelog


[HDS-1967]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ