### PR TITLE
HDS-1834 Change Linkbox size to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes that are not related to specific components
 - [Component] What has been changed
+- [Notification] Change auto closing notification progressbar to decrease instead of increase.
+- [LinkBox] Change size prop to an enum (LinkboxSize.Small, LinkboxSize.Medium, LinkboxSize.Large), not a breaking change though since the enum values are identical to the old ones.
 
 #### Fixed
 

--- a/packages/react/src/components/linkbox/Linkbox.tsx
+++ b/packages/react/src/components/linkbox/Linkbox.tsx
@@ -5,6 +5,12 @@ import styles from './Linkbox.module.scss';
 import { IconArrowRight, IconLinkExternal } from '../../icons';
 import classNames from '../../utils/classNames';
 
+export enum LinkboxSize {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+}
+
 export type LinkboxProps = {
   /**
    * Boolean indicating for external link that takes user to an entirely new web site. Defaults to false.
@@ -58,7 +64,7 @@ export type LinkboxProps = {
   /**
    * Size variant for the linkbox. Affects texts and paddings.
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: LinkboxSize;
 } & Omit<React.ComponentPropsWithoutRef<'a'>, 'tabIndex'>;
 
 export const Linkbox = ({
@@ -77,7 +83,7 @@ export const Linkbox = ({
   openInNewTabAriaLabel,
   text,
   border = false,
-  size = 'medium',
+  size = LinkboxSize.Medium,
   ...rest
 }: LinkboxProps) => {
   const linkRef = useRef(null);
@@ -117,12 +123,12 @@ export const Linkbox = ({
           !noBackground && styles.withBackground,
           noBackground && !imgProps && styles.paddingWithoutImageAndWithoutBackground,
           !noBackground && !imgProps && styles.paddingWithoutImageAndWithBackground,
-          imgProps && size === 'small' && styles.withSmallImage,
-          imgProps && size === 'medium' && styles.withMediumImage,
-          imgProps && size === 'large' && styles.withLargeImage,
-          size === 'small' && styles.contentSmall,
-          size === 'medium' && styles.contentMedium,
-          size === 'large' && styles.contentLarge,
+          imgProps && size === LinkboxSize.Small && styles.withSmallImage,
+          imgProps && size === LinkboxSize.Medium && styles.withMediumImage,
+          imgProps && size === LinkboxSize.Large && styles.withLargeImage,
+          size === LinkboxSize.Small && styles.contentSmall,
+          size === LinkboxSize.Medium && styles.contentMedium,
+          size === LinkboxSize.Large && styles.contentLarge,
         )}
       >
         {heading && (
@@ -130,9 +136,9 @@ export const Linkbox = ({
             role="heading"
             aria-level={headingAriaLevel}
             className={classNames(
-              size === 'small' && styles.headingSmall,
-              size === 'medium' && styles.headingMedium,
-              size === 'large' && styles.headingLarge,
+              size === LinkboxSize.Small && styles.headingSmall,
+              size === LinkboxSize.Medium && styles.headingMedium,
+              size === LinkboxSize.Large && styles.headingLarge,
             )}
           >
             {heading}
@@ -156,7 +162,7 @@ export const Linkbox = ({
               styles.icon,
               noBackground
                 ? styles.iconWhenNoBackground
-                : size === 'large' && styles.iconPositionForLinkboxLargeVariant,
+                : size === LinkboxSize.Large && styles.iconPositionForLinkboxLargeVariant,
             )}
             size="l"
             aria-hidden
@@ -167,7 +173,7 @@ export const Linkbox = ({
               styles.icon,
               noBackground
                 ? styles.iconWhenNoBackground
-                : size === 'large' && styles.iconPositionForLinkboxLargeVariant,
+                : size === LinkboxSize.Large && styles.iconPositionForLinkboxLargeVariant,
             )}
             size="l"
             aria-hidden

--- a/packages/react/src/components/linkbox/LinkboxEmpty.stories.tsx
+++ b/packages/react/src/components/linkbox/LinkboxEmpty.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Linkbox } from './Linkbox';
+import { Linkbox, LinkboxSize } from './Linkbox';
 
 export default {
   component: Linkbox,
@@ -49,7 +49,7 @@ export const External = () => (
 
 export const SmallSize = () => (
   <div style={{ width: '288px' }}>
-    <Linkbox linkboxAriaLabel="Linkbox: HDS" linkAriaLabel="HDS" href="https://hds.hel.fi" size="small">
+    <Linkbox linkboxAriaLabel="Linkbox: HDS" linkAriaLabel="HDS" href="https://hds.hel.fi" size={LinkboxSize.Small}>
       <div style={{ height: '192px' }} />
     </Linkbox>
   </div>
@@ -57,7 +57,7 @@ export const SmallSize = () => (
 
 export const MediumSize = () => (
   <div style={{ width: '320px' }}>
-    <Linkbox linkboxAriaLabel="Linkbox: HDS" linkAriaLabel="HDS" href="https://hds.hel.fi" size="medium">
+    <Linkbox linkboxAriaLabel="Linkbox: HDS" linkAriaLabel="HDS" href="https://hds.hel.fi" size={LinkboxSize.Medium}>
       <div style={{ height: '224px' }} />
     </Linkbox>
   </div>
@@ -65,7 +65,7 @@ export const MediumSize = () => (
 
 export const LargeSize = () => (
   <div style={{ width: '400px' }}>
-    <Linkbox linkboxAriaLabel="Linkbox: HDS" linkAriaLabel="HDS" href="https://hds.hel.fi" size="large">
+    <Linkbox linkboxAriaLabel="Linkbox: HDS" linkAriaLabel="HDS" href="https://hds.hel.fi" size={LinkboxSize.Large}>
       <div style={{ height: '296px' }} />
     </Linkbox>
   </div>

--- a/packages/react/src/components/linkbox/LinkboxWithHeadingAndTitle.stories.tsx
+++ b/packages/react/src/components/linkbox/LinkboxWithHeadingAndTitle.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Linkbox } from './Linkbox';
+import { Linkbox, LinkboxSize } from './Linkbox';
 
 export default {
   component: Linkbox,
@@ -75,7 +75,7 @@ export const SmallSize = () => (
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      size="small"
+      size={LinkboxSize.Small}
     />
   </div>
 );
@@ -88,7 +88,7 @@ export const MediumSize = () => (
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      size="medium"
+      size={LinkboxSize.Medium}
     />
   </div>
 );
@@ -100,6 +100,6 @@ export const LargeSize = () => (
     href="https://hds.hel.fi"
     heading="Linkbox title"
     text="Linkbox text"
-    size="large"
+    size={LinkboxSize.Large}
   />
 );

--- a/packages/react/src/components/linkbox/LinkboxWithImage.stories.tsx
+++ b/packages/react/src/components/linkbox/LinkboxWithImage.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Linkbox } from './Linkbox';
+import { Linkbox, LinkboxSize } from './Linkbox';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import smallImage from '../../assets/img/linkbox/placeholder-small.png';
@@ -88,7 +88,7 @@ export const SmallSize = () => (
       heading="Linkbox title"
       text="Linkbox text"
       imgProps={{ src: smallImage, width: 284, height: 181 }}
-      size="small"
+      size={LinkboxSize.Small}
     />
   </div>
 );
@@ -102,7 +102,7 @@ export const MediumSize = () => (
       heading="Linkbox title"
       text="Linkbox text"
       imgProps={{ src: mediumImage, width: 384, height: 245 }}
-      size="medium"
+      size={LinkboxSize.Medium}
     />
   </div>
 );
@@ -116,7 +116,7 @@ export const LargeSize = () => (
       heading="Linkbox title"
       text="Linkbox text"
       imgProps={{ src: largeImage, width: 567, height: 363 }}
-      size="large"
+      size={LinkboxSize.Large}
     />
   </div>
 );

--- a/site/src/docs/components/linkbox/code.mdx
+++ b/site/src/docs/components/linkbox/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/linkbox/code'
 title: 'Linkbox - Code'
 ---
 
-import { Linkbox } from 'hds-react';
+import { Linkbox, LinkboxSize } from 'hds-react';
 import { withPrefix } from "gatsby"
 import TabsLayout from './tabs.mdx';
 
@@ -164,10 +164,10 @@ import { Linkbox } from 'hds-react';
 </Playground>
 
 ### Linkbox size variants
-<Playground scope={{ Linkbox, withPrefix }}>
+<Playground scope={{ Linkbox, LinkboxSize, withPrefix }}>
 
 ```jsx
-import { Linkbox } from 'hds-react';
+import { Linkbox, LinkboxSize } from 'hds-react';
 
 () => (
   <div style={{ backgroundColor: 'var(--color-black-5)', padding: 'var(--spacing-s)' }}>
@@ -178,7 +178,7 @@ import { Linkbox } from 'hds-react';
         href="https://hds.hel.fi"
         heading="Linkbox title"
         text="Linkbox text"
-        size="small"
+        size={LinkboxSize.Small}
         imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 284, height: 181 }}
       />
     </div>
@@ -189,7 +189,7 @@ import { Linkbox } from 'hds-react';
         href="https://hds.hel.fi"
         heading="Linkbox title"
         text="Linkbox text"
-        size="medium"
+        size={LinkboxSize.Medium}
         imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 384, height: 245 }}
       />
     </div>
@@ -200,7 +200,7 @@ import { Linkbox } from 'hds-react';
         href="https://hds.hel.fi"
         heading="Linkbox title"
         text="Linkbox text"
-        size="large"
+        size={LinkboxSize.Large}
         imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 567, height: 363 }}
       />
     </div>
@@ -227,7 +227,7 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `openInExternalDomainAriaLabel` | Aria-label which is read if the link is external.                                                                                                                       | `string`                         | -             |
 | `openInNewTab`                  | If set to true, the link opens in a new tab.                                                                                                                            | `boolean`                        | false         |
 | `openInNewTabAriaLabel`         | Aria-label which is read if the link is opened in a new tab.                                                                                                            | `string`                         | -             |
-| `size`                          | Controls the size of the Linkbox.                                                                                                                                       | `"small"`, `"medium"`, `"large"` | `"medium"`    |
+| `size`                          | Controls the size of the Linkbox.                                                                                                                                       | `LinkboxSize.Small`, `LinkboxSize.Medium`, `LinkboxSize.Large` | `LinkboxSize.Medium`    |
 | `href`                          | Hypertext reference of the link.                                                                                                                                        | `string`                         | -             |
 | `linkAriaLabel`                 | Aria-label for the link (arrow or external icon) that is located at the bottom of the linkbox.                                                                          | `string`                         | -             |
 | `linkboxAriaLabel`              | Aria label for the whole linkbox region. Remember to tell users of assistive technology that they are inside a linkbox. Check storybook examples on how it can be done. | `string`                         | -             |

--- a/site/src/docs/components/linkbox/index.mdx
+++ b/site/src/docs/components/linkbox/index.mdx
@@ -4,7 +4,7 @@ title: 'Linkbox'
 navTitle: 'Linkbox'
 ---
 
-import { Linkbox } from 'hds-react';
+import { Linkbox, LinkboxSize } from 'hds-react';
 import { withPrefix } from "gatsby"
 import TabsLayout from './tabs.mdx';
 
@@ -170,7 +170,7 @@ HDS offers styling for a Linkbox with an image as its content.
 
 #### Linkbox size variants
 
-HDS Linkbox includes three (3) size variants; small, default, and large.
+HDS Linkbox includes three (3) size variants; small, default, and large (LinkboxSize.Small, LinkboxSize.Medium and LinkboxSize.Large).
 You can use different sizes depending on the screen size or use case.
 Size variants differ in (default) heading size and inner spacing. Use the size property to alter the size.
 
@@ -182,7 +182,7 @@ Size variants differ in (default) heading size and inner spacing. Use the size p
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      size="small"
+      size={LinkboxSize.Small}
       imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 284, height: 181 }}
     />
   </div>
@@ -193,7 +193,7 @@ Size variants differ in (default) heading size and inner spacing. Use the size p
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      size="medium"
+      size={LinkboxSize.Medium}
       imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 384, height: 245 }}
     />
   </div>
@@ -204,7 +204,7 @@ Size variants differ in (default) heading size and inner spacing. Use the size p
       href="https://hds.hel.fi"
       heading="Linkbox title"
       text="Linkbox text"
-      size="large"
+      size={LinkboxSize.Large}
       imgProps={{ src: withPrefix('/images/foundation/visual-assets/placeholders/image-m@3x.png'), width: 567, height: 363 }}
     />
   </div>


### PR DESCRIPTION
## Description

Change Linkbox size prop to enum

## Related Issue

[HDS-1834](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1834)

## How Has This Been Tested?

- local machine test run

## Demos:
[Docs](https://city-of-helsinki.github.io/hds-demo/preview_1276/)

[Core Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1276/storybook/core)

[React Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1276/storybook/react)

## Add to changelog
- [x] Added needed line to changelog


[HDS-1834]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ