### PR TITLE
HDS-2326: Fix ActionBarItems outside menu in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Header] Fixed an issue with ActionBarItem dropdowns not inside the menu in mobile
 
 ### Core
 
@@ -39,6 +40,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -49,7 +51,7 @@ Changes that are not related to specific components
 
 #### Changed
 
-- Changed colour `black-60` from `#666666` to `#595959` due to contrast issues and the accessibility and readability improvement. 
+- Changed colour `black-60` from `#666666` to `#595959` due to contrast issues and the accessibility and readability improvement.
 
 ### Documentation
 
@@ -64,6 +66,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -83,6 +86,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -102,6 +106,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -121,6 +126,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -140,6 +146,7 @@ Changes that are not related to specific components
 #### Changed
 
 Changes that are not related to specific components
+
 - [Component] What has been changed
 
 #### Fixed
@@ -196,6 +203,7 @@ Changes that are not related to specific components
 ### Figma
 
 #### Added
+
 - [Header] New functionalities for Actionbar: Action items can have an option for dropdown menus. For now only Logged in user has custom user menu and button (Header.Login)
 - [Header] In mobile breakpoints (XS-M) login button and logged-in user menu jump inside the Header.Mobilemenu that has a special accordion menu for dropdown.
 - [Header] Added missing Breadcrumbs to dark theme.
@@ -205,11 +213,13 @@ Changes that are not related to specific components
 - [PhoneInput, PasswordInput] Added missing read-only focus ring.
 
 #### Fixed
+
 - [Header] Mobilemenu link 2nd level names changed to Second level.
 - [Header] Mobilemenu now aligned to right border. Menu button should always be the rightmost element in mobile breakpoints.
 - [Hero] Flipped image 180 degrees in imageLeft, imageRight, imageBottom in XS size and diagonalKoros in all sizes.
 
 #### Changed
+
 - [Header] Login button now has sign-in icon instead of user - old Login actionitem is removed, please use Header.Login.
 - [Header] Breakpoint width numbers added to property names to match Footer
 - [Header] Nested instances revealed

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
             class="headerActions"
           >
             <div
-              class="container visible hasContent fullWidth menuItem"
+              class="container visible hasContent menuItem"
               id="Menu"
             >
               <button

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
@@ -130,7 +130,7 @@ export const HeaderActionBarItem = (properties: HeaderActionBarItemProps) => {
     visible,
     [classes.visible]: visible,
     [classes.hasContent]: hasContent,
-    [classes.fullWidth]: fullWidth || isSmallScreen,
+    [classes.fullWidth]: fullWidth || (isSmallScreen && fixedRightPosition),
     [classes.hasSubItems]: hasSubItems,
     [classes.menuItem]: id === 'Menu',
   };


### PR DESCRIPTION
## Description
Items without "fixedRightPosition" should not be fullwidth or the item breaks in mobil

## Related Issue
Closes [HDS-2326
](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2326)


## How Has This Been Tested?

Manually. There are no stories which show this error.

To test it, add new item to the last story in `Header.stories.tsx`:

```
          <Header.ActionBarItem label="Apua" id="action-bar-help" icon={<IconQuestionCircle />}>
            <Header.ActionBarSubItem label="FAQ" href="/" />
            <Header.ActionBarSubItem label="Ota yhteyttä" href="/" />
          </Header.ActionBarItem>
```



## Demos:
Links to demos are in the comments. **This fix is not visible in demos!**

## Screenshots (if appropriate):
Fixed:
<img width="810" alt="image" src="https://github.com/user-attachments/assets/cdf72920-df85-46aa-a9e5-291721e83233">


## Add to changelog
- [x ] Added needed line to changelog 



[HDS-2326]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ