### PR TITLE
HDS-2245: login strict mode issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - [Component] What is added?
+- [Login] Added a utility function to detect login callback error that could be ignored.
 
 #### Changed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Component] What bugs/typos are fixed?
 - [Footer] Fix Koros height issue (Calm type was of wrong height)
+- [Login] Fixed initialization failure in React strict mode when external modules are used.
 
 ### Core
 
@@ -98,6 +100,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+
+### Hds-js
+
+#### Added
+
+- [login] Added a utility function to detect login callback error that could be ignored.
 
 ## [3.7.0] - April, 11, 2024
 

--- a/packages/react/src/components/login/components/LoginCallbackHandler.tsx
+++ b/packages/react/src/components/login/components/LoginCallbackHandler.tsx
@@ -4,6 +4,7 @@ import { User } from 'oidc-client-ts';
 import { useOidcClient } from '../client/hooks';
 import { OidcClientError, oidcClientErrors } from '../client/oidcClientError';
 import { oidcClientStates } from '../client';
+import { createCallbackStateErrorMessage } from './LoginCallbackHandler.util';
 
 type LoginCallbackHandlerProps = {
   children: React.ReactNode | React.ReactNode[] | null;
@@ -34,12 +35,7 @@ export function LoginCallbackHandler({
   } else if (getState() === oidcClientStates.VALID_SESSION) {
     onSuccess(getUser() as User);
   } else {
-    onError(
-      new OidcClientError(
-        `Current state (${getState()}) cannot be handled by a callback`,
-        oidcClientErrors.SIGNIN_ERROR,
-      ),
-    );
+    onError(new OidcClientError(createCallbackStateErrorMessage(getState()), oidcClientErrors.SIGNIN_ERROR));
   }
   // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;

--- a/packages/react/src/components/login/components/LoginCallbackHandler.util.ts
+++ b/packages/react/src/components/login/components/LoginCallbackHandler.util.ts
@@ -1,0 +1,12 @@
+import { OidcClientError } from '../client/oidcClientError';
+import { OidcClientState, oidcClientStates } from '../client';
+
+export function createCallbackStateErrorMessage(state: OidcClientState) {
+  return `Current state (${state}) cannot be handled by a callback`;
+}
+
+export function isHandlingLoginCallbackError(error: OidcClientError): boolean {
+  return (
+    error.isSignInError && error.message === createCallbackStateErrorMessage(oidcClientStates.HANDLING_LOGIN_CALLBACK)
+  );
+}

--- a/packages/react/src/components/login/components/LoginProvider.tsx
+++ b/packages/react/src/components/login/components/LoginProvider.tsx
@@ -25,7 +25,7 @@ export const LoginProvider = ({
   apiTokensClientSettings,
   sessionPollerSettings,
   debug,
-  modules = [],
+  modules,
   children,
 }: React.PropsWithChildren<LoginProviderProps>) => {
   const loginProps: OidcClientProps = {
@@ -35,14 +35,15 @@ export const LoginProvider = ({
     debug,
   };
 
+  const mods = modules || [];
   if (sessionPollerSettings) {
-    modules.push(createSessionPoller(sessionPollerSettings));
+    mods.push(createSessionPoller(sessionPollerSettings));
   }
   if (apiTokensClientSettings) {
-    modules.push(createApiTokenClient(apiTokensClientSettings));
+    mods.push(createApiTokenClient(apiTokensClientSettings));
   }
   return (
-    <LoginContextProvider loginProps={loginProps} modules={modules}>
+    <LoginContextProvider loginProps={loginProps} modules={mods}>
       {children}
     </LoginContextProvider>
   );

--- a/packages/react/src/components/login/index.vanilla-js.ts
+++ b/packages/react/src/components/login/index.vanilla-js.ts
@@ -55,6 +55,9 @@ export * from './apiTokensClient/apiTokensClientError';
 export * from './client/oidcClientError';
 export * from './sessionPoller/sessionPollerError';
 
+// utils
+export { isHandlingLoginCallbackError } from './components/LoginCallbackHandler.util';
+
 // events
 export { apiTokensClientEvents } from './apiTokensClient/index';
 export { oidcClientEvents } from './client/index';

--- a/site/src/docs/components/login/api.mdx
+++ b/site/src/docs/components/login/api.mdx
@@ -101,6 +101,8 @@ Button text is passed and rendered as a child.
 | `onSuccess`                                                 | **Required**. The function is called when a response is handled successfully. The function is called with a <OidcClientTsLink>User</OidcClientTsLink> object. |
 | [Table 3: Properties of the LoginCallbackHandler component] |
 
+In some scenarios, when the component is rendered multiple times, usually in development mode with strict mode enabled, the `onError` callback is called with an error that can usually be ignored. The error indicates a login callback is already being handled. The error can be checked with the exported function `isHandlingLoginCallbackError(error)`.
+
 #### LoginProvider
 
 | Property                                             | Description                                                                                                                                                                                                                                                                                                                                                             |

--- a/site/src/docs/components/login/usage.mdx
+++ b/site/src/docs/components/login/usage.mdx
@@ -125,7 +125,7 @@ return (
 
 </PlaygroundPreview>
 
-All component properties are listed on the <ApiPageAnchorLink anchor="logincallbackhandler">API page</ApiPageAnchorLink>.
+All component properties are listed on the <ApiPageAnchorLink anchor="logincallbackhandler">API page</ApiPageAnchorLink>. See also a note about `isHandlingLoginCallbackError(error)`.
 
 #### LoginProvider
 


### PR DESCRIPTION
## Description

Login had issue with external modules and strict mode. Passed array was mishandled.

Added a utility function to detect ignoreable login callback errors. Kukkuu used the error message to detect these, so adding a function would make it less error prone.

Could not add strict mode to Storybook, because there is a add-on that fails. There is a separate ticket for that.

## Related Issue

Closes [HDS-2245](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2245)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Added local test for the function. StrictMode cannot be used in tests.

## Demos:
[Docs](https://city-of-helsinki.github.io/hds-demo/preview_1273/)
[React](https://city-of-helsinki.github.io/hds-demo/login/iframe.html?args=useKeycloak:false&id=components-login--example-application&viewMode=story). It has strict mode on, because add-on was removed for this.


## Screenshots (if appropriate):

## Add to changelog
- [x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2245]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ