### PR TITLE
HDS-2333 header animation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Header] Fixed an issue with ActionBarItem dropdowns not inside the menu in mobile
+- [Header] Fix broken layout in mobile menu animations
 
 ### Core
 

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.module.scss
@@ -42,6 +42,9 @@
 }
 
 .headerNavigationMenu {
+  background-color: var(--nav-mobile-menu-bottom-background-color);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   position: absolute;
   transform: translateY(-100%) translateY(1px);
@@ -50,6 +53,7 @@
     var(--animation-duration-dropwdown) min-height
       calc(var(--animation-duration-dropwdown) + var(--animation-close-delay-dropdown));
   width: 100%;
+  z-index: calc(var(--header-z-index) - 1);
 }
 
 .menu {
@@ -185,9 +189,6 @@
 }
 
 .mobileMenuOpen {
-  background-color: var(--nav-mobile-menu-bottom-background-color);
-  display: flex;
-  flex-direction: column;
   min-height: calc(100vh - var(--action-bar-container-height));
   transform: translateY(0%);
   transition:


### PR DESCRIPTION
## Description

When mobile menu is closed, elements shift and layout looks broken.

## Related Issue
Closes [HDS-2333](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2333)

## How Has This Been Tested?

Manually. 

Compare current version: https://hds.hel.fi/storybook/react/?path=/story/components-header--with-full-features
And demo version:

## Demos:
Links to demos are in the comments


## Add to changelog
- [x ] Added needed line to changelog 
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2333]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ