### PR TITLE
fix icon before and after selectors

### DIFF
--- a/packages/core/src/icons/icon.css
+++ b/packages/core/src/icons/icon.css
@@ -33,32 +33,28 @@
   --icon-size: var(--spacing-layout-l);
 }
 
-[class*="hds-icon-start--"] {
-  &:before {  
-    background-color: currentcolor;
-    content: "";
-    display: inline-flex;
-    height: var(--icon-size, 24px);
-    -webkit-mask-image: var(--mask-image-before);
-    mask-image: var(--mask-image-before);
-    mask-position: center;
-    mask-repeat: no-repeat;
-    mask-size: contain;
-    width: var(--icon-size, 24px);
-  }
+[class*="hds-icon-start--"]:before {  
+  background-color: currentcolor;
+  content: "";
+  display: inline-flex;
+  height: var(--icon-size, 24px);
+  -webkit-mask-image: var(--mask-image-before);
+  mask-image: var(--mask-image-before);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  width: var(--icon-size, 24px);
 }
 
-[class*="hds-icon-end--"] {
-  &:after {
-    background-color: currentcolor;
-    content: "";
-    display: inline-flex;
-    height: var(--icon-size, 24px);
-    -webkit-mask-image: var(--mask-image-after);
-    mask-image: var(--mask-image-after);
-    mask-position: center;
-    mask-repeat: no-repeat;
-    mask-size: contain;
-    width: var(--icon-size, 24px);
-  }
+[class*="hds-icon-end--"]:after {
+  background-color: currentcolor;
+  content: "";
+  display: inline-flex;
+  height: var(--icon-size, 24px);
+  -webkit-mask-image: var(--mask-image-after);
+  mask-image: var(--mask-image-after);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  width: var(--icon-size, 24px);
 }


### PR DESCRIPTION
## Description

Fix hds-icon &:before and &:after selectors which broke in demo-sites at least.

## How Has This Been Tested?

- local machine

## Demos:
[Docs](https://city-of-helsinki.github.io/hds-demo/preview_1287/)

[Core Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1287/storybook/core)

[React Storybook](https://city-of-helsinki.github.io/hds-demo/preview_1287/storybook/react)
