### PR TITLE
Hds 2254 remove login warning text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- [Component] What has been changed
+- [Login] Login system is good enough to start using in production as well. We still welcome feedback and improve the component.
 
 #### Fixed
 

--- a/site/src/docs/components/login/tabs.mdx
+++ b/site/src/docs/components/login/tabs.mdx
@@ -19,11 +19,6 @@ import StatusLabel from '../../../components/StatusLabel';
 
 <LeadParagraph>Login components include React components, context and hooks for handling user authorisation, api tokens and session polling.</LeadParagraph>
 
-<Notification label="A work in progress!" className="siteNotification">
-  The HDS Login system is a set of components the HDS team is currently making. This means
-  that this component is subject to change, and we don't recommend using it in production.
-</Notification>
-
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>
     <PageTabs.Tab href="/">Intro</PageTabs.Tab>


### PR DESCRIPTION
Remove warning saying it should not be used in production

## Description

We wish to encourage projects to use HDS login instead of making their own solution. 

## Related Issue

[HDS-2254](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2254)

Closes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Checking demo site

## Demos:
[Docs](https://city-of-helsinki.github.io/hds-demo/preview_1282/)

[Core Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1282/storybook/core)

[React Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1282/storybook/react)

## Screenshots (if appropriate):

## Add to changelog
- [x] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2254]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ