### PR TITLE
Add stylelint no-important warning

### DIFF
--- a/packages/core/.stylelintrc.json
+++ b/packages/core/.stylelintrc.json
@@ -15,6 +15,7 @@
     "property-no-vendor-prefix": null,
     "selector-class-pattern": null,
     "selector-not-notation": "simple",
-    "selector-pseudo-element-colon-notation": "single"
+    "selector-pseudo-element-colon-notation": "single",
+    "declaration-no-important": [ true, { "severity": "warning" }]
   }
 }

--- a/packages/react/.stylelintrc.json
+++ b/packages/react/.stylelintrc.json
@@ -19,6 +19,7 @@
     "scss/percent-placeholder-pattern": "([a-z][A-z]*)",
     "selector-class-pattern": null,
     "selector-not-notation": "simple",
-    "selector-pseudo-element-colon-notation": "single"
+    "selector-pseudo-element-colon-notation": "single",
+    "declaration-no-important": [ true, { "severity": "warning" }]
   }
 }

--- a/site/.stylelintrc.json
+++ b/site/.stylelintrc.json
@@ -16,6 +16,7 @@
     "scss/percent-placeholder-pattern": "([a-z][A-z]*)",
     "selector-class-pattern": null,
     "selector-not-notation": "simple",
-    "selector-pseudo-element-colon-notation": "single"
+    "selector-pseudo-element-colon-notation": "single",
+    "declaration-no-important": [ true, { "severity": "warning" }]
   }
 }


### PR DESCRIPTION
## Description

- Adds Stylelint rule `"declaration-no-important": [ true, { "severity": "warning" }]`

## Motivation and Context

- Using `!important` in styles is a bad habit which we want to discourage.

## How Has This Been Tested?

 - local machine

## Add to changelog
Not needed
