### PR TITLE
HDS-2246: graphql module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - [Component] What is added?
+- [Login] GraphQL module with api token integration
 
 #### Changed
 
 Changes that are not related to specific components
+
 - [FileInput](packages/react/src/components/fileInput/FileInput.tsx) Added `minSize` property (default 0) for cases when the uploaded file must have non-zero length content
 
 #### Fixed
@@ -40,6 +42,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -56,10 +59,12 @@ Changes that are not related to specific components
 #### Added
 
 - More detailed information on upcoming releases 4.0.0 and 5.0.0
+- [Login] GraphQL module documentation
 
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -79,6 +84,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -98,6 +104,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -117,6 +124,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -131,11 +139,12 @@ Changes that are not related to specific components
 
 #### Added
 
-- [Component] What is added?
+- [Login] GraphQL module with api token integration
 
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -192,14 +201,17 @@ Changes that are not related to specific components
 ### Figma
 
 #### Added:
+
 - [Hero] Added secondary buttons and a responsive wrapper to buttons.
 - [Hero] Added buttons for the NoImage variant.
 - [Hero] Introduced XXL variant sizes.
 
 #### Fixed:
+
 - [Hero] Adjusted arrow and photographer info for improved responsiveness and ensured all variants are built using the same component structure.
 
 #### Removed:
+
 - [Hero] Replaced preselected images with placeholders.
 - [Hero] Replaced Diagonal variant's image with Placeholder image component (breaking change – resets used image).
 - [Hero] Replaced ImageBottom variant's links with buttons (breaking change).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
     "@testing-library/user-event": "^12.8.1",
     "@types/jest": "^26.0.1",
     "@types/jest-axe": "^3.5.3",
-    "@types/lodash": "^4.17.4",
+    "@types/lodash": "4.17.4",
     "@types/react": "17.0.2",
     "@types/react-dom": "17.0.2",
     "@types/rollup-plugin-generate-package-json": "^3.2.8",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -122,6 +122,7 @@
     "typescript": "4.6.4"
   },
   "dependencies": {
+    "@apollo/client": "^3.10.1",
     "@babel/runtime": "7.17.9",
     "@emotion/styled-base": "^11.0.0",
     "@hookform/resolvers": "^2.9.11",
@@ -136,6 +137,7 @@
     "crc-32": "1.2.0",
     "date-fns": "2.16.1",
     "downshift": "6.0.6",
+    "graphql": "^16.8.1",
     "hds-core": "3.8.0",
     "http-status-typed": "^1.0.1",
     "jwt-decode": "^3.1.2",

--- a/packages/react/src/components/cookieConsent/content.builder.test.ts
+++ b/packages/react/src/components/cookieConsent/content.builder.test.ts
@@ -7,6 +7,7 @@ import { CookieData, CookieGroup, Content, Category } from './contexts/ContentCo
 import { COOKIE_NAME } from './cookieConsentController';
 import mockWindowLocation from '../../utils/mockWindowLocation';
 import { VERSION_COOKIE_NAME } from './cookieStorageProxy';
+import { cloneWithJSONConversion } from '../../utils/cloneObject';
 
 describe(`content.builder.ts`, () => {
   const mockedWindowControls = mockWindowLocation();
@@ -124,7 +125,7 @@ describe(`content.builder.ts`, () => {
 
   // jest toEqual fails if functions exist.
   const filterContentWithoutFunctions = (content: Content): Content => {
-    return JSON.parse(JSON.stringify(content));
+    return cloneWithJSONConversion(content) as Content;
   };
 
   afterAll(() => {

--- a/packages/react/src/components/login/README.md
+++ b/packages/react/src/components/login/README.md
@@ -1,0 +1,92 @@
+# Settings for hds-demo site
+
+Tunnistamo and Keycloak require registered callback urls. For the demo site, it must be
+
+https://city-of-helsinki.github.io/hds-demo/login/
+
+### Paths in html files
+
+Callback htmls in `/storybookStatic` folder must be changed:
+
+- callback.html
+- callback_kc.html
+- logout.html
+
+Change `${window.origin}/storybook/react/` to `${window.origin}/hds-demo/login/`
+
+### Story settings
+
+In `Login.stories.tsx` change settings to
+
+```jsx
+const loginProviderProps: LoginProviderProps = {
+  userManagerSettings: {
+    authority: 'https://tunnistamo.dev.hel.ninja/',
+    client_id: 'exampleapp-ui-dev',
+    scope: 'openid profile email https://api.hel.fi/auth/helsinkiprofiledev https://api.hel.fi/auth/exampleappdev',
+    redirect_uri: `${window.origin}/hds-demo/login/static-login/callback.html`,
+    silent_redirect_uri: `${window.origin}/hds-demo/login/static-login/silent_renew.html`,
+    post_logout_redirect_uri: `${window.origin}/hds-demo/login/static-login/logout.html`,
+  },
+  apiTokensClientSettings: { url: 'https://tunnistamo.dev.hel.ninja/api-tokens/' },
+  sessionPollerSettings: { pollIntervalInMs: 10000 },
+};
+
+const loginProviderPropsForKeycloak: LoginProviderProps = {
+  userManagerSettings: {
+    authority: 'https://tunnistus.dev.hel.ninja/auth/realms/helsinki-tunnistus',
+    client_id: 'exampleapp-ui-dev',
+    scope: 'openid profile',
+    redirect_uri: `${window.origin}/hds-demo/login/static-login/callback_kc.html`,
+    silent_redirect_uri: `${window.origin}/hds-demo/login/static-login/silent_renew.html`,
+    post_logout_redirect_uri: `${window.origin}/hds-demo/login/static-login/logout.html`,
+  },
+  apiTokensClientSettings: {
+    url: 'https://tunnistus.dev.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect/token',
+    queryProps: {
+      grantType: 'urn:ietf:params:oauth:grant-type:uma-ticket',
+      permission: '#access',
+    },
+    audiences: ['exampleapp-api-test', 'profile-api-test'],
+  },
+  sessionPollerSettings: { pollIntervalInMs: 10000 },
+};
+
+```
+
+and in `createGraphQLModule()` settings
+
+```jsx
+const profileGraphQL = createGraphQLModule({
+  query: MyProfileQuery,
+  queryOptions: {
+    // this is needed with Profile BE, because it returns an error in result.data with weak authentication
+    errorPolicy: 'all',
+  },
+  graphQLClient: new ApolloClient({ uri: 'https://profile-api.dev.hel.ninja/graphql/', cache: new InMemoryCache() }),
+  options: {
+    apiTokenKey: 'https://api.hel.fi/auth/helsinkiprofiledev',
+  },
+});
+```
+
+# Settings for localhost
+
+In `Login.stories.tsx` change settings to
+
+```jsx
+const loginProviderProps: LoginProviderProps = {
+  userManagerSettings: {
+    authority: 'https://tunnistamo.dev.hel.ninja/',
+    client_id: 'exampleapp-ui-dev',
+    scope: 'openid profile email https://api.hel.fi/auth/helsinkiprofiledev https://api.hel.fi/auth/exampleappdev',
+    redirect_uri: `${window.origin}/static-login/callback.html`,
+    silent_redirect_uri: `${window.origin}/static-login/silent_renew.html`,
+    post_logout_redirect_uri: `${window.origin}/static-login/logout.html`,
+  },
+  apiTokensClientSettings: { url: 'https://tunnistamo.dev.hel.ninja/api-tokens/' },
+  sessionPollerSettings: { pollIntervalInMs: 10000 },
+};
+```
+
+`createGraphQLModule` settings are the same as for hds-demo site (above)

--- a/packages/react/src/components/login/beacon/signals.ts
+++ b/packages/react/src/components/login/beacon/signals.ts
@@ -26,6 +26,7 @@ export type NamespacedBeacon = {
   emitEvent: (eventType: EventType, data?: EventData) => void;
   emitStateChange: (state: StateChangeType, previousState?: StateChangeType) => void;
   namespace: SignalNamespace;
+  getBeacon: () => Beacon | undefined;
 };
 export type ScopedSignalListener = (signal: Signal, module: NamespacedBeacon, beacon: Beacon) => void;
 export const errorSignalType = 'error' as const;
@@ -64,6 +65,7 @@ export function createNamespacedBeacon(namespace: SignalNamespace): NamespacedBe
       });
       pendingListenerCalls.length = 0;
     },
+    getBeacon: () => beacon,
     emit(signalType, payload) {
       return beacon ? beacon.emit({ type: signalType, namespace, payload }) : undefined;
     },

--- a/packages/react/src/components/login/graphQLModule/__mocks__/apolloClient.mock.ts
+++ b/packages/react/src/components/login/graphQLModule/__mocks__/apolloClient.mock.ts
@@ -1,0 +1,30 @@
+import { ApolloClient, ApolloLink, from, HttpLink, InMemoryCache } from '@apollo/client/core';
+
+import { GraphQLQueryResult } from '..';
+
+export const mockedGraphQLUri = 'https://apollo.backend.com';
+export const defaultAuthToken = 'default token';
+
+export function createApolloClientMock(): ApolloClient<GraphQLQueryResult> {
+  const link = new HttpLink({
+    uri: mockedGraphQLUri,
+  });
+
+  const authMiddleware = new ApolloLink((operation, forward) => {
+    const token = defaultAuthToken;
+    if (token) {
+      operation.setContext({
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
+    }
+
+    return forward(operation);
+  });
+
+  return new ApolloClient({
+    cache: new InMemoryCache(),
+    link: from([authMiddleware, link]),
+  });
+}

--- a/packages/react/src/components/login/graphQLModule/__mocks__/mockData.ts
+++ b/packages/react/src/components/login/graphQLModule/__mocks__/mockData.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+// https://www.apollographql.com/docs/react/development-testing/testing/
+export const USER_QUERY = gql`
+  query user {
+    id
+    name
+    profile {
+      email
+    }
+  }
+`;

--- a/packages/react/src/components/login/graphQLModule/__mocks__/mockResponses.ts
+++ b/packages/react/src/components/login/graphQLModule/__mocks__/mockResponses.ts
@@ -1,0 +1,29 @@
+const mockResponse = {
+  data: {
+    user: {
+      id: 13,
+      name: 'Name',
+      profile: {
+        email: 'email@dot.com',
+      },
+    },
+  },
+};
+
+export const createQueryResponse = (overrides: Record<string, unknown> = {}) => {
+  return {
+    data: {
+      user: {
+        ...mockResponse.data.user,
+        ...overrides,
+      },
+    },
+  };
+};
+
+export const createQueryResponseWithErrors = (overrides: Record<string, unknown> = {}) => {
+  return {
+    ...createQueryResponse(overrides),
+    errors: [new Error('error1')],
+  };
+};

--- a/packages/react/src/components/login/graphQLModule/demoData/MyProfileQuery.ts
+++ b/packages/react/src/components/login/graphQLModule/demoData/MyProfileQuery.ts
@@ -1,0 +1,92 @@
+import { gql } from '@apollo/client/core';
+
+export const MyProfileQuery = gql`
+  query MyProfileQuery {
+    myProfile {
+      id
+      firstName
+      lastName
+      nickname
+      language
+      primaryAddress {
+        id
+        primary
+        address
+        postalCode
+        city
+        countryCode
+        addressType
+      }
+      addresses {
+        edges {
+          node {
+            primary
+            id
+            address
+            postalCode
+            city
+            countryCode
+            addressType
+          }
+        }
+      }
+      primaryEmail {
+        id
+        email
+        primary
+        emailType
+        verified
+      }
+      emails {
+        edges {
+          node {
+            primary
+            id
+            email
+            emailType
+            verified
+          }
+        }
+      }
+      primaryPhone {
+        id
+        phone
+        primary
+        phoneType
+      }
+      phones {
+        edges {
+          node {
+            primary
+            id
+            phone
+            phoneType
+          }
+        }
+      }
+      verifiedPersonalInformation {
+        firstName
+        lastName
+        givenName
+        nationalIdentificationNumber
+        municipalityOfResidence
+        municipalityOfResidenceNumber
+        permanentAddress {
+          streetAddress
+          postalCode
+          postOffice
+        }
+        temporaryAddress {
+          streetAddress
+          postalCode
+          postOffice
+        }
+        permanentForeignAddress {
+          streetAddress
+          additionalAddress
+          countryCode
+        }
+      }
+    }
+  }
+`;

--- a/packages/react/src/components/login/graphQLModule/graphQLModule.test.ts
+++ b/packages/react/src/components/login/graphQLModule/graphQLModule.test.ts
@@ -1,0 +1,1259 @@
+/* eslint-disable jest/expect-expect */
+/* eslint-disable jest/no-mocks-import */
+import HttpStatusCode from 'http-status-typed';
+import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock';
+import { to } from 'await-to-js';
+import { ApolloQueryResult, QueryResult, TypedDocumentNode, QueryOptions } from '@apollo/client';
+import { waitFor } from '@testing-library/react';
+
+import { Beacon, ConnectedModule, createBeacon } from '../beacon/beacon';
+import { emitInitializationSignals, EventPayload, eventSignalType } from '../beacon/signals';
+import {
+  createConnectedBeaconModule,
+  createTestListenerModule,
+  getReceivedErrorSignalPayloads,
+  getReceivedEventSignalPayloads,
+} from '../testUtils/beaconTestUtil';
+import { createControlledFetchMockUtil } from '../testUtils/fetchMockTestUtil';
+import { createGraphQLModule } from './graphQLModule';
+import {
+  GraphQLModule,
+  GraphQLModuleEvent,
+  graphQLModuleEvents,
+  GraphQLModuleModuleProps,
+  graphQLModuleNamespace,
+  GraphQLQueryResult,
+} from './index';
+import { graphQLModuleError, GraphQLModuleError, GraphQLModuleErrorType } from './graphQLModuleError';
+import { createApolloClientMock, mockedGraphQLUri } from './__mocks__/apolloClient.mock';
+import { ApiTokenClient, apiTokensClientEvents, apiTokensClientNamespace, TokenData } from '../apiTokensClient';
+import { createQueryResponse, createQueryResponseWithErrors } from './__mocks__/mockResponses';
+import { USER_QUERY } from './__mocks__/mockData';
+import { advanceUntilPromiseResolved } from '../testUtils/timerTestUtil';
+import { getLastMockCallArgs } from '../../../utils/testHelpers';
+import { cloneObject } from '../../../utils/cloneObject';
+
+type ResponseType = { returnedStatus: HttpStatusCode; data?: GraphQLQueryResult | null; error?: Error };
+
+type TestQueryStep = {
+  response?: ResponseType;
+  eventSignals?: GraphQLModuleEvent[];
+  errorSignals?: GraphQLModuleErrorType[];
+  expectPromiseToFail?: boolean;
+  expectedQueryError?: GraphQLModuleErrorType;
+  expectedResult?: unknown;
+  expectToKeepResults?: boolean;
+  expectToKeepError?: boolean;
+  willLoad?: boolean;
+  willBePending?: boolean;
+  willHaveErrorsInResult?: boolean;
+  willAutoStart?: boolean;
+  execute?: (promiseCatcher: jest.Mock) => Promise<void | ApolloQueryResult<GraphQLQueryResult>>;
+  postQueryTest?: (promise: Promise<unknown>) => Promise<unknown>;
+};
+
+type TestStepResult = { error: Error | GraphQLModuleError | null; data: GraphQLQueryResult | null };
+
+describe(`graphQLModule`, () => {
+  const defaultApiTokens: TokenData = { token1: 'token1Value', token2: 'token2Value' };
+  const { cleanUp, setResponders, addResponse } = createControlledFetchMockUtil([{ path: mockedGraphQLUri }]);
+
+  let currentModule: GraphQLModule<GraphQLQueryResult>;
+  let currentBeacon: Beacon;
+  let currentApolloClient: ReturnType<typeof createApolloClientMock>;
+  let listenerModule: ReturnType<typeof createConnectedBeaconModule>;
+  let apiTokenStorage: TokenData | null = null;
+  let apolloClientQuerySpy: jest.SpyInstance | undefined;
+
+  const promiseCatcher = jest.fn();
+
+  const getQueryParams = () => {
+    if (!apolloClientQuerySpy) {
+      return undefined;
+    }
+    return getLastMockCallArgs(apolloClientQuerySpy)[0];
+  };
+
+  const initTests = ({
+    responses,
+    createApiTokenClient,
+    apiTokens,
+    moduleOptions = {},
+    queryOptions = {},
+    noApolloClient = false,
+    noQuery = false,
+    queryHelper,
+  }: {
+    responses: ResponseType[];
+    createApiTokenClient?: boolean;
+    noApolloClient?: boolean;
+    noQuery?: boolean;
+    apiTokens?: TokenData;
+    moduleOptions?: GraphQLModuleModuleProps['options'];
+    queryOptions?: GraphQLModuleModuleProps['queryOptions'];
+    queryHelper?: GraphQLModuleModuleProps['queryHelper'];
+  }) => {
+    const defaultTestingModuleOptions: GraphQLModuleModuleProps['options'] = {
+      requireApiTokens: false,
+    };
+    responses.forEach((response) => {
+      addResponse({ status: response.returnedStatus, body: response.data ? JSON.stringify(response.data) : undefined });
+    });
+    currentApolloClient = createApolloClientMock();
+    apolloClientQuerySpy = jest.spyOn(currentApolloClient, 'query');
+    currentModule = createGraphQLModule({
+      graphQLClient: noApolloClient ? undefined : currentApolloClient,
+      query: noQuery ? undefined : USER_QUERY,
+      queryOptions: {
+        fetchPolicy: 'no-cache',
+        ...queryOptions,
+      },
+      options: { ...defaultTestingModuleOptions, ...moduleOptions },
+      queryHelper,
+    });
+    // A module for listening and tracking all events in graphQLModule
+    listenerModule = createTestListenerModule(graphQLModuleNamespace, 'graphQLModuleListener');
+    currentBeacon = createBeacon();
+    currentBeacon.addSignalContext(currentModule);
+    currentBeacon.addSignalContext(listenerModule);
+    if (createApiTokenClient || apiTokens) {
+      apiTokenStorage = apiTokens || null;
+      const fakeApiTokensClient: ConnectedModule & Partial<ApiTokenClient> = {
+        getTokens: () => {
+          return apiTokenStorage;
+        },
+        connect: () => {},
+        namespace: apiTokensClientNamespace,
+      };
+      currentBeacon.addSignalContext(fakeApiTokensClient);
+    }
+    // initialize all modules
+    emitInitializationSignals(currentBeacon);
+  };
+
+  const getEmittedErrors = () => {
+    return getReceivedErrorSignalPayloads<GraphQLModuleError>(listenerModule);
+  };
+
+  const getEmittedEventTypes = () => {
+    return getReceivedEventSignalPayloads(listenerModule).map((payload) => payload.type);
+  };
+
+  // helpers for emitting api token signals
+  const emitApiTokensClientStateChange = (payload: EventPayload) => {
+    currentBeacon.emit({ type: eventSignalType, namespace: apiTokensClientNamespace, payload });
+  };
+
+  const emitApiTokensUpdatedStateChange = (tokens: TokenData) => {
+    apiTokenStorage = tokens;
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_UPDATED };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  const emitApiTokensRemovedStateChange = () => {
+    apiTokenStorage = null;
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_REMOVED };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  // standard fetch responses
+  const createSuccessResponse = (overrides: { id?: number; name?: string; profile?: unknown } = {}): ResponseType => {
+    return { returnedStatus: HttpStatusCode.OK, data: createQueryResponse(overrides) };
+  };
+
+  const successfulResponse: ResponseType = createSuccessResponse();
+
+  const errorResponse: ResponseType = {
+    returnedStatus: HttpStatusCode.SERVICE_UNAVAILABLE,
+    error: new Error('Failed'),
+  };
+
+  /**
+   * Tests follow usually the same pattern:
+   * - define responses
+   * - query
+   * - await for query to end
+   * - check result / errors
+   * - check emitted event / error signals
+   *
+   * "TestQueryStep" is metadata for the test pattern described above. Steps tell the runTestSequence() what to expect in each step of a test sequence.
+   * Instead of repeating same expect() calls, the runTestSequence() has all necessary tests.
+   *
+   * Each step calls automatically graphQLModule.query(), unless a test step has an "executor()" that is called instead.
+   *
+   */
+
+  // step for doing nothing and useful as a base for some other steps
+  const createEmptyStep = (overrides: Partial<TestQueryStep> = {}): Partial<TestQueryStep> => {
+    return {
+      willHaveErrorsInResult: false,
+      willLoad: false,
+      willAutoStart: false,
+      willBePending: false,
+      errorSignals: undefined,
+      expectPromiseToFail: false,
+      expectToKeepError: false,
+      expectedResult: undefined,
+      expectToKeepResults: false,
+      expectedQueryError: undefined,
+      execute: () => {
+        return Promise.resolve();
+      },
+      eventSignals: undefined,
+      ...overrides,
+    };
+  };
+
+  // basic successful query and its expected results.
+  const createSuccessfulStep = (id: number = 1): TestQueryStep => {
+    const response = createSuccessResponse({ id });
+    return {
+      response,
+      eventSignals: [graphQLModuleEvents.GRAPHQL_MODULE_LOADING, graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS],
+      expectedResult: (response.data as GraphQLQueryResult).data,
+      willBePending: true,
+      willLoad: true,
+      expectPromiseToFail: false,
+      expectedQueryError: undefined,
+      errorSignals: [],
+    };
+  };
+
+  // basic unsuccessful query and its expected results.
+  const createErrorStep = (): TestQueryStep => {
+    return {
+      response: errorResponse,
+      errorSignals: [graphQLModuleError.GRAPHQL_LOAD_FAILED],
+      eventSignals: [graphQLModuleEvents.GRAPHQL_MODULE_LOADING],
+      expectedQueryError: graphQLModuleError.GRAPHQL_LOAD_FAILED,
+    };
+  };
+
+  // step for calling just module.clear() and expects no results or rejections or errors
+  const createClearModuleStep = (): TestQueryStep => {
+    return {
+      execute: () => {
+        currentModule.clear();
+        return Promise.resolve();
+      },
+      expectPromiseToFail: false,
+      expectedQueryError: undefined,
+      expectedResult: undefined,
+      willBePending: false,
+      willLoad: false,
+      eventSignals: [graphQLModuleEvents.GRAPHQL_MODULE_CLEARED],
+    };
+  };
+
+  // step for calling module.cancel() and expects module to keep previous results/errors and not to emit signals
+  const createCancelModuleStep = (expectToKeepResults = false, expectToKeepError = false): TestQueryStep => {
+    return {
+      execute: () => {
+        currentModule.cancel();
+        return Promise.resolve();
+      },
+      willBePending: false,
+      willLoad: false,
+      expectToKeepResults,
+      expectToKeepError,
+    };
+  };
+
+  // step for calling module.query(), but calls module.clear/cancel() after that
+  const createQueryWithCancelOrClearStep = (cancelOrClear: 'cancel' | 'clear'): TestQueryStep => {
+    const willClear = cancelOrClear === 'clear';
+    return {
+      execute: (errorCatcher) => {
+        const promise = currentModule.query().catch(errorCatcher);
+        if (willClear) {
+          // test isPending until clear() unsets promises
+          expect(currentModule.isPending()).toBeTruthy();
+          currentModule.clear();
+        } else {
+          currentModule.cancel();
+        }
+        return promise;
+      },
+      // clear() will unset promises and isPending() === false
+      willBePending: !willClear,
+      willLoad: true,
+      expectPromiseToFail: true,
+      response: createSuccessResponse({ id: 66 }),
+      eventSignals: willClear
+        ? [
+            graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+            graphQLModuleEvents.GRAPHQL_MODULE_CLEARED,
+            graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+          ]
+        : [graphQLModuleEvents.GRAPHQL_MODULE_LOADING, graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED],
+    };
+  };
+
+  // test props for auto-started queries.
+  const createAutoStartedQueryStep = (): Partial<TestQueryStep> => {
+    return {
+      willAutoStart: true,
+      execute: () => {
+        return currentModule.getQueryPromise();
+      },
+      eventSignals: [graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS],
+    };
+  };
+
+  // test props for a scenario where module.query() fails before actual apolloClient.query() is called.
+  const createFailingQueryWithoutEmittedSignalsStep = (): Partial<TestQueryStep> => {
+    return {
+      ...createSuccessfulStep(),
+      response: undefined,
+      expectPromiseToFail: true,
+      eventSignals: [],
+      errorSignals: [],
+      willLoad: false,
+      willBePending: false,
+      expectedResult: undefined,
+    };
+  };
+
+  // just emit api tokens updated signal
+  const createEmitApiTokenChangeWithNoChangesStep = (): TestQueryStep => ({
+    ...createEmptyStep(),
+    execute: async () => {
+      emitApiTokensUpdatedStateChange(defaultApiTokens);
+      return Promise.resolve();
+    },
+  });
+
+  // just emit api tokens removed signal
+  const createEmitApiTokensRemovedWithNoChangesStep = (): TestQueryStep => ({
+    ...createEmptyStep(),
+    execute: async () => {
+      emitApiTokensRemovedStateChange();
+      return Promise.resolve();
+    },
+  });
+
+  // emit api tokens updated signal and return pending query promise. If auto-start is set, query is executed in the
+  const createEmitApiTokenChangeAndReturnQueryPromiseStep = (): TestQueryStep => ({
+    ...createSuccessfulStep(),
+    execute: async () => {
+      emitApiTokensUpdatedStateChange(defaultApiTokens);
+      return currentModule.getQueryPromise();
+    },
+  });
+
+  // manually run query and wait for api tokens update and also trigger the update.
+  // tests that apiTokenPromise is a success
+  const createQueryAndThenUpdateApiTokensStep = (): TestQueryStep => {
+    let awaitPromise: Promise<unknown>;
+    return {
+      ...createSuccessfulStep(),
+      execute: async (handlePromiseFailure) => {
+        const promise = currentModule.query().catch(handlePromiseFailure);
+        awaitPromise = currentModule.waitForApiTokens().catch(handlePromiseFailure);
+        expect(getEmittedEventTypes().includes(graphQLModuleEvents.GRAPHQL_MODULE_LOADING)).toBeFalsy();
+        emitApiTokensUpdatedStateChange(defaultApiTokens);
+        return promise;
+      },
+      postQueryTest: async () => {
+        const apiTokenSuccess = await awaitPromise;
+        expect(apiTokenSuccess === true).toBeTruthy();
+        return awaitPromise;
+      },
+      // query fetch will not start immediately
+      willLoad: false,
+    };
+  };
+  // manually run query and remove apiTokens after that.
+  // update tokens in postQueryTest. Query is not affected, it is already cancelled.
+  const createQueryAndRemoveAndUpdateApiTokensStep = (): TestQueryStep => {
+    return {
+      ...createSuccessfulStep(),
+      execute: async (handlePromiseFailure) => {
+        const promise = currentModule.query().catch(handlePromiseFailure);
+        emitApiTokensRemovedStateChange();
+        return promise;
+      },
+      postQueryTest: async () => {
+        const tokenPromise = currentModule.waitForApiTokens();
+        emitApiTokensUpdatedStateChange(defaultApiTokens);
+        const apiTokenSuccess = await tokenPromise;
+        expect(apiTokenSuccess === true).toBeTruthy();
+        return tokenPromise;
+      },
+      expectPromiseToFail: true,
+      expectedResult: undefined,
+      eventSignals: [graphQLModuleEvents.GRAPHQL_MODULE_LOADING, graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED],
+    };
+  };
+  // wait for api tokens and emit update signal
+  const createWaitForApiTokensAndEmitApiTokenChangeWithStep = (): TestQueryStep => ({
+    ...createEmptyStep(),
+    execute: async (handlePromiseFailure) => {
+      const tokenPromise = currentModule.waitForApiTokens().catch(handlePromiseFailure);
+      emitApiTokensUpdatedStateChange(defaultApiTokens);
+      const apiTokenSuccess = await tokenPromise;
+      expect(apiTokenSuccess === true).toBeTruthy();
+      return Promise.resolve();
+    },
+  });
+
+  // wait for api tokens and let them timeout
+  const createWaitForApiTokensPromiseTimeoutStep = (): TestQueryStep => ({
+    ...createEmptyStep(),
+    execute: async (handlePromiseFailure) => {
+      expect(handlePromiseFailure).toHaveBeenCalledTimes(0);
+      const tokenPromise = currentModule.waitForApiTokens(1000).catch(handlePromiseFailure);
+      const apiTokenSuccess = await tokenPromise;
+      expect(apiTokenSuccess === false).toBeTruthy();
+      // then() has empty function to return undefined or results are compared.
+      return tokenPromise.then(() => {});
+    },
+    expectPromiseToFail: false,
+    // when called, apiTokensPromise exists and isPending() is true
+    willBePending: true,
+  });
+
+  // module.query is executed automatically and in postQueryTest()
+  // cancel the query and verify that apiTokenPromise is fulfilled
+  // query will fail due cancel() but no errors.
+  const createQueryButCancelWithApiTokenAwaitCheckStep = (): TestQueryStep => ({
+    ...createSuccessfulStep(),
+    postQueryTest: async () => {
+      const tokenPromise = currentModule.waitForApiTokens();
+      currentModule.cancel();
+      const apiTokenSuccess = await tokenPromise;
+      expect(apiTokenSuccess === false).toBeTruthy();
+      return Promise.resolve();
+    },
+    expectPromiseToFail: true,
+    expectedResult: undefined,
+    eventSignals: [graphQLModuleEvents.GRAPHQL_MODULE_LOADING, graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED],
+  });
+
+  const runTestSequence = async (sequence: TestQueryStep[]): Promise<Array<TestStepResult>> => {
+    let queryPromise: Promise<QueryResult | void> | undefined;
+    /* eslint-disable jest/no-conditional-expect, no-await-in-loop, no-restricted-syntax */
+    const sequenceResults: Array<TestStepResult> = [];
+    const handlePromiseFailure = jest.fn();
+    for (const step of sequence) {
+      const {
+        execute,
+        errorSignals,
+        eventSignals,
+        expectedQueryError,
+        expectedResult,
+        expectPromiseToFail,
+        willBePending,
+        willLoad,
+        expectToKeepResults,
+        expectToKeepError,
+        willAutoStart,
+        postQueryTest,
+      } = step;
+      const stepResults: TestStepResult = { error: null, data: null };
+      const eventSignalsBefore = getEmittedEventTypes();
+      const errorSignalsBefore = getEmittedErrors();
+
+      // reset promise.catch() handler to detect errors in just this step
+      handlePromiseFailure.mockReset();
+
+      const willQuery = !!expectedResult || !!expectedQueryError;
+      const isPendingResult = willBePending !== undefined ? willBePending : willQuery;
+      const isLoadingResult = willLoad !== undefined ? willLoad : willQuery;
+      const dataNow = expectToKeepResults ? currentModule.getData() : undefined;
+      const resultNow = expectToKeepResults ? currentModule.getResult() : undefined;
+      const errorNow = expectToKeepError ? currentModule.getError() : undefined;
+      const clientErrorsNow = expectToKeepError ? currentModule.getClientErrors() : undefined;
+      // auto-started queries should already be running
+      expect(currentModule.isLoading()).toBe(willAutoStart === true);
+      expect(currentModule.isPending()).toBe(willAutoStart === true);
+      // execute() or query(), but do not await yet
+      queryPromise = execute ? execute(handlePromiseFailure) : currentModule.query().catch(handlePromiseFailure);
+      expect(currentModule.isLoading()).toBe(isLoadingResult);
+      expect(currentModule.isPending()).toBe(isPendingResult);
+      // make some additional testing
+      if (postQueryTest) {
+        await postQueryTest(queryPromise);
+      }
+      await advanceUntilPromiseResolved(queryPromise);
+      // if promise failed, handlePromiseFailure catched it.
+      const error = getLastMockCallArgs(handlePromiseFailure);
+      const result = (await queryPromise) as QueryResult;
+
+      expect(currentModule.isLoading()).toBe(false);
+      expect(currentModule.isPending()).toBe(false);
+
+      if (expectedResult) {
+        stepResults.data = currentModule.getData() || null;
+        // result is an apollo object including more than just data
+        expect(result).toBeDefined();
+        expect(result.data).toBeDefined();
+        expect(result.loading).toBeDefined();
+        expect(result.networkStatus).toBeDefined();
+        expect(expectedResult).toEqual(currentModule.getData());
+        expect(currentModule.getError()).toBeUndefined();
+        expect(currentModule.isLoading()).toBeFalsy();
+        expect(currentModule.isPending()).toBeFalsy();
+        expect(currentModule.getClientErrors()).toHaveLength(0);
+      } else if (expectToKeepResults) {
+        expect(currentModule.getData()).toBe(dataNow);
+        expect(currentModule.getResult()).toBe(resultNow);
+      } else {
+        expect(result).toBeUndefined();
+        expect(currentModule.getData()).toBeUndefined();
+      }
+      if (expectPromiseToFail && !expectedQueryError) {
+        expect(error).toBeDefined();
+      } else if (expectedQueryError) {
+        expect(error).toBeDefined();
+        expect(currentModule.getClientErrors()).toHaveLength(1);
+        expect((currentModule.getError() as GraphQLModuleError).type).toBe(expectedQueryError);
+      } else if (expectToKeepError) {
+        expect(currentModule.getClientErrors()).toEqual(clientErrorsNow);
+        expect(currentModule.getError()).toBe(errorNow);
+      } else {
+        expect(error).toBeUndefined();
+        expect(currentModule.getError()).toBeUndefined();
+        expect(currentModule.getClientErrors()).toHaveLength(0);
+      }
+
+      stepResults.error = currentModule.getClientErrors()[0] || null;
+
+      const eventSignalsAfter = getEmittedEventTypes();
+      const errorSignalsAfter = getEmittedErrors();
+      const newEvents = eventSignalsAfter.slice(eventSignalsBefore.length);
+      const newErrors = errorSignalsAfter.slice(errorSignalsBefore.length);
+      if (eventSignals) {
+        expect(eventSignals).toEqual(newEvents);
+      } else {
+        expect(newEvents).toHaveLength(0);
+      }
+      if (errorSignals) {
+        expect(errorSignals).toEqual(newErrors.map((e) => e.type));
+      } else {
+        expect(newErrors).toHaveLength(0);
+      }
+      sequenceResults.push(stepResults);
+      /* eslint-enable jest/no-conditional-expect, no-await-in-loop, no-restricted-syntax */
+    }
+    if (queryPromise) {
+      await to(queryPromise);
+    }
+    return sequenceResults;
+  };
+
+  const pickSequeceResponsesToInit = (sequence: TestQueryStep[]) => {
+    return sequence.map((s) => s.response).filter((r) => !!r) as ResponseType[];
+  };
+
+  // ApolloClient emits errors when cached data is invalid. That does not matter in these tests.
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    enableFetchMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setResponders([{ path: mockedGraphQLUri }]);
+  });
+
+  afterEach(async () => {
+    if (currentModule) {
+      const promise = currentModule.getQueryPromise().catch(promiseCatcher);
+      jest.advanceTimersByTime(100000);
+      await advanceUntilPromiseResolved(promise);
+      currentModule.clear();
+    }
+    await cleanUp();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    currentBeacon.clear();
+    apiTokenStorage = null;
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('The module is initiated in idle state.', async () => {
+    initTests({
+      responses: [],
+    });
+    expect(currentModule.isLoading()).toBeFalsy();
+    expect(currentModule.isPending()).toBeFalsy();
+    expect(currentModule.getClientErrors()).toHaveLength(0);
+    expect(currentModule.getData()).toBeUndefined();
+    expect(currentModule.getError()).toBeUndefined();
+    expect(currentModule.getResult()).toBeUndefined();
+  });
+
+  it('Query() executes a fetch and event signals are emitted. Result is stored to module.', async () => {
+    // query() is called in the runTestSequence(step)
+    const sequence = [createSuccessfulStep()];
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+    });
+    const sequenceResults = await runTestSequence(sequence);
+    const stepResult = sequenceResults[0];
+    expect(sequenceResults).toHaveLength(1);
+    expect(stepResult.error).toBeNull();
+    expect(stepResult.data).not.toBeNull();
+  });
+
+  it('Failing queries are handled and error signals are emitted', async () => {
+    const sequence = [createErrorStep()];
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+    });
+    const sequenceResults = await runTestSequence(sequence);
+    const stepResult = sequenceResults[0];
+    expect(sequenceResults).toHaveLength(1);
+    expect(stepResult.error).not.toBeNull();
+    expect(stepResult.data).toBeNull();
+    const emittedErrors = getEmittedErrors();
+    expect(emittedErrors).toHaveLength(1);
+    expect(emittedErrors[0].isLoadError).toBeTruthy();
+    expect(emittedErrors[0].originalError).toBeDefined();
+  });
+
+  it('Clear() cancels a query and removes all stored results and errors', async () => {
+    const errorQueryWithClearStep: TestQueryStep = {
+      ...createErrorStep(),
+      ...createQueryWithCancelOrClearStep('clear'),
+      expectedQueryError: undefined,
+      errorSignals: undefined,
+    };
+
+    const sequence: TestQueryStep[] = [
+      createSuccessfulStep(),
+      createClearModuleStep(),
+      createQueryWithCancelOrClearStep('clear'),
+      errorQueryWithClearStep,
+    ];
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+    });
+    const sequenceResults = await runTestSequence(sequence);
+    expect(sequenceResults).toHaveLength(4);
+    expect(getEmittedErrors()).toHaveLength(0);
+    expect(getEmittedEventTypes()).toHaveLength(9);
+  });
+
+  it('Cancel() aborts the query and emits signals', async () => {
+    const errorQueryWithCancelStep: TestQueryStep = {
+      ...createErrorStep(),
+      ...createQueryWithCancelOrClearStep('cancel'),
+      expectedQueryError: undefined,
+      errorSignals: undefined,
+    };
+
+    const sequence: TestQueryStep[] = [
+      createSuccessfulStep(),
+      createCancelModuleStep(true),
+      // cancel does not clear results
+      { ...createQueryWithCancelOrClearStep('cancel'), expectToKeepResults: true },
+      createErrorStep(),
+      errorQueryWithCancelStep,
+    ];
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+    });
+    const sequenceResults = await runTestSequence(sequence);
+    expect(sequenceResults).toHaveLength(5);
+    expect(getEmittedErrors()).toHaveLength(1);
+    expect(getEmittedEventTypes()).toHaveLength(7);
+  });
+
+  it('Multiple query executions clear previous results/errors and stores new', async () => {
+    const sequence: TestQueryStep[] = [
+      createSuccessfulStep(1),
+      createErrorStep(),
+      createCancelModuleStep(false, true),
+      createSuccessfulStep(2),
+      { ...createQueryWithCancelOrClearStep('cancel'), expectToKeepResults: true },
+      createSuccessfulStep(3),
+      createErrorStep(),
+      createErrorStep(),
+      createClearModuleStep(),
+      createClearModuleStep(),
+      createCancelModuleStep(),
+      createCancelModuleStep(),
+      createClearModuleStep(),
+      createSuccessfulStep(4),
+      createSuccessfulStep(5),
+    ];
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+    });
+
+    await runTestSequence(sequence);
+  });
+
+  it('If apiTokens exists on initialization, query is executed automatically', async () => {
+    const sequence: TestQueryStep[] = [{ ...createSuccessfulStep(), ...createAutoStartedQueryStep() }];
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+      },
+    });
+    await runTestSequence(sequence);
+  });
+
+  it('ApiToken update signal triggers load only once', async () => {
+    const emitApiTokenChangeStepAndExpectQueryToStart: TestQueryStep = {
+      ...createSuccessfulStep(),
+      execute: async () => {
+        emitApiTokensUpdatedStateChange(defaultApiTokens);
+        return currentModule.getQueryPromise();
+      },
+    };
+
+    const sequence: TestQueryStep[] = [
+      createEmptyStep(),
+      emitApiTokenChangeStepAndExpectQueryToStart,
+      { ...createEmitApiTokenChangeWithNoChangesStep(), expectToKeepResults: true },
+      createClearModuleStep(),
+      createEmitApiTokenChangeWithNoChangesStep(),
+    ];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      moduleOptions: {
+        requireApiTokens: true,
+      },
+      createApiTokenClient: true,
+    });
+    expect(currentModule.isLoading()).toBeFalsy();
+
+    await runTestSequence(sequence);
+
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      graphQLModuleEvents.GRAPHQL_MODULE_CLEARED,
+    ]);
+  });
+
+  it('When querying twice and options.abortIfLoading is false, second query is not started and on-going promise is returned', async () => {
+    const queryAgainAfterFirstStep: TestQueryStep = {
+      ...createSuccessfulStep(),
+      postQueryTest: async () => {
+        const firstQueryPromise = currentModule.getQueryPromise();
+        currentModule.query();
+        const secondQueryPromise = currentModule.getQueryPromise();
+        expect(firstQueryPromise === secondQueryPromise).toBeTruthy();
+        return Promise.resolve();
+      },
+    };
+
+    const sequence = [queryAgainAfterFirstStep];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        abortIfLoading: false,
+      },
+    });
+    await runTestSequence(sequence);
+  });
+
+  it('When querying twice and options.abortIfLoading is true (default), first query is aborted and new a one started', async () => {
+    const queryAgainAfterFirstStep: TestQueryStep = {
+      ...createSuccessfulStep(),
+      execute: async (errorCatcher) => {
+        // this has intentionally another catcher
+        currentModule.query().catch(jest.fn());
+        const firstQueryPromise = currentModule.getQueryPromise();
+        currentModule.query().catch(errorCatcher);
+        await waitFor(() => {
+          // first should be aborted
+          expect(getEmittedEventTypes().includes(graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED)).toBeTruthy();
+          // wait until second promise has started.
+          expect(firstQueryPromise === currentModule.getQueryPromise()).toBeFalsy();
+        });
+
+        await firstQueryPromise.catch(jest.fn());
+        return currentModule.getQueryPromise();
+      },
+      eventSignals: [
+        graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+        graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+        graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+        graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      ],
+    };
+
+    const sequence = [{ ...createEmptyStep(), response: createSuccessResponse() }, queryAgainAfterFirstStep];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        abortIfLoading: true,
+      },
+    });
+    await runTestSequence(sequence);
+  });
+  it('When options.keepOldResultOnError is true, failed request does not clear previous result', async () => {
+    const sequence: TestQueryStep[] = [createSuccessfulStep(), { ...createErrorStep(), expectToKeepResults: true }];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        keepOldResultOnError: true,
+      },
+    });
+    await runTestSequence(sequence);
+  });
+
+  it('If apiTokens are required, but not ready, querying will return a rejected promise. Query auto-starts after api tokens update.', async () => {
+    const sequence: TestQueryStep[] = [
+      { ...createFailingQueryWithoutEmittedSignalsStep(), errorSignals: [graphQLModuleError.GRAPHQL_NO_API_TOKENS] },
+      createEmitApiTokenChangeAndReturnQueryPromiseStep(),
+    ];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      createApiTokenClient: true,
+      moduleOptions: {
+        requireApiTokens: true,
+      },
+    });
+    await runTestSequence(sequence);
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+  });
+
+  it('If apiTokens are removed/renewed, a query will wait for api tokens to update', async () => {
+    const sequence: TestQueryStep[] = [
+      createEmitApiTokensRemovedWithNoChangesStep(),
+      createQueryAndThenUpdateApiTokensStep(),
+    ];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+    await runTestSequence(sequence);
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+  });
+
+  it('If apiTokens are removed/renewed while querying, a query will be cancelled.', async () => {
+    const sequence: TestQueryStep[] = [
+      createQueryAndRemoveAndUpdateApiTokensStep(),
+      createWaitForApiTokensAndEmitApiTokenChangeWithStep(),
+      createSuccessfulStep(),
+    ];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+    await runTestSequence(sequence);
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+  });
+
+  it('If apiTokens are awaited, cancel() will fulfill the pending api token promise and reject query() promise.', async () => {
+    const sequence: TestQueryStep[] = [
+      createEmitApiTokensRemovedWithNoChangesStep(),
+      {
+        ...createQueryButCancelWithApiTokenAwaitCheckStep(),
+        willLoad: false,
+        eventSignals: [],
+        errorSignals: [graphQLModuleError.GRAPHQL_NO_API_TOKENS],
+      },
+    ];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+    await runTestSequence(sequence);
+  });
+
+  it('Pending apiTokens will timeout. The promise will never reject, it returns true/false', async () => {
+    const sequence: TestQueryStep[] = [
+      createEmitApiTokensRemovedWithNoChangesStep(),
+      createWaitForApiTokensPromiseTimeoutStep(),
+    ];
+
+    initTests({
+      responses: pickSequeceResponsesToInit(sequence),
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+    await runTestSequence(sequence);
+  });
+
+  it('If api tokens already exists, waitForApiTokens() resolves immediately', async () => {
+    initTests({
+      responses: [successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+      },
+    });
+    const success = await currentModule.waitForApiTokens().catch(promiseCatcher);
+    expect(success === true).toBeTruthy();
+    expect(promiseCatcher).toHaveBeenCalledTimes(0);
+  });
+
+  it('If api tokens are not set and a query is executed, it is immediately rejected', async () => {
+    initTests({
+      responses: [successfulResponse],
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+    await currentModule.query().catch(promiseCatcher);
+    expect((getLastMockCallArgs(promiseCatcher)[0] as GraphQLModuleError).isNoApiTokensError).toBeTruthy();
+    expect(getEmittedErrors().map((e) => e.type)).toEqual([graphQLModuleError.GRAPHQL_NO_API_TOKENS]);
+  });
+  it('If api tokens are removed and a query is executed, api tokens are loaded. Timing out rejects the query.', async () => {
+    initTests({
+      responses: [successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+    apiTokenStorage = null;
+    await advanceUntilPromiseResolved(currentModule.query().catch(promiseCatcher));
+    expect(promiseCatcher).toHaveBeenCalledTimes(1);
+    expect((getLastMockCallArgs(promiseCatcher)[0] as GraphQLModuleError).isNoApiTokensError).toBeTruthy();
+    expect(getEmittedErrors().map((e) => e.type)).toEqual([graphQLModuleError.GRAPHQL_NO_API_TOKENS]);
+  });
+
+  it('If client is not defined, query() is rejected immediately', async () => {
+    initTests({
+      responses: [successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+      noApolloClient: true,
+    });
+    const result = await currentModule.query().catch(promiseCatcher);
+    expect(promiseCatcher).toHaveBeenCalledTimes(1);
+    expect((getLastMockCallArgs(promiseCatcher)[0] as GraphQLModuleError).isNoClientError).toBeTruthy();
+    expect(currentModule.isLoading()).toBeFalsy();
+    expect(result).toBeUndefined();
+    expect(getEmittedErrors().map((e) => e.type)).toEqual([graphQLModuleError.GRAPHQL_NO_CLIENT]);
+  });
+
+  it('If query is not defined, query() is rejected immediately', async () => {
+    initTests({
+      responses: [successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+      },
+      noQuery: true,
+    });
+    const result = await currentModule.query().catch(promiseCatcher);
+    expect(promiseCatcher).toHaveBeenCalledTimes(1);
+    expect(currentModule.isLoading()).toBeFalsy();
+    expect(result).toBeUndefined();
+  });
+
+  it('getQueryPromise() returns a the promise currently active query. Or a rejected promise if a query is not pending', async () => {
+    initTests({
+      responses: [successfulResponse],
+    });
+    const [err] = await to(currentModule.getQueryPromise());
+    expect(err).toBeDefined();
+    // this must be catched as it is returned from an async func
+    const promise = currentModule.query().catch(promiseCatcher);
+    // no need to catch this, it is catched in the module
+    const queryPromise = currentModule.getQueryPromise();
+    await advanceUntilPromiseResolved(promise);
+    const result1 = await queryPromise;
+    const result2 = await promise;
+    expect(result1).toMatchObject(result2);
+  });
+
+  it('props passed to query() override inital props passed when creating the module. Initial or passed object are not mutated.', async () => {
+    const queryOptions: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: 'cache-only',
+      variables: {
+        initial: true,
+      },
+    };
+    const clonedQueryOptions = cloneObject(queryOptions);
+    initTests({
+      responses: [successfulResponse, successfulResponse, successfulResponse],
+      moduleOptions: {
+        requireApiTokens: false,
+      },
+      queryOptions,
+    });
+
+    // this query has "cache-only", so no fetch is done
+    const promise = currentModule.query().catch(promiseCatcher);
+    await promise;
+    expect(promiseCatcher).toHaveBeenCalledTimes(0);
+    expect(getQueryParams()).toMatchObject({ ...queryOptions, query: USER_QUERY });
+
+    const overrides: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: 'network-only',
+      variables: {
+        initial: false,
+        override: true,
+      },
+    };
+    const clonedOverrides = cloneObject(overrides);
+    const query: GraphQLModuleModuleProps['query'] = 'queryDocument' as unknown as TypedDocumentNode;
+    const newPromise = currentModule.query({ queryOptions: overrides, query }).catch(promiseCatcher);
+    currentModule.cancel();
+    await advanceUntilPromiseResolved(newPromise);
+    expect(getQueryParams()).toMatchObject({ ...queryOptions, ...overrides });
+
+    const abortOverride: GraphQLModuleModuleProps['queryOptions'] = {
+      variables: {
+        abortOverride: true,
+      },
+      context: { fetchOptions: { mode: 'no-cors', priority: 'high' } },
+    };
+    const clonedAbortOverride = cloneObject(abortOverride);
+    const lastPromise = currentModule
+      .query({ queryOptions: abortOverride, query: { fake: true } as unknown as TypedDocumentNode })
+      .catch(promiseCatcher);
+    currentModule.cancel();
+    await advanceUntilPromiseResolved(lastPromise);
+    expect(getQueryParams()).toMatchObject({ ...queryOptions, ...abortOverride });
+    expect(getQueryParams().context.fetchOptions.signal).toBeDefined();
+
+    expect(clonedQueryOptions).toMatchObject(queryOptions);
+    expect(clonedOverrides).toMatchObject(overrides);
+    expect(clonedAbortOverride).toMatchObject(abortOverride);
+  });
+
+  it('queryHelper receives current options, api token client and beacon as  arguments. Returned value is passed to client.query()', async () => {
+    const queryOptions: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: 'cache-only',
+      errorPolicy: 'all',
+      variables: {
+        initial: true,
+      },
+    };
+    const queryHelperReturnValue: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: undefined,
+      variables: {
+        helper: true,
+      },
+    };
+    const queryHelper = jest.fn().mockImplementation((opt) => {
+      return {
+        ...opt,
+        ...queryHelperReturnValue,
+      };
+    });
+    initTests({
+      responses: [successfulResponse, successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: false,
+      },
+      queryHelper,
+      queryOptions,
+    });
+
+    const promise = currentModule.query().catch(promiseCatcher);
+    await advanceUntilPromiseResolved(promise);
+    expect(getQueryParams()).toMatchObject({
+      ...queryOptions,
+      ...queryHelperReturnValue,
+    });
+    expect(getLastMockCallArgs(queryHelper)).toMatchObject([
+      queryOptions,
+      currentBeacon.getSignalContext(apiTokensClientNamespace),
+      currentBeacon,
+    ]);
+
+    const secondQuery: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: 'network-only',
+      variables: {
+        initial: false,
+        override: true,
+      },
+    };
+
+    const newPromise = currentModule.query({ queryOptions: secondQuery }).catch(promiseCatcher);
+    await advanceUntilPromiseResolved(newPromise);
+    expect(getQueryParams()).toMatchObject({
+      ...queryOptions,
+      ...queryHelperReturnValue,
+    });
+  });
+
+  it('If apiTokenKey is set, query headers will include the token. QueryHelper receives the token too', async () => {
+    const queryOptions: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: 'cache-only',
+      errorPolicy: 'all',
+      variables: {
+        initial: true,
+      },
+    };
+
+    const queryHelperReturnValue: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: undefined,
+      variables: {
+        helper: true,
+      },
+    };
+    const queryHelper = jest.fn().mockImplementation((opt) => {
+      return {
+        ...opt,
+        ...queryHelperReturnValue,
+      };
+    });
+    const apiTokenKey = 'token2';
+    initTests({
+      responses: [successfulResponse, successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: false,
+        apiTokenKey,
+      },
+      queryHelper,
+      queryOptions,
+    });
+
+    const expectedHeaders = {
+      authorization: `Bearer ${(apiTokenStorage as TokenData)[apiTokenKey]}`,
+    };
+    const promise = currentModule.query().catch(promiseCatcher);
+    await advanceUntilPromiseResolved(promise);
+    const queryParams = getQueryParams() as QueryOptions;
+    expect(queryParams).toMatchObject({
+      ...queryOptions,
+      ...queryHelperReturnValue,
+    });
+    expect(queryParams.context?.headers).toMatchObject(expectedHeaders);
+    expect(getLastMockCallArgs(queryHelper)).toMatchObject([
+      queryOptions,
+      currentBeacon.getSignalContext(apiTokensClientNamespace),
+      currentBeacon,
+    ]);
+
+    const secondQueryOptions: GraphQLModuleModuleProps['queryOptions'] = {
+      fetchPolicy: 'network-only',
+      variables: {
+        initial: false,
+        override: true,
+      },
+      context: {
+        headers: {
+          secondAuth: 'token1',
+        },
+      },
+    };
+
+    const newPromise = currentModule.query({ queryOptions: secondQueryOptions }).catch(promiseCatcher);
+    await advanceUntilPromiseResolved(newPromise);
+    const queryParams2 = getQueryParams() as QueryOptions;
+    expect(queryParams2).toMatchObject({
+      ...secondQueryOptions,
+      ...queryHelperReturnValue,
+    });
+    expect(queryParams2.context?.headers).toMatchObject({ ...expectedHeaders, ...secondQueryOptions.context?.headers });
+    expect(getLastMockCallArgs(queryHelper)).toMatchObject([
+      secondQueryOptions,
+      currentBeacon.getSignalContext(apiTokensClientNamespace),
+      currentBeacon,
+    ]);
+  });
+
+  it('getClientErrors() returns an array of actual errors or errors in returned data', async () => {
+    initTests({
+      responses: [{ returnedStatus: HttpStatusCode.OK, data: createQueryResponseWithErrors() }, errorResponse],
+      moduleOptions: {
+        requireApiTokens: false,
+      },
+      queryOptions: {
+        // without this, error in data causes query to fail
+        errorPolicy: 'all',
+      },
+    });
+    const promise = currentModule.query().catch(promiseCatcher);
+    await advanceUntilPromiseResolved(promise);
+    expect(promiseCatcher).toHaveBeenCalledTimes(0);
+    expect(currentModule.getClientErrors()).toHaveLength(1);
+    expect(currentModule.getData()).toBeDefined();
+    expect(currentModule.getError()).toBeUndefined();
+
+    const promise2 = currentModule.query().catch(promiseCatcher);
+    await advanceUntilPromiseResolved(promise2);
+    expect(promiseCatcher).toHaveBeenCalledTimes(1);
+    expect(currentModule.getClientErrors()).toHaveLength(1);
+    expect(currentModule.getData()).toBeUndefined();
+    expect(currentModule.getError()).toBeDefined();
+  });
+
+  it('isLoading() indicates actual fetch, isPending() indicates a api token / query promise is pending', async () => {
+    initTests({
+      responses: [successfulResponse, successfulResponse, successfulResponse],
+      apiTokens: defaultApiTokens,
+      moduleOptions: {
+        requireApiTokens: true,
+        autoFetch: false,
+      },
+    });
+
+    const promise1 = currentModule.query().catch(promiseCatcher);
+    expect(currentModule.isLoading()).toBeTruthy();
+    expect(currentModule.isPending()).toBeTruthy();
+    await advanceUntilPromiseResolved(promise1);
+    expect(currentModule.isLoading()).toBeFalsy();
+    expect(currentModule.isPending()).toBeFalsy();
+
+    emitApiTokensRemovedStateChange();
+    const promise2 = currentModule.query().catch(promiseCatcher);
+    expect(currentModule.isLoading()).toBeFalsy();
+    expect(currentModule.isPending()).toBeTruthy();
+    emitApiTokensUpdatedStateChange(defaultApiTokens);
+    await waitFor(() => {
+      expect(currentModule.isLoading()).toBeTruthy();
+      expect(currentModule.isPending()).toBeTruthy();
+    });
+    await advanceUntilPromiseResolved(promise2);
+    expect(currentModule.isLoading()).toBeFalsy();
+    expect(currentModule.isPending()).toBeFalsy();
+  });
+});

--- a/packages/react/src/components/login/graphQLModule/graphQLModule.ts
+++ b/packages/react/src/components/login/graphQLModule/graphQLModule.ts
@@ -1,0 +1,336 @@
+import { ApolloClient, ApolloError, ApolloQueryResult, QueryOptions } from '@apollo/client/core';
+
+import {
+  GraphQLModuleModuleProps,
+  GraphQLModule,
+  GraphQLModuleState,
+  graphQLModuleStates,
+  GraphQLQueryResult,
+  GraphQLCache,
+  graphQLModuleNamespace,
+  graphQLModuleEvents,
+  defaultOptions,
+} from '.';
+import { Beacon, SignalListener } from '../beacon/beacon';
+import {
+  createEventTriggerProps,
+  createInitTriggerProps,
+  createNamespacedBeacon,
+  waitForSignals,
+} from '../beacon/signals';
+import { createFetchAborter, isAbortError } from '../utils/abortFetch';
+import { ApiTokenClient, apiTokensClientEvents, apiTokensClientNamespace } from '../apiTokensClient';
+import { isApiTokensRemovedSignal, isApiTokensUpdatedSignal } from '../apiTokensClient/signals';
+import { graphQLModuleError, GraphQLModuleError } from './graphQLModuleError';
+import { appendFetchOptions, mergeQueryOptionModifiers } from './utils';
+import { cloneObject } from '../../../utils/cloneObject';
+
+export function createGraphQLModule<Q = GraphQLQueryResult, T = GraphQLCache>({
+  graphQLClient,
+  query,
+  queryOptions,
+  options = {},
+  queryHelper,
+}: GraphQLModuleModuleProps<T, Q>): GraphQLModule<T, Q> {
+  const mergedOptions = {
+    ...defaultOptions,
+    ...options,
+  };
+
+  // custom beacon for sending signals in graphQLModuleNamespace
+  const dedicatedBeacon = createNamespacedBeacon(graphQLModuleNamespace);
+
+  // abortController for requests
+  const fetchAborter = createFetchAborter();
+
+  // tools for waiting for apiTokens and stopping awaits
+  let apiTokenAwaitPromise: Promise<unknown> | null;
+  const signalTypeToRejectApiTokenAwait = 'REJECT_API_TOKEN_AWAIT';
+  const emitApiTokenAwaitRejectionSignal = () => {
+    if (!apiTokenAwaitPromise) {
+      return;
+    }
+    const beacon = dedicatedBeacon.getBeacon();
+    if (beacon) {
+      beacon.emit({ type: signalTypeToRejectApiTokenAwait });
+    }
+  };
+
+  // current promise for a query
+  let queryPromise: Promise<ApolloQueryResult<Q>> | undefined;
+  // store client
+  let client: ApolloClient<T> | undefined = graphQLClient;
+
+  let state: GraphQLModuleState = graphQLModuleStates.IDLE;
+  // saved last result
+  let result: ApolloQueryResult<Q> | undefined;
+  // saved last error
+  let error: GraphQLModuleError | undefined;
+  // if api tokens have been fetched once, no need to check existance again.
+  let apiTokensHaveBeenLoadedOnce: boolean = false;
+
+  const getApiTokensClient = () => {
+    const beacon = dedicatedBeacon.getBeacon();
+    return beacon ? (beacon.getSignalContext(apiTokensClientNamespace) as ApiTokenClient) : undefined;
+  };
+
+  const emptyPromiseCatcher = () => {
+    // promise rejection catcher to avoid "unhandled promise" exception
+  };
+
+  const getData: GraphQLModule<T, Q>['getData'] = () => {
+    return result ? result.data : undefined;
+  };
+
+  const setAndEmitError = (graphQLEror: GraphQLModuleError) => {
+    if (!mergedOptions.keepOldResultOnError) {
+      result = undefined;
+    }
+    error = graphQLEror;
+    dedicatedBeacon.emitError(error);
+  };
+
+  // attaches .then and .catch to a promise
+  const handleQueryPromise = (promise: Promise<ApolloQueryResult<Q>>) => {
+    if (queryPromise) {
+      throw new Error('queryPromise already exists');
+    }
+    queryPromise = promise;
+    queryPromise
+      .then((queryResult: ApolloQueryResult<Q>) => {
+        error = undefined;
+        result = queryResult;
+        state = graphQLModuleStates.IDLE;
+        queryPromise = undefined;
+        dedicatedBeacon.emitEvent(graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS, getData());
+      })
+      .catch((queryError: ApolloError) => {
+        state = graphQLModuleStates.IDLE;
+        queryPromise = undefined;
+        if (isAbortError(queryError.networkError as Error)) {
+          error = undefined;
+          dedicatedBeacon.emitEvent(graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED);
+        } else {
+          setAndEmitError(
+            new GraphQLModuleError('Graphql query failed', graphQLModuleError.GRAPHQL_LOAD_FAILED, queryError),
+          );
+        }
+      });
+    return queryPromise;
+  };
+
+  const doApiTokensExist = () => {
+    const apiTokenClient = getApiTokensClient();
+    return !!apiTokenClient && !!apiTokenClient.getTokens();
+  };
+
+  // if query is started when api tokens are renewed, wait for it to complete.
+  const waitForApiTokens: GraphQLModule['waitForApiTokens'] = async (timeout = 0) => {
+    if (apiTokenAwaitPromise) {
+      return apiTokenAwaitPromise;
+    }
+    if (doApiTokensExist()) {
+      return Promise.resolve(true);
+    }
+    let timeOutId: ReturnType<typeof setTimeout> | null = null;
+    const beacon = dedicatedBeacon.getBeacon() as Beacon;
+    if (!beacon) {
+      return Promise.reject(new Error('No Beacon found'));
+    }
+
+    apiTokenAwaitPromise = null;
+    const signalPromise = waitForSignals(
+      dedicatedBeacon.getBeacon() as Beacon,
+      [{ payload: { type: apiTokensClientEvents.API_TOKENS_UPDATED } }],
+      {
+        rejectOn: [{ payload: { type: graphQLModuleEvents.GRAPHQL_MODULE_CLEARED } }, signalTypeToRejectApiTokenAwait],
+      },
+    );
+
+    const timeoutPromise = timeout
+      ? new Promise((resolve, reject) => {
+          timeOutId = setTimeout(() => {
+            reject(new Error('Timeout for waitForApiTokens() reached'));
+            timeOutId = null;
+          }, timeout);
+        })
+      : null;
+
+    apiTokenAwaitPromise = (timeoutPromise ? Promise.race([signalPromise, timeoutPromise]) : signalPromise)
+      .then(() => {
+        if (timeOutId) {
+          clearTimeout(timeOutId);
+          timeOutId = null;
+        }
+        apiTokenAwaitPromise = null;
+        return Promise.resolve(true);
+      })
+      .catch(() => {
+        apiTokenAwaitPromise = null;
+        return Promise.resolve(false);
+      });
+
+    return apiTokenAwaitPromise;
+  };
+
+  const queryExecutor: GraphQLModule<T, Q>['query'] = async (props = {}) => {
+    // if aborting is not enabled and there is an active query, return the current promise
+    if (queryPromise && !mergedOptions.abortIfLoading) {
+      return queryPromise;
+    }
+    // abort and wait for current promise to end
+    if (queryPromise) {
+      fetchAborter.abort();
+      await queryPromise.catch(emptyPromiseCatcher);
+    }
+    if (props.graphQLClient) {
+      client = props.graphQLClient;
+    }
+    if (!client) {
+      setAndEmitError(new GraphQLModuleError('No client defined', graphQLModuleError.GRAPHQL_NO_CLIENT));
+      return Promise.reject(error);
+    }
+
+    if (mergedOptions.requireApiTokens && !apiTokensHaveBeenLoadedOnce) {
+      setAndEmitError(
+        new GraphQLModuleError('Required apiTokens not loaded', graphQLModuleError.GRAPHQL_NO_API_TOKENS),
+      );
+      return Promise.reject(error);
+    }
+
+    if (mergedOptions.requireApiTokens && apiTokensHaveBeenLoadedOnce && !doApiTokensExist()) {
+      await waitForApiTokens(mergedOptions.apiTokensWaitTime);
+      if (!doApiTokensExist()) {
+        setAndEmitError(new GraphQLModuleError('ApiTokens timed out', graphQLModuleError.GRAPHQL_NO_API_TOKENS));
+        return Promise.reject(error);
+      }
+    }
+
+    const queryDocument = props.query || query;
+    if (!queryDocument) {
+      setAndEmitError(
+        new GraphQLModuleError('No query document (TypedDocumentNode)', graphQLModuleError.GRAPHQL_LOAD_FAILED),
+      );
+      return Promise.reject(error);
+    }
+    try {
+      const cloneAndMergeOptions = () => {
+        const initialContext = queryOptions && queryOptions.context ? cloneObject(queryOptions.context) : {};
+        const propsContext =
+          props && props.queryOptions && props.queryOptions.context ? cloneObject(props.queryOptions.context) : {};
+        return {
+          ...{ ...queryOptions, ...props.queryOptions },
+          context: {
+            ...initialContext,
+            ...propsContext,
+          },
+          query: queryDocument,
+        };
+      };
+
+      const addAbortSignalToQueryOptions = (currentOptions: QueryOptions) => {
+        return appendFetchOptions(currentOptions, { signal: fetchAborter.getSignal() });
+      };
+
+      const queryOptionsModifier = mergeQueryOptionModifiers({ options, queryHelper });
+      const promise = client.query<Q>(
+        addAbortSignalToQueryOptions(
+          queryOptionsModifier(cloneAndMergeOptions(), getApiTokensClient(), dedicatedBeacon.getBeacon()),
+        ),
+      );
+      state = graphQLModuleStates.LOADING;
+      dedicatedBeacon.emitEvent(graphQLModuleEvents.GRAPHQL_MODULE_LOADING);
+      return handleQueryPromise(promise);
+    } catch (e) {
+      state = graphQLModuleStates.IDLE;
+      setAndEmitError(new GraphQLModuleError('Graphql query failed', graphQLModuleError.GRAPHQL_LOAD_FAILED, e));
+      return Promise.reject(error);
+    }
+  };
+
+  const cancel = () => {
+    emitApiTokenAwaitRejectionSignal();
+    fetchAborter.abort();
+  };
+
+  // autoLoad is done only once
+  const autoLoadWithApiTokens = async () => {
+    if (!result && !queryPromise && mergedOptions.autoFetch && apiTokensHaveBeenLoadedOnce) {
+      await queryExecutor().catch(emptyPromiseCatcher);
+      mergedOptions.autoFetch = false;
+    }
+  };
+
+  const apiTokensClientEventListener: SignalListener = (signal) => {
+    const wasApiTokensUpdatedSignal = isApiTokensUpdatedSignal(signal);
+    apiTokensHaveBeenLoadedOnce = apiTokensHaveBeenLoadedOnce || wasApiTokensUpdatedSignal;
+    if (isApiTokensRemovedSignal(signal)) {
+      cancel();
+    } else if (wasApiTokensUpdatedSignal) {
+      autoLoadWithApiTokens();
+    }
+  };
+
+  const apiTokensClientInitListener: SignalListener = (signal) => {
+    const apiTokensClient = signal.context as ApiTokenClient;
+    if (apiTokensClient && apiTokensClient.getTokens()) {
+      apiTokensHaveBeenLoadedOnce = true;
+      autoLoadWithApiTokens();
+    }
+  };
+
+  const listenToApiTokenClient = () => {
+    if (mergedOptions.requireApiTokens) {
+      dedicatedBeacon.addListener(createEventTriggerProps(apiTokensClientNamespace), apiTokensClientEventListener);
+      dedicatedBeacon.addListener(createInitTriggerProps(apiTokensClientNamespace), apiTokensClientInitListener);
+    }
+  };
+
+  return {
+    namespace: 'graphQLModule',
+    connect: (beacon) => {
+      dedicatedBeacon.storeBeacon(beacon);
+      listenToApiTokenClient();
+    },
+    getData,
+    getError: () => {
+      return error;
+    },
+    getClientErrors: () => {
+      if (error && error.originalError) {
+        return [error.originalError as ApolloError];
+      }
+      if (result) {
+        if (result.errors) {
+          return result.errors as unknown as ApolloError[];
+        }
+        if (result.error) {
+          return [result.error];
+        }
+      }
+      return [];
+    },
+    getResult: () => {
+      return result;
+    },
+    isLoading: () => {
+      return state === graphQLModuleStates.LOADING;
+    },
+    isPending: () => {
+      return !!(apiTokenAwaitPromise || queryPromise);
+    },
+    query: queryExecutor,
+    getQueryPromise: () => {
+      return queryPromise || Promise.reject(new Error(`No ${graphQLModuleNamespace} load promise`));
+    },
+    cancel,
+    clear: () => {
+      cancel();
+      queryPromise = undefined;
+      result = undefined;
+      error = undefined;
+      dedicatedBeacon.emitEvent(graphQLModuleEvents.GRAPHQL_MODULE_CLEARED);
+    },
+    waitForApiTokens,
+  };
+}

--- a/packages/react/src/components/login/graphQLModule/graphQLModule.ts
+++ b/packages/react/src/components/login/graphQLModule/graphQLModule.ts
@@ -22,7 +22,7 @@ import { createFetchAborter, isAbortError } from '../utils/abortFetch';
 import { ApiTokenClient, apiTokensClientEvents, apiTokensClientNamespace } from '../apiTokensClient';
 import { isApiTokensRemovedSignal, isApiTokensUpdatedSignal } from '../apiTokensClient/signals';
 import { graphQLModuleError, GraphQLModuleError } from './graphQLModuleError';
-import { appendFetchOptions, mergeQueryOptionModifiers } from './utils';
+import { appendFetchOptions, mergeQueryOptionModifiers, mergeQueryOptionsToModuleProps } from './utils';
 import { cloneObject } from '../../../utils/cloneObject';
 
 export function createGraphQLModule<Q = GraphQLQueryResult, T = GraphQLCache>({
@@ -319,6 +319,9 @@ export function createGraphQLModule<Q = GraphQLQueryResult, T = GraphQLCache>({
     isPending: () => {
       return !!(apiTokenAwaitPromise || queryPromise);
     },
+    setClient: (newClient) => {
+      client = newClient;
+    },
     query: queryExecutor,
     getQueryPromise: () => {
       return queryPromise || Promise.reject(new Error(`No ${graphQLModuleNamespace} load promise`));
@@ -332,5 +335,11 @@ export function createGraphQLModule<Q = GraphQLQueryResult, T = GraphQLCache>({
       dedicatedBeacon.emitEvent(graphQLModuleEvents.GRAPHQL_MODULE_CLEARED);
     },
     waitForApiTokens,
+    queryCache: (props) => {
+      return queryExecutor(mergeQueryOptionsToModuleProps(props || {}, { fetchPolicy: 'cache-only' }));
+    },
+    queryServer: (props) => {
+      return queryExecutor(mergeQueryOptionsToModuleProps(props || {}, { fetchPolicy: 'network-only' }));
+    },
   };
 }

--- a/packages/react/src/components/login/graphQLModule/graphQLModuleError.ts
+++ b/packages/react/src/components/login/graphQLModule/graphQLModuleError.ts
@@ -1,0 +1,31 @@
+export type GraphQLModuleErrorType = keyof typeof graphQLModuleError;
+
+export const graphQLModuleError = {
+  GRAPHQL_LOAD_FAILED: 'GRAPHQL_LOAD_FAILED',
+  GRAPHQL_NO_CLIENT: 'GRAPHQL_NO_CLIENT',
+  GRAPHQL_NO_API_TOKENS: 'GRAPHQL_NO_API_TOKENS',
+} as const;
+
+export class GraphQLModuleError extends Error {
+  constructor(
+    public message: string,
+    public type: GraphQLModuleErrorType,
+    public originalError?: Error | null,
+  ) {
+    super(message);
+    this.type = type;
+    this.originalError = originalError;
+  }
+
+  get isLoadError() {
+    return this.type === graphQLModuleError.GRAPHQL_LOAD_FAILED;
+  }
+
+  get isNoClientError() {
+    return this.type === graphQLModuleError.GRAPHQL_NO_CLIENT;
+  }
+
+  get isNoApiTokensError() {
+    return this.type === graphQLModuleError.GRAPHQL_NO_API_TOKENS;
+  }
+}

--- a/packages/react/src/components/login/graphQLModule/hooks.test.tsx
+++ b/packages/react/src/components/login/graphQLModule/hooks.test.tsx
@@ -1,0 +1,579 @@
+/* eslint-disable jest/no-mocks-import */
+import HttpStatusCode from 'http-status-typed';
+import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock';
+import React, { useRef } from 'react';
+import { isObject } from 'lodash';
+import { act, waitFor } from '@testing-library/react';
+
+import { ConnectedModule } from '../beacon/beacon';
+import { EventPayload, eventSignalType, isErrorSignal } from '../beacon/signals';
+import {
+  createConnectedBeaconModule,
+  createTestListenerModule,
+  getReceivedErrorSignalPayloads,
+  getReceivedEventSignalPayloads,
+} from '../testUtils/beaconTestUtil';
+import { createControlledFetchMockUtil } from '../testUtils/fetchMockTestUtil';
+import { createGraphQLModule } from './graphQLModule';
+import { GraphQLCache, GraphQLModule, graphQLModuleEvents, graphQLModuleNamespace, GraphQLQueryResult } from './index';
+import { createMockTestUtil } from '../testUtils/mockTestUtil';
+import { graphQLModuleError, GraphQLModuleError } from './graphQLModuleError';
+import { createApolloClientMock, mockedGraphQLUri } from './__mocks__/apolloClient.mock';
+import { ApiTokenClient, apiTokensClientEvents, apiTokensClientNamespace, TokenData } from '../apiTokensClient';
+import { createQueryResponse } from './__mocks__/mockResponses';
+import { USER_QUERY } from './__mocks__/mockData';
+import { useGraphQL, useGraphQLModule, useGraphQLModuleTracking } from './hooks';
+import { HookTestUtil, createHookTestEnvironment } from '../testUtils/hooks.testUtil';
+import { getGraphQLModuleEventPayload } from './signals';
+
+const elementIds = {
+  namespaceElement: 'graphql-namespace-element',
+  errorElement: 'graphql-error-element',
+  dataElement: 'graphql-data-element',
+  queryButton: 'graphql-query-button',
+  cancelButton: 'graphql-cancel-button',
+  clearButton: 'graphql-clear-button',
+  refetchButton: 'graphql-refetch-button',
+  lastSignal: 'last-signal-element',
+  errorSignal: 'error-signal-element',
+  isLoading: 'graphql-is-loading-element',
+  isLoadingInHook: 'graphql-is-loading-in-hook-element',
+  isPending: 'graphql-is-pending-element',
+  notUpdatingRenderTime: 'graphql-not-updating-render-time-element',
+} as const;
+
+type ResponseType = { returnedStatus: HttpStatusCode; data?: GraphQLQueryResult | null; error?: Error };
+
+let testUtil: HookTestUtil;
+const mockMapForAbort = createMockTestUtil();
+
+describe(`graphQLModule`, () => {
+  const createSuccessResponse = (overrides: { id?: number; name?: string; profile?: unknown } = {}): ResponseType => {
+    return { returnedStatus: HttpStatusCode.OK, data: createQueryResponse(overrides) };
+  };
+
+  const successfulResponse: ResponseType = createSuccessResponse();
+
+  const errorResponse: ResponseType = {
+    returnedStatus: HttpStatusCode.SERVICE_UNAVAILABLE,
+    error: new Error('Failed'),
+  };
+  const { cleanUp, setResponders, addResponse } = createControlledFetchMockUtil([{ path: mockedGraphQLUri }]);
+
+  let currentModule: GraphQLModule;
+  let currentApolloClient: ReturnType<typeof createApolloClientMock>;
+  let listenerModule: ReturnType<typeof createConnectedBeaconModule>;
+  let apiTokenStorage: TokenData | null = null;
+  const defaultApiTokens: TokenData = { token1: 'token1', token2: 'token2' };
+
+  const GraphQLHookOutput = () => {
+    const [, { data, loading, error }] = useGraphQL();
+    return (
+      <div>
+        <span id={elementIds.dataElement}>{data ? JSON.stringify(data) : ''}</span>
+        <span id={elementIds.errorElement}>{error ? error.type : ''}</span>
+        <span id={elementIds.isLoadingInHook}>{String(loading)}</span>
+      </div>
+    );
+  };
+
+  const ActionButtons = () => {
+    const graphQLModule = useGraphQLModule();
+    const [query, { refetch }] = useGraphQL();
+    const onQueryClick = () => {
+      query();
+    };
+    const onRefetchClick = () => {
+      refetch();
+    };
+    const onCancelClick = () => {
+      graphQLModule.cancel();
+    };
+    const onClearClick = () => {
+      graphQLModule.clear();
+    };
+    return (
+      <div>
+        <button type="button" id={elementIds.queryButton} onClick={onQueryClick}>
+          Query
+        </button>
+        <button type="button" id={elementIds.cancelButton} onClick={onCancelClick}>
+          Cancel
+        </button>
+        <button type="button" id={elementIds.clearButton} onClick={onClearClick}>
+          Clear
+        </button>
+        <button type="button" id={elementIds.refetchButton} onClick={onRefetchClick}>
+          Refetch
+        </button>
+      </div>
+    );
+  };
+
+  const NotListeningComponent = () => {
+    const graphQLModule = useGraphQLModule<GraphQLCache, GraphQLQueryResult>();
+    return (
+      <div>
+        <span key="namespace" id={elementIds.namespaceElement}>
+          {graphQLModule.namespace}
+        </span>
+        <span key="notUpdatingRenderTime" id={elementIds.notUpdatingRenderTime}>
+          {Date.now()}
+        </span>
+      </div>
+    );
+  };
+
+  const ListeningComponent = () => {
+    useGraphQLModuleTracking();
+    const graphQLModule = useGraphQLModule<GraphQLCache, GraphQLQueryResult>();
+    return (
+      <div>
+        <span key="isLoading" id={elementIds.isLoading}>
+          {String(graphQLModule.isLoading())}
+        </span>
+        <span key="isPending" id={elementIds.isPending}>
+          {String(graphQLModule.isPending())}
+        </span>
+      </div>
+    );
+  };
+
+  const GraphQLModuleCheck = () => {
+    return (
+      <div>
+        <ListeningComponent />
+        <NotListeningComponent />
+        <GraphQLHookOutput />
+        <ActionButtons />
+      </div>
+    );
+  };
+
+  const SignalCheck = () => {
+    const [signal] = useGraphQLModuleTracking();
+    const error = signal && isErrorSignal(signal) ? (signal?.payload as GraphQLModuleError) : null;
+    const eventPayload = signal ? getGraphQLModuleEventPayload(signal) : null;
+    // useRef to store last error and payload
+    const errorRef = useRef<GraphQLModuleError | undefined>(undefined);
+    const payloadRef = useRef<EventPayload | undefined>(undefined);
+    if (error) {
+      errorRef.current = error;
+    }
+    if (eventPayload) {
+      payloadRef.current = eventPayload;
+    }
+    return (
+      <div>
+        <span key="lastSignal" id={elementIds.lastSignal}>
+          {payloadRef.current ? (payloadRef.current.type as React.ReactNode) : ''}
+        </span>
+        <span key="error" id={elementIds.errorSignal}>
+          {errorRef.current ? errorRef.current.type : ''}
+        </span>
+      </div>
+    );
+  };
+
+  const App = ({ renderSignalCheck }: { renderSignalCheck?: boolean } = {}) => {
+    return (
+      <>
+        <GraphQLModuleCheck key="mod" />
+        {renderSignalCheck && <SignalCheck key="signal" />}
+      </>
+    );
+  };
+
+  const initTests = ({
+    responses,
+    createApiTokenClient,
+    apiTokens,
+    renderSignalCheck,
+    requireApiTokens = false,
+  }: {
+    responses: ResponseType[];
+    createApiTokenClient?: boolean;
+    apiTokens?: TokenData;
+    renderSignalCheck?: boolean;
+    requireApiTokens?: boolean;
+  }) => {
+    responses.forEach((response) => {
+      addResponse({ status: response.returnedStatus, body: response.data ? JSON.stringify(response.data) : undefined });
+    });
+    currentApolloClient = createApolloClientMock();
+    currentModule = createGraphQLModule({
+      graphQLClient: currentApolloClient,
+      query: USER_QUERY,
+      queryOptions: {
+        fetchPolicy: 'no-cache',
+      },
+      options: {
+        requireApiTokens,
+      },
+    });
+
+    listenerModule = createTestListenerModule(graphQLModuleNamespace, 'graphQLModuleListener');
+
+    const modules: ConnectedModule[] = [currentModule, listenerModule];
+
+    if (createApiTokenClient || apiTokens) {
+      apiTokenStorage = apiTokens || null;
+      const fakeApiTokensClient: ConnectedModule & Partial<ApiTokenClient> = {
+        getTokens: () => {
+          return apiTokenStorage;
+        },
+        connect: () => {},
+        namespace: apiTokensClientNamespace,
+      };
+      modules.push(fakeApiTokensClient);
+    }
+
+    testUtil = createHookTestEnvironment(
+      {
+        waitForRenderToggle: false,
+        children: [<App key="app" renderSignalCheck={renderSignalCheck} />],
+        noOidcClient: true,
+      },
+      {},
+      modules,
+    );
+    const getData = () => {
+      return testUtil.getElementJSON(elementIds.dataElement);
+    };
+    const getErrorType = () => {
+      return testUtil.getInnerHtml(elementIds.errorElement);
+    };
+    const clickLoadButton = () => {
+      return testUtil.clickElement(elementIds.queryButton);
+    };
+    const clickRefetchButton = () => {
+      return testUtil.clickElement(elementIds.refetchButton);
+    };
+    const clickCancelButton = () => {
+      return testUtil.clickElement(elementIds.cancelButton);
+    };
+    const clickClearButton = () => {
+      return testUtil.clickElement(elementIds.clearButton);
+    };
+    const getIsLoading = () => {
+      if (testUtil.getInnerHtml(elementIds.isLoading) !== testUtil.getInnerHtml(elementIds.isLoadingInHook)) {
+        throw new Error('isLoading hook mismatch');
+      }
+      return testUtil.getInnerHtml(elementIds.isLoading) === 'true';
+    };
+    const getIsPending = () => {
+      return testUtil.getInnerHtml(elementIds.isPending) === 'true';
+    };
+    const getNotListeningComponentRenderTime = () => {
+      return parseInt(testUtil.getInnerHtml(elementIds.notUpdatingRenderTime), 10);
+    };
+    const waitForReturnValueChange = async (func: () => unknown, advanceTime = 0) => {
+      const current = func();
+      const compareObjects = isObject(current);
+      await waitFor(() => {
+        if (advanceTime) {
+          jest.advanceTimersByTime(advanceTime);
+        }
+        const newValue = func();
+        if (compareObjects && isObject(newValue)) {
+          expect(newValue).not.toMatchObject(current as object);
+        } else if (newValue === current) {
+          throw new Error('Same value');
+        }
+      });
+    };
+
+    const waitForIsLoadingChange = async (advanceTime = 0) => {
+      await waitForReturnValueChange(getIsLoading, advanceTime);
+    };
+    const waitForDataChange = async (advanceTime = 0) => {
+      await waitForReturnValueChange(getData, advanceTime);
+    };
+    const waitForValue = async (func: () => unknown, advanceTime = 0, expectedValue: unknown) => {
+      await waitFor(() => {
+        if (advanceTime) {
+          jest.advanceTimersByTime(advanceTime);
+        }
+        const value = func();
+        if (value !== expectedValue) {
+          throw new Error(`Not correct value. Expected ${expectedValue}, but got ${value}`);
+        }
+      });
+    };
+    const waitForIsLoadingToMatch = async (isLoading: boolean, advanceTime = 0) => {
+      await waitForValue(getIsLoading, advanceTime, isLoading);
+    };
+
+    const emitApiTokensUpdatedStateChange = (tokens: TokenData) => {
+      apiTokenStorage = tokens;
+      const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_UPDATED };
+      testUtil.emit({ type: eventSignalType, namespace: apiTokensClientNamespace, payload });
+    };
+
+    return {
+      ...testUtil,
+      getData,
+      getErrorType,
+      getIsPending,
+      getIsLoading,
+      clickLoadButton,
+      clickCancelButton,
+      clickClearButton,
+      clickRefetchButton,
+      waitForIsLoadingChange,
+      waitForDataChange,
+      waitForIsLoadingToMatch,
+      getNotListeningComponentRenderTime,
+      emitApiTokensUpdatedStateChange,
+    };
+  };
+
+  const initResponder = () => {
+    setResponders([{ path: mockedGraphQLUri }]);
+  };
+
+  const getEmittedErrors = () => {
+    return getReceivedErrorSignalPayloads<GraphQLModuleError>(listenerModule);
+  };
+
+  const getEmittedEventTypes = () => {
+    return getReceivedEventSignalPayloads(listenerModule).map((payload) => payload.type);
+  };
+
+  const getResponseDataObj = (response: ResponseType) => {
+    return response.data ? response.data.data : undefined;
+  };
+
+  // ApolloClient emits errors when cached data is invalid. That does not matter in these tests.
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    enableFetchMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    initResponder();
+  });
+
+  afterEach(async () => {
+    await cleanUp();
+    apiTokenStorage = null;
+    if (currentModule) {
+      act(() => {
+        currentModule.clear();
+      });
+    }
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    mockMapForAbort.clear();
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('Components can use hooks and make queries and components update when module updates.', async () => {
+    const {
+      clickLoadButton,
+      getIsPending,
+      getIsLoading,
+      waitForDataChange,
+      getData,
+      getErrorType,
+      waitForIsLoadingToMatch,
+      getNotListeningComponentRenderTime,
+    } = initTests({
+      responses: [successfulResponse, errorResponse],
+    });
+    // track re-render time of the component using just the useGraphQLModule
+    const initialRenderTime = getNotListeningComponentRenderTime();
+    expect(getIsLoading()).toBeFalsy();
+    expect(getIsPending()).toBeFalsy();
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+
+    expect(getIsLoading()).toBeTruthy();
+    expect(getIsPending()).toBeTruthy();
+
+    await waitForDataChange(200);
+    await waitForIsLoadingToMatch(false);
+    expect(getIsLoading()).toBeFalsy();
+    expect(getIsPending()).toBeFalsy();
+
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+
+    expect(getData()).toEqual(getResponseDataObj(successfulResponse));
+    expect(getErrorType()).toEqual('');
+
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+    await waitForIsLoadingToMatch(false);
+    expect(getIsLoading()).toBeFalsy();
+    expect(getIsPending()).toBeFalsy();
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+    ]);
+    expect(getEmittedErrors()[0].type).toEqual(graphQLModuleError.GRAPHQL_LOAD_FAILED);
+    expect(getErrorType()).toEqual(graphQLModuleError.GRAPHQL_LOAD_FAILED);
+    expect(getData()).toEqual(null);
+    // make sure the component using just the useGraphQLModule hook is not auto-rerendered
+    expect(getNotListeningComponentRenderTime()).toBe(initialRenderTime);
+  });
+  it('Cancel() works', async () => {
+    const { clickLoadButton, clickCancelButton, waitForIsLoadingToMatch, getErrorType, getData } = initTests({
+      responses: [successfulResponse, successfulResponse],
+    });
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+    clickCancelButton();
+    await waitForIsLoadingToMatch(false);
+    expect(getEmittedErrors().length).toBe(0);
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+    ]);
+    expect(getErrorType()).toEqual('');
+    expect(getData()).toEqual(null);
+  });
+  it('clear() works', async () => {
+    const { clickLoadButton, clickClearButton, waitForDataChange, getData, getErrorType, waitForIsLoadingToMatch } =
+      initTests({
+        responses: [successfulResponse, successfulResponse],
+      });
+
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+    await waitForDataChange(200);
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+
+    clickClearButton();
+    await waitForIsLoadingToMatch(false);
+
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_CLEARED,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+    ]);
+    expect(getData()).toEqual(null);
+    expect(getErrorType()).toEqual('');
+  });
+  it('refetchButton() queries from server', async () => {
+    const responses = [createSuccessResponse({ id: 1 }), createSuccessResponse({ id: 2 })];
+    const { clickLoadButton, clickRefetchButton, waitForDataChange, getData, waitForIsLoadingToMatch } = initTests({
+      responses,
+    });
+
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+    await waitForDataChange(200);
+    expect(getData()).toEqual(getResponseDataObj(responses[0]));
+    await waitForIsLoadingToMatch(false);
+    clickRefetchButton();
+    await waitForIsLoadingToMatch(true);
+    await waitForDataChange(200);
+    expect(getData()).toEqual(getResponseDataObj(responses[1]));
+  });
+
+  it('Calling query multiple times is handled', async () => {
+    const responses = [
+      createSuccessResponse({ id: 1 }),
+      createSuccessResponse({ id: 2 }),
+      errorResponse,
+      createSuccessResponse({ id: 3 }),
+      createSuccessResponse({ id: 4 }),
+    ];
+    const { clickLoadButton, getErrorType, waitForDataChange, getData, waitForIsLoadingToMatch } = initTests({
+      responses,
+    });
+    clickLoadButton();
+    await waitForDataChange(200);
+    await waitForIsLoadingToMatch(false);
+
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+
+    expect(getData()).toEqual(getResponseDataObj(responses[0]));
+    expect(getErrorType()).toEqual('');
+
+    clickLoadButton();
+    await waitForDataChange(200);
+    await waitForIsLoadingToMatch(false);
+    expect(getData()).toEqual(getResponseDataObj(responses[1]));
+    expect(getErrorType()).toEqual('');
+
+    clickLoadButton();
+    await waitForDataChange(200);
+    await waitForIsLoadingToMatch(false);
+    expect(getData()).toEqual(null);
+    expect(getErrorType()).toEqual(graphQLModuleError.GRAPHQL_LOAD_FAILED);
+
+    clickLoadButton();
+    await waitForIsLoadingToMatch(true);
+    // second load aborts previous signal
+    clickLoadButton();
+    await waitForIsLoadingToMatch(false);
+    expect(getData()).toEqual(getResponseDataObj(responses[4]));
+    expect(getErrorType()).toEqual('');
+
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+  });
+  it('ApiTokens updated event triggers load', async () => {
+    const { waitForDataChange, waitForIsLoadingToMatch, emitApiTokensUpdatedStateChange } = initTests({
+      responses: [successfulResponse, successfulResponse],
+      requireApiTokens: true,
+      createApiTokenClient: true,
+    });
+    await waitForIsLoadingToMatch(false);
+    act(() => {
+      emitApiTokensUpdatedStateChange(defaultApiTokens);
+    });
+
+    await waitForIsLoadingToMatch(true);
+    await waitForDataChange(200);
+    await waitForIsLoadingToMatch(false);
+    expect(getEmittedEventTypes()).toEqual([
+      graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+    ]);
+  });
+  it('If apiTokens exists, query is triggered automatically.', async () => {
+    await act(async () => {
+      const { waitForDataChange, waitForIsLoadingToMatch } = initTests({
+        responses: [successfulResponse, successfulResponse],
+        apiTokens: defaultApiTokens,
+        requireApiTokens: true,
+      });
+      await waitForIsLoadingToMatch(true);
+      await waitForDataChange(200);
+      await waitForIsLoadingToMatch(false);
+      expect(getEmittedEventTypes()).toEqual([
+        graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+        graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      ]);
+    });
+  });
+});

--- a/packages/react/src/components/login/graphQLModule/hooks.tsx
+++ b/packages/react/src/components/login/graphQLModule/hooks.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import { ApolloQueryResult } from '@apollo/client';
+
+import { useConnectedModule, useSignalTrackingWithReturnValue } from '../beacon/hooks';
+import { graphQLModuleNamespace, GraphQLModule, GraphQLQueryResult, GraphQLCache } from './index';
+import { triggerForAllGraphQLModuleSignals } from './signals';
+import { GraphQLModuleError } from './graphQLModuleError';
+import { Signal } from '../beacon/beacon';
+
+export type UseGraphQLModuleHookObject<T, Q> = {
+  data: Q | undefined;
+  error: GraphQLModuleError | undefined;
+  loading: boolean;
+  refetch: GraphQLModule<T, Q>['query'];
+};
+export type UseGraphQLModuleHookReturnType<T, Q> = [GraphQLModule<T, Q>['query'], UseGraphQLModuleHookObject<T, Q>];
+
+/**
+ * Returns the GraphQL module.
+ * @returns GraphQLModule
+ */
+export const useGraphQLModule = <T = GraphQLCache, Q = GraphQLQueryResult>(): GraphQLModule<T, Q> => {
+  const graphQLModule = useConnectedModule<GraphQLModule<T, Q>>(graphQLModuleNamespace);
+  if (!graphQLModule) {
+    throw new Error('Cannot find graphQLModule from LoginContext.');
+  }
+  return graphQLModule;
+};
+
+/**
+ * The hook forces the component using it to re-render each time the listener is triggered.
+ * @returns [Signal, resetFunction, GraphQL module instance]
+ */
+export const useGraphQLModuleTracking = (): [Signal | undefined, () => void, GraphQLModule] => {
+  const module = useGraphQLModule();
+  return [...useSignalTrackingWithReturnValue(triggerForAllGraphQLModuleSignals), module];
+};
+
+/**
+ * Mimics the useLazyQuery hook of the Apollo GraphQL library. The hook forces the component using it to re-render each time the module emits a signal.
+ * @returns [query, {data, error, loading, refetch}]
+ */
+export const useGraphQL = <T = GraphQLCache, Q = GraphQLQueryResult>(): UseGraphQLModuleHookReturnType<T, Q> => {
+  const graphQLModule = useGraphQLModule<T, Q>();
+  const catchedQuery: GraphQLModule<T, Q>['query'] = async (props) => {
+    const promise = graphQLModule.queryServer(props).catch(() => {
+      // catch error to prevent "unhandled promise" error.
+    });
+    return promise as Promise<ApolloQueryResult<Q>>;
+  };
+  // causes re-render when the module emits something
+  useGraphQLModuleTracking();
+  const createReturnObject = useMemo<() => UseGraphQLModuleHookObject<T, Q>>(() => {
+    return () => {
+      return {
+        data: graphQLModule.getData() || undefined,
+        error: graphQLModule.getError() || undefined,
+        loading: graphQLModule.isLoading(),
+        refetch: catchedQuery,
+      };
+    };
+  }, [graphQLModule]);
+  return [catchedQuery, createReturnObject()];
+};

--- a/packages/react/src/components/login/graphQLModule/index.ts
+++ b/packages/react/src/components/login/graphQLModule/index.ts
@@ -17,38 +17,113 @@ export type GraphQLQueryResult = { [key: string]: unknown };
 export type GraphQLCache = NormalizedCacheObject;
 
 export type GraphQLModule<T = NormalizedCacheObject, Q = GraphQLQueryResult> = ConnectedModule & {
+  /**
+   * Cancels current query. The pending query is aborted.
+   */
   cancel: () => void;
+  /**
+   * Calls cancel() and also clears errors and results. Emits a GRAPHQL_MODULE_CLEARED event.
+   */
   clear: () => void;
+  /**
+   * Returns array of query errors and/or errors in the result data.
+   */
   getClientErrors: () => ApolloError[];
+  /**
+   * Returns the data property of last successful query result.
+   */
   getData: () => Q | undefined;
+  /**
+   * Returns a query error.
+   */
   getError: () => GraphQLModuleError | undefined;
+  /**
+   * Returns the current pending query promise or an immediately rejected promise.
+   */
   getQueryPromise: () => Promise<ApolloQueryResult<Q>>;
+  /**
+   * Returns the latest query result.
+   */
   getResult: () => ApolloQueryResult<Q> | undefined;
+  /**
+   * Returns true if a query fetch is currently active.
+   */
   isLoading: () => boolean;
+  /**
+   * Returns true if the module is waiting for api tokens or query results.
+   */
   isPending: () => boolean;
+  /**
+   * Executes a query.
+   */
   query: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  /**
+   * Calls query(options) with fetchPolicy: 'cache-only' in options.
+   */
   queryCache: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  /**
+   * Calls query(options) with fetchPolicy: 'network-only' in options.
+   */
   queryServer: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  /**
+   * Sets the graphQLClient.
+   */
   setClient: (client: ApolloClient<T>) => void;
+  /**
+   * Returns a promise that is resolved when api tokens are found.
+   */
   waitForApiTokens: (timeout?: number) => Promise<unknown>;
 };
 
 export type GraphQLModuleModuleProps<T = NormalizedCacheObject, Q = GraphQLQueryResult> = {
+  /**
+   * Optional property, but must be set before the query is executed.
+   */
   graphQLClient?: ApolloClient<T>;
+  /**
+   * GraphQL module options.
+   */
   options?: Partial<{
+    /**
+     * Should query be executed automatically on initialization. Default true.
+     */
     autoFetch: boolean;
+    /**
+     * Are api tokens required for queries. Default true.
+     */
     requireApiTokens: boolean;
+    /**
+     * Should an on-going query be aborted when querying again. Default true.
+     */
     abortIfLoading: boolean;
+    /**
+     * Should old result be kept, if a newer query fails. Default false.
+     */
     keepOldResultOnError: boolean;
+    /**
+     * How long in milliseconds should api tokens be awaited before rejecting a query. Default 15 000.
+     */
     apiTokensWaitTime: number;
+    /**
+     * An object key for the api token to use in a query.
+     */
     apiTokenKey?: string;
   }>;
+  /**
+   * A graphQL query document.
+   */
   query?: TypedDocumentNode<Q, OperationVariables> | DocumentNode;
+  /**
+   * This function is called before a query is executed. The options object returned by the function is used as query options.
+   */
   queryHelper?: (
     currentOptions: QueryOptions<OperationVariables, Q>,
     apiTokenClient: ApiTokenClient | undefined,
     beacon: Beacon | undefined,
   ) => QueryOptions<OperationVariables, Q>;
+  /**
+   * Other ApolloClient queryOptions except query document.
+   */
   queryOptions?: Omit<QueryOptions<OperationVariables, Q>, 'query'>;
 };
 

--- a/packages/react/src/components/login/graphQLModule/index.ts
+++ b/packages/react/src/components/login/graphQLModule/index.ts
@@ -1,0 +1,76 @@
+import {
+  ApolloClient,
+  TypedDocumentNode,
+  OperationVariables,
+  QueryOptions,
+  NormalizedCacheObject,
+  ApolloQueryResult,
+  ApolloError,
+  DocumentNode,
+} from '@apollo/client/core';
+
+import { ApiTokenClient } from '../apiTokensClient';
+import { Beacon, ConnectedModule } from '../beacon/beacon';
+import { GraphQLModuleError } from './graphQLModuleError';
+
+export type GraphQLQueryResult = { [key: string]: unknown };
+export type GraphQLCache = NormalizedCacheObject;
+
+export type GraphQLModule<T = NormalizedCacheObject, Q = GraphQLQueryResult> = ConnectedModule & {
+  cancel: () => void;
+  clear: () => void;
+  getClientErrors: () => ApolloError[];
+  getData: () => Q | undefined;
+  getError: () => GraphQLModuleError | undefined;
+  getQueryPromise: () => Promise<ApolloQueryResult<Q>>;
+  getResult: () => ApolloQueryResult<Q> | undefined;
+  isLoading: () => boolean;
+  isPending: () => boolean;
+  query: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  waitForApiTokens: (timeout?: number) => Promise<unknown>;
+};
+
+export type GraphQLModuleModuleProps<T = NormalizedCacheObject, Q = GraphQLQueryResult> = {
+  graphQLClient?: ApolloClient<T>;
+  options?: Partial<{
+    autoFetch: boolean;
+    requireApiTokens: boolean;
+    abortIfLoading: boolean;
+    keepOldResultOnError: boolean;
+    apiTokensWaitTime: number;
+    apiTokenKey?: string;
+  }>;
+  query?: TypedDocumentNode<Q, OperationVariables> | DocumentNode;
+  queryHelper?: (
+    currentOptions: QueryOptions<OperationVariables, Q>,
+    apiTokenClient: ApiTokenClient | undefined,
+    beacon: Beacon | undefined,
+  ) => QueryOptions<OperationVariables, Q>;
+  queryOptions?: Omit<QueryOptions<OperationVariables, Q>, 'query'>;
+};
+
+export type GraphQLModuleState = keyof typeof graphQLModuleStates;
+
+export const graphQLModuleNamespace = 'graphQLModule';
+
+export const graphQLModuleStates = {
+  IDLE: 'IDLE',
+  LOADING: 'LOADING',
+} as const;
+
+export type GraphQLModuleEvent = keyof typeof graphQLModuleEvents;
+
+export const graphQLModuleEvents = {
+  GRAPHQL_MODULE_LOADING: 'GRAPHQL_MODULE_LOADING',
+  GRAPHQL_MODULE_LOAD_SUCCESS: 'GRAPHQL_MODULE_LOAD_SUCCESS',
+  GRAPHQL_MODULE_LOAD_ABORTED: 'GRAPHQL_MODULE_LOAD_ABORTED',
+  GRAPHQL_MODULE_CLEARED: 'GRAPHQL_MODULE_CLEARED',
+} as const;
+
+export const defaultOptions: GraphQLModuleModuleProps['options'] = {
+  autoFetch: true,
+  requireApiTokens: true,
+  abortIfLoading: true,
+  keepOldResultOnError: false,
+  apiTokensWaitTime: 15000,
+};

--- a/packages/react/src/components/login/graphQLModule/index.ts
+++ b/packages/react/src/components/login/graphQLModule/index.ts
@@ -27,6 +27,9 @@ export type GraphQLModule<T = NormalizedCacheObject, Q = GraphQLQueryResult> = C
   isLoading: () => boolean;
   isPending: () => boolean;
   query: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  queryCache: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  queryServer: (props?: Partial<GraphQLModuleModuleProps<T, Q>>) => Promise<ApolloQueryResult<Q>>;
+  setClient: (client: ApolloClient<T>) => void;
   waitForApiTokens: (timeout?: number) => Promise<unknown>;
 };
 

--- a/packages/react/src/components/login/graphQLModule/signals.test.ts
+++ b/packages/react/src/components/login/graphQLModule/signals.test.ts
@@ -1,0 +1,179 @@
+/* eslint-disable jest/no-mocks-import */
+import { GraphQLModuleEvent, graphQLModuleNamespace, graphQLModuleEvents } from '.';
+import {
+  createTriggerForAllNamespaces,
+  createTriggerPropsForAllSignals,
+  errorSignalType,
+  eventSignalType,
+  isEventSignal,
+} from '../beacon/signals';
+import {
+  createGraphQLModuleErrorSignal,
+  createGraphQLModuleEventSignal,
+  isGraphQLModuleClearedSignal,
+  isGraphQLModuleLoadAbortedSignal,
+  isGraphQLModuleNoApiTokensErrorSignal,
+  isGraphQLModuleNoClientErrorSignal,
+  graphQLModuleLoadAbortedTrigger,
+  graphQLModuleClearedTrigger,
+  graphQLModuleLoadSuccessTrigger,
+  graphQLModuleLoadingTrigger,
+  noClientErrorTrigger,
+  noApiTokensErrorTrigger,
+  getGraphQLModuleEventPayload,
+  isGraphQLModuleSignal,
+  triggerForAllGraphQLModuleErrors,
+  triggerForAllGraphQLModuleEvents,
+  isGraphQLModuleLoadSuccessSignal,
+  isGraphQLModuleLoadingSignal,
+  loadFailedErrorTrigger,
+  isGraphQLModuleLoadFailedSignal,
+} from './signals';
+import { SignalTrigger, createSignalTrigger } from '../beacon/beacon';
+import { GraphQLModuleError, GraphQLModuleErrorType, graphQLModuleError } from './graphQLModuleError';
+import { oidcClientNamespace } from '../client';
+import { createQueryResponse } from './__mocks__/mockResponses';
+
+describe(`Signals`, () => {
+  const eventData = createQueryResponse();
+  const eventChecks: Array<[typeof isGraphQLModuleClearedSignal, GraphQLModuleEvent, SignalTrigger]> = [
+    [isGraphQLModuleClearedSignal, graphQLModuleEvents.GRAPHQL_MODULE_CLEARED, graphQLModuleClearedTrigger],
+    [isGraphQLModuleLoadingSignal, graphQLModuleEvents.GRAPHQL_MODULE_LOADING, graphQLModuleLoadingTrigger],
+    [
+      isGraphQLModuleLoadSuccessSignal,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+      graphQLModuleLoadSuccessTrigger,
+    ],
+    [
+      isGraphQLModuleLoadAbortedSignal,
+      graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+      graphQLModuleLoadAbortedTrigger,
+    ],
+  ];
+  // create array of [basic signal, signal with more data] in same order as eventChecks
+  const eventSignals = eventChecks.map(([, type]) => {
+    return [createGraphQLModuleEventSignal({ type }), createGraphQLModuleEventSignal({ type, data: { foo: 'bar' } })];
+  });
+  const errorChecks: Array<[typeof isGraphQLModuleNoApiTokensErrorSignal, GraphQLModuleErrorType, SignalTrigger]> = [
+    [isGraphQLModuleNoApiTokensErrorSignal, graphQLModuleError.GRAPHQL_NO_API_TOKENS, noApiTokensErrorTrigger],
+    [isGraphQLModuleNoClientErrorSignal, graphQLModuleError.GRAPHQL_NO_CLIENT, noClientErrorTrigger],
+    [isGraphQLModuleLoadFailedSignal, graphQLModuleError.GRAPHQL_LOAD_FAILED, loadFailedErrorTrigger],
+  ];
+  const errorSignals = errorChecks.map(([, type]) => {
+    return [createGraphQLModuleErrorSignal(new GraphQLModuleError('test', type))];
+  });
+  describe(`isGraphQLModuleSignal`, () => {
+    it(`returns true when signal.namespace equals graphQLModuleNamespace`, () => {
+      expect(isGraphQLModuleSignal({ type: eventSignalType, namespace: graphQLModuleNamespace })).toBeTruthy();
+      expect(isGraphQLModuleSignal({ type: 'any', namespace: graphQLModuleNamespace })).toBeTruthy();
+      expect(isGraphQLModuleSignal({ type: '', namespace: graphQLModuleNamespace })).toBeTruthy();
+      expect(isGraphQLModuleSignal({ namespace: graphQLModuleNamespace })).toBeTruthy();
+    });
+    it(`returns false when signal.namespace does not equal graphQLModuleNamespace`, () => {
+      expect(isGraphQLModuleSignal({ type: eventSignalType, namespace: oidcClientNamespace })).toBeFalsy();
+      expect(isGraphQLModuleSignal({ type: errorSignalType, namespace: 'any' })).toBeFalsy();
+      expect(isGraphQLModuleSignal({ namespace: '' })).toBeFalsy();
+      expect(isGraphQLModuleSignal(createTriggerPropsForAllSignals())).toBeFalsy();
+    });
+  });
+
+  describe(`event signal functions`, () => {
+    describe(`createGraphQLModuleEventSignal`, () => {
+      const payload = { type: graphQLModuleEvents.GRAPHQL_MODULE_LOADING, data: eventData };
+      it(`creates a signal with event type and payload has type and data`, () => {
+        const signal = createGraphQLModuleEventSignal(payload);
+        expect(signal.type).toBe(eventSignalType);
+        expect(signal.namespace).toBe(graphQLModuleNamespace);
+        expect(signal.payload.type).toBe(payload.type);
+        expect(signal.payload.data).toEqual(eventData);
+        expect(isGraphQLModuleSignal(signal)).toBeTruthy();
+        expect(isEventSignal(signal)).toBeTruthy();
+      });
+      it(`Created signal must trigger associated listener`, () => {
+        const trigger = createSignalTrigger({ type: eventSignalType, namespace: graphQLModuleNamespace });
+        expect(trigger(createGraphQLModuleEventSignal(payload))).toBeTruthy();
+
+        const trigger2 = createSignalTrigger({ type: eventSignalType });
+        expect(trigger2(createGraphQLModuleEventSignal(payload))).toBeTruthy();
+
+        const trigger3 = createSignalTrigger({ type: eventSignalType, payload });
+        expect(trigger3(createGraphQLModuleEventSignal(payload))).toBeTruthy();
+      });
+
+      describe(`event signal creator, checker and trigger should be compatible with each other`, () => {
+        eventChecks.forEach(([checker, event, trigger], index) => {
+          const signal = eventSignals[index][0];
+          const signalWithMoreProps = eventSignals[index][1];
+          it(`Signal with ${event} is match with ${checker.name} and ${trigger.name} and returns true`, () => {
+            expect(checker(signal)).toBeTruthy();
+            expect(trigger(signal)).toBeTruthy();
+            expect(trigger(signalWithMoreProps)).toBeTruthy();
+            expect(triggerForAllGraphQLModuleEvents(signal)).toBeTruthy();
+            expect(triggerForAllGraphQLModuleEvents(signalWithMoreProps)).toBeTruthy();
+          });
+          it(`Check ${checker.name} and ${trigger.name} do not return true with wrong namespace or signals`, () => {
+            expect(trigger({ ...signal, namespace: oidcClientNamespace })).toBeFalsy();
+            expect(trigger({ ...signal, ...createTriggerForAllNamespaces() })).toBeFalsy();
+            expect(triggerForAllGraphQLModuleErrors(signal)).toBeFalsy();
+            // cross check others. None should work with wrong signals
+            eventChecks.forEach(([anotherChecker, anotherEvent, wrongTrigger], anotherIndex) => {
+              if (event === anotherEvent) {
+                return;
+              }
+              const wrongSignal = eventSignals[anotherIndex][0];
+              expect(checker(wrongSignal)).toBeFalsy();
+              expect(trigger(wrongSignal)).toBeFalsy();
+              expect(anotherChecker(signal)).toBeFalsy();
+              expect(wrongTrigger(signal)).toBeFalsy();
+            });
+
+            errorChecks.forEach(([errorChecker, , wrongTrigger], errorIndex) => {
+              const wrongSignal = errorSignals[errorIndex][0];
+              expect(checker(wrongSignal)).toBeFalsy();
+              expect(trigger(wrongSignal)).toBeFalsy();
+              expect(errorChecker(signal)).toBeFalsy();
+              expect(wrongTrigger(signal)).toBeFalsy();
+            });
+          });
+        });
+      });
+    });
+    describe(`getGraphQLModuleEventPayload`, () => {
+      it(`Returns signal's payload, if signal is a event signal`, () => {
+        const payload = { type: graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS, data: eventData };
+        const signal = createGraphQLModuleEventSignal(payload);
+        expect(getGraphQLModuleEventPayload(signal)).toEqual(payload);
+        expect(getGraphQLModuleEventPayload({ ...signal, type: errorSignalType })).toBeNull();
+        expect(getGraphQLModuleEventPayload({})).toBeNull();
+      });
+    });
+  });
+  describe(`error signal functions`, () => {
+    describe(`error signal creator, checker and trigger should be compatible with each other`, () => {
+      errorChecks.forEach(([checker, errorType, trigger], index) => {
+        const signal = errorSignals[index][0];
+        it(`Signal with ${errorType} is match with ${checker.name} and ${trigger.name} and returns true`, () => {
+          expect(checker(signal)).toBeTruthy();
+          expect(trigger(signal)).toBeTruthy();
+          expect(triggerForAllGraphQLModuleErrors(signal)).toBeTruthy();
+        });
+        it(`Check ${checker.name} and ${trigger.name} do not return true with wrong namespace or signals`, () => {
+          expect(trigger({ ...signal, namespace: oidcClientNamespace })).toBeFalsy();
+          expect(trigger({ ...signal, ...createTriggerForAllNamespaces() })).toBeFalsy();
+          expect(triggerForAllGraphQLModuleEvents(signal)).toBeFalsy();
+          // cross check others. None should work with wrong signals
+          errorChecks.forEach(([anotherChecker, anotherErrorType, wrongTrigger], anotherIndex) => {
+            if (errorType === anotherErrorType) {
+              return;
+            }
+            const wrongSignal = errorSignals[anotherIndex][0];
+            expect(checker(wrongSignal)).toBeFalsy();
+            expect(trigger(wrongSignal)).toBeFalsy();
+            expect(anotherChecker(signal)).toBeFalsy();
+            expect(wrongTrigger(signal)).toBeFalsy();
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/react/src/components/login/graphQLModule/signals.ts
+++ b/packages/react/src/components/login/graphQLModule/signals.ts
@@ -1,0 +1,163 @@
+import { GraphQLModuleEvent, graphQLModuleEvents, graphQLModuleNamespace, GraphQLQueryResult } from '.';
+import { Signal, SignalTrigger, SignalTriggerProps, createSignalTrigger } from '../beacon/beacon';
+import {
+  EventSignal,
+  isNamespacedSignal,
+  createTriggerPropsForAllSignals,
+  createEventSignal,
+  ErrorSignal,
+  createErrorSignal,
+  EventPayload,
+  getEventSignalPayload,
+  checkErrorSignalPayload,
+  createErrorTriggerProps,
+  checkEventSignalPayload,
+  createEventTriggerProps,
+  getErrorSignalPayload,
+} from '../beacon/signals';
+import { graphQLModuleError, GraphQLModuleError, GraphQLModuleErrorType } from './graphQLModuleError';
+
+export type GraphQLModuleEventSignal = EventSignal & {
+  payload: {
+    type: GraphQLModuleEvent;
+    data: GraphQLQueryResult | null;
+  };
+};
+
+export function isGraphQLModuleSignal(signal: Signal) {
+  return isNamespacedSignal(signal, graphQLModuleNamespace);
+}
+
+export function getGraphQLModuleEventPayload(signal: Signal): EventPayload | null {
+  return isGraphQLModuleSignal(signal) ? (getEventSignalPayload(signal) as EventPayload) : null;
+}
+
+export function getGraphQLModuleErrorPayload(signal: Signal): GraphQLModuleError | null {
+  return isGraphQLModuleSignal(signal) ? (getErrorSignalPayload(signal) as GraphQLModuleError) : null;
+}
+
+/**
+ *  is...ErrorSignal checkers
+ */
+export function isGraphQLModuleNoApiTokensErrorSignal(signal: Signal): boolean {
+  return (
+    isGraphQLModuleSignal(signal) &&
+    checkErrorSignalPayload(signal, (errorPayload) => (errorPayload as GraphQLModuleError).isNoApiTokensError)
+  );
+}
+
+export function isGraphQLModuleNoClientErrorSignal(signal: Signal): boolean {
+  return (
+    isGraphQLModuleSignal(signal) &&
+    checkErrorSignalPayload(signal, (errorPayload) => (errorPayload as GraphQLModuleError).isNoClientError)
+  );
+}
+
+export function isGraphQLModuleLoadFailedSignal(signal: Signal): boolean {
+  return (
+    isGraphQLModuleSignal(signal) &&
+    checkErrorSignalPayload(signal, (errorPayload) => (errorPayload as GraphQLModuleError).isLoadError)
+  );
+}
+
+/**
+ * Signal creators
+ */
+
+export function createGraphQLModuleEventSignal({
+  type,
+  data = null,
+}: Partial<GraphQLModuleEventSignal['payload']>): GraphQLModuleEventSignal {
+  return createEventSignal(graphQLModuleNamespace, {
+    type,
+    data,
+  }) as GraphQLModuleEventSignal;
+}
+
+export function createGraphQLModuleErrorSignal(error: GraphQLModuleError): ErrorSignal {
+  return createErrorSignal(graphQLModuleNamespace, error);
+}
+
+/**
+ *  trigger creators
+ */
+
+export function createTriggerPropsForAllGraphQLModuleSignals(): SignalTriggerProps {
+  return createTriggerPropsForAllSignals(graphQLModuleNamespace);
+}
+
+function createGraphQLModuleErrorTrigger(error: GraphQLModuleErrorType): SignalTrigger {
+  return createSignalTrigger(createErrorTriggerProps(graphQLModuleNamespace, error));
+}
+
+function createGraphQLModuleEventTrigger(type: GraphQLModuleEvent): SignalTrigger {
+  return createSignalTrigger(createEventTriggerProps(graphQLModuleNamespace, type));
+}
+
+/**
+ * Triggers
+ */
+
+export const triggerForAllGraphQLModuleSignals: SignalTrigger = createSignalTrigger(
+  createTriggerPropsForAllGraphQLModuleSignals(),
+);
+
+export const triggerForAllGraphQLModuleEvents: SignalTrigger = createSignalTrigger(
+  createEventTriggerProps(graphQLModuleNamespace),
+);
+
+export const triggerForAllGraphQLModuleErrors: SignalTrigger = createSignalTrigger(
+  createErrorTriggerProps(graphQLModuleNamespace),
+);
+
+export const loadFailedErrorTrigger: SignalTrigger = createGraphQLModuleErrorTrigger(
+  graphQLModuleError.GRAPHQL_LOAD_FAILED,
+);
+
+export const noApiTokensErrorTrigger: SignalTrigger = createGraphQLModuleErrorTrigger(
+  graphQLModuleError.GRAPHQL_NO_API_TOKENS,
+);
+
+export const noClientErrorTrigger: SignalTrigger = createGraphQLModuleErrorTrigger(
+  graphQLModuleError.GRAPHQL_NO_CLIENT,
+);
+
+export const graphQLModuleClearedTrigger: SignalTrigger = createGraphQLModuleEventTrigger(
+  graphQLModuleEvents.GRAPHQL_MODULE_CLEARED,
+);
+
+export const graphQLModuleLoadingTrigger: SignalTrigger = createGraphQLModuleEventTrigger(
+  graphQLModuleEvents.GRAPHQL_MODULE_LOADING,
+);
+
+export const graphQLModuleLoadAbortedTrigger: SignalTrigger = createGraphQLModuleEventTrigger(
+  graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED,
+);
+
+export const graphQLModuleLoadSuccessTrigger: SignalTrigger = createGraphQLModuleEventTrigger(
+  graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS,
+);
+
+/**
+ *  is...EventSignal checkers
+ */
+function isGivenEventSignal(signal: Signal, eventType: GraphQLModuleEvent): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  return isGraphQLModuleSignal(signal) && checkEventSignalPayload(signal, (payload) => payload.type === eventType);
+}
+
+export function isGraphQLModuleClearedSignal(signal?: Signal): boolean {
+  return !!signal && isGivenEventSignal(signal, graphQLModuleEvents.GRAPHQL_MODULE_CLEARED);
+}
+
+export function isGraphQLModuleLoadingSignal(signal?: Signal): boolean {
+  return !!signal && isGivenEventSignal(signal, graphQLModuleEvents.GRAPHQL_MODULE_LOADING);
+}
+
+export function isGraphQLModuleLoadAbortedSignal(signal?: Signal): boolean {
+  return !!signal && isGivenEventSignal(signal, graphQLModuleEvents.GRAPHQL_MODULE_LOAD_ABORTED);
+}
+
+export function isGraphQLModuleLoadSuccessSignal(signal?: Signal): boolean {
+  return !!signal && isGivenEventSignal(signal, graphQLModuleEvents.GRAPHQL_MODULE_LOAD_SUCCESS);
+}

--- a/packages/react/src/components/login/graphQLModule/utils.test.ts
+++ b/packages/react/src/components/login/graphQLModule/utils.test.ts
@@ -1,0 +1,199 @@
+import { DocumentNode, QueryOptions } from '@apollo/client';
+
+import { cloneWithJSONConversion } from '../../../utils/cloneObject';
+import {
+  appendFetchOptions,
+  mergeAuthorizationHeaderToQueryOptions,
+  mergeHeadersToQueryOptions,
+  mergeQueryOptionContexts,
+  mergeQueryOptions,
+  setBearerToQueryOptions,
+} from './utils';
+
+describe(`Utils`, () => {
+  const createQueryOptions = ({
+    id = 'default',
+    errorPolicy = 'all',
+    fetchPolicy = 'cache-first',
+  }: { id: string } & Pick<QueryOptions, 'errorPolicy' | 'fetchPolicy'>): Required<QueryOptions> => {
+    const queryOptionsContextFetchOptions: Parameters<typeof fetch>[1] = {
+      headers: {
+        [`${id}Prop1`]: `${id}Prop1Value`,
+        [`${id}Prop2`]: `${id}Prop2Value`,
+      },
+      method: 'GET',
+      signal: `${id}abortSignal` as unknown as AbortSignal,
+    };
+    const contextHeaders: Record<string, string> = {
+      [`${id}ContextHeader1`]: `${id}ContextHeader1Value`,
+      [`${id}ContextHeader2`]: `${id}ContextHeader2Value`,
+      authorization: `${id}authorization`,
+    };
+
+    const queryOptionsContext: QueryOptions['context'] = {
+      uri: `${id}queryOptionsContext.com`,
+      fetchOptions: { ...queryOptionsContextFetchOptions },
+      headers: { ...contextHeaders },
+    };
+
+    // omitted query because it makes object comparisons in Jest to fail
+    return {
+      query: {
+        [`${id}Query`]: `${id}QueryValue`,
+      } as unknown as DocumentNode,
+      context: queryOptionsContext,
+      variables: {
+        [`${id}Var1`]: `${id}Var2Value`,
+        [`${id}Var2`]: `${id}Var2Value`,
+      },
+      errorPolicy,
+      fetchPolicy,
+      pollInterval: 0,
+      notifyOnNetworkStatusChange: false,
+      returnPartialData: false,
+      partialRefetch: false,
+      canonizeResults: false,
+    };
+  };
+
+  const getEmptyQueryOptions = () => {
+    return {} as QueryOptions;
+  };
+
+  describe(`mergeQueryOptionContexts`, () => {
+    it(`Deep merges a new context to existing context. Passed options are mutated. Passed context is not mutated.`, () => {
+      const options1 = createQueryOptions({ id: 'one' });
+      const options2 = createQueryOptions({ id: 'two', fetchPolicy: 'cache-only', errorPolicy: 'ignore' });
+      const options1Clone = cloneWithJSONConversion(options1);
+      const options2ContextClone = cloneWithJSONConversion(options2.context);
+      const expectedResult = {
+        uri: options2.context.uri,
+        fetchOptions: {
+          ...options1.context.fetchOptions,
+          ...options2.context.fetchOptions,
+          headers: {
+            ...options1.context.fetchOptions.headers,
+            ...options2.context.fetchOptions.headers,
+          },
+        },
+        headers: {
+          ...options1.context.headers,
+          ...options2.context.headers,
+        },
+      };
+      const result1 = mergeQueryOptionContexts(options1, options2.context);
+      expect(result1.context).toEqual(expectedResult);
+      expect(options1.context).toEqual(expectedResult);
+      expect(options1).not.toMatchObject(options1Clone);
+      expect(options2.context).toMatchObject(options2ContextClone);
+      expect(mergeQueryOptionContexts(getEmptyQueryOptions(), options2.context).context).toEqual(options2.context);
+      expect(mergeQueryOptionContexts(options1, {}).context).toEqual(options1.context);
+    });
+  });
+  describe(`mergeQueryOptions`, () => {
+    it(`Deep merges two queryOption objects. Second argument is merged to first, second is not mutated. Query objects are not deep merged.`, () => {
+      const options1 = createQueryOptions({ id: 'one' });
+      const options2 = createQueryOptions({ id: 'two', fetchPolicy: 'cache-only', errorPolicy: 'ignore' });
+      Reflect.deleteProperty(options1, 'query');
+      Reflect.deleteProperty(options2, 'query');
+      const options1Clone = cloneWithJSONConversion(options1);
+      const options2Clone = cloneWithJSONConversion(options2);
+      const expectedContext = {
+        uri: options2.context.uri,
+        fetchOptions: {
+          ...options1.context.fetchOptions,
+          ...options2.context.fetchOptions,
+          headers: {
+            ...options1.context.fetchOptions.headers,
+            ...options2.context.fetchOptions.headers,
+          },
+        },
+        headers: {
+          ...options1.context.headers,
+          ...options2.context.headers,
+        },
+      };
+      const expectedResult = {
+        ...options2,
+        context: expectedContext,
+        variables: {
+          ...options1.variables,
+          ...options2.variables,
+        },
+      };
+
+      const result1 = mergeQueryOptions(options1, options2);
+      expect(result1).toEqual(expectedResult);
+      expect(options1).toEqual(expectedResult);
+      expect(options1).not.toMatchObject(options1Clone);
+      expect(options2).toMatchObject(options2Clone);
+      expect(mergeQueryOptions(getEmptyQueryOptions(), options2)).toEqual(options2);
+      expect(mergeQueryOptions(options1, {})).toEqual(options1);
+    });
+  });
+  describe(`mergeHeadersToQueryOptions`, () => {
+    it(`Merges a new headers to existing context headers`, () => {
+      const options1 = createQueryOptions({ id: 'one' });
+      const options2 = createQueryOptions({ id: 'two', fetchPolicy: 'cache-only', errorPolicy: 'ignore' });
+      const expectedResult = {
+        ...options1.context.headers,
+        ...options2.context.headers,
+      };
+      expect(mergeHeadersToQueryOptions(options1, options2.context.headers).context?.headers).toEqual(expectedResult);
+      expect(mergeHeadersToQueryOptions(options1, {}).context?.headers).toEqual(options1.context.headers);
+      expect(mergeHeadersToQueryOptions(getEmptyQueryOptions(), options2.context.headers).context?.headers).toEqual(
+        options2.context.headers,
+      );
+    });
+  });
+  describe(`mergeAuthorizationHeaderToQueryOptions`, () => {
+    it(`Adds a authorization prop to context headers`, () => {
+      const options1 = createQueryOptions({ id: 'one' });
+      const expectedResult = {
+        ...options1.context.headers,
+        authorization: 'hello',
+      };
+      expect(mergeAuthorizationHeaderToQueryOptions(options1, expectedResult.authorization).context?.headers).toEqual(
+        expectedResult,
+      );
+    });
+  });
+  describe(`setBearerToQueryOptions`, () => {
+    it(`Adds a authorization Bearer to context headers`, () => {
+      const options1 = createQueryOptions({ id: 'one' });
+      const token = 'token-1234';
+      const expectedResult = {
+        ...options1.context.headers,
+        authorization: `Bearer ${token}`,
+      };
+      expect(setBearerToQueryOptions(options1, token).context?.headers).toEqual(expectedResult);
+    });
+  });
+  describe(`appendFetchOptions`, () => {
+    it(`Adds given props to context fetch Options`, () => {
+      const options1 = createQueryOptions({ id: 'one' });
+      const fetchOptions = {
+        signal: 'fake-test-signal' as unknown as AbortSignal,
+        method: 'POST',
+      };
+      const expectedResult = {
+        ...options1.context.fetchOptions,
+        ...fetchOptions,
+      };
+      expect(appendFetchOptions(options1, fetchOptions).context?.fetchOptions).toEqual(expectedResult);
+    });
+    it(`Adds context and fetchOptions if not found`, () => {
+      const options1 = {} as QueryOptions;
+      const fetchOptions = {
+        signal: 'fake-test-signal' as unknown as AbortSignal,
+        method: 'POST',
+      };
+      const expectedResult = {
+        context: {
+          fetchOptions,
+        },
+      };
+      expect(appendFetchOptions(options1, fetchOptions)).toEqual(expectedResult);
+    });
+  });
+});

--- a/packages/react/src/components/login/graphQLModule/utils.ts
+++ b/packages/react/src/components/login/graphQLModule/utils.ts
@@ -1,0 +1,118 @@
+import { QueryOptions } from '@apollo/client/core';
+import { merge } from 'lodash';
+
+import { GraphQLModuleModuleProps } from '.';
+import { ApiTokenClient } from '../apiTokensClient';
+
+type PartialContext = Partial<QueryOptions['context']>;
+type QueryHeaders = Record<string, unknown>;
+
+function mergeQueryOptionsContexts(target: PartialContext, overrides: PartialContext): PartialContext {
+  return merge(target, overrides);
+}
+
+export function mergeQueryOptionContexts(options: QueryOptions, overrideContext: PartialContext): QueryOptions {
+  const context: PartialContext = options.context || {};
+  // eslint-disable-next-line no-param-reassign
+  options.context = mergeQueryOptionsContexts(context, overrideContext);
+  return options;
+}
+
+export function mergeHeadersToQueryOptions(options: QueryOptions, headers: QueryHeaders): QueryOptions {
+  const context: PartialContext = {
+    headers,
+  };
+  return mergeQueryOptionContexts(options, context);
+}
+
+export function mergeAuthorizationHeaderToQueryOptions(options: QueryOptions, authHeader: string): QueryOptions {
+  const headers: QueryHeaders = {
+    authorization: authHeader,
+  };
+  return mergeHeadersToQueryOptions(options, headers);
+}
+
+export function mergeQueryOptions(
+  target: Partial<GraphQLModuleModuleProps['queryOptions']>,
+  overrides: Partial<GraphQLModuleModuleProps['queryOptions']>,
+) {
+  return merge(target, overrides);
+}
+
+/* No need to export to hds-react package */
+export function mergeQueryOptionsToModuleProps<T, Q>(
+  target: Partial<GraphQLModuleModuleProps<T, Q>>,
+  queryOptions: Partial<QueryOptions<Q>>,
+) {
+  const { query, ...rest } = queryOptions;
+  // eslint-disable-next-line no-param-reassign
+  target.queryOptions = mergeQueryOptions(target.queryOptions || {}, rest);
+  if (query) {
+    // eslint-disable-next-line no-param-reassign
+    target.query = query;
+  }
+  return target;
+}
+
+export function setBearerToQueryOptions(queryOptions: QueryOptions, token: string) {
+  if (!token) {
+    return queryOptions;
+  }
+  return mergeAuthorizationHeaderToQueryOptions(queryOptions, `Bearer ${token}`);
+}
+
+export function appendFetchOptions(queryOptions: QueryOptions, newOptions: Partial<Parameters<typeof fetch>[1]>) {
+  if (!queryOptions.context) {
+    // eslint-disable-next-line no-param-reassign
+    queryOptions.context = {};
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  queryOptions.context.fetchOptions = {
+    ...queryOptions.context.fetchOptions,
+    ...newOptions,
+  };
+  return queryOptions;
+}
+
+/* No need to export to hds-react package */
+export function mergeQueryOptionModifiers({
+  options,
+  queryHelper,
+}: Pick<GraphQLModuleModuleProps, 'queryHelper' | 'options'>): Required<GraphQLModuleModuleProps>['queryHelper'] {
+  const { apiTokenKey } = options || {};
+  if (!apiTokenKey && !queryHelper) {
+    return (opt: QueryOptions) => opt;
+  }
+
+  if (!apiTokenKey && queryHelper) {
+    return queryHelper;
+  }
+
+  const tokenPicker = (apiTokenClient: ApiTokenClient, key: string) => {
+    if (!apiTokenClient) {
+      return undefined;
+    }
+    const tokens = apiTokenClient.getTokens();
+    return tokens ? tokens[key] : undefined;
+  };
+
+  const apiTokenSetter: GraphQLModuleModuleProps['queryHelper'] = (opt, apiTokenClient) => {
+    if (!apiTokenKey || !apiTokenClient) {
+      return opt;
+    }
+    const token = tokenPicker(apiTokenClient, apiTokenKey);
+    if (token) {
+      return setBearerToQueryOptions(opt, token);
+    }
+    return opt;
+  };
+
+  if (!queryHelper) {
+    return apiTokenSetter;
+  }
+
+  return (opt, apiTokenClient, beacon) => {
+    return queryHelper(apiTokenSetter(opt, apiTokenClient, beacon), apiTokenClient, beacon);
+  };
+}

--- a/packages/react/src/components/login/index.vanilla-js.ts
+++ b/packages/react/src/components/login/index.vanilla-js.ts
@@ -6,6 +6,7 @@
 export * from './types';
 export { ApiTokenClientProps, TokenData, ApiTokenClient, ApiTokensClientEvent } from './apiTokensClient/index';
 export { SessionPoller, SessionPollerEvent, SessionPollerOptions } from './sessionPoller/sessionPoller';
+export { GraphQLModule, GraphQLModuleModuleProps, GraphQLModuleEvent } from './graphQLModule/index';
 export {
   OidcClient,
   OidcClientEvent,
@@ -46,6 +47,7 @@ export {
 export * from './client/oidcClient';
 export * from './apiTokensClient/apiTokensClient';
 export { createSessionPoller } from './sessionPoller/sessionPoller';
+export { createGraphQLModule } from './graphQLModule/graphQLModule';
 
 // beacon
 export { createBeacon, createSignalTrigger } from './beacon/beacon';
@@ -54,14 +56,24 @@ export { createBeacon, createSignalTrigger } from './beacon/beacon';
 export * from './apiTokensClient/apiTokensClientError';
 export * from './client/oidcClientError';
 export * from './sessionPoller/sessionPollerError';
+export * from './graphQLModule/graphQLModuleError';
 
 // utils
 export { isHandlingLoginCallbackError } from './components/LoginCallbackHandler.util';
+export {
+  appendFetchOptions,
+  setBearerToQueryOptions,
+  mergeQueryOptions,
+  mergeAuthorizationHeaderToQueryOptions,
+  mergeHeadersToQueryOptions,
+  mergeQueryOptionContexts,
+} from './graphQLModule/utils';
 
 // events
 export { apiTokensClientEvents } from './apiTokensClient/index';
 export { oidcClientEvents } from './client/index';
 export { sessionPollerEvents } from './sessionPoller/sessionPoller';
+export { graphQLModuleEvents } from './graphQLModule/index';
 
 // stateChanges
 export { oidcClientStates } from './client/index';
@@ -73,11 +85,13 @@ export { createLoginSystem } from './createLoginSystem';
 export { apiTokensClientNamespace } from './apiTokensClient/index';
 export { oidcClientNamespace } from './client/index';
 export { sessionPollerNamespace } from './sessionPoller/sessionPoller';
+export { graphQLModuleNamespace } from './graphQLModule/index';
 
 // signals
 export * from './apiTokensClient/signals';
 export * from './client/signals';
 export * from './sessionPoller/signals';
+export * from './graphQLModule/signals';
 export {
   initSignalType,
   errorSignalType,

--- a/packages/react/src/utils/cloneObject.test.ts
+++ b/packages/react/src/utils/cloneObject.test.ts
@@ -1,0 +1,26 @@
+import { cloneObject, cloneWithJSONConversion } from './cloneObject';
+
+describe('cloneObject helpers', () => {
+  describe('cloneWithIterator()', () => {
+    it('Clones an object', async () => {
+      const source = { a: 1, b: undefined, deep: { value: 1, deepest: 'very deep' } };
+      const jsonClone = cloneWithJSONConversion(source);
+      const result = cloneObject(source);
+      expect(result).toEqual(source);
+      expect(result).toEqual(jsonClone);
+      // modifying clone does not alter source
+      Reflect.set(result, 'b', 2);
+      Reflect.set(result.deep, 'value', 2);
+      Reflect.set(result.deep, 'deepest', 'cloned deep');
+      expect(source).toEqual(jsonClone);
+    });
+    it('Clones object with "entries()"', async () => {
+      const source = new Headers();
+      source.set('key1', 'value1');
+      source.set('key2', 'value2');
+      const expectedResult = { key1: 'value1', key2: 'value2' };
+      const result = cloneObject(source);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/packages/react/src/utils/cloneObject.ts
+++ b/packages/react/src/utils/cloneObject.ts
@@ -1,0 +1,103 @@
+import { isObject, cloneDeep, clone as _clone } from 'lodash';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type IterableObject = Record<any, any> &
+  InstanceType<typeof Object> & { entries?(): IterableIterator<[string, string]> };
+
+/**
+ * Shallow clones objects, Headers, etc.
+ */
+
+export function shallowClone(source: IterableObject): IterableObject {
+  if (!isObject(source)) {
+    return {};
+  }
+  return _clone(source);
+}
+
+/**
+ * Deep clones an object, but drops out values that are functions, undefined, instances.
+ * Useful for example in tests where jest cannot compare objects with functions
+ */
+
+export function cloneWithJSONConversion(source: unknown): IterableObject {
+  if (!isObject(source)) {
+    return {};
+  }
+  return JSON.parse(JSON.stringify(source));
+}
+
+/**
+ * Deep clones source
+ */
+
+export function deepClone(source: unknown): IterableObject {
+  if (!isObject(source)) {
+    return {};
+  }
+  return cloneDeep(source);
+}
+
+function getObjectAsKeyValuePairs(source: IterableObject) {
+  if (!isObject(source)) {
+    return [];
+  }
+  const filterDangerousKeys = ([key]: [string, unknown]) => {
+    if (!key) {
+      return false;
+    }
+    if (typeof key === 'string') {
+      // avoid prototype pollution
+      return key !== 'prototype' && key.startsWith('__') === false;
+    }
+    return true;
+  };
+  const entriesArray = typeof source.entries !== 'function' ? Object.entries(source) : Array.from(source.entries());
+  return entriesArray.filter(filterDangerousKeys);
+}
+
+function copyIterableObject(source: IterableObject): IterableObject {
+  // @ts-ignore is for  Object.fromEntries
+  return Object.fromEntries(getObjectAsKeyValuePairs(source)) as IterableObject;
+}
+
+/**
+ * Helper for copying any object, or converting to an object, anything that has "entries()" property. Like Headers.
+ * Deep clones by default.
+ * @param source IterableObject any object
+ * @param iterator (obj: IterableObject, key: string, value: unknown) => unknown, any non-undefined value is set as obj[key]=value.
+ * @param deep If true (default), the source is checked for nested objects
+ */
+
+export function cloneWithIterator(
+  source: IterableObject,
+  iterator: (obj: IterableObject, key: string, value: unknown) => unknown,
+  deep = true,
+): IterableObject {
+  const clone = copyIterableObject(source);
+  Object.entries(clone).forEach(([key, value]) => {
+    const handledValue = iterator(clone, key, value);
+    const newValue = handledValue !== undefined ? handledValue : value;
+    if (deep && isObject(newValue)) {
+      clone[key] = cloneWithIterator(value, iterator, deep);
+    } else if (newValue !== value) {
+      clone[key] = value;
+    }
+  });
+  return clone;
+}
+
+/**
+ *
+ * Uses cloneIterableObject(), but adds an iterator that returns obj value.
+ * @see cloneWithIterator
+ * @param source IterableObject any object
+ * @param deep If true (default), the source is checked for nested objects
+ */
+
+export function cloneObject(source: IterableObject, deep = true): IterableObject {
+  if (!deep) {
+    return copyIterableObject(source);
+  }
+  return cloneWithIterator(source, (obj, k, v) => v, deep);
+}

--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -1,10 +1,10 @@
 @charset "utf-8";
-@import "~hds-core/lib/base.min.css";
-@import "~hds-core/lib/components/all.min.css";
-@import "~hds-core/lib/icons/icon.min.css";
-@import "~hds-core/lib/icons/icons.min.css";
-@import "~hds-design-tokens/lib/all.scss";
-@import "utils.scss";
+@import '~hds-core/lib/base.min.css';
+@import '~hds-core/lib/components/all.min.css';
+@import '~hds-core/lib/icons/icon.min.css';
+@import '~hds-core/lib/icons/icons.min.css';
+@import '~hds-design-tokens/lib/all.scss';
+@import 'utils.scss';
 
 :root {
   --page-border-color: var(--color-black-20);
@@ -14,56 +14,56 @@
   font-family: HelsinkiGrotesk;
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/565d73a693abe0776c801607ac28f0bf.woff") format("woff");
+  src: url('../fonts/565d73a693abe0776c801607ac28f0bf.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: italic;
   font-weight: 400;
-  src: url("../fonts/5bb29e3b7b1d3ef30121229bbe67c3e1.woff") format("woff");
+  src: url('../fonts/5bb29e3b7b1d3ef30121229bbe67c3e1.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: normal;
   font-weight: 500;
-  src: url("../fonts/7c46f288e8133b87e6b12b45dac71865.woff") format("woff");
+  src: url('../fonts/7c46f288e8133b87e6b12b45dac71865.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: italic;
   font-weight: 500;
-  src: url("../fonts/e62dc97e83a385e4d8cdc939cf1e4213.woff") format("woff");
+  src: url('../fonts/e62dc97e83a385e4d8cdc939cf1e4213.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: normal;
   font-weight: 700;
-  src: url("../fonts/533af26cf28d7660f24c2884d3c27eac.woff") format("woff");
+  src: url('../fonts/533af26cf28d7660f24c2884d3c27eac.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: italic;
   font-weight: 700;
-  src: url("../fonts/20d494430c87e15e194932b729d48270.woff") format("woff");
+  src: url('../fonts/20d494430c87e15e194932b729d48270.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: normal;
   font-weight: 900;
-  src: url("../fonts/a50a1bd245ce63abcc0d1da80ff790d2.woff") format("woff");
+  src: url('../fonts/a50a1bd245ce63abcc0d1da80ff790d2.woff') format('woff');
 }
 
 @font-face {
   font-family: HelsinkiGrotesk;
   font-style: italic;
   font-weight: 900;
-  src: url("../fonts/62a1781d8b396fbb025b0552cf6304d2.woff") format("woff");
+  src: url('../fonts/62a1781d8b396fbb025b0552cf6304d2.woff') format('woff');
 }
 
 html {
@@ -273,4 +273,44 @@ code {
   font-family: courier, monospace;
   padding: var(--spacing-4-xs) var(--spacing-3-xs);
   word-wrap: break-word;
+}
+
+.container-for-table-10-30-50-10 table {
+  table-layout: fixed;
+
+  td:first-of-type {
+    width: 10%;
+  }
+
+  td:nth-of-type(2) {
+    width: 30%;
+  }
+
+  td:nth-of-type(3) {
+    width: 50%;
+  }
+
+  td:nth-of-type(4) {
+    width: 10%;
+  }
+}
+
+.container-for-table-10-50-30-10 table {
+  table-layout: fixed;
+
+  td:first-of-type {
+    width: 10%;
+  }
+
+  td:nth-of-type(2) {
+    width: 50%;
+  }
+
+  td:nth-of-type(3) {
+    width: 30%;
+  }
+
+  td:nth-of-type(4) {
+    width: 10%;
+  }
 }

--- a/site/src/docs/components/login/api.mdx
+++ b/site/src/docs/components/login/api.mdx
@@ -70,10 +70,12 @@ export const CustomisationPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>Oidc Client</AnchorLink>
   - <AnchorLink>Api tokens client</AnchorLink>
   - <AnchorLink>Session poller</AnchorLink>
+  - <AnchorLink>GraphQL module</AnchorLink>
 
 - <AnchorLink>Oidc client hooks</AnchorLink>
 - <AnchorLink>Api tokens client hooks</AnchorLink>{' '}
 - <AnchorLink>Session poller hooks</AnchorLink>{' '}
+- <AnchorLink>GraphQL module hooks</AnchorLink>{' '}
 - <AnchorLink>Generic signal hooks</AnchorLink>{' '}
 
 - <AnchorLink>Beacon</AnchorLink>
@@ -111,7 +113,7 @@ In some scenarios, when the component is rendered multiple times, usually in dev
 | `modules`                                            | Optional. An array of <CustomisationPageAnchorLink>custom modules</CustomisationPageAnchorLink>.                                                                                                                                                                                                                                                                        |
 | `sessionPollerSettings`                              | Optional. <AnchorLink anchor="settings-2">Settings for the Session poller</AnchorLink>. If omitted, the `Session poller` is not created. If default values are acceptable, an empty object is required to create the poller.                                                                                                                                            |
 | `userManagerSettings`                                | **Required**. The <AnchorLink anchor="oidc-client">HDS Oidc client</AnchorLink> uses <ExternalLink href="https://github.com/authts/oidc-client-ts">oidc-client-ts</ExternalLink> to handle redirect URLs, token parsing and expiration. Both use the same `userManagerSettings`, but <AnchorLink anchor="default-usermanager-settings">different defaults</AnchorLink>. |
-| [Table 1: Properties of the LoginProvider component] |
+| [Table 4: Properties of the LoginProvider component] |
 
 #### SessionEndedHandler
 
@@ -120,7 +122,7 @@ In some scenarios, when the component is rendered multiple times, usually in dev
 | `content`                                                  | **Required**. Textual content with properties `title`, `text`, `buttonText` and `closeButtonLabelText`.              |
 | `dialogProps`                                              | Optional. Additional <GitHubSourceLink path="dialog/Dialog.tsx">DialogProps</GitHubSourceLink> passed to the Dialog. |
 | `ids`                                                      | Optional. Ids for the dialog elements with properties `dialog`, `title`, and `text`. If omitted, ids are created.    |
-| [Table 4: Properties of the SessionEndedHandler component] |
+| [Table 5: Properties of the SessionEndedHandler component] |
 
 #### WithAuthentication
 
@@ -128,32 +130,34 @@ In some scenarios, when the component is rendered multiple times, usually in dev
 | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AuthorisedComponent`                                     | Optional. Component to render if the user is authenticated. The <OidcClientTsLink>user</OidcClientTsLink> object is passed to the component. |
 | `UnauthorisedComponent`                                   | Optional. Component to render if the user is not authenticated.                                                                              |
-| [Table 5: Properties of the WithAuthentication component] |
+| [Table 6: Properties of the WithAuthentication component] |
 
 #### WithAuthenticatedUser
 
 | Property                                                     | Description                                                                                 |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
 | `children`                                                   | React children. A <OidcClientTsLink>user</OidcClientTsLink> object is passed to each child. |
-| [Table 6: Properties of the WithAuthenticatedUser component] |
+| [Table 7: Properties of the WithAuthenticatedUser component] |
 
 #### WithoutAuthenticatedUser
 
 | Property                                                     | Description     |
 | ------------------------------------------------------------ | --------------- |
 | `children`                                                   | React children. |
-| [Table 7: Properties of the WithAuthenticatedUser component] |
+| [Table 8: Properties of the WithAuthenticatedUser component] |
 
 ### Modules
 
 Usually, just logging in is not enough. The user must be able to fetch data from backend servers. That cannot be done unless the user's access token is exchanged for API tokens. Api tokens are sent in the headers of backend requests to authenticate the user.
 HDS Login modules include also API token handling. It is an independent module, but it communicates with the `Oidc client` and updates automatically when the user logs in or is updated. The modules emit signals that can be listened to and reacted to.
 
-There are three modules to handle the user's needs:
+There are four modules to handle the user's needs:
 
 - <AnchorLink>Oidc client</AnchorLink> for user data.
 - <AnchorLink>Api tokens client</AnchorLink> for acquiring backend tokens.
 - <AnchorLink>Session poller</AnchorLink> for checking if the user's session is still valid at the Oidc provider.
+- <AnchorLink>GraphQL module</AnchorLink> for fetching data from a graphQL server. Fetching can be automatically linked to
+  the Api Tokens client.
 
 All modules can be used without React and without each other. But a <OidcClientTsLink>>user</OidcClientTsLink> object is required to get API tokens and poll the session.
 
@@ -167,22 +171,22 @@ The `Oidc client` uses the <ExternalLink href="https://github.com/authts/oidc-cl
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `debug`                                | Optional. If true, debugging is enabled in the oidc-client-ts instance with `Log.setLevel(Log.Debug)` and `Log.setLogger(console)`. |
 | `userManagerSettings`                  | **Required**, but not all options. At least `authority`, `client_id` and `scope` must be set.                                       |
-| [Table 8: Settings of the Oidc client] |
+| [Table 9: Settings of the Oidc client] |
 
 ##### Default userManager settings
 
-| Property                                                    | Default value                      |
-| ----------------------------------------------------------- | ---------------------------------- |
-| `automaticSilentRenew`                                      | true                               |
-| `includeIdTokenInSilentRenew`                               | true                               |
-| `loadUserInfo`                                              | true                               |
-| `monitorSession`                                            | false                              |
-| `post_logout_redirect_uri`                                  | window.origin + /                  |
-| `redirect_uri`                                              | window.origin + /callback          |
-| `response_type`                                             | code                               |
-| `silent_redirect_uri`                                       | window.origin + /silent_renew.html |
-| `validateSubOnSilentRenew`                                  | false                              |
-| [Table 9: Default userManager settings of the Oidc client ] |
+| Property                                                     | Default value                      |
+| ------------------------------------------------------------ | ---------------------------------- |
+| `automaticSilentRenew`                                       | true                               |
+| `includeIdTokenInSilentRenew`                                | true                               |
+| `loadUserInfo`                                               | true                               |
+| `monitorSession`                                             | false                              |
+| `post_logout_redirect_uri`                                   | window.origin + /                  |
+| `redirect_uri`                                               | window.origin + /callback          |
+| `response_type`                                              | code                               |
+| `silent_redirect_uri`                                        | window.origin + /silent_renew.html |
+| `validateSubOnSilentRenew`                                   | false                              |
+| [Table 10: Default userManager settings of the Oidc client ] |
 
 These override the default settings of the <ExternalLink href="https://github.com/authts/oidc-client-ts/blob/main/src/UserManagerSettings.ts">oidc-client-ts</ExternalLink>.
 
@@ -201,7 +205,7 @@ These override the default settings of the <ExternalLink href="https://github.co
 | `login`                                | Calls the `authorization_endpoint` with given parameters. The browser window is redirected and the returned promise is fulfilled only, if an error occurs when redirecting.                                                                                                                                                                                              | `Promise<never>`                                             |
 | `logout`                               | Calls the `end_session_endpoint` with given parameters. The browser window is redirected so the returned promise is never fulfilled.                                                                                                                                                                                                                                     | `Promise<never>`                                             |
 | `renewUser`                            | For manual user renewal. The Promise will never be rejected.                                                                                                                                                                                                                                                                                                             | `Promise<User>`                                              |
-| [Table 10: Methods of the Oidc client] |
+| [Table 11: Methods of the Oidc client] |
 
 ##### Other exported utility functions
 
@@ -215,7 +219,7 @@ The following functions can be imported and used without the `Oidc client` modul
 | `isUserExpired(user)`                                    | Returns true if the user is expired.                             | <OidcClientTsLink>User</OidcClientTsLink> object.                                                                                      | `boolean`                                           |
 | `isValidUser(user)`                                      | Returns true if the user is not expired and has an access token. | <OidcClientTsLink>User</OidcClientTsLink> object.                                                                                      | `boolean`                                           |
 | `pickUserToken(user, tokenType)`                         | Returns one of the user's tokens: `access`, `id` or `refresh`.   | <OidcClientTsLink>User</OidcClientTsLink> object, token type ( `access`, `id` or `refresh`).                                           | `string` or `undefined`                             |
-| [Table 11: Other Oidc client and user-related functions] |
+| [Table 12: Other Oidc client and user-related functions] |
 
 <PlaygroundPreview>
 
@@ -243,7 +247,7 @@ There are utility functions for each state change. Use these to check if the emi
 | `LOGGING_OUT`                  | State changes to this when `logout()` is called.                         | `isLoggingOutSignal(signal)`            |
 | `NO_SESSION`                   | No valid user exists.                                                    | `isNoSessionSignal(signal)`             |
 | `VALID_SESSION`                | User is found and is valid.                                              | `isValidSessionSignal(signal)`          |
-| [Table 12: Oidc client states] |
+| [Table 13: Oidc client states] |
 
 ##### Error signal types
 
@@ -255,7 +259,7 @@ The error object also contains the thrown error in `error.originalError` propert
 | `INVALID_OR_EXPIRED_USER`      | The returned <OidcClientTsLink>user</OidcClientTsLink> object is expired or invalid. | `error.isInvalidUserError`     | `isInvalidUserErrorSignal(signal) `  |
 | `RENEWAL_FAILED`               | User renewal failed.                                                                 | `error.isRenewalError`         | `isRenewalErrorSignal(signal)`       |
 | `SIGNIN_ERROR`                 | Emitted when `handleCallback()` or `login()` failed.                                 | `error.isSignInError`          | `isSigninErroSignal(signal) `        |
-| [Table 13: Oidc client errors] |
+| [Table 14: Oidc client errors] |
 
 ##### Event signals
 
@@ -266,7 +270,7 @@ The `Oidc client` also emits event signals when an action is complete or startin
 | `USER_UPDATED`                 | User data has changed. Includes also changes to `null`, if login or renewal fail.                        | `isUserUpdatedSignal(signal) `        |
 | `USER_REMOVED`                 | User data was removed. Happens when the user logs out or tokens expire.                                  | `isUserRemovedSignal(signal) `        |
 | `USER_RENEWAL_STARTED`         | User is being renewed. Current access_token and API tokens may be invalid until the renewal is complete. | `isUserRenewalStartedSignal(signal) ` |
-| [Table 14: Oidc client events] |
+| [Table 15: Oidc client events] |
 
 ##### Dedicated signal triggers
 
@@ -278,7 +282,7 @@ Generic triggers for `Oidc client` signals. These trigger only if the signal ori
 | `triggerForAllOidcClientEvents`       | `Oidc client` namespace and type `event`.       |
 | `triggerForAllOidcClientSignals`      | `Oidc client` namespace.                        |
 | `triggerForAllOidcClientStateChanges` | `Oidc client` namespace and type `stateChange`. |
-| [Table 15: Oidc client triggers]      |
+| [Table 16: Oidc client triggers]      |
 
 State change triggers require the signal to have the `Oidc client` namespace and type `stateChange`.
 `Signal.payload.type` must contain one of the <AnchorLink anchor="state-change-signals">states</AnchorLink>.
@@ -289,7 +293,7 @@ State change triggers require the signal to have the `Oidc client` namespace and
 | `loggingOutTrigger`                           | `payload.type` has a matching state.          |
 | `noSessionTrigger`                            | `payload.type` has a matching state.          |
 | `validSessionTrigger`                         | `payload.type` has a matching state.          |
-| [Table 16: Oidc client state change triggers] |
+| [Table 17: Oidc client state change triggers] |
 
 Event triggers require the signal to have the `Oidc client` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals">events</AnchorLink>.
@@ -299,7 +303,7 @@ Event triggers require the signal to have the `Oidc client` namespace and type `
 | `userRemovedTrigger`                   | `payload.type` has a matching event.          |
 | `userRenewalStartedTrigger`            | `payload.type` has a matching event.          |
 | `userUpdatedTrigger`                   | `payload.type` has a matching event.          |
-| [Table 17: Oidc client event triggers] |
+| [Table 18: Oidc client event triggers] |
 
 Error triggers require the signal to have the `Oidc client` namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types">errors</AnchorLink>.
@@ -309,7 +313,7 @@ Error triggers require the signal to have the `Oidc client` namespace and type `
 | `invalidUserErrorTrigger`              | `payload.type` has a matching error.          |
 | `renewalErrorTrigger`                  | `payload.type` has a matching error.          |
 | `signInErrorTrigger`                   | `payload.type` has a matching error.          |
-| [Table 18: Oidc client error triggers] |
+| [Table 19: Oidc client error triggers] |
 
 ##### Getting signal payloads
 
@@ -321,7 +325,7 @@ If the given signal is not from `Oidc client` or is not of the given type, the f
 | `getOidcClientEventPayload`                    | `null` or `{type, data}`. The data is usually a <OidcClientTsLink>user</OidcClientTsLink> object. |
 | `getOidcClientErrorPayload`                    | `null` or <AnchorLink anchor="error-signal-types">OidcClientError</AnchorLink> object.            |
 | `getOidcClientStateChangePayload`              | `null` or `{state, previousState}`.                                                               |
-| [Table 19: Oidc client signal payload getters] |
+| [Table 20: Oidc client signal payload getters] |
 
 ##### Hooks
 
@@ -347,7 +351,7 @@ URL where to get the tokens from. A user's access token is also required, so the
 | `queryProps`                           | Optional. An object. Used with Keycloak api token requests. Contains properties `grantType` and `permission`. | none          |
 | `retryInterval`                        | Optional. Waiting time in milliseconds between failed requests.                                               | 500           |
 | `url`                                  | **Required**. URL to the API tokens endpoint.                                                                 | none          |
-| [Table 20: Api tokens client settings] |
+| [Table 21: Api tokens client settings] |
 
 ##### Methods
 
@@ -357,22 +361,22 @@ URL where to get the tokens from. A user's access token is also required, so the
 | `fetch`                               | Fetches the tokens from the given URI.        | `Promise<Tokens>` |
 | `getTokens`                           | Gets locally stored tokens.                   | `Tokens`          |
 | `isRenewing`                          | Returns true if tokens are currently fetched. | `boolean`         |
-| [Table 21: Api tokens client methods] |
+| [Table 22: Api tokens client methods] |
 
 ##### Other exported utility functions
 
 The following functions can be imported and used without the `Api tokens client` module:
 
-| Function                                              | Description                                        | Argument(s)                                                                                        | Return value                                                                                  |
-| ----------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `createApiTokenClient(props)`                         | Creates the client.                                | ApiTokenClientProps.                                                                               | `ApiTokensClient`                                                                             |
-| `getApiTokensFromStorage(storage)`                    | Gets the API tokens from session storage.          | Storage to get the tokens from. (optional, default is session storage).                            | <GitHubSourceLink path="login/apiTokensClient/index.ts">TokenData</GitHubSourceLink>`or`null` |
-| `getUserReferenceFromStorage(storage)`                | Gets the user's access token used as reference.    | Storage to get the reference from. (optional, default is session storage).                         | `string`                                                                                      |
-| `removeApiTokensFromStorage(storage)`                 | Removes the API tokens from session storage.       | Storage to remove the tokens from. (optional, default is session storage).                         | none                                                                                          |
-| `removeUserReferenceFromStorage(storage)`             | Removes the user's access token used as reference. | Storage to remove the reference from. (optional, default is session storage).                      | none                                                                                          |
-| `setApiTokensToStorage(tokens, storage)`              | Sets the API tokens to storage.                    | Tokens, storage to set the tokens to. (optional, default is session storage).                      | none                                                                                          |
-| `setUserReferenceToStorage(reference,storage)`        | Sets the user's access token used as reference.    | Reference as string, tokens, storage to set the tokens to. (optional, default is session storage). | none                                                                                          |
-| [Table 22: Other Api tokens client-related functions] |
+| Function                                              | Description                                        | Argument(s)                                                                                        | Return value                                                                                   |
+| ----------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `createApiTokenClient(props)`                         | Creates the client.                                | ApiTokenClientProps.                                                                               | `ApiTokensClient`                                                                              |
+| `getApiTokensFromStorage(storage)`                    | Gets the API tokens from session storage.          | Storage to get the tokens from. (optional, default is session storage).                            | <GitHubSourceLink path="login/apiTokensClient/index.ts">TokenData</GitHubSourceLink> or `null` |
+| `getUserReferenceFromStorage(storage)`                | Gets the user's access token used as reference.    | Storage to get the reference from. (optional, default is session storage).                         | `string`                                                                                       |
+| `removeApiTokensFromStorage(storage)`                 | Removes the API tokens from session storage.       | Storage to remove the tokens from. (optional, default is session storage).                         | none                                                                                           |
+| `removeUserReferenceFromStorage(storage)`             | Removes the user's access token used as reference. | Storage to remove the reference from. (optional, default is session storage).                      | none                                                                                           |
+| `setApiTokensToStorage(tokens, storage)`              | Sets the API tokens to storage.                    | Tokens, storage to set the tokens to. (optional, default is session storage).                      | none                                                                                           |
+| `setUserReferenceToStorage(reference,storage)`        | Sets the user's access token used as reference.    | Reference as string, tokens, storage to set the tokens to. (optional, default is session storage). | none                                                                                           |
+| [Table 23: Other Api tokens client-related functions] |
 
 <PlaygroundPreview>
 
@@ -400,7 +404,7 @@ Returned errors are instances of the `ApiTokensClientError`. It is an extended E
 | `API_TOKEN_FETCH_FAILED`             | Fetch failed.                           | `error.isFetchError`                | `isApiTokensFetchFailedErrorSignal(signal)` |
 | `INVALID_API_TOKENS`                 | The returned object is an invalid json. | `error.isInvalidTokensError`        | `isInvalidApiTokensErrorSignal(signal)`     |
 | `INVALID_USER_FOR_API_TOKENS`        | User is not valid.                      | `error.isInvalidApiTokensUserError` | `isInvalidApiTokensUserErrorSignal(signal)` |
-| [Table 23: Api tokens client errors] |
+| [Table 24: Api tokens client errors] |
 
 ##### Event signals
 
@@ -411,7 +415,7 @@ The `Api tokens client` also emits events when an action is complete or starting
 | `API_TOKENS_UPDATED`                 | Tokens have changed. Includes also changes to `null`.                                          | `isApiTokensUpdatedSignal(signal)`        |
 | `API_TOKENS_REMOVED`                 | Tokens have been removed. Happens usually when the user object has been removed or is renewed. | `isApiTokensRemovedSignal(signal)`        |
 | `API_TOKENS_RENEWAL_STARTED`         | Api tokens are renewed. Happens usually right after user renewal.                              | `isApiTokensRenewalStartedSignal(signal)` |
-| [Table 24: Api tokens client events] |
+| [Table 25: Api tokens client events] |
 
 ##### Dedicated signal triggers
 
@@ -422,7 +426,7 @@ Triggers for `Api tokens client` signals. These trigger signals only originated 
 | `triggerForAllApiTokensClientErrors`   | `Api tokens client` namespace and type `error`. |
 | `triggerForAllApiTokensClientEvents`   | `Api tokens client` namespace and type `event`. |
 | `triggerForAllApiTokensClientSignals`  | `Api tokens client` namespace.                  |
-| [Table 25: Api tokens client triggers] |
+| [Table 26: Api tokens client triggers] |
 
 Event triggers require the signal to have `Api tokens client` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals-1">events</AnchorLink>.
@@ -432,7 +436,7 @@ Event triggers require the signal to have `Api tokens client` namespace and type
 | `apiTokensRemovedTrigger`                    | `payload.type` has a matching event.          |
 | `apiTokensRenewalStartedTrigger`             | `payload.type` has a matching event.          |
 | `apiTokensUpdatedTrigger`                    | `payload.type` has a matching event.          |
-| [Table 26: Api tokens client event triggers] |
+| [Table 27: Api tokens client event triggers] |
 
 Error triggers require the signal to have `Api tokens client` namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types-1">errors</AnchorLink>.
@@ -442,7 +446,7 @@ Error triggers require the signal to have `Api tokens client` namespace and type
 | `apiTokensFetchFailedErrorTrigger`           | `payload.type` has a matching error.          |
 | `invalidApiTokensErrorTrigger`               | `payload.type` has a matching error.          |
 | `invalidApiTokensUserErrorTrigger`           | `payload.type` has a matching error.          |
-| [Table 27: Api tokens client error triggers] |
+| [Table 28: Api tokens client error triggers] |
 
 ##### Getting signal payloads
 
@@ -453,7 +457,7 @@ If the given signal is not from `Api tokens client` or is not given type, the fu
 | ---------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `getApiTokensClientErrorPayload`                     | `null` or <AnchorLink anchor="error-signal-types-1">ApiTokensClientError</AnchorLink> object. |
 | `getApiTokensClientEventPayload`                     | `null` or `{type, data}`. The data is usually tokens.                                         |
-| [Table 28: Api tokens client signal payload getters] |
+| [Table 29: Api tokens client signal payload getters] |
 
 ##### Hooks
 
@@ -473,7 +477,7 @@ Polling requires a user and the `userManager` from the `Oidc client`. The pollin
 | Property                            | Description                                                                      | Default value |
 | ----------------------------------- | -------------------------------------------------------------------------------- | ------------- |
 | `pollIntervalInMs`                  | Optional. Waiting time between polls in milliseconds. The default is one minute. | 60000         |
-| [Table 29: Session poller settings] |
+| [Table 30: Session poller settings] |
 
 ##### Methods
 
@@ -481,7 +485,7 @@ Polling requires a user and the `userManager` from the `Oidc client`. The pollin
 | ---------------------------------- | ----------------------------------------------------------------------------------------------- | ------------ |
 | `start`                            | Starts the polling. The first check is done after pollIntervalInMs is expired. Not immediately. |              |
 | `stop`                             | Stops the polling and aborts current requests, if any.                                          | `Tokens`     |
-| [Table 30: Session poller methods] |
+| [Table 31: Session poller methods] |
 
 ##### Other exported utility functions
 
@@ -490,7 +494,7 @@ The following function can be imported and used without the `Session poller` mod
 | Property                                   | Description         | Argument(s)           | Return value    |
 | ------------------------------------------ | ------------------- | --------------------- | --------------- |
 | `createSessionPoller(options)`             | Creates the poller. | SessionPollerOptions. | `SessionPoller` |
-| [Table 31: Other Session poller functions] |
+| [Table 32: Other Session poller functions] |
 
 <PlaygroundPreview>
 
@@ -514,7 +518,7 @@ Returned errors are instances of the `SessionPollerError`. It is an extended Err
 | -------------------------------------------- | ------------------------------------------------------------ | ------------------------------- | --------------------------------------- |
 | `SESSION_ENDED`                              | The server returned a forbidden or unauthorized status code. | `error.isSessionEnded`          | `isSessionEndedSignal(signal) `         |
 | `SESSION_POLLING_FAILED`                     | Polling has failed and max retries have been reached.        | `error.isSessionPollingFailure` | `isSessionPollingFailureSignal(signal)` |
-| [Table 32: Other Session poller error types] |
+| [Table 33: Other Session poller error types] |
 
 ##### Event signals
 
@@ -524,7 +528,7 @@ The `Session poller` also emits events when an action is complete or starting.
 | -------------------------------------------- | -------------------- | -------------------------------------- |
 | `SESSION_POLLING_STARTED`                    | Polling has started. | `isSessionPollerStartedSignal(signal)` |
 | `SESSION_POLLING_STOPPED`                    | Polling has stopped. | `isSessionPollerStoppedSignal(signal)` |
-| [Table 33: Other Session poller event types] |
+| [Table 34: Other Session poller event types] |
 
 ##### Dedicated signal triggers
 
@@ -535,7 +539,7 @@ Triggers for `Session poller`signals. These trigger signals only originated from
 | `triggerForAllSessionPollerErrors`  | `Session poller` namespace and type `error`.  |
 | `triggerForAllSessionPollerEvents`  | `Session poller` namespace and type `event`.  |
 | `triggerForAllSessionPollerSignals` | `Session poller` namespace.                   |
-| [Table 34: Session poller triggers] |
+| [Table 35: Session poller triggers] |
 
 Event triggers require the signal to have a `Session poller` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals-2">events</AnchorLink>.
@@ -544,7 +548,7 @@ Event triggers require the signal to have a `Session poller` namespace and type 
 | ----------------------------------------- | --------------------------------------------- |
 | `sessionPollingStartedTrigger`            | `payload.type` has a matching event.          |
 | `sessionPollingStoppedTrigger`            | `payload.type` has a matching event.          |
-| [Table 35: Session poller event triggers] |
+| [Table 36: Session poller event triggers] |
 
 Error triggers require the signal to have a `Session poller`namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types-2">errors</AnchorLink>.
@@ -553,7 +557,7 @@ Error triggers require the signal to have a `Session poller`namespace and type `
 | ----------------------------------------- | --------------------------------------------- |
 | `sessionEndedTrigger`                     | `payload.type` has a matching error.          |
 | `sessionPollingFailedTrigger`             | `payload.type` has a matching error.          |
-| [Table 36: Session poller error triggers] |
+| [Table 37: Session poller error triggers] |
 
 ##### Getting signal payloads
 
@@ -564,7 +568,193 @@ If the given signal is not from the `Session poller` or is not given type, the f
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `getSessionPollerErrorPayload`                    | `null` or <AnchorLink anchor="error-signal-types-2">SessionPollerError</AnchorLink> object. |
 | `getSessionPollerEventPayload`                    | `null` or `{type, data}`. The data is usually tokens.                                       |
-| [Table 37: Session poller signal payload getters] |
+| [Table 38: Session poller signal payload getters] |
+
+#### GraphQL Module
+
+Loading data from a graphQL server may require user authentication and api tokens. The GraphQL module can be set to listen to the Api token client and start querying when api tokens are ready. It can pick the correct api token and set it to the query headers.
+
+The module can also be used without api tokens and can be controlled manually.
+
+Unlike the `Api token client` and `Session Poller`, the `GraphQL Module` must be manually added to the `<LoginProvider>`.
+
+<PlaygroundPreview>
+
+```jsx
+import { ApolloClient } from '@apollo/client/core';
+import { createGraphQLModule } from 'hds-react';
+import { queryDocument } from './<path to queries>';
+
+const graphQLClient = new ApolloClient({
+  uri: 'https://graphql.endpoint.com/graphql/',
+  cache: new InMemoryCache(),
+});
+
+const options = {
+  graphQLClient,
+  query: queryDocument,
+  queryOptions: {
+    errorPolicy: 'all',
+  },
+};
+const graphQLModule = createGraphQLModule(options);
+
+<LoginProvider {...loginProps} modules={[graphQLModule]}></LoginProvider>;
+```
+
+</PlaygroundPreview>
+
+##### Requirements
+
+To execute a query, the following requirements must be met:
+
+- A graphQLClient (ApolloClient) must be configured and passed to the `GraphQL module`.
+- A query document must be provided.
+
+If the graphQL end-point requires an authentication, then the authentication headers must be set by
+
+- Providing them in `queryOptions.header`.
+- Setting them in `queryHelper()`.
+- Requiring api tokens with `options.requireApiTokens` and setting `options.apiTokenKey`.
+
+##### Important
+
+The module props do not require a query document or a graphQLClient, but a query cannot be executed without them. Both can also be passed as arguments to the `query(options)`. The client can also be set by calling `setClient(client)`.
+
+Once set, the client is stored, and there is no need to pass it again. The query document is not stored, so different queries can be used every time.
+
+When used with Helsinki City Profile, the `queryOptions.errorPolicy` should be set to "all". Otherwise, queries will fail when a weakly authenticated user tries to get the profile. The resulting data will include (dismissable) errors, and an ApolloClient query will fail when the data has an error property.
+
+The `createGraphQLModule` function is a Generic Typescript function with two types: `createGraphQLModule<Q = GraphQLQueryResult, T = NormalizedCacheObject>`. The first type, `Q`, defines what kind of results the query returns. The latter, `T`, only describes the cache type of the ApolloClient and is not usually changed.
+
+##### Settings
+
+<div className="container-for-table-10-30-50-10">
+
+| Property                            | Type                                                                                                   | Description                                                                                                                                                       | Default value |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `graphQLClient`                     | <ExternalLink href="https://www.apollographql.com/docs/react/get-started">Apollo Client</ExternalLink> | Optional property, but must be set before the query is executed. Can be set with `setApolloClient` or when calling a `query(options)`.                            | -             |
+| `query`                             | `TypedDocumentNode or DocumentNode`                                                                    | A graphQL query document.                                                                                                                                         | -             |
+| `queryHelper`                       | `(currentOptions:QueryOptions, apiTokenClient?: ApiTokenClient, beacon?:Beacon) => QueryOptions`       | This function is called before a query is executed. The options object returned by the function is used as query options.                                         | -             |
+| `options`                           | `object`                                                                                               | GraphQL module options.                                                                                                                                           | {}            |
+| `options.autoFetch`                 | `boolean`                                                                                              | Should query be executed automatically on initialization.                                                                                                         | `true`        |
+| `options.requireApiTokens`          | `boolean`                                                                                              | Are api tokens required for queries.                                                                                                                              | `true`        |
+| `options.abortIfLoading`            | `boolean`                                                                                              | Should an on-going query be aborted when `query()` is called again. If false, the `query()` will return a pending promise, and a new query is not started.        | `true`        |
+| `options.keepOldResultOnError`      | `boolean`                                                                                              | Should old result be kept, if a newer query fails.                                                                                                                | `false`       |
+| `options.apiTokensWaitTime`         | `number`                                                                                               | How long in milliseconds should api tokens be awaited before rejecting a query.                                                                                   | 15 000        |
+| `options.apiTokenKey`               | `string`                                                                                               | An object key for the api token to use in a query. The token is picked with `apiTokens[key]`.                                                                     | -             |
+| `queryOptions`                      | `QueryOptions` excluding the `query` property                                                          | Other <ExternalLink href="https://www.apollographql.com/docs/react/api/core/ApolloClient#query">ApolloClient queryOptions</ExternalLink> except `query` document. | -             |
+| [Table 39: GraphQL module settings] |
+
+</div>
+
+##### Methods
+
+| Property                           | Description                                                                                | Argument(s)                                                                                                      | Return value                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `cancel`                           | Cancels current query. The pending query is aborted.                                       | -                                                                                                                | -                                                |
+| `clear`                            | Calls `cancel()` and also clears errors and results. Emits a GRAPHQL_MODULE_CLEARED event. | -                                                                                                                | -                                                |
+| `getClientErrors`                  | Returns array of query errors and/or errors in the result data.                            | -                                                                                                                | `ApolloError[]`                                  |
+| `getData`                          | Returns the `data` property of last successful query result.                               | -                                                                                                                | The `result.data` of latest query or `undefined` |
+| `getError`                         | Returns a query error.                                                                     | -                                                                                                                | `ApolloError` or `undefined`                     |
+| `getQueryPromise`                  | Returns the current pending query promise or an immediately rejected promise.              | -                                                                                                                | `Promise<ApolloQueryResult>`                     |
+| `getResult`                        | Returns the latest query result.                                                           | -                                                                                                                | `ApolloQueryResult` or `undefined`               |
+| `isLoading`                        | Returns true if a query fetch is currently active.                                         | -                                                                                                                | `boolean`                                        |
+| `isPending`                        | Returns true if the module is waiting for api tokens or query results.                     | -                                                                                                                | `boolean`                                        |
+| `query`                            | Executes a query.                                                                          | `Partial<GraphQLModuleModuleProps>`                                                                              | `Promise<QueryResult>`                           |
+| `queryCache`                       | Calls `query(options)` with `fetchPolicy: 'cache-only'` in options.                        | `Partial<GraphQLModuleModuleProps>`                                                                              | `Promise<QueryResult>`                           |
+| `queryServer`                      | Calls `query(options)` with `fetchPolicy: 'network-only'` in options.                      | `Partial<GraphQLModuleModuleProps>`                                                                              | `Promise<QueryResult>`                           |
+| `setClient`                        | Sets the graphQLClient.                                                                    | <ExternalLink href="https://www.apollographql.com/docs/react/get-started">Apollo Client</ExternalLink>           | -                                                |
+| `waitForApiTokens`                 | Returns a promise that is resolved when api tokens are found.                              | `timeout?: number`. Time in milliseconds when the Promise is rejected. If omitted, the promise will not timeout. | `Promise<void>`                                  |
+| [Table 40: GraphQL module methods] |
+
+##### Other exported utility functions
+
+The following functions can be imported and used without the `GraphQL module` module:
+
+<div className="container-for-table-10-50-30-10">
+
+| Function                                     | Description                                                                                                       | Argument(s)                             | Return value    |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------- | --------------- |
+| `createGraphQLModule(options)`               | Creates the module.                                                                                               | `GraphQLModuleModuleProps`.             | `GraphQLModule` |
+| `mergeQueryOptionContexts(options, context)` | Deep merges given context to `queryOptions`.                                                                      | `QueryOptions, QueryOptions['context']` | QueryOptions    |
+| `mergeHeadersToQueryOptions`                 | Deep merges given headers to `queryOptions.context`.                                                              | `QueryOptions, Record`                  | QueryOptions    |
+| `mergeAuthorizationHeaderToQueryOptions`     | Sets `authorization: <given header>` to `queryOptions.context.headers`. Typically the value is `Bearer: <token>`. | `QueryOptions, string`                  | QueryOptions    |
+| `mergeQueryOptions`                          | Deep merges given queryOptions to another queryOptions object                                                     | `QueryOptions, QueryOptions`            | QueryOptions    |
+| `setBearerToQueryOptions`                    | Shortcut for calling `mergeAuthorizationHeaderToQueryOptions(options, 'Bearer: <token>')`.                        | `QueryOptions, string`                  | QueryOptions    |
+| `appendFetchOptions`                         | Appends fetchOptions to `queryOptions.context`.                                                                   | `QueryOptions, Partial<RequestInit>`    | QueryOptions    |
+| [Table 41: Other GraphQL module functions]   |
+
+</div>
+##### State change signals
+
+The `GraphQL module` has no state changes.
+
+##### Error signal types
+
+Returned errors are instances of the `GraphQLModuleError`. It is an extended Error object with type property and multiple `.is...` getters for checking error types. The error object also contains the thrown error in `error.originalError` property.
+
+| Error type                                    | Description                                                        | Error object property to check | Utility function to check the signal             |
+| --------------------------------------------- | ------------------------------------------------------------------ | ------------------------------ | ------------------------------------------------ |
+| `GRAPHQL_LOAD_FAILED`                         | Query failed.                                                      | `error.isLoadError`            | `isGraphQLModuleLoadFailedSignal(signal) `       |
+| `GRAPHQL_NO_CLIENT`                           | Query failed, because client is not provided.                      | `error.isNoClientError`        | `isGraphQLModuleNoClientErrorSignal(signal) `    |
+| `GRAPHQL_NO_API_TOKENS`                       | Api tokens are required, but not found or fetching them timed out. | `error.isNoApiTokensError`     | `isGraphQLModuleNoApiTokensErrorSignal(signal) ` |
+| [Table 42: GraphQL module error signal types] |
+
+##### Event signals
+
+The `GraphQL module` also emits events when an action is complete or starting.
+
+| Event type                                   | Description             | Utility function to check the signal       |
+| -------------------------------------------- | ----------------------- | ------------------------------------------ |
+| `GRAPHQL_MODULE_LOADING`                     | Query has started.      | `isGraphQLModuleLoadingSignal(signal)`     |
+| `GRAPHQL_MODULE_LOAD_SUCCESS`                | Query was successful.   | `isGraphQLModuleLoadSuccessSignal(signal)` |
+| `GRAPHQL_MODULE_LOAD_ABORTED`                | Query was aborted.      | `isGraphQLModuleLoadAbortedSignal(signal)` |
+| `GRAPHQL_MODULE_CLEARED`                     | The module was cleared. | `isGraphQLModuleClearedSignal(signal)`     |
+| [Table 43: Other GraphQL module event types] |
+
+##### Dedicated signal triggers
+
+Triggers for `GraphQL module`signals. These trigger signals only originated from the `GraphQL module`.
+
+| Generic triggers                    | Required signal props to trigger the listener |
+| ----------------------------------- | --------------------------------------------- |
+| `triggerForAllGraphQLModuleErrors`  | `GraphQL module` namespace and type `error`.  |
+| `triggerForAllGraphQLModuleEvents`  | `GraphQL module` namespace and type `event`.  |
+| `triggerForAllGraphQLModuleSignals` | `GraphQL module` namespace.                   |
+| [Table 44: GraphQL module triggers] |
+
+Event triggers require the signal to have a `GraphQL module` namespace and type `event`.
+`Signal.payload.type` contains one of the <AnchorLink anchor="event-signals-3">events</AnchorLink>.
+
+| Event triggers                            | Required signal props to trigger the listener |
+| ----------------------------------------- | --------------------------------------------- |
+| `graphQLModuleClearedTrigger`             | `payload.type` has a matching event.          |
+| `graphQLModuleLoadAbortedTrigger`         | `payload.type` has a matching event.          |
+| `graphQLModuleLoadingTrigger`             | `payload.type` has a matching event.          |
+| `graphQLModuleLoadSuccessTrigger`         | `payload.type` has a matching event.          |
+| [Table 45: GraphQL module event triggers] |
+
+Error triggers require the signal to have a `GraphQL module`namespace and type `error`.
+`Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types-3">errors</AnchorLink>.
+
+| Error triggers                            | Required signal props to trigger the listener |
+| ----------------------------------------- | --------------------------------------------- |
+| `loadFailedErrorTrigger`                  | `payload.type` has a matching error.          |
+| `noApiTokensErrorTrigger`                 | `payload.type` has a matching error.          |
+| `noClientErrorTrigger`                    | `payload.type` has a matching error.          |
+| [Table 46: GraphQL module error triggers] |
+
+##### Getting signal payloads
+
+Sometimes the most significant part of a signal is the payload. There are predefined payload getters for the `GraphQL module`.
+If the given signal is not from the `GraphQL module` or is not given type, the function returns null. So there is no need to pre-check the signal namespace or type.
+
+| Payload getter                                    | Returns                                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `getGraphQLModuleErrorPayload`                    | `null` or <AnchorLink anchor="error-signal-types-3">GraphQLModuleError</AnchorLink> object. |
+| `getGraphQLModuleEventPayload`                    | `null` or `{type, data}`.                                                                   |
+| [Table 47: GraphQL module signal payload getters] |
 
 #### Oidc client hooks
 
@@ -574,7 +764,7 @@ If the given signal is not from the `Session poller` or is not given type, the f
 | `useCachedAmr`                | Returns the user's `amr` value. It is cached because in some cases it must be decrypted from `id_token`.                                                          | `string[]`                                          |
 | `useOidcClient`               | Returns the `Oidc client`.                                                                                                                                        | `OidcClient`                                        |
 | `useOidcClientTracking`       | Returns an array of `[Signal, resetFunction, oidcClient instance]`. The hook forces the component using it to re-render each time the listener is triggered.      | `[Signal or undefined, ()=>void, OidcClient]`       |
-| [Table 38: Oidc client hooks] |
+| [Table 48: Oidc client hooks] |
 
 The usage of the `Oidc client` hooks is described in the <UsagePageAnchorLink anchor="useoidcclient">usage</UsagePageAnchorLink> section.
 
@@ -585,7 +775,7 @@ The usage of the `Oidc client` hooks is described in the <UsagePageAnchorLink an
 | `useApiTokens`                      | Returns functions for checking tokens and the status of renewal.                                                                                                  | `{getStoredApiTokens(), isRenewing()}`             |
 | `useApiTokensClient`                | Returns the `Api tokens client`.                                                                                                                                  | `ApiTokensClient`                                  |
 | `useApiTokensClientTracking`        | Returns an array of `[Signal, resetFunction, apiTokensClient instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[Signal or undefined, ()=>void, ApiTokensClient]` |
-| [Table 39: Api tokens client hooks] |
+| [Table 49: Api tokens client hooks] |
 
 The usage of the `Api tokens client` hooks is described in the <UsagePageAnchorLink anchor="useapitokensclient">usage</UsagePageAnchorLink> section.
 
@@ -595,9 +785,20 @@ The usage of the `Api tokens client` hooks is described in the <UsagePageAnchorL
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `useSessionPoller`               | Returns the `Session poller`.                                                                                                                                   | `SessionPoller`                                  |
 | `useSessionPollerTracking`       | Returns an array of `[Signal, resetFunction, sessionPoller instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[Signal or undefined, ()=>void, SessionPoller]` |
-| [Table 40: Session poller hooks] |
+| [Table 50: Session poller hooks] |
 
 The usage of the `Session poller` hooks is described in the <UsagePageAnchorLink anchor="usesessionpoller">usage</UsagePageAnchorLink> section.
+
+#### GraphQL module hooks
+
+| Hook                             | Description                                                                                                                                                                                                                                                                       | Return value                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `useGraphQLModule`               | Returns the `GraphQL module`.                                                                                                                                                                                                                                                     | `GraphQLModule`                                     |
+| `useGraphQLModuleTracking`       | Returns `[Signal, resetFunction, GraphQL module instance]`. The hook forces the component using it to re-render each time the listener is triggered.                                                                                                                              | `[signal, reset function, GraphQL module instance]` |
+| `useGraphQL`                     | Mimics the <ExternalLink href="https://www.apollographql.com/docs/react/data/queries#manual-execution-with-uselazyquery">useLazyQuery</ExternalLink> hook of the Apollo GraphQL library. The hook forces the component using it to re-render each time the module emits a signal. | `[query, {data, error, loading, refetch}]`          |
+| [Table 51: GraphQL module hooks] |
+
+The usage of the `GraphQL module` hooks is described in the <UsagePageAnchorLink anchor="usegraphql">usage</UsagePageAnchorLink> section.
 
 #### Generic signal hooks
 
@@ -606,7 +807,7 @@ The usage of the `Session poller` hooks is described in the <UsagePageAnchorLink
 | `useSignalListener(listener)`                           | The listener function. There are no trigger props. The listener is always called when any signal is emitted in any namespace. The listener should return `true` if the component should re-render. | An array of `[Signal or undefined, ()=>void]`. Latter is a reset function that clears the signal and re-renders the component. |
 | `useSignalTrackingWithCallback(triggerProps, callback)` | Signal props need to match the incoming signal to trigger the callback function. The hook never causes a re-render. The callback must do it.                                                       | none                                                                                                                           |
 | `useSignalTrackingWithReturnValue(triggerProps)`        | Signal props need to match the incoming signal to trigger re-rendering. The hook creates a trigger from the props and re-renders if the trigger returns `true`.                                    | Same as above.                                                                                                                 |
-| [Table 41: Generic signal listener hooks]               |
+| [Table 52: Generic signal listener hooks]               |
 
 **Important!** The listener passed to `useSignalListener` must be memoized or the hook will attach a new listener on each render because the props changed. The old one is disposed of but to avoid unnecessary listeners, use memoization with `useMemo` or `useCallback`. Note that all `triggerFor...` functions are constants and do not need memoization.
 
@@ -629,7 +830,7 @@ Modules are added and connected by calling `beacon.addContext(module)`. The beac
 | `emit(signal)`                      | A signal to emit.                                                                              | none                                         |
 | `getAllSignalContextsAsObject()`    | Returns all stored contexts as on object of `{[context.namespace]:context}`.                   | `Object`                                     |
 | `getSignalContext(module)`          | Returns context for the given namespace.                                                       | Context module or `undefined`.               |
-| [Table 42: Beacon methods]          |
+| [Table 53: Beacon methods]          |
 
 ##### Important
 
@@ -649,7 +850,7 @@ A signal is an object with the following properties:
 | `namespace`                          | **Required**. The namespace is the name of the module that emitted the signal.                                                                                                              | `string`   |
 | `payload`                            | Optional. The payload contains metadata. For example type of the event. A payload can also be an Error object.                                                                              | unknown    |
 | `type`                               | **Required**. Type of the signal. Can be any string, but HDS emits `init`, `error`, `event` and `stateChange` signals.                                                                      | `string`   |
-| [Table 43: Signal object properties] |
+| [Table 54: Signal object properties] |
 
 ##### Signal types and payloads
 
@@ -659,7 +860,7 @@ A signal is an object with the following properties:
 | `event`                               | `eventSignalType`       | Usually `{type:event type}` indicating what kind of event is emitted. May also have `data` property containing for example User or Tokens. |
 | `init`                                | `initSignalType`        | Emitted when all modules are connected and everything is ready. Emitted only once. Note that modules may emit other signals before this.   |
 | `stateChange`                         | `stateChangeSignalType` | `{state, previousState}` New state and the previous state, if any.                                                                         |
-| [Table 44: Signal types and payloads] |
+| [Table 55: Signal types and payloads] |
 
 Custom modules may emit any other kind of signal with different payloads.
 
@@ -691,6 +892,7 @@ Instead of writing signal types as strings, it is better to use predefined trigg
 - <AnchorLink anchor="dedicated-signal-triggers">Oidc client triggers</AnchorLink>.
 - <AnchorLink anchor="dedicated-signal-triggers-1">Api tokens client triggers</AnchorLink>.
 - <AnchorLink anchor="dedicated-signal-triggers-2">Session poller triggers</AnchorLink>.
+- <AnchorLink anchor="dedicated-signal-triggers-3">GraphQL module triggers</AnchorLink>.
 - <AnchorLink anchor="dedicated-signal-triggers">Generic triggers</AnchorLink>.
 
 ##### Generic triggers
@@ -705,7 +907,7 @@ Generic `create...` functions create trigger functions from given props. Creator
 | `createStateChangeTriggerProps(namespace, state, previousState)` | Namespace to listen to. Given state and previousState must also match. Both are optional. | all namespaces |
 | `createTriggerForAllNamespaces()`                                | Listens to all signals in any namespace.                                                  | none           |
 | `createTriggerPropsForAllSignals(namespace)`                     | Namespace to listen to. If omitted listens to all signals.                                | all namespaces |
-| [Table 45: Generic trigger creators]                             |
+| [Table 56: Generic trigger creators]                             |
 
 See also <AnchorLink anchor="hooks">hooks</AnchorLink>.
 
@@ -720,7 +922,7 @@ Signals are easier to create with functions than by manually setting all propert
 | `createErrorSignal(namespace, payload)`                    | Creates an error signal with the given namespace and error payload.                |
 | `createEventSignal(namespace, payload)`                    | Creates an event signal with the given namespace and event payload.                |
 | `createStateChangeSignal(namespace, state, previousState)` | Creates a `stateChange` signal with the given namespace and `stateChange` payload. |
-| [Table 46: Generic signal creators]                        |
+| [Table 57: Generic signal creators]                        |
 
 ###### Check
 
@@ -733,7 +935,7 @@ Check the signal type or namespace with these utilities.
 | `isEventSignal(signal)`                 | Returns true if the given signal is an event signal.        |
 | `isNamespacedSignal(signal, namespace)` | Returns true if the given signal has given namespace.       |
 | `isStateChangeSignal(signal)`           | Returns true if the given signal is a `stateChange` signal. |
-| [Table 47: Generic signal checks]       |
+| [Table 58: Generic signal checks]       |
 
 ###### Get payloads
 
@@ -744,7 +946,7 @@ Returns signal payload if the signal type is a match.
 | `getErrorSignalPayload(signal)`       | Returns the payload if the given signal is an error signal. |
 | `getEventSignalPayload(signal)`       | Returns true if the given signal is an event signal.        |
 | `getStateChangeSignalPayload(signal)` | Returns true if the given signal is a `stateChange` signal. |
-| [Table 48: Generic payloads getters]  |
+| [Table 59: Generic payloads getters]  |
 
 ###### Convert and filter
 
@@ -752,7 +954,7 @@ Returns signal payload if the signal type is a match.
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `convertSignalToTrigger(signal)`               | Removes the `context` from the signal if the property exists. The given signal is not mutated. |
 | `filterSignals(arrayOfSignals, matchingProps)` | Filters signals from the array. Returns signals which match given props.                       |
-| [Table 49: Convert and filter signals]         |
+| [Table 60: Convert and filter signals]         |
 
 ##### waitForSignals
 
@@ -774,7 +976,7 @@ When the promise is resolved, it returns an array of received signals. If it is 
 | `options.allowSkipping`            | `boolean`  | If true, and triggers are in order A, B, C, D and signal "C" is received. "A", "B", "C" are all removed from the array and are not checked again. | `true`  |
 | `options.strictOrder`              | `boolean`  | If true, signals are not tracked in strict order. If true and signals are received in the wrong order, the promise is rejected.                   | `false` |
 | `options.rejectOn`                 | `Object[]` | Array of signals/signal props, which cause promise rejection, if a match is found.                                                                | none    |
-| [Table 50: waitForSignals utility] |
+| [Table 61: waitForSignals utility] |
 
 There is no timeout. The promise can be rejected by setting a custom signal type to `options.rejectOn` and emit a matching signal.
 

--- a/site/src/docs/components/login/index.mdx
+++ b/site/src/docs/components/login/index.mdx
@@ -30,7 +30,7 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
 
 ## Introduction
 
-HDS Login components include React context, components and hooks for handling user authorisation, API tokens and session polling. React is not a requirement, but currently, no plain JavaScript UI components exist.
+HDS Login components include React context, components and hooks for handling user authorisation, API tokens, session polling and graphQL queries. React is not a requirement, but currently, no plain JavaScript UI components exist.
 
 Implementation requires an OIDC provider, which is a server for user authorization. The City of Helsinki uses <ExternalLink href="https://github.com/City-of-Helsinki/tunnistamo">Tunnistamo</ExternalLink>, but HDS login components can be used with any compatible OIDC provider. Read more about <ExternalLink href="https://auth0.com/intro-to-iam/what-is-openid-connect-oidc">OpenID Connect (OIDC)</ExternalLink>.
 
@@ -119,12 +119,14 @@ Detailed documentation is in the <UsagePageAnchorLink anchor="oidc-client-hooks"
 
 ### Modules
 
-There are three modules to handle the user's needs:
+There are four modules to handle the user's needs:
 
 - <UsagePageAnchorLink>Oidc client</UsagePageAnchorLink> for user data.
 - <UsagePageAnchorLink>Api tokens client</UsagePageAnchorLink> for acquiring backend tokens.
 - <UsagePageAnchorLink>Session poller</UsagePageAnchorLink> for checking if the user's session is still valid at the Oidc
   provider.
+- <UsagePageAnchorLink>GraphQL module</UsagePageAnchorLink> for fetching data from a graphQL server. Fetching can be automatically
+  linked to the Api Tokens client.
 
 If a module is not needed, it can be dropped with settings. <InternalLink href="/components/login/customisation">Custom modules</InternalLink> can also be added. All modules can be used without React and without each other. But a valid user object is required to get API tokens and poll the session.
 
@@ -144,6 +146,10 @@ This module exchanges the user's tokens for API tokens. API tokens are used for 
 
 This module polls the user's session from the Oidc provider and signals an error if polling returns an unauthorized response. If you have logged in with the same user in multiple browser windows, this module detects when the user is logged out in any browser window.
 
+#### GraphQL module
+
+This module was added to make it easier to use the login system with authenticated graphQL queries. The GraphQL module waits for api tokens and automatically picks a token and uses it in queries.
+
 #### Custom modules
 
 Other modules can be added. Detailed information is in the <InternalLink href="/components/login/customisation">custom modules section</InternalLink>.
@@ -160,6 +166,8 @@ Detailed information is in the <UsagePageAnchorLink anchor="signals">signals sec
 
 Every service must have its own `client_id` and `scope`, but these settings can be used for testing.
 They only work in `http://localhost:3000`. Make sure you have `redirect_uri`, `silent_redirect_uri` and `post_logout_redirect_uri` registered at the OIDC server.
+
+GraphQL module is not automatically added, but <ApiPageAnchorLink anchor="graphql-module">it's setup is simple</ApiPageAnchorLink>.
 
 ```js
 const loginProviderProps: LoginProviderProps = {

--- a/site/src/docs/components/login/tabs.mdx
+++ b/site/src/docs/components/login/tabs.mdx
@@ -13,11 +13,16 @@ import StatusLabel from '../../../components/StatusLabel';
 
 <div className="status-label-description">
   <StatusLabel type="error">Draft</StatusLabel>
-  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>Accessible</StatusLabel>
+  <StatusLabel type="success" style={{ marginLeft: 'var(--spacing-xs)' }}>
+    Accessible
+  </StatusLabel>
   <StatusLabelTooltip />
 </div>
 
-<LeadParagraph>Login components include React components, context and hooks for handling user authorisation, api tokens and session polling.</LeadParagraph>
+<LeadParagraph>
+  Login components include React components, context and hooks for handling user authorisation, api tokens, session
+  polling and GraphQL queries.
+</LeadParagraph>
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/login/usage.mdx
+++ b/site/src/docs/components/login/usage.mdx
@@ -52,6 +52,12 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>useSessionPoller</AnchorLink>
   - <AnchorLink>useSessionPollerTracking</AnchorLink>
 
+- <AnchorLink>GraphQL module hooks</AnchorLink>{' '}
+
+  - <AnchorLink>useGraphQLModule</AnchorLink>
+  - <AnchorLink>useGraphQLModuleTracking</AnchorLink>
+  - <AnchorLink>useGraphQL</AnchorLink>
+
 - <AnchorLink>Generic signal hooks</AnchorLink>{' '}
 
   - <AnchorLink>useSignalListener</AnchorLink>
@@ -63,6 +69,7 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>Oidc Client</AnchorLink>
   - <AnchorLink>Api tokens client</AnchorLink>
   - <AnchorLink>Session poller</AnchorLink>
+  - <AnchorLink>GraphQL module</AnchorLink>
 
 - <AnchorLink>Silent renewal</AnchorLink>
 
@@ -352,7 +359,7 @@ Returns the <AnchorLink>Session poller</AnchorLink> module.
 
 #### useSessionPollerTracking
 
-Returns an array of `[signal, reset function, sessionPoller instance]`. The hook re-renders the component each time the client emits a signal.
+Returns an array of `[signal, reset function, sessionPoller instance]`. The hook re-renders the component each time the poller emits a signal.
 
 <PlaygroundPreview>
 
@@ -371,6 +378,63 @@ const SessionPollerHooks = () => {
       Start polling!
     </Button>;
   }
+};
+```
+
+</PlaygroundPreview>
+
+### GraphQL module hooks
+
+More detailed information about <AnchorLink>GraphQL module</AnchorLink> hooks are listed on the <ApiPageAnchorLink anchor="graphql-module">API page</ApiPageAnchorLink>.
+
+#### useGraphQLModule
+
+Returns the <AnchorLink>GraphQL module</AnchorLink>.
+
+#### useGraphQLModuleTracking
+
+Returns an array of `[signal, reset function, GraphQL module instance]`. The hook re-renders the component each time the module emits a signal.
+
+#### useGraphQL
+
+This function mimics the <ExternalLink href="https://www.apollographql.com/docs/react/data/queries#manual-execution-with-uselazyquery">useLazyQuery</ExternalLink> hook of the Apollo GraphQL library.
+It returns an array of `[query, {data, error, loading, refetch}]`. The component using this hook is re-rendered each time the module changes and emits a signal. The returned array updates accordingly.
+
+<PlaygroundPreview>
+
+```jsx
+import { useGraphQL, Button, LoadingSpinner, Notification } from 'hds-react';
+
+const GraphQLModuleHooks = () => {
+  const [query, { data, error, loading, refetch }] = useGraphQL();
+  if (loading) {
+    return <LoadingSpinner loadingText="loading" />;
+  }
+  if (error) {
+    return (
+      <div>
+        <Notification type="error">An error occured.</Notification>
+        <Button
+          onClick={() => {
+            refetch();
+          }}
+        >
+          Try again.
+        </Button>;
+      </div>
+    );
+  }
+  if (data) {
+    // ...render data
+  }
+
+  <Button
+    onClick={() => {
+      query();
+    }}
+  >
+    Load data
+  </Button>;
 };
 ```
 
@@ -555,6 +619,41 @@ All `Session poller` settings, properties, methods and signals are detailed on t
 - <AnchorLink>useSessionPollerTracking</AnchorLink>
 
 Detailed information about these hooks is listed on the <ApiPageAnchorLink anchor="session-poller-hooks">API page</ApiPageAnchorLink>.
+
+#### GraphQL module
+
+Loading data from a graphQL server may require user authentication and api tokens. The GraphQL module can be set to listen to the Api token client and start querying when api tokens are ready. It can pick the correct api token and set it to the query headers.
+
+The module can also be used without api tokens and can be controlled manually.
+
+##### Requirements
+
+To execute a query, the following requirements must be met:
+
+- A graphQLClient (ApolloClient) must be configured and passed to the `GraphQL module`.
+- A query document must be provided.
+
+Detailed information about authenticated queries is on the <ApiPageAnchorLink anchor="requirements-2">API page</ApiPageAnchorLink>.
+
+##### API
+
+All `GraphQL module` settings, properties, methods and signals are detailed on the API page:
+
+- <ApiPageAnchorLink anchor="settings-3">Module settings</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="methods-3">Methods</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="other-exported-utility-functions-3">Utility functions</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="event-signals-3">Event signals</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="error-signal-types-3">Error signal types</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="dedicated-signal-triggers-3">Dedicated signal triggers</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="getting-signal-payloads-3">Getting signal payloads</ApiPageAnchorLink>.
+
+##### Hooks
+
+- <AnchorLink>useGraphQLModule</AnchorLink>
+- <AnchorLink>useGraphQLModuleTracking</AnchorLink>
+- <AnchorLink>useGraphQL</AnchorLink>
+
+Detailed information about these hooks is listed on the <ApiPageAnchorLink anchor="graphql-module-hooks">API page</ApiPageAnchorLink>.
 
 #### Silent renewal
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,15 +7159,15 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@4.17.4":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
+  integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
+
 "@types/lodash@^4.14.92":
   version "4.14.196"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.196.tgz#a7c3d6fc52d8d71328b764e28e080b4169ec7a95"
   integrity sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==
-
-"@types/lodash@^4.17.21":
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
-  integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
 
 "@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,26 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
+"@apollo/client@^3.10.1":
+  version "3.10.4"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.10.4.tgz#1abc488c79cf37dc63edf041aee6f9dc5aabc692"
+  integrity sha512-51gk0xOwN6Ls1EbTG5svFva1kdm2APHYTzmFhaAdvUQoJFDxfc0UwQgDxGptzH84vkPlo1qunY1FuboyF9LI3Q==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/caches" "^1.0.0"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.5.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.18.0"
+    prop-types "^15.7.2"
+    rehackt "^0.1.0"
+    response-iterator "^0.2.6"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@ardatan/relay-compiler@12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz#2e4cca43088e807adc63450e8cab037020e91106"
@@ -7996,6 +8016,41 @@
   resolved "https://registry.yarnpkg.com/@wessberg/stringutil/-/stringutil-1.0.19.tgz#baadcb6f4471fe2d46462a7d7a8294e4b45b29ad"
   integrity sha512-9AZHVXWlpN8Cn9k5BC/O0Dzb9E9xfEMXzYrNunwvkUTvuK7xgQPVRZpLo+jWCOZ5r8oBa8NIrHuPEu1hzbb6bg==
 
+"@wry/caches@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wry/caches/-/caches-1.0.1.tgz#8641fd3b6e09230b86ce8b93558d44cf1ece7e52"
+  integrity sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/context@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.4.tgz#e32d750fa075955c4ab2cfb8c48095e1d42d5990"
+  integrity sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.6":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.7.tgz#72ec1a73760943d439d56b7b1e9985aec5d497bb"
+  integrity sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.4.3.tgz#077d52c22365871bf3ffcbab8e95cb8bc5689af4"
+  integrity sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.5.0.tgz#11e783f3a53f6e4cd1d42d2d1323f5bc3fa99c94"
+  integrity sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==
+  dependencies:
+    tslib "^2.3.0"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -15295,7 +15350,7 @@ graphql-type-json@0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql@^16.6.0:
+graphql@^16.6.0, graphql@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
   integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
@@ -15747,7 +15802,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -21304,6 +21359,16 @@ opentracing@^0.14.7:
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
   integrity sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==
 
+optimism@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.18.0.tgz#e7bb38b24715f3fdad8a9a7fc18e999144bbfa63"
+  integrity sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==
+  dependencies:
+    "@wry/caches" "^1.0.0"
+    "@wry/context" "^0.7.0"
+    "@wry/trie" "^0.4.3"
+    tslib "^2.3.0"
+
 optionator@^0.9.1, optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
@@ -24651,6 +24716,11 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
+rehackt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.1.0.tgz#a7c5e289c87345f70da8728a7eb878e5d03c696b"
+  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
+
 rehype-infer-description-meta@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rehype-infer-description-meta/-/rehype-infer-description-meta-1.1.0.tgz#11f76329e524782a53d55b57b150ce9fb042b0d3"
@@ -25000,6 +25070,11 @@ resolve@^2.0.0-next.4:
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+response-iterator@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/response-iterator/-/response-iterator-0.2.6.tgz#249005fb14d2e4eeb478a3f735a28fd8b4c9f3da"
+  integrity sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==
 
 responselike@^2.0.0:
   version "2.0.1"
@@ -26920,6 +26995,11 @@ swap-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -27496,6 +27576,13 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
 
 ts-jest@^26.0.1:
   version "26.5.6"
@@ -29610,6 +29697,18 @@ yurnalist@^2.1.0:
     is-ci "^2.0.0"
     read "^1.0.7"
     strip-ansi "^5.2.0"
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## Description

Using HDS Login and Api tokens module with GraphQL was not as straight forward as it could be.

Devs had to manually wait and handle api tokens and then make queries and hand-pick api tokens.

Now GraphQL queries with api tokens can be automatic.

The module is just like the Api tokens module and the Session poller.

## Related Issue

Closes [HDS-2246](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2246)

## How Has This Been Tested?

Unit tests and manual testing on demo site.

## Demo note:
React demo is now for Header Login/Logout buttons. Login only works in the url `https://city-of-helsinki.github.io/hds-demo/login`/ and it is now reserved for the other PR.

The automatically created React demo cannot log in.



## Screenshots (if appropriate):

## Add to changelog
- [x ] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2246]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ