### PR TITLE
Add a pre-filled link to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 <!-- If suggesting a new feature or change, please discuss it in an issue first -->
 <!-- If fixing a bug, please link to the issue here: -->
 
-Closes #
+Closes [HDS-xxxx](https://helsinkisolutionoffice.atlassian.net/browse/HDS-xxxx)
 
 ## Motivation and Context
 
@@ -17,10 +17,12 @@ Closes #
 ## How Has This Been Tested?
 
 ## Demos:
+
 Links to demos are in the comments
 
 ## Screenshots (if appropriate):
 
 ## Add to changelog
-- [ ] Added needed line to changelog 
+
+- [ ] Added needed line to changelog
 <!-- Or comment here why it is not relevant in the change log -->


### PR DESCRIPTION
## Description

Annoyed of adding the same link to every PR, so added a pre-filled link to Jira.
