### PR TITLE
HDS-1838 Icon size to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Accordion] Changed size prop to use AccordionSize enum (AccordionSize.Small, AccordionSize.Medium and AccordionSize.Large) or without usin Typescript ("small", "medium" and "large"). Also theming has changed variables.
 - [Notification] Changed size prop to enum (NotificationSize.Small, NotificationSize.Medium and NotificationSize.Large) or without using Typescript ("small", "medium" and "large"). The "default" size was removed and replaced with "medium".
 - [ErrorSummary] Changed size prop to enum (ErrorSummarySize.Medium and ErrorSummarySize.Large) or without using Typescript ("medium" and "large"). The "default" size was removed and replaced with "medium".
+- [Icon] Icon size changed to enum (IconSize.ExtraSmall, IconSize.Small, IconSize.Medium, IconSize.Large and IconSize.ExtraLarge) or without Typescript ("extraSmall", "small", "medium", "large" and "extraLarge").
 
 #### Added
 
@@ -75,6 +76,7 @@ Changes that are not related to specific components
 - [Button] Renewed Button component with theming support
 - [Notification] Changed according to new size enum.
 - [ErrorSummary] Changed according to new size enum.
+- [Icon] Document the size prop as enum usage.
 
 #### Fixed
 

--- a/packages/react/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react/src/components/accordion/__snapshots__/Accordion.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`<Accordion /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="angle-down"
-              class="icon s"
+              class="icon small"
               role="img"
               style="width: 100%; height: 100%;"
               viewBox="0 0 24 24"
@@ -71,7 +71,7 @@ exports[`<Accordion /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-up"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/Breadcrumb.tsx
@@ -6,6 +6,7 @@ import { Link } from '../link';
 import { IconAngleLeft, IconAngleRight } from '../../icons';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
+import { IconSize } from '../../icons/Icon.interface';
 
 export interface BreadcrumbCustomTheme {
   /**
@@ -59,7 +60,7 @@ const Separator = ({ direction = 'right' }: { direction?: 'left' | 'right' }) =>
   const isRightArrow = direction === 'right';
   const IconComponent = isRightArrow ? IconAngleRight : IconAngleLeft;
   const classList = isRightArrow ? styles.separator : styles.backArrow;
-  const size = isRightArrow ? 'xs' : 's';
+  const size = isRightArrow ? IconSize.ExtraSmall : IconSize.Small;
   return (
     <span className={classList} aria-hidden>
       <IconComponent size={size} />

--- a/packages/react/src/components/breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<Breadcrumb /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon xs"
+            class="icon extraSmall"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -55,7 +55,7 @@ exports[`<Breadcrumb /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon xs"
+            class="icon extraSmall"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -85,7 +85,7 @@ exports[`<Breadcrumb /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon xs"
+            class="icon extraSmall"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -115,7 +115,7 @@ exports[`<Breadcrumb /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon xs"
+            class="icon extraSmall"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -150,7 +150,7 @@ exports[`<Breadcrumb /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="angle-left"
-          class="icon s"
+          class="icon small"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/cookieConsent/cookieModal/__snapshots__/CookieModal.test.tsx.snap
+++ b/packages/react/src/components/cookieConsent/cookieModal/__snapshots__/CookieModal.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="angle-down"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -129,7 +129,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
               <svg
                 aria-hidden="true"
                 aria-label="angle-up"
-                class="icon s"
+                class="icon small"
                 role="img"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
@@ -152,7 +152,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="angle-down"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -284,7 +284,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s"
+                            class="icon small"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"
@@ -450,7 +450,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s"
+                            class="icon small"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"
@@ -635,7 +635,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s"
+                            class="icon small"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"
@@ -777,7 +777,7 @@ exports[`<CookieModal /> spec renders the component 1`] = `
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s"
+                            class="icon small"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/cookieConsent/cookiePage/__snapshots__/CookiePage.test.tsx.snap
+++ b/packages/react/src/components/cookieConsent/cookiePage/__snapshots__/CookiePage.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`<Page /> spec renders the component 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-down"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -300,7 +300,7 @@ exports[`<Page /> spec renders the component 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-down"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -485,7 +485,7 @@ exports[`<Page /> spec renders the component 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-down"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -627,7 +627,7 @@ exports[`<Page /> spec renders the component 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-down"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
             <svg
               aria-hidden="true"
               aria-label="calendar"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -137,7 +137,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -275,7 +275,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -302,7 +302,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-left"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -324,7 +324,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-right"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -1431,7 +1431,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="check"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -1460,7 +1460,7 @@ exports[`<DateInput /> spec renders the component with Finnish language 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="cross"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -1515,7 +1515,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
             <svg
               aria-hidden="true"
               aria-label="calendar"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -1623,7 +1623,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -1761,7 +1761,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -1788,7 +1788,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-left"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -1810,7 +1810,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-right"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -2917,7 +2917,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="check"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -2946,7 +2946,7 @@ exports[`<DateInput /> spec renders the component with Swedish language 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="cross"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -3007,7 +3007,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
             <svg
               aria-hidden="true"
               aria-label="calendar"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -3115,7 +3115,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -3253,7 +3253,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -3280,7 +3280,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-left"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -3302,7 +3302,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-right"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -4407,7 +4407,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="cross"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -4462,7 +4462,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
             <svg
               aria-hidden="true"
               aria-label="calendar"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -4570,7 +4570,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -4708,7 +4708,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label="angle-down"
-                        class="icon s"
+                        class="icon small"
                         role="img"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
@@ -4735,7 +4735,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-left"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -4757,7 +4757,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label="angle-right"
-                      class="icon s"
+                      class="icon small"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"
@@ -5864,7 +5864,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="check"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -5893,7 +5893,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="cross"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`<Dialog /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="cross"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -67,7 +67,7 @@ exports[`<Dialog /> spec renders the component 1`] = `
               <svg
                 aria-hidden="true"
                 aria-label="alert-circle"
-                class="icon s"
+                class="icon small"
                 role="img"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/dropdown/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/components/dropdown/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`<Combobox /> renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="angle-down"
-          class="icon s angleIcon"
+          class="icon small angleIcon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -100,7 +100,7 @@ exports[`<Combobox /> renders the component without label when aria-labelledby i
         <svg
           aria-hidden="true"
           aria-label="angle-down"
-          class="icon s angleIcon"
+          class="icon small angleIcon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/dropdown/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react/src/components/dropdown/select/__snapshots__/Select.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`<Select /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="angle-down"
-          class="icon s angleIcon"
+          class="icon small angleIcon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -73,7 +73,7 @@ exports[`<Select /> spec renders the component without label when aria-labelledb
         <svg
           aria-hidden="true"
           aria-label="angle-down"
-          class="icon s angleIcon"
+          class="icon small angleIcon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/errorSummary/__snapshots__/ErrorSummary.test.tsx.snap
+++ b/packages/react/src/components/errorSummary/__snapshots__/ErrorSummary.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`<ErrorSummary /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="error-fill"
-          class="icon s icon"
+          class="icon small icon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/fileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/components/fileInput/__snapshots__/FileInput.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`<FileInput /> spec renders the component 1`] = `
               <svg
                 aria-hidden="true"
                 aria-label="plus"
-                class="icon s"
+                class="icon small"
                 role="img"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/components/footer/__snapshots__/Footer.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`<Footer /> spec renders the component 1`] = `
               <svg
                 aria-hidden="true"
                 aria-label="arrow-up"
-                class="icon s"
+                class="icon small"
                 role="img"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`<Footer.Base /> spec renders the component 1`] = `
               <svg
                 aria-hidden="true"
                 aria-label="arrow-up"
-                class="icon s"
+                class="icon small"
                 role="img"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/footer/components/footerLink/FooterLink.tsx
+++ b/packages/react/src/components/footer/components/footerLink/FooterLink.tsx
@@ -7,6 +7,7 @@ import { MergeElementProps } from '../../../../common/types';
 import classNames from '../../../../utils/classNames';
 import { IconAngleRight, IconLinkExternal } from '../../../../icons';
 import { FooterVariant } from '../../Footer.interface';
+import { IconSize } from '../../../../icons/Icon.interface';
 
 type ItemProps<Element> = React.PropsWithChildren<{
   /**
@@ -83,7 +84,11 @@ export const FooterLink = <T extends React.ElementType = 'a'>({
       {subItem && <IconAngleRight className={styles.subItemIcon} aria-hidden />}
       {label && <span>{label}</span>}
       {external && label && (
-        <IconLinkExternal size={variant === FooterVariant.Base ? 'xs' : 's'} className={styles.icon} aria-hidden />
+        <IconLinkExternal
+          size={variant === FooterVariant.Base ? IconSize.ExtraSmall : IconSize.Small}
+          className={styles.icon}
+          aria-hidden
+        />
       )}
     </Item>
   );

--- a/packages/react/src/components/footer/components/footerUtilityGroup/__snapshots__/FooterUtilityGroup.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerUtilityGroup/__snapshots__/FooterUtilityGroup.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`<Footer.UtilityGroup /> spec renders the utility groups 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="facebook"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"
@@ -134,7 +134,7 @@ exports[`<Footer.UtilityGroup /> spec renders the utility groups 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="facebook"
-                    class="icon s"
+                    class="icon small"
                     role="img"
                     viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                 <svg
                   aria-hidden="true"
                   aria-label="cross"
-                  class="icon s"
+                  class="icon small"
                   role="img"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -137,7 +137,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s chevron"
+                            class="icon small chevron"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"
@@ -175,7 +175,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                                 <svg
                                   aria-hidden="true"
                                   aria-label="angle-right"
-                                  class="icon s chevron"
+                                  class="icon small chevron"
                                   role="img"
                                   viewBox="0 0 24 24"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -252,7 +252,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                                 <svg
                                   aria-hidden="true"
                                   aria-label="angle-right"
-                                  class="icon s chevron"
+                                  class="icon small chevron"
                                   role="img"
                                   viewBox="0 0 24 24"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -336,7 +336,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s chevron"
+                            class="icon small chevron"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"
@@ -374,7 +374,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                                 <svg
                                   aria-hidden="true"
                                   aria-label="angle-right"
-                                  class="icon s chevron"
+                                  class="icon small chevron"
                                   role="img"
                                   viewBox="0 0 24 24"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -474,7 +474,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                           <svg
                             aria-hidden="true"
                             aria-label="angle-down"
-                            class="icon s chevron"
+                            class="icon small chevron"
                             role="img"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"
@@ -524,7 +524,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                                 <svg
                                   aria-hidden="true"
                                   aria-label="angle-right"
-                                  class="icon s chevron"
+                                  class="icon small chevron"
                                   role="img"
                                   viewBox="0 0 24 24"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -601,7 +601,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
                                 <svg
                                   aria-hidden="true"
                                   aria-label="angle-right"
-                                  class="icon s chevron"
+                                  class="icon small chevron"
                                   role="img"
                                   viewBox="0 0 24 24"
                                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/header/components/headerLanguageSelector/__snapshots__/HeaderLanguageSelector.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerLanguageSelector/__snapshots__/HeaderLanguageSelector.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component correct
           <svg
             aria-hidden="true"
             aria-label="globe"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -75,7 +75,7 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component correct
           <svg
             aria-hidden="true"
             aria-label="angle-down"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -131,7 +131,7 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component correct
               <svg
                 aria-hidden="true"
                 aria-label="link-external"
-                class="icon s icon verticalAlignMediumIcon"
+                class="icon small icon verticalAlignMediumIcon"
                 role="img"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
@@ -242,7 +242,7 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component with pr
                 <svg
                   aria-hidden="true"
                   aria-label="globe"
-                  class="icon s"
+                  class="icon small"
                   role="img"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -261,7 +261,7 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component with pr
                 <svg
                   aria-hidden="true"
                   aria-label="angle-down"
-                  class="icon s"
+                  class="icon small"
                   role="img"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -317,7 +317,7 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component with pr
                     <svg
                       aria-hidden="true"
                       aria-label="link-external"
-                      class="icon s icon verticalAlignMediumIcon"
+                      class="icon small icon verticalAlignMediumIcon"
                       role="img"
                       viewBox="0 0 24 24"
                       xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/header/components/headerSearch/__snapshots__/HeaderSearch.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerSearch/__snapshots__/HeaderSearch.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`<Header.HeaderSearch /> spec renders the component 1`] = `
                 <svg
                   aria-hidden="true"
                   aria-label="search"
-                  class="icon s searchIcon"
+                  class="icon small searchIcon"
                   role="img"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/link/Link.stories.tsx
+++ b/packages/react/src/components/link/Link.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Link, LinkSize } from './Link';
 import { IconDocument, IconEnvelope, IconPhone, IconPhoto } from '../../icons';
+import { IconSize } from '../../icons/Icon.interface';
 
 export default {
   component: Link,
@@ -173,64 +174,84 @@ export const withCustomIcon = (args) => {
     <div style={{ display: 'grid', columnGap: '10px', gridTemplateColumns: '1fr 1fr 1fr' }}>
       <div>
         <p>Small</p>
-        <Link {...args} iconStart={<IconDocument size="xs" aria-hidden />} size={LinkSize.Small} href="/#">
+        <Link
+          {...args}
+          iconStart={<IconDocument size={IconSize.ExtraSmall} aria-hidden />}
+          size={LinkSize.Small}
+          href="/#"
+        >
           Document link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconPhone size="xs" aria-hidden />} size={LinkSize.Small} href="/#">
+        <Link
+          {...args}
+          iconStart={<IconPhone size={IconSize.ExtraSmall} aria-hidden />}
+          size={LinkSize.Small}
+          href="/#"
+        >
           Phone link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconEnvelope size="xs" aria-hidden />} size={LinkSize.Small} href="/#">
+        <Link
+          {...args}
+          iconStart={<IconEnvelope size={IconSize.ExtraSmall} aria-hidden />}
+          size={LinkSize.Small}
+          href="/#"
+        >
           Envelope link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconPhoto size="xs" aria-hidden />} size={LinkSize.Small} href="/#">
+        <Link
+          {...args}
+          iconStart={<IconPhoto size={IconSize.ExtraSmall} aria-hidden />}
+          size={LinkSize.Small}
+          href="/#"
+        >
           Photo link
         </Link>
       </div>
       <div>
         <p>Medium</p>
-        <Link {...args} iconStart={<IconDocument size="s" aria-hidden />} size={LinkSize.Medium} href="/#">
+        <Link {...args} iconStart={<IconDocument size={IconSize.Small} aria-hidden />} size={LinkSize.Medium} href="/#">
           Document link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconPhone size="s" aria-hidden />} size={LinkSize.Medium} href="/#">
+        <Link {...args} iconStart={<IconPhone size={IconSize.Small} aria-hidden />} size={LinkSize.Medium} href="/#">
           Phone link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconEnvelope size="s" aria-hidden />} size={LinkSize.Medium} href="/#">
+        <Link {...args} iconStart={<IconEnvelope size={IconSize.Small} aria-hidden />} size={LinkSize.Medium} href="/#">
           Envelope link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconPhoto size="s" aria-hidden />} size={LinkSize.Medium} href="/#">
+        <Link {...args} iconStart={<IconPhoto size={IconSize.Small} aria-hidden />} size={LinkSize.Medium} href="/#">
           Photo link
         </Link>
       </div>
       <div>
         <p>Large</p>
-        <Link {...args} iconStart={<IconDocument size="l" aria-hidden />} size={LinkSize.Large} href="/#">
+        <Link {...args} iconStart={<IconDocument size={IconSize.Large} aria-hidden />} size={LinkSize.Large} href="/#">
           Document link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconPhone size="l" aria-hidden />} size={LinkSize.Large} href="/#">
+        <Link {...args} iconStart={<IconPhone size={IconSize.Large} aria-hidden />} size={LinkSize.Large} href="/#">
           Phone Link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconEnvelope size="l" aria-hidden />} size={LinkSize.Large} href="/#">
+        <Link {...args} iconStart={<IconEnvelope size={IconSize.Large} aria-hidden />} size={LinkSize.Large} href="/#">
           Envelope Link
         </Link>
         <br />
         <br />
-        <Link {...args} iconStart={<IconPhoto size="l" aria-hidden />} size={LinkSize.Large} href="/#">
+        <Link {...args} iconStart={<IconPhoto size={IconSize.Large} aria-hidden />} size={LinkSize.Large} href="/#">
           Photo Link
         </Link>
       </div>

--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -5,6 +5,7 @@ import styles from './Link.module.scss';
 import { IconLinkExternal } from '../../icons';
 import classNames from '../../utils/classNames';
 import { getTextFromReactChildren } from '../../utils/getTextFromReactChildren';
+import { IconSize } from '../../icons/Icon.interface';
 
 export enum LinkSize {
   Small = 'small',
@@ -63,12 +64,6 @@ export type LinkProps = {
   useButtonStyles?: boolean;
 } & Omit<React.ComponentPropsWithoutRef<'a'>, 'target' | 'href' | 'onPointerEnterCapture' | 'onPointerLeaveCapture'>;
 
-enum LinkSizeToIconSize {
-  large = 'l',
-  medium = 's',
-  small = 'xs',
-}
-
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   (
     {
@@ -101,10 +96,15 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       return [childrenText, newTabText, externalText].filter((text) => text).join(' ');
     };
 
+    const mapLinkSizeToExternalIconSize = {
+      [LinkSize.Large]: IconSize.Large,
+      [LinkSize.Medium]: IconSize.Small,
+      [LinkSize.Small]: IconSize.ExtraSmall,
+    };
     const mapLinkSizeToIconVerticalStyling = {
-      large: styles.verticalAlignBigIcon,
-      medium: styles.verticalAlignMediumIcon,
-      small: styles.verticalAlignSmallIcon,
+      [LinkSize.Large]: styles.verticalAlignBigIcon,
+      [LinkSize.Medium]: styles.verticalAlignMediumIcon,
+      [LinkSize.Small]: styles.verticalAlignSmallIcon,
     };
 
     const linkStyles = classNames(
@@ -132,7 +132,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         {useButtonStyles ? <span className={styles.buttonLabel}>{children}</span> : children}
         {external && (
           <IconLinkExternal
-            size={LinkSizeToIconSize[size]}
+            size={mapLinkSizeToExternalIconSize[size]}
             className={classNames(styles.icon, mapLinkSizeToIconVerticalStyling[size])}
             aria-hidden
           />

--- a/packages/react/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<Link /> spec external link that is opened in to a new tab should not h
     <svg
       aria-hidden="true"
       aria-label="link-external"
-      class="icon s icon verticalAlignMediumIcon"
+      class="icon small icon verticalAlignMediumIcon"
       role="img"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/linkbox/Linkbox.tsx
+++ b/packages/react/src/components/linkbox/Linkbox.tsx
@@ -4,6 +4,7 @@ import '../../styles/base.module.css';
 import styles from './Linkbox.module.scss';
 import { IconArrowRight, IconLinkExternal } from '../../icons';
 import classNames from '../../utils/classNames';
+import { IconSize } from '../../icons/Icon.interface';
 
 export enum LinkboxSize {
   Small = 'small',
@@ -164,7 +165,7 @@ export const Linkbox = ({
                 ? styles.iconWhenNoBackground
                 : size === LinkboxSize.Large && styles.iconPositionForLinkboxLargeVariant,
             )}
-            size="l"
+            size={IconSize.Large}
             aria-hidden
           />
         ) : (
@@ -175,7 +176,7 @@ export const Linkbox = ({
                 ? styles.iconWhenNoBackground
                 : size === LinkboxSize.Large && styles.iconPositionForLinkboxLargeVariant,
             )}
-            size="l"
+            size={IconSize.Large}
             aria-hidden
           />
         )}

--- a/packages/react/src/components/linkbox/__snapshots__/Linkbox.test.tsx.snap
+++ b/packages/react/src/components/linkbox/__snapshots__/Linkbox.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<Linkbox /> spec external linkbox that is opened in to a new tab should
       <svg
         aria-hidden="true"
         aria-label="link-external"
-        class="icon l icon"
+        class="icon large icon"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -85,7 +85,7 @@ exports[`<Linkbox /> spec renders the component 1`] = `
       <svg
         aria-hidden="true"
         aria-label="arrow-right"
-        class="icon l icon"
+        class="icon large icon"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<Notification /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="info-circle-fill"
-          class="icon s icon"
+          class="icon small icon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -77,7 +77,7 @@ exports[`<Notification /> spec uses toast notification props in non-inline notif
         <svg
           aria-hidden="true"
           aria-label="info-circle-fill"
-          class="icon s icon"
+          class="icon small icon"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/numberInput/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react/src/components/numberInput/__snapshots__/NumberInput.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`<NumberInput /> spec renders the component with steppers 1`] = `
             <svg
               aria-hidden="true"
               aria-label="minus"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -106,7 +106,7 @@ exports[`<NumberInput /> spec renders the component with steppers 1`] = `
             <svg
               aria-hidden="true"
               aria-label="plus"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<Pagination /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -142,7 +142,7 @@ exports[`<Pagination /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -195,7 +195,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -286,7 +286,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -337,7 +337,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -454,7 +454,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -505,7 +505,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -644,7 +644,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -695,7 +695,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -858,7 +858,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -909,7 +909,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1096,7 +1096,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1147,7 +1147,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1358,7 +1358,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1409,7 +1409,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1495,7 +1495,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1546,7 +1546,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1656,7 +1656,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1707,7 +1707,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1841,7 +1841,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1892,7 +1892,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2050,7 +2050,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2101,7 +2101,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2283,7 +2283,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2334,7 +2334,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2540,7 +2540,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2591,7 +2591,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2682,7 +2682,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2733,7 +2733,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2848,7 +2848,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2899,7 +2899,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3038,7 +3038,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3089,7 +3089,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3252,7 +3252,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3303,7 +3303,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3490,7 +3490,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3541,7 +3541,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3752,7 +3752,7 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3805,7 +3805,7 @@ exports[`<Pagination /> spec should return only first page when page count is 1 
           <svg
             aria-hidden="true"
             aria-label="angle-left"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -3855,7 +3855,7 @@ exports[`<Pagination /> spec should return only first page when page count is 1 
           <svg
             aria-hidden="true"
             aria-label="angle-right"
-            class="icon s angleRightIcon"
+            class="icon small angleRightIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/passwordInput/__snapshots__/PasswordInput.test.tsx.snap
+++ b/packages/react/src/components/passwordInput/__snapshots__/PasswordInput.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<PasswordInput /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="eye"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/searchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react/src/components/searchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`<SearchInput /> spec renders the component 1`] = `
           <svg
             aria-hidden="true"
             aria-label="search"
-            class="icon s searchIcon"
+            class="icon small searchIcon"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/sideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/packages/react/src/components/sideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<SideNavigation /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="angle-down"
-          class="icon s"
+          class="icon small"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -60,7 +60,7 @@ exports[`<SideNavigation /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="home"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -85,7 +85,7 @@ exports[`<SideNavigation /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="angle-up"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -136,7 +136,7 @@ exports[`<SideNavigation /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="home"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -161,7 +161,7 @@ exports[`<SideNavigation /> spec renders the component 1`] = `
             <svg
               aria-hidden="true"
               aria-label="link-external"
-              class="icon s"
+              class="icon small"
               role="img"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/stepper/Step.tsx
+++ b/packages/react/src/components/stepper/Step.tsx
@@ -4,6 +4,7 @@ import '../../styles/base.module.css';
 import styles from './Stepper.module.scss';
 import { IconCheck, IconError, IconPlaybackPause } from '../../icons';
 import classNames from '../../utils/classNames';
+import { IconSize } from '../../icons/Icon.interface';
 
 export enum StepState {
   available,
@@ -165,8 +166,8 @@ export const Step = React.forwardRef<HTMLButtonElement, StepProps>(
               </div>
             ) : (
               <div className={classNames(styles.circle)}>
-                {state === StepState.attention && <IconError size="xs" aria-hidden />}
-                {state === StepState.paused && <IconPlaybackPause size="xs" aria-hidden />}
+                {state === StepState.attention && <IconError size={IconSize.ExtraSmall} aria-hidden />}
+                {state === StepState.paused && <IconPlaybackPause size={IconSize.ExtraSmall} aria-hidden />}
                 {(state === StepState.available ||
                   state === StepState.disabled ||
                   (state === StepState.completed && selected)) && <span className={styles.number}>{index + 1}</span>}

--- a/packages/react/src/components/stepper/Stepper.tsx
+++ b/packages/react/src/components/stepper/Stepper.tsx
@@ -6,6 +6,7 @@ import { Step, StepState } from './Step';
 import classNames from '../../utils/classNames';
 import { IconAngleLeft, IconAngleRight } from '../../icons';
 import { useTheme } from '../../hooks/useTheme';
+import { IconSize } from '../../icons/Icon.interface';
 
 type Language = 'en' | 'fi' | 'sv' | string;
 
@@ -198,7 +199,7 @@ export const Stepper = ({
             }}
             tabIndex={-1}
           >
-            <IconAngleLeft size="m" />
+            <IconAngleLeft size={IconSize.Medium} />
           </button>
         </div>
       )}
@@ -213,7 +214,7 @@ export const Stepper = ({
             }}
             tabIndex={-1}
           >
-            <IconAngleRight size="m" />
+            <IconAngleRight size={IconSize.Medium} />
           </button>
         </div>
       )}

--- a/packages/react/src/components/tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/react/src/components/tag/__snapshots__/Tag.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Tag /> spec renders properties of the component 1`] = `
     <svg
       aria-hidden="true"
       aria-label="cross"
-      class="icon s icon"
+      class="icon small icon"
       role="img"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/textInput/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/components/textInput/__snapshots__/TextInput.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`<TextInput /> spec renders the component with search clear button 1`] =
           <svg
             aria-hidden="true"
             aria-label="cross-circle"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -131,7 +131,7 @@ exports[`<TextInput /> spec renders the component with tooltip 1`] = `
           <svg
             aria-hidden="true"
             aria-label="question-circle"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/textarea/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/react/src/components/textarea/__snapshots__/TextArea.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`<Textarea /> spec renders the component with tooltip 1`] = `
           <svg
             aria-hidden="true"
             aria-label="question-circle"
-            class="icon s"
+            class="icon small"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/toggleButton/ToggleButton.tsx
+++ b/packages/react/src/components/toggleButton/ToggleButton.tsx
@@ -6,6 +6,7 @@ import classNames from '../../utils/classNames';
 import { IconCrossCircleFill, IconCheckCircleFill } from '../../icons';
 import { Tooltip } from '../tooltip/Tooltip';
 import { useTheme } from '../../hooks/useTheme';
+import { IconSize } from '../../icons/Icon.interface';
 
 export type ToggleButtonVariant = 'default' | 'inline';
 
@@ -111,10 +112,10 @@ export const ToggleButton = React.forwardRef<HTMLButtonElement, ToggleButtonProp
           }}
         >
           <div className={classNames(styles.toggleButtonIcon, styles.offIcon)}>
-            <IconCrossCircleFill size="m" aria-hidden="true" />
+            <IconCrossCircleFill size={IconSize.Medium} aria-hidden="true" />
           </div>
           <div className={classNames(styles.toggleButtonIcon, styles.onIcon)}>
-            <IconCheckCircleFill size="m" aria-hidden="true" />
+            <IconCheckCircleFill size={IconSize.Medium} aria-hidden="true" />
           </div>
         </button>
       </div>

--- a/packages/react/src/components/toggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/react/src/components/toggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<ToggleButton /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="cross-circle-fill"
-          class="icon m"
+          class="icon medium"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -48,7 +48,7 @@ exports[`<ToggleButton /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="check-circle-fill"
-          class="icon m"
+          class="icon medium"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<TooltipNew /> spec opens the tooltip when button is clicked 1`] = `
         <svg
           aria-hidden="true"
           aria-label="question-circle"
-          class="icon s"
+          class="icon small"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -65,7 +65,7 @@ exports[`<TooltipNew /> spec renders the component 1`] = `
         <svg
           aria-hidden="true"
           aria-label="question-circle"
-          class="icon s"
+          class="icon small"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/icons/Icon.interface.ts
+++ b/packages/react/src/icons/Icon.interface.ts
@@ -1,5 +1,13 @@
 import { CSSProperties, SVGAttributes } from 'react';
 
+export enum IconSize {
+  ExtraSmall = 'extraSmall',
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+  ExtraLarge = 'extraLarge',
+}
+
 export type IconProps = SVGAttributes<SVGElement> & {
   ariaLabel?: string;
   ariaLabelledby?: string;
@@ -9,6 +17,6 @@ export type IconProps = SVGAttributes<SVGElement> & {
   /**
    * Icon size
    */
-  size?: 'xs' | 's' | 'm' | 'l' | 'xl';
+  size?: IconSize;
   style?: CSSProperties;
 };

--- a/packages/react/src/icons/Icon.module.css
+++ b/packages/react/src/icons/Icon.module.css
@@ -3,22 +3,22 @@
   composes: hds-icon from 'hds-core/lib/icons/icon.css';
 }
 
-.xs {
+.extraSmall {
   composes: hds-icon--size-xs from 'hds-core/lib/icons/icon.css';
 }
 
-.s {
+.small {
   composes: hds-icon--size-s from 'hds-core/lib/icons/icon.css';
 }
 
-.m {
+.medium {
   composes: hds-icon--size-m from 'hds-core/lib/icons/icon.css';
 }
 
-.l {
+.large {
   composes: hds-icon--size-l from 'hds-core/lib/icons/icon.css';
 }
 
-.xl {
+.extraLarge {
   composes: hds-icon--size-xl from 'hds-core/lib/icons/icon.css';
 }

--- a/packages/react/src/icons/IconAlertCircle.tsx
+++ b/packages/react/src/icons/IconAlertCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAlertCircle = ({
   ariaLabel = 'alert-circle',
@@ -9,7 +9,7 @@ export const IconAlertCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconAlertCircleFill.tsx
+++ b/packages/react/src/icons/IconAlertCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAlertCircleFill = ({
   ariaLabel = 'alert-circle-fill',
@@ -9,7 +9,7 @@ export const IconAlertCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconAngleDown.tsx
+++ b/packages/react/src/icons/IconAngleDown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAngleDown = ({
   ariaLabel = 'angle-down',
@@ -9,7 +9,7 @@ export const IconAngleDown = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconAngleLeft.tsx
+++ b/packages/react/src/icons/IconAngleLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAngleLeft = ({
   ariaLabel = 'angle-left',
@@ -9,7 +9,7 @@ export const IconAngleLeft = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconAngleRight.tsx
+++ b/packages/react/src/icons/IconAngleRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAngleRight = ({
   ariaLabel = 'angle-right',
@@ -9,7 +9,7 @@ export const IconAngleRight = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconAngleUp.tsx
+++ b/packages/react/src/icons/IconAngleUp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAngleUp = ({
   ariaLabel = 'angle-up',
@@ -9,7 +9,7 @@ export const IconAngleUp = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowBottomLeft.tsx
+++ b/packages/react/src/icons/IconArrowBottomLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowBottomLeft = ({
   ariaLabel = 'arrow-bottom-left',
@@ -9,7 +9,7 @@ export const IconArrowBottomLeft = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowBottomRight.tsx
+++ b/packages/react/src/icons/IconArrowBottomRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowBottomRight = ({
   ariaLabel = 'arrow-bottom-right',
@@ -9,7 +9,7 @@ export const IconArrowBottomRight = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowDown.tsx
+++ b/packages/react/src/icons/IconArrowDown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowDown = ({
   ariaLabel = 'arrow-down',
@@ -9,7 +9,7 @@ export const IconArrowDown = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowLeft.tsx
+++ b/packages/react/src/icons/IconArrowLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowLeft = ({
   ariaLabel = 'arrow-left',
@@ -9,7 +9,7 @@ export const IconArrowLeft = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowRedo.tsx
+++ b/packages/react/src/icons/IconArrowRedo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowRedo = ({
   ariaLabel = 'arrow-redo',
@@ -9,7 +9,7 @@ export const IconArrowRedo = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowRight.tsx
+++ b/packages/react/src/icons/IconArrowRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowRight = ({
   ariaLabel = 'arrow-right',
@@ -9,7 +9,7 @@ export const IconArrowRight = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowRightDashed.tsx
+++ b/packages/react/src/icons/IconArrowRightDashed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowRightDashed = ({
   ariaLabel = 'arrow-right-dashed',
@@ -9,7 +9,7 @@ export const IconArrowRightDashed = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowTopLeft.tsx
+++ b/packages/react/src/icons/IconArrowTopLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowTopLeft = ({
   ariaLabel = 'arrow-top-left',
@@ -9,7 +9,7 @@ export const IconArrowTopLeft = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowTopRight.tsx
+++ b/packages/react/src/icons/IconArrowTopRight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowTopRight = ({
   ariaLabel = 'arrow-top-right',
@@ -9,7 +9,7 @@ export const IconArrowTopRight = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowUndo.tsx
+++ b/packages/react/src/icons/IconArrowUndo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowUndo = ({
   ariaLabel = 'arrow-undo',
@@ -9,7 +9,7 @@ export const IconArrowUndo = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconArrowUp.tsx
+++ b/packages/react/src/icons/IconArrowUp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconArrowUp = ({
   ariaLabel = 'arrow-up',
@@ -9,7 +9,7 @@ export const IconArrowUp = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconAtSign.tsx
+++ b/packages/react/src/icons/IconAtSign.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconAtSign = ({
   ariaLabel = 'at-sign',
@@ -9,7 +9,7 @@ export const IconAtSign = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconBagCogwheel.tsx
+++ b/packages/react/src/icons/IconBagCogwheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconBagCogwheel = ({
   ariaLabel = 'bag-cogwheel',
@@ -9,7 +9,7 @@ export const IconBagCogwheel = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconBell.tsx
+++ b/packages/react/src/icons/IconBell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconBell = ({
   ariaLabel = 'bell',
@@ -9,7 +9,7 @@ export const IconBell = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconBellCrossed.tsx
+++ b/packages/react/src/icons/IconBellCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconBellCrossed = ({
   ariaLabel = 'bell-crossed',
@@ -9,7 +9,7 @@ export const IconBellCrossed = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconBinoculars.tsx
+++ b/packages/react/src/icons/IconBinoculars.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconBinoculars = ({
   ariaLabel = 'binoculars',
@@ -9,7 +9,7 @@ export const IconBinoculars = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconBox.tsx
+++ b/packages/react/src/icons/IconBox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconBox = ({
   ariaLabel = 'box',
@@ -9,7 +9,7 @@ export const IconBox = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCake.tsx
+++ b/packages/react/src/icons/IconCake.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCake = ({
   ariaLabel = 'cake',
@@ -9,7 +9,7 @@ export const IconCake = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCalendar.tsx
+++ b/packages/react/src/icons/IconCalendar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCalendar = ({
   ariaLabel = 'calendar',
@@ -9,7 +9,7 @@ export const IconCalendar = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCalendarClock.tsx
+++ b/packages/react/src/icons/IconCalendarClock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCalendarClock = ({
   ariaLabel = 'calendar-clock',
@@ -9,7 +9,7 @@ export const IconCalendarClock = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCalendarCross.tsx
+++ b/packages/react/src/icons/IconCalendarCross.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCalendarCross = ({
   ariaLabel = 'calendar-cross',
@@ -9,7 +9,7 @@ export const IconCalendarCross = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCalendarEvent.tsx
+++ b/packages/react/src/icons/IconCalendarEvent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCalendarEvent = ({
   ariaLabel = 'calendar-event',
@@ -9,7 +9,7 @@ export const IconCalendarEvent = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCalendarPlus.tsx
+++ b/packages/react/src/icons/IconCalendarPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCalendarPlus = ({
   ariaLabel = 'calendar-plus',
@@ -9,7 +9,7 @@ export const IconCalendarPlus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCalendarRecurring.tsx
+++ b/packages/react/src/icons/IconCalendarRecurring.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCalendarRecurring = ({
   ariaLabel = 'calendar-recurring',
@@ -9,7 +9,7 @@ export const IconCalendarRecurring = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCamera.tsx
+++ b/packages/react/src/icons/IconCamera.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCamera = ({
   ariaLabel = 'camera',
@@ -9,7 +9,7 @@ export const IconCamera = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCheck.tsx
+++ b/packages/react/src/icons/IconCheck.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCheck = ({
   ariaLabel = 'check',
@@ -9,7 +9,7 @@ export const IconCheck = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCheckCircle.tsx
+++ b/packages/react/src/icons/IconCheckCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCheckCircle = ({
   ariaLabel = 'check-circle',
@@ -9,7 +9,7 @@ export const IconCheckCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCheckCircleFill.tsx
+++ b/packages/react/src/icons/IconCheckCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCheckCircleFill = ({
   ariaLabel = 'check-circle-fill',
@@ -9,7 +9,7 @@ export const IconCheckCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconChildren.tsx
+++ b/packages/react/src/icons/IconChildren.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconChildren = ({
   ariaLabel = 'children',
@@ -9,7 +9,7 @@ export const IconChildren = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconClock.tsx
+++ b/packages/react/src/icons/IconClock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconClock = ({
   ariaLabel = 'clock',
@@ -9,7 +9,7 @@ export const IconClock = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconClockCross.tsx
+++ b/packages/react/src/icons/IconClockCross.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconClockCross = ({
   ariaLabel = 'clock-cross',
@@ -9,7 +9,7 @@ export const IconClockCross = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconClockPlus.tsx
+++ b/packages/react/src/icons/IconClockPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconClockPlus = ({
   ariaLabel = 'clock-plus',
@@ -9,7 +9,7 @@ export const IconClockPlus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCoffeeCupSaucer.tsx
+++ b/packages/react/src/icons/IconCoffeeCupSaucer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCoffeeCupSaucer = ({
   ariaLabel = 'coffee-cup-saucer',
@@ -9,7 +9,7 @@ export const IconCoffeeCupSaucer = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCogwheel.tsx
+++ b/packages/react/src/icons/IconCogwheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCogwheel = ({
   ariaLabel = 'cogwheel',
@@ -9,7 +9,7 @@ export const IconCogwheel = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCogwheels.tsx
+++ b/packages/react/src/icons/IconCogwheels.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCogwheels = ({
   ariaLabel = 'cogwheels',
@@ -9,7 +9,7 @@ export const IconCogwheels = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCollapse.tsx
+++ b/packages/react/src/icons/IconCollapse.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCollapse = ({
   ariaLabel = 'collapse',
@@ -9,7 +9,7 @@ export const IconCollapse = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCompany.tsx
+++ b/packages/react/src/icons/IconCompany.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCompany = ({
   ariaLabel = 'company',
@@ -9,7 +9,7 @@ export const IconCompany = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCopy.tsx
+++ b/packages/react/src/icons/IconCopy.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCopy = ({
   ariaLabel = 'copy',
@@ -9,7 +9,7 @@ export const IconCopy = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCross.tsx
+++ b/packages/react/src/icons/IconCross.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCross = ({
   ariaLabel = 'cross',
@@ -9,7 +9,7 @@ export const IconCross = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCrossCircle.tsx
+++ b/packages/react/src/icons/IconCrossCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCrossCircle = ({
   ariaLabel = 'cross-circle',
@@ -9,7 +9,7 @@ export const IconCrossCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCrossCircleFill.tsx
+++ b/packages/react/src/icons/IconCrossCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCrossCircleFill = ({
   ariaLabel = 'cross-circle-fill',
@@ -9,7 +9,7 @@ export const IconCrossCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCustomerBotNegative.tsx
+++ b/packages/react/src/icons/IconCustomerBotNegative.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCustomerBotNegative = ({
   ariaLabel = 'customer-bot-negative',
@@ -9,7 +9,7 @@ export const IconCustomerBotNegative = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCustomerBotNeutral.tsx
+++ b/packages/react/src/icons/IconCustomerBotNeutral.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCustomerBotNeutral = ({
   ariaLabel = 'customer-bot-neutral',
@@ -9,7 +9,7 @@ export const IconCustomerBotNeutral = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconCustomerBotPositive.tsx
+++ b/packages/react/src/icons/IconCustomerBotPositive.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconCustomerBotPositive = ({
   ariaLabel = 'customer-bot-positive',
@@ -9,7 +9,7 @@ export const IconCustomerBotPositive = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDiscord.tsx
+++ b/packages/react/src/icons/IconDiscord.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDiscord = ({
   ariaLabel = 'discord',
@@ -9,7 +9,7 @@ export const IconDiscord = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDisplay.tsx
+++ b/packages/react/src/icons/IconDisplay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDisplay = ({
   ariaLabel = 'display',
@@ -9,7 +9,7 @@ export const IconDisplay = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDocument.tsx
+++ b/packages/react/src/icons/IconDocument.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDocument = ({
   ariaLabel = 'document',
@@ -9,7 +9,7 @@ export const IconDocument = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDocumentBlank.tsx
+++ b/packages/react/src/icons/IconDocumentBlank.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDocumentBlank = ({
   ariaLabel = 'document-blank',
@@ -9,7 +9,7 @@ export const IconDocumentBlank = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDocumentBlankGroup.tsx
+++ b/packages/react/src/icons/IconDocumentBlankGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDocumentBlankGroup = ({
   ariaLabel = 'document-blank-group',
@@ -9,7 +9,7 @@ export const IconDocumentBlankGroup = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDocumentGroup.tsx
+++ b/packages/react/src/icons/IconDocumentGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDocumentGroup = ({
   ariaLabel = 'document-group',
@@ -9,7 +9,7 @@ export const IconDocumentGroup = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDownload.tsx
+++ b/packages/react/src/icons/IconDownload.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDownload = ({
   ariaLabel = 'download',
@@ -9,7 +9,7 @@ export const IconDownload = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDownloadCloud.tsx
+++ b/packages/react/src/icons/IconDownloadCloud.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDownloadCloud = ({
   ariaLabel = 'download-cloud',
@@ -9,7 +9,7 @@ export const IconDownloadCloud = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconDrag.tsx
+++ b/packages/react/src/icons/IconDrag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconDrag = ({
   ariaLabel = 'drag',
@@ -9,7 +9,7 @@ export const IconDrag = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconEntrepreneur.tsx
+++ b/packages/react/src/icons/IconEntrepreneur.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconEntrepreneur = ({
   ariaLabel = 'entrepreneur',
@@ -9,7 +9,7 @@ export const IconEntrepreneur = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconEnvelope.tsx
+++ b/packages/react/src/icons/IconEnvelope.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconEnvelope = ({
   ariaLabel = 'envelope',
@@ -9,7 +9,7 @@ export const IconEnvelope = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconError.tsx
+++ b/packages/react/src/icons/IconError.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconError = ({
   ariaLabel = 'error',
@@ -9,7 +9,7 @@ export const IconError = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconErrorFill.tsx
+++ b/packages/react/src/icons/IconErrorFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconErrorFill = ({
   ariaLabel = 'error-fill',
@@ -9,7 +9,7 @@ export const IconErrorFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconEuroSign.tsx
+++ b/packages/react/src/icons/IconEuroSign.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconEuroSign = ({
   ariaLabel = 'euro-sign',
@@ -9,7 +9,7 @@ export const IconEuroSign = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconEye.tsx
+++ b/packages/react/src/icons/IconEye.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconEye = ({
   ariaLabel = 'eye',
@@ -9,7 +9,7 @@ export const IconEye = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconEyeCrossed.tsx
+++ b/packages/react/src/icons/IconEyeCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconEyeCrossed = ({
   ariaLabel = 'eye-crossed',
@@ -9,7 +9,7 @@ export const IconEyeCrossed = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFaceNeutral.tsx
+++ b/packages/react/src/icons/IconFaceNeutral.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFaceNeutral = ({
   ariaLabel = 'face-neutral',
@@ -9,7 +9,7 @@ export const IconFaceNeutral = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFaceSad.tsx
+++ b/packages/react/src/icons/IconFaceSad.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFaceSad = ({
   ariaLabel = 'face-sad',
@@ -9,7 +9,7 @@ export const IconFaceSad = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFaceSmile.tsx
+++ b/packages/react/src/icons/IconFaceSmile.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFaceSmile = ({
   ariaLabel = 'face-smile',
@@ -9,7 +9,7 @@ export const IconFaceSmile = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFacebook.tsx
+++ b/packages/react/src/icons/IconFacebook.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFacebook = ({
   ariaLabel = 'facebook',
@@ -9,7 +9,7 @@ export const IconFacebook = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFamily.tsx
+++ b/packages/react/src/icons/IconFamily.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFamily = ({
   ariaLabel = 'family',
@@ -9,7 +9,7 @@ export const IconFamily = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFolder.tsx
+++ b/packages/react/src/icons/IconFolder.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFolder = ({
   ariaLabel = 'folder',
@@ -9,7 +9,7 @@ export const IconFolder = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconFolderGroup.tsx
+++ b/packages/react/src/icons/IconFolderGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconFolderGroup = ({
   ariaLabel = 'folder-group',
@@ -9,7 +9,7 @@ export const IconFolderGroup = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconGlobe.tsx
+++ b/packages/react/src/icons/IconGlobe.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconGlobe = ({
   ariaLabel = 'globe',
@@ -9,7 +9,7 @@ export const IconGlobe = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconGoogle.tsx
+++ b/packages/react/src/icons/IconGoogle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconGoogle = ({
   ariaLabel = 'google',
@@ -9,7 +9,7 @@ export const IconGoogle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconGraphColumns.tsx
+++ b/packages/react/src/icons/IconGraphColumns.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconGraphColumns = ({
   ariaLabel = 'graph-columns',
@@ -9,7 +9,7 @@ export const IconGraphColumns = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconGroup.tsx
+++ b/packages/react/src/icons/IconGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconGroup = ({
   ariaLabel = 'group',
@@ -9,7 +9,7 @@ export const IconGroup = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHammers.tsx
+++ b/packages/react/src/icons/IconHammers.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHammers = ({
   ariaLabel = 'hammers',
@@ -9,7 +9,7 @@ export const IconHammers = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHeadphones.tsx
+++ b/packages/react/src/icons/IconHeadphones.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHeadphones = ({
   ariaLabel = 'headphones',
@@ -9,7 +9,7 @@ export const IconHeadphones = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHeart.tsx
+++ b/packages/react/src/icons/IconHeart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHeart = ({
   ariaLabel = 'heart',
@@ -9,7 +9,7 @@ export const IconHeart = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHeartFill.tsx
+++ b/packages/react/src/icons/IconHeartFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHeartFill = ({
   ariaLabel = 'heart-fill',
@@ -9,7 +9,7 @@ export const IconHeartFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHistory.tsx
+++ b/packages/react/src/icons/IconHistory.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHistory = ({
   ariaLabel = 'history',
@@ -9,7 +9,7 @@ export const IconHistory = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHome.tsx
+++ b/packages/react/src/icons/IconHome.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHome = ({
   ariaLabel = 'home',
@@ -9,7 +9,7 @@ export const IconHome = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconHomeSmoke.tsx
+++ b/packages/react/src/icons/IconHomeSmoke.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconHomeSmoke = ({
   ariaLabel = 'home-smoke',
@@ -9,7 +9,7 @@ export const IconHomeSmoke = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconInfoCircle.tsx
+++ b/packages/react/src/icons/IconInfoCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconInfoCircle = ({
   ariaLabel = 'info-circle',
@@ -9,7 +9,7 @@ export const IconInfoCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconInfoCircleFill.tsx
+++ b/packages/react/src/icons/IconInfoCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconInfoCircleFill = ({
   ariaLabel = 'info-circle-fill',
@@ -9,7 +9,7 @@ export const IconInfoCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconInstagram.tsx
+++ b/packages/react/src/icons/IconInstagram.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconInstagram = ({
   ariaLabel = 'instagram',
@@ -9,7 +9,7 @@ export const IconInstagram = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconKey.tsx
+++ b/packages/react/src/icons/IconKey.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconKey = ({
   ariaLabel = 'key',
@@ -9,7 +9,7 @@ export const IconKey = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLayers.tsx
+++ b/packages/react/src/icons/IconLayers.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLayers = ({
   ariaLabel = 'layers',
@@ -9,7 +9,7 @@ export const IconLayers = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLightbulb.tsx
+++ b/packages/react/src/icons/IconLightbulb.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLightbulb = ({
   ariaLabel = 'lightbulb',
@@ -9,7 +9,7 @@ export const IconLightbulb = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLink.tsx
+++ b/packages/react/src/icons/IconLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLink = ({
   ariaLabel = 'link',
@@ -9,7 +9,7 @@ export const IconLink = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLinkExternal.tsx
+++ b/packages/react/src/icons/IconLinkExternal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLinkExternal = ({
   ariaLabel = 'link-external',
@@ -9,7 +9,7 @@ export const IconLinkExternal = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLinkedin.tsx
+++ b/packages/react/src/icons/IconLinkedin.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLinkedin = ({
   ariaLabel = 'linkedin',
@@ -9,7 +9,7 @@ export const IconLinkedin = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLocate.tsx
+++ b/packages/react/src/icons/IconLocate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLocate = ({
   ariaLabel = 'locate',
@@ -9,7 +9,7 @@ export const IconLocate = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLocation.tsx
+++ b/packages/react/src/icons/IconLocation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLocation = ({
   ariaLabel = 'location',
@@ -9,7 +9,7 @@ export const IconLocation = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLock.tsx
+++ b/packages/react/src/icons/IconLock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLock = ({
   ariaLabel = 'lock',
@@ -9,7 +9,7 @@ export const IconLock = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconLockOpen.tsx
+++ b/packages/react/src/icons/IconLockOpen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconLockOpen = ({
   ariaLabel = 'lock-open',
@@ -9,7 +9,7 @@ export const IconLockOpen = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMap.tsx
+++ b/packages/react/src/icons/IconMap.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMap = ({
   ariaLabel = 'map',
@@ -9,7 +9,7 @@ export const IconMap = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMenuDots.tsx
+++ b/packages/react/src/icons/IconMenuDots.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMenuDots = ({
   ariaLabel = 'menu-dots',
@@ -9,7 +9,7 @@ export const IconMenuDots = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMenuHamburger.tsx
+++ b/packages/react/src/icons/IconMenuHamburger.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMenuHamburger = ({
   ariaLabel = 'menu-hamburger',
@@ -9,7 +9,7 @@ export const IconMenuHamburger = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMicrophone.tsx
+++ b/packages/react/src/icons/IconMicrophone.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMicrophone = ({
   ariaLabel = 'microphone',
@@ -9,7 +9,7 @@ export const IconMicrophone = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMicrophoneCrossed.tsx
+++ b/packages/react/src/icons/IconMicrophoneCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMicrophoneCrossed = ({
   ariaLabel = 'microphone-crossed',
@@ -9,7 +9,7 @@ export const IconMicrophoneCrossed = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMinus.tsx
+++ b/packages/react/src/icons/IconMinus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMinus = ({
   ariaLabel = 'minus',
@@ -9,7 +9,7 @@ export const IconMinus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMinusCircle.tsx
+++ b/packages/react/src/icons/IconMinusCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMinusCircle = ({
   ariaLabel = 'minus-circle',
@@ -9,7 +9,7 @@ export const IconMinusCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMinusCircleFill.tsx
+++ b/packages/react/src/icons/IconMinusCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMinusCircleFill = ({
   ariaLabel = 'minus-circle-fill',
@@ -9,7 +9,7 @@ export const IconMinusCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMobile.tsx
+++ b/packages/react/src/icons/IconMobile.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMobile = ({
   ariaLabel = 'mobile',
@@ -9,7 +9,7 @@ export const IconMobile = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMoneyBag.tsx
+++ b/packages/react/src/icons/IconMoneyBag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMoneyBag = ({
   ariaLabel = 'money-bag',
@@ -9,7 +9,7 @@ export const IconMoneyBag = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMoneyBagFill.tsx
+++ b/packages/react/src/icons/IconMoneyBagFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMoneyBagFill = ({
   ariaLabel = 'money-bag-fill',
@@ -9,7 +9,7 @@ export const IconMoneyBagFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconMover.tsx
+++ b/packages/react/src/icons/IconMover.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconMover = ({
   ariaLabel = 'mover',
@@ -9,7 +9,7 @@ export const IconMover = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconOccupation.tsx
+++ b/packages/react/src/icons/IconOccupation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconOccupation = ({
   ariaLabel = 'occupation',
@@ -9,7 +9,7 @@ export const IconOccupation = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPaperclip.tsx
+++ b/packages/react/src/icons/IconPaperclip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPaperclip = ({
   ariaLabel = 'paperclip',
@@ -9,7 +9,7 @@ export const IconPaperclip = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPen.tsx
+++ b/packages/react/src/icons/IconPen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPen = ({
   ariaLabel = 'pen',
@@ -9,7 +9,7 @@ export const IconPen = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPenLine.tsx
+++ b/packages/react/src/icons/IconPenLine.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPenLine = ({
   ariaLabel = 'pen-line',
@@ -9,7 +9,7 @@ export const IconPenLine = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPersonFemale.tsx
+++ b/packages/react/src/icons/IconPersonFemale.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPersonFemale = ({
   ariaLabel = 'person-female',
@@ -9,7 +9,7 @@ export const IconPersonFemale = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPersonGenderless.tsx
+++ b/packages/react/src/icons/IconPersonGenderless.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPersonGenderless = ({
   ariaLabel = 'person-genderless',
@@ -9,7 +9,7 @@ export const IconPersonGenderless = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPersonMale.tsx
+++ b/packages/react/src/icons/IconPersonMale.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPersonMale = ({
   ariaLabel = 'person-male',
@@ -9,7 +9,7 @@ export const IconPersonMale = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPersonWheelchair.tsx
+++ b/packages/react/src/icons/IconPersonWheelchair.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPersonWheelchair = ({
   ariaLabel = 'person-wheelchair',
@@ -9,7 +9,7 @@ export const IconPersonWheelchair = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPhone.tsx
+++ b/packages/react/src/icons/IconPhone.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPhone = ({
   ariaLabel = 'phone',
@@ -9,7 +9,7 @@ export const IconPhone = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPhoto.tsx
+++ b/packages/react/src/icons/IconPhoto.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPhoto = ({
   ariaLabel = 'photo',
@@ -9,7 +9,7 @@ export const IconPhoto = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPhotoPlus.tsx
+++ b/packages/react/src/icons/IconPhotoPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPhotoPlus = ({
   ariaLabel = 'photo-plus',
@@ -9,7 +9,7 @@ export const IconPhotoPlus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackFastforward.tsx
+++ b/packages/react/src/icons/IconPlaybackFastforward.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackFastforward = ({
   ariaLabel = 'playback-fastforward',
@@ -9,7 +9,7 @@ export const IconPlaybackFastforward = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackNext.tsx
+++ b/packages/react/src/icons/IconPlaybackNext.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackNext = ({
   ariaLabel = 'playback-next',
@@ -9,7 +9,7 @@ export const IconPlaybackNext = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackPause.tsx
+++ b/packages/react/src/icons/IconPlaybackPause.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackPause = ({
   ariaLabel = 'playback-pause',
@@ -9,7 +9,7 @@ export const IconPlaybackPause = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackPlay.tsx
+++ b/packages/react/src/icons/IconPlaybackPlay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackPlay = ({
   ariaLabel = 'playback-play',
@@ -9,7 +9,7 @@ export const IconPlaybackPlay = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackPrevious.tsx
+++ b/packages/react/src/icons/IconPlaybackPrevious.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackPrevious = ({
   ariaLabel = 'playback-previous',
@@ -9,7 +9,7 @@ export const IconPlaybackPrevious = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackRecord.tsx
+++ b/packages/react/src/icons/IconPlaybackRecord.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackRecord = ({
   ariaLabel = 'playback-record',
@@ -9,7 +9,7 @@ export const IconPlaybackRecord = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackRewind.tsx
+++ b/packages/react/src/icons/IconPlaybackRewind.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackRewind = ({
   ariaLabel = 'playback-rewind',
@@ -9,7 +9,7 @@ export const IconPlaybackRewind = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlaybackStop.tsx
+++ b/packages/react/src/icons/IconPlaybackStop.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlaybackStop = ({
   ariaLabel = 'playback-stop',
@@ -9,7 +9,7 @@ export const IconPlaybackStop = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlus.tsx
+++ b/packages/react/src/icons/IconPlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlus = ({
   ariaLabel = 'plus',
@@ -9,7 +9,7 @@ export const IconPlus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlusCircle.tsx
+++ b/packages/react/src/icons/IconPlusCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlusCircle = ({
   ariaLabel = 'plus-circle',
@@ -9,7 +9,7 @@ export const IconPlusCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPlusCircleFill.tsx
+++ b/packages/react/src/icons/IconPlusCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPlusCircleFill = ({
   ariaLabel = 'plus-circle-fill',
@@ -9,7 +9,7 @@ export const IconPlusCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPodcast.tsx
+++ b/packages/react/src/icons/IconPodcast.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPodcast = ({
   ariaLabel = 'podcast',
@@ -9,7 +9,7 @@ export const IconPodcast = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconPrinter.tsx
+++ b/packages/react/src/icons/IconPrinter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconPrinter = ({
   ariaLabel = 'printer',
@@ -9,7 +9,7 @@ export const IconPrinter = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconQuestionCircle.tsx
+++ b/packages/react/src/icons/IconQuestionCircle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconQuestionCircle = ({
   ariaLabel = 'question-circle',
@@ -9,7 +9,7 @@ export const IconQuestionCircle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconQuestionCircleFill.tsx
+++ b/packages/react/src/icons/IconQuestionCircleFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconQuestionCircleFill = ({
   ariaLabel = 'question-circle-fill',
@@ -9,7 +9,7 @@ export const IconQuestionCircleFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconRefresh.tsx
+++ b/packages/react/src/icons/IconRefresh.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconRefresh = ({
   ariaLabel = 'refresh',
@@ -9,7 +9,7 @@ export const IconRefresh = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconRestaurant.tsx
+++ b/packages/react/src/icons/IconRestaurant.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconRestaurant = ({
   ariaLabel = 'restaurant',
@@ -9,7 +9,7 @@ export const IconRestaurant = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconRss.tsx
+++ b/packages/react/src/icons/IconRss.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconRss = ({
   ariaLabel = 'rss',
@@ -9,7 +9,7 @@ export const IconRss = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSaveDiskette.tsx
+++ b/packages/react/src/icons/IconSaveDiskette.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSaveDiskette = ({
   ariaLabel = 'save-diskette',
@@ -9,7 +9,7 @@ export const IconSaveDiskette = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSaveDisketteFill.tsx
+++ b/packages/react/src/icons/IconSaveDisketteFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSaveDisketteFill = ({
   ariaLabel = 'save-diskette-fill',
@@ -9,7 +9,7 @@ export const IconSaveDisketteFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconScroll.tsx
+++ b/packages/react/src/icons/IconScroll.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconScroll = ({
   ariaLabel = 'scroll',
@@ -9,7 +9,7 @@ export const IconScroll = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconScrollCogwheel.tsx
+++ b/packages/react/src/icons/IconScrollCogwheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconScrollCogwheel = ({
   ariaLabel = 'scroll-cogwheel',
@@ -9,7 +9,7 @@ export const IconScrollCogwheel = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconScrollContent.tsx
+++ b/packages/react/src/icons/IconScrollContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconScrollContent = ({
   ariaLabel = 'scroll-content',
@@ -9,7 +9,7 @@ export const IconScrollContent = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconScrollGroup.tsx
+++ b/packages/react/src/icons/IconScrollGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconScrollGroup = ({
   ariaLabel = 'scroll-group',
@@ -9,7 +9,7 @@ export const IconScrollGroup = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSearch.tsx
+++ b/packages/react/src/icons/IconSearch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSearch = ({
   ariaLabel = 'search',
@@ -9,7 +9,7 @@ export const IconSearch = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSenior.tsx
+++ b/packages/react/src/icons/IconSenior.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSenior = ({
   ariaLabel = 'senior',
@@ -9,7 +9,7 @@ export const IconSenior = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconShare.tsx
+++ b/packages/react/src/icons/IconShare.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconShare = ({
   ariaLabel = 'share',
@@ -9,7 +9,7 @@ export const IconShare = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconShield.tsx
+++ b/packages/react/src/icons/IconShield.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconShield = ({
   ariaLabel = 'shield',
@@ -9,7 +9,7 @@ export const IconShield = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconShoppingCart.tsx
+++ b/packages/react/src/icons/IconShoppingCart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconShoppingCart = ({
   ariaLabel = 'shopping-cart',
@@ -9,7 +9,7 @@ export const IconShoppingCart = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSignin.tsx
+++ b/packages/react/src/icons/IconSignin.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSignin = ({
   ariaLabel = 'signin',
@@ -9,7 +9,7 @@ export const IconSignin = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSignout.tsx
+++ b/packages/react/src/icons/IconSignout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSignout = ({
   ariaLabel = 'signout',
@@ -9,7 +9,7 @@ export const IconSignout = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSitemap.tsx
+++ b/packages/react/src/icons/IconSitemap.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSitemap = ({
   ariaLabel = 'sitemap',
@@ -9,7 +9,7 @@ export const IconSitemap = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSliders.tsx
+++ b/packages/react/src/icons/IconSliders.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSliders = ({
   ariaLabel = 'sliders',
@@ -9,7 +9,7 @@ export const IconSliders = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSnapchat.tsx
+++ b/packages/react/src/icons/IconSnapchat.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSnapchat = ({
   ariaLabel = 'snapchat',
@@ -9,7 +9,7 @@ export const IconSnapchat = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSort.tsx
+++ b/packages/react/src/icons/IconSort.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSort = ({
   ariaLabel = 'sort',
@@ -9,7 +9,7 @@ export const IconSort = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSortAlphabeticalAscending.tsx
+++ b/packages/react/src/icons/IconSortAlphabeticalAscending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSortAlphabeticalAscending = ({
   ariaLabel = 'sort-alphabetical-ascending',
@@ -9,7 +9,7 @@ export const IconSortAlphabeticalAscending = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSortAlphabeticalDescending.tsx
+++ b/packages/react/src/icons/IconSortAlphabeticalDescending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSortAlphabeticalDescending = ({
   ariaLabel = 'sort-alphabetical-descending',
@@ -9,7 +9,7 @@ export const IconSortAlphabeticalDescending = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSortAscending.tsx
+++ b/packages/react/src/icons/IconSortAscending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSortAscending = ({
   ariaLabel = 'sort-ascending',
@@ -9,7 +9,7 @@ export const IconSortAscending = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSortDescending.tsx
+++ b/packages/react/src/icons/IconSortDescending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSortDescending = ({
   ariaLabel = 'sort-descending',
@@ -9,7 +9,7 @@ export const IconSortDescending = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSpeechbubble.tsx
+++ b/packages/react/src/icons/IconSpeechbubble.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSpeechbubble = ({
   ariaLabel = 'speechbubble',
@@ -9,7 +9,7 @@ export const IconSpeechbubble = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSpeechbubbleText.tsx
+++ b/packages/react/src/icons/IconSpeechbubbleText.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSpeechbubbleText = ({
   ariaLabel = 'speechbubble-text',
@@ -9,7 +9,7 @@ export const IconSpeechbubbleText = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconStar.tsx
+++ b/packages/react/src/icons/IconStar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconStar = ({
   ariaLabel = 'star',
@@ -9,7 +9,7 @@ export const IconStar = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconStarFill.tsx
+++ b/packages/react/src/icons/IconStarFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconStarFill = ({
   ariaLabel = 'star-fill',
@@ -9,7 +9,7 @@ export const IconStarFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconSwapUser.tsx
+++ b/packages/react/src/icons/IconSwapUser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconSwapUser = ({
   ariaLabel = 'swap-user',
@@ -9,7 +9,7 @@ export const IconSwapUser = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTextBold.tsx
+++ b/packages/react/src/icons/IconTextBold.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTextBold = ({
   ariaLabel = 'text-bold',
@@ -9,7 +9,7 @@ export const IconTextBold = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTextItalic.tsx
+++ b/packages/react/src/icons/IconTextItalic.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTextItalic = ({
   ariaLabel = 'text-italic',
@@ -9,7 +9,7 @@ export const IconTextItalic = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTextTool.tsx
+++ b/packages/react/src/icons/IconTextTool.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTextTool = ({
   ariaLabel = 'text-tool',
@@ -9,7 +9,7 @@ export const IconTextTool = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconThumbsDown.tsx
+++ b/packages/react/src/icons/IconThumbsDown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconThumbsDown = ({
   ariaLabel = 'thumbs-down',
@@ -9,7 +9,7 @@ export const IconThumbsDown = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconThumbsDownFill.tsx
+++ b/packages/react/src/icons/IconThumbsDownFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconThumbsDownFill = ({
   ariaLabel = 'thumbs-down-fill',
@@ -9,7 +9,7 @@ export const IconThumbsDownFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconThumbsUp.tsx
+++ b/packages/react/src/icons/IconThumbsUp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconThumbsUp = ({
   ariaLabel = 'thumbs-up',
@@ -9,7 +9,7 @@ export const IconThumbsUp = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconThumbsUpFill.tsx
+++ b/packages/react/src/icons/IconThumbsUpFill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconThumbsUpFill = ({
   ariaLabel = 'thumbs-up-fill',
@@ -9,7 +9,7 @@ export const IconThumbsUpFill = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTicket.tsx
+++ b/packages/react/src/icons/IconTicket.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTicket = ({
   ariaLabel = 'ticket',
@@ -9,7 +9,7 @@ export const IconTicket = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTiktok.tsx
+++ b/packages/react/src/icons/IconTiktok.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTiktok = ({
   ariaLabel = 'tiktok',
@@ -9,7 +9,7 @@ export const IconTiktok = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTrash.tsx
+++ b/packages/react/src/icons/IconTrash.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTrash = ({
   ariaLabel = 'trash',
@@ -9,7 +9,7 @@ export const IconTrash = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTraveler.tsx
+++ b/packages/react/src/icons/IconTraveler.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTraveler = ({
   ariaLabel = 'traveler',
@@ -9,7 +9,7 @@ export const IconTraveler = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTwitch.tsx
+++ b/packages/react/src/icons/IconTwitch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTwitch = ({
   ariaLabel = 'twitch',
@@ -9,7 +9,7 @@ export const IconTwitch = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconTwitter.tsx
+++ b/packages/react/src/icons/IconTwitter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconTwitter = ({
   ariaLabel = 'twitter',
@@ -9,7 +9,7 @@ export const IconTwitter = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconUpload.tsx
+++ b/packages/react/src/icons/IconUpload.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconUpload = ({
   ariaLabel = 'upload',
@@ -9,7 +9,7 @@ export const IconUpload = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconUploadCloud.tsx
+++ b/packages/react/src/icons/IconUploadCloud.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconUploadCloud = ({
   ariaLabel = 'upload-cloud',
@@ -9,7 +9,7 @@ export const IconUploadCloud = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconUser.tsx
+++ b/packages/react/src/icons/IconUser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconUser = ({
   ariaLabel = 'user',
@@ -9,7 +9,7 @@ export const IconUser = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVaccine.tsx
+++ b/packages/react/src/icons/IconVaccine.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVaccine = ({
   ariaLabel = 'vaccine',
@@ -9,7 +9,7 @@ export const IconVaccine = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVideocamera.tsx
+++ b/packages/react/src/icons/IconVideocamera.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVideocamera = ({
   ariaLabel = 'videocamera',
@@ -9,7 +9,7 @@ export const IconVideocamera = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVideocameraCrossed.tsx
+++ b/packages/react/src/icons/IconVideocameraCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVideocameraCrossed = ({
   ariaLabel = 'videocamera-crossed',
@@ -9,7 +9,7 @@ export const IconVideocameraCrossed = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVimeo.tsx
+++ b/packages/react/src/icons/IconVimeo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVimeo = ({
   ariaLabel = 'vimeo',
@@ -9,7 +9,7 @@ export const IconVimeo = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVirus.tsx
+++ b/packages/react/src/icons/IconVirus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVirus = ({
   ariaLabel = 'virus',
@@ -9,7 +9,7 @@ export const IconVirus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVolumeHigh.tsx
+++ b/packages/react/src/icons/IconVolumeHigh.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVolumeHigh = ({
   ariaLabel = 'volume-high',
@@ -9,7 +9,7 @@ export const IconVolumeHigh = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVolumeLow.tsx
+++ b/packages/react/src/icons/IconVolumeLow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVolumeLow = ({
   ariaLabel = 'volume-low',
@@ -9,7 +9,7 @@ export const IconVolumeLow = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVolumeMinus.tsx
+++ b/packages/react/src/icons/IconVolumeMinus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVolumeMinus = ({
   ariaLabel = 'volume-minus',
@@ -9,7 +9,7 @@ export const IconVolumeMinus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVolumeMute.tsx
+++ b/packages/react/src/icons/IconVolumeMute.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVolumeMute = ({
   ariaLabel = 'volume-mute',
@@ -9,7 +9,7 @@ export const IconVolumeMute = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconVolumePlus.tsx
+++ b/packages/react/src/icons/IconVolumePlus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconVolumePlus = ({
   ariaLabel = 'volume-plus',
@@ -9,7 +9,7 @@ export const IconVolumePlus = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconWhatsapp.tsx
+++ b/packages/react/src/icons/IconWhatsapp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconWhatsapp = ({
   ariaLabel = 'whatsapp',
@@ -9,7 +9,7 @@ export const IconWhatsapp = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconWifi.tsx
+++ b/packages/react/src/icons/IconWifi.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconWifi = ({
   ariaLabel = 'wifi',
@@ -9,7 +9,7 @@ export const IconWifi = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconWifiCrossed.tsx
+++ b/packages/react/src/icons/IconWifiCrossed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconWifiCrossed = ({
   ariaLabel = 'wifi-crossed',
@@ -9,7 +9,7 @@ export const IconWifiCrossed = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconX.tsx
+++ b/packages/react/src/icons/IconX.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconX = ({
   ariaLabel = 'x',
@@ -9,7 +9,7 @@ export const IconX = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconYle.tsx
+++ b/packages/react/src/icons/IconYle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconYle = ({
   ariaLabel = 'yle',
@@ -9,7 +9,7 @@ export const IconYle = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconYouth.tsx
+++ b/packages/react/src/icons/IconYouth.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconYouth = ({
   ariaLabel = 'youth',
@@ -9,7 +9,7 @@ export const IconYouth = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconYoutube.tsx
+++ b/packages/react/src/icons/IconYoutube.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconYoutube = ({
   ariaLabel = 'youtube',
@@ -9,7 +9,7 @@ export const IconYoutube = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconZoomIn.tsx
+++ b/packages/react/src/icons/IconZoomIn.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconZoomIn = ({
   ariaLabel = 'zoom-in',
@@ -9,7 +9,7 @@ export const IconZoomIn = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconZoomOut.tsx
+++ b/packages/react/src/icons/IconZoomOut.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconZoomOut = ({
   ariaLabel = 'zoom-out',
@@ -9,7 +9,7 @@ export const IconZoomOut = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/IconZoomText.tsx
+++ b/packages/react/src/icons/IconZoomText.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const IconZoomText = ({
   ariaLabel = 'zoom-text',
@@ -9,7 +9,7 @@ export const IconZoomText = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/packages/react/src/icons/index.ts
+++ b/packages/react/src/icons/index.ts
@@ -1,4 +1,4 @@
-export { IconProps } from './Icon.interface';
+export { IconProps, IconSize } from './Icon.interface';
 
 export { IconAlertCircle } from './IconAlertCircle';
 export { IconAlertCircleFill } from './IconAlertCircleFill';

--- a/packages/react/src/internal/menuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/react/src/internal/menuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<MenuButton /> spec renders the component 1`] = `
       <svg
         aria-hidden="true"
         aria-label="angle-down"
-        class="icon s"
+        class="icon small"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/internal/selectedItems/tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/react/src/internal/selectedItems/tag/__snapshots__/Tag.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`<Tag /> spec renders properties of the component 1`] = `
       <svg
         aria-hidden="true"
         aria-label="cross"
-        class="icon s icon"
+        class="icon small icon"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"

--- a/release/icon-kit-template-react-tsx.eta
+++ b/release/icon-kit-template-react-tsx.eta
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Icon.module.css';
-import { IconProps } from './Icon.interface';
+import { IconProps, IconSize } from './Icon.interface';
 
 export const <%= it.componentJSName %> = ({
   ariaLabel = '<%= it.iconName %>',
@@ -9,7 +9,7 @@ export const <%= it.componentJSName %> = ({
   ariaHidden = true,
   className = '',
   color,
-  size = 's',
+  size = IconSize.Small,
   style = {},
 }: React.SVGProps<SVGSVGElement> & IconProps) => (
   <svg

--- a/site/src/docs/components/icon/code.mdx
+++ b/site/src/docs/components/icon/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/icon/code'
 title: 'Icon - Code'
 ---
 
-import { IconFaceSmile, IconPlusCircle } from 'hds-react';
+import { IconFaceSmile, IconPlusCircle, IconSize } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -32,18 +32,18 @@ import { IconFaceSmile } from 'hds-react';
 
 ### Icon sizes
 
-<Playground scope={{ IconFaceSmile }}>
+<Playground scope={{ IconFaceSmile, IconSize }}>
 
 
 ```jsx
-import { IconFaceSmile } from 'hds-react';
+import { IconFaceSmile, IconSize } from 'hds-react';
 
 () => (<>
-  <IconFaceSmile size="xs" aria-hidden="true" />
-  <IconFaceSmile size="s" aria-hidden="true" />
-  <IconFaceSmile size="m" aria-hidden="true" />
-  <IconFaceSmile size="l" aria-hidden="true" />
-  <IconFaceSmile size="xl" aria-hidden="true" />
+  <IconFaceSmile size={IconSize.ExtraSmall} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.Small} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.Medium} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.Large} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.ExtraLarge} aria-hidden="true" />
 </>)
 ```
 

--- a/site/src/docs/components/icon/customisation.mdx
+++ b/site/src/docs/components/icon/customisation.mdx
@@ -3,7 +3,7 @@ slug: '/components/icon/customisation'
 title: 'Icon - Customisation'
 ---
 
-import { IconFaceSmile } from 'hds-react';
+import { IconFaceSmile, IconSize } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -14,19 +14,19 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 Customising icons is rather simple. Use the `size` property to control size and the `color` property to control colour.
 
 ### Customisation example
-<Playground scope={{ IconFaceSmile }}>
+<Playground scope={{ IconFaceSmile, IconSize }}>
 
 
 ```jsx
-import { IconFaceSmile } from 'hds-react';
+import { IconFaceSmile, IconSize } from 'hds-react';
 
 () => (
 <>
-<IconFaceSmile size="xs" color="var(--color-bus)" aria-hidden="true" />
-<IconFaceSmile size="s" color="var(--color-brick)" aria-hidden="true" />
-<IconFaceSmile size="m" color="var(--color-coat-of-arms)" aria-hidden="true" />
-<IconFaceSmile size="l" color="var(--color-tram)" aria-hidden="true" />
-<IconFaceSmile size="xl" color="var(--color-metro)" aria-hidden="true" />
+<IconFaceSmile size={IconSize.ExtraSmall} color="var(--color-bus)" aria-hidden="true" />
+<IconFaceSmile size={IconSize.Small} color="var(--color-brick)" aria-hidden="true" />
+<IconFaceSmile size={IconSize.Medium} color="var(--color-coat-of-arms)" aria-hidden="true" />
+<IconFaceSmile size={IconSize.Large} color="var(--color-tram)" aria-hidden="true" />
+<IconFaceSmile size={IconSize.ExtraLarge} color="var(--color-metro)" aria-hidden="true" />
 </>)
 ```
 

--- a/site/src/docs/components/icon/index.mdx
+++ b/site/src/docs/components/icon/index.mdx
@@ -4,7 +4,7 @@ title: 'Icon'
 navTitle: 'Icon'
 ---
 
-import { IconFaceSmile, IconPlusCircle } from 'hds-react';
+import { IconFaceSmile, IconPlusCircle, IconSize } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -36,11 +36,11 @@ See the <InternalLink href="/foundation/visual-assets/icons">the icon library</I
 #### Icon sizes
 
 <PlaygroundPreview>
-  <IconFaceSmile size="xs" aria-hidden="true" />
-  <IconFaceSmile size="s" aria-hidden="true" />
-  <IconFaceSmile size="m" aria-hidden="true" />
-  <IconFaceSmile size="l" aria-hidden="true" />
-  <IconFaceSmile size="xl" aria-hidden="true" />
+  <IconFaceSmile size={IconSize.ExtraSmall} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.Small} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.Medium} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.Large} aria-hidden="true" />
+  <IconFaceSmile size={IconSize.ExtraLarge} aria-hidden="true" />
 </PlaygroundPreview>
 
 ### Icon visible for assistive technologies

--- a/site/src/docs/components/link/code.mdx
+++ b/site/src/docs/components/link/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/link/code'
 title: 'Link - Code'
 ---
 
-import { IconDocument, IconEnvelope, IconPhone, IconPhoto, Link, LinkSize } from 'hds-react';
+import { IconDocument, IconEnvelope, IconPhone, IconPhoto, IconSize, Link, LinkSize } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -149,15 +149,15 @@ import { Link } from 'hds-react';
 
 ### Links with icons
 
-<Playground scope={{ Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto }}>
+<Playground scope={{ Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto, IconSize }}>
 
 
 ```jsx
-import { Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto } from 'hds-react';
+import { Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto, IconSize } from 'hds-react';
 
 () => (<>
   <Link
-    iconStart={<IconDocument size="s" aria-hidden />}
+    iconStart={<IconDocument size={IconSize.Small} aria-hidden />}
     size={LinkSize.Medium}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
@@ -165,7 +165,7 @@ import { Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto } from
     Document link
   </Link>
   <Link
-    iconStart={<IconPhone size="s" aria-hidden />}
+    iconStart={<IconPhone size={IconSize.Small} aria-hidden />}
     size={LinkSize.Medium}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
@@ -173,7 +173,7 @@ import { Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto } from
     Phone link
   </Link>
   <Link
-    iconStart={<IconEnvelope size="s" aria-hidden />}
+    iconStart={<IconEnvelope size={IconSize.Small} aria-hidden />}
     size={LinkSize.Medium}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
@@ -181,7 +181,7 @@ import { Link, LinkSize, IconDocument, IconPhone, IconEnvelope, IconPhoto } from
     Email link
   </Link>
   <Link
-    iconStart={<IconPhoto size="s" aria-hidden />}
+    iconStart={<IconPhoto size={IconSize.Small} aria-hidden />}
     size={LinkSize.Medium}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}

--- a/site/src/docs/components/link/index.mdx
+++ b/site/src/docs/components/link/index.mdx
@@ -4,7 +4,7 @@ title: 'Link'
 navTitle: 'Link'
 ---
 
-import { IconDocument, IconPhone, IconEnvelope, IconPhoto, LinkSize } from 'hds-react';
+import { IconDocument, IconPhone, IconEnvelope, IconPhoto, IconSize, LinkSize } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -101,26 +101,26 @@ Note! These icons are meant to describe the link target. If you need a direction
 
 <PlaygroundPreview>
   <Link
-    iconLeft={<IconDocument size="s" aria-hidden />}
     size={LinkSize.Medium}
+    iconStart={<IconDocument size={IconSize.Small} aria-hidden />}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
   >Document link</Link>
   <Link
-    iconLeft={<IconPhone size="s" aria-hidden />}
     size={LinkSize.Medium}
+    iconStart={<IconPhone size={IconSize.Small} aria-hidden />}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
   >Phone link</Link>
   <Link
-    iconLeft={<IconEnvelope size="s" aria-hidden />}
     size={LinkSize.Medium}
+    iconStart={<IconEnvelope size={IconSize.Small} aria-hidden />}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
   >Email link</Link>
   <Link
-    iconLeft={<IconPhoto size="s" aria-hidden />}
     size={LinkSize.Medium}
+    iconStart={<IconPhoto size={IconSize.Small} aria-hidden />}
     href="/#"
     style={{ display: 'block', width: 'fit-content' }}
   >Photo link</Link>

--- a/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
+++ b/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
@@ -73,3 +73,10 @@ while ErrorSummary has `ErrorSummarySize.Medium` and `ErrorSummarySize.Large` va
 
 - <InternalLink size="M" href="/components/notification">Notification documentation</InternalLink>
 - <InternalLink size="M" href="/components/error-summary">ErrorSummary documentation</InternalLink>
+
+### Icon size
+
+#### React
+The Icon size prop has been changed to enum (`IconSize.ExtraSmall`, `IconSize.Small`, `IconSize.Medium`, `IconSize.Large`, `IconSize.ExtraLarge`)
+
+- <InternalLink size="M" href="/components/icon">Documentation</InternalLink>


### PR DESCRIPTION
## Description

Change Icon size to use enum

## Related Issue

[HDS-1838](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1838)

## How Has This Been Tested?

- local machine

## Demos:
[Docs](https://city-of-helsinki.github.io/hds-demo/preview_1281/)
[React Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1281/storybook/react/?path=/docs/icons-icons)
[Core Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1281/storybook/core/?path=/docs/icons-icons)

## Add to changelog
- [x] Added needed line to changelog


[HDS-1838]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ