### PR TITLE
HDS-2269: component native element props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes that are not related to specific components
 
-- [Component] What has been changed
+- [Accordion] Component accepts all div element properties
+- [Breadcrumb] Component accepts all nav element properties
+- [Button] Component accepts all button element properties
+- [Card] Component accepts all div element properties
+- [Checkbox] Component accepts all input element properties
+- [Columns] Component accepts all div element properties
+- [DateInput] Component accepts all input element properties
+- [Dialog] Component and its subcomponents accept all native elements properties
+- [FileInput] Component accepts all div element properties
+- [ErrorSummary] Component accepts all div element properties
+- [Fieldset] Component accepts all fieldset element properties
+- [Footer] Component and its subcomponents accept all native elements properties
+- [Header] Component and its subcomponents accept all native elements properties
+- [Hero] Component and its subcomponents accept all native elements properties
+- [Highlight] Component accepts all figure element properties
+- [ImageWithCard] Component accepts all div element properties
+- [Koros] Component accepts all div element properties
+- [Logo] Component accepts all img element properties
+- [Notification] Component accepts all div element properties
+- [SearchInput] Component and its subcomponents accept all native elements properties
+- [Pagination] Component accepts all nav element properties
+- [Section] Component accepts all div element properties
+- [StatusLabel] Component accepts all span element properties
+- [StepByStep] Component accepts all div element properties
+- [Stepper] Component accepts all div element properties
+- [Tabs] Component accepts all div element properties
+- [Tags] Component accepts all div element properties
+- [TextInput] Component accepts all input element properties
+- [ToggleButton] Component accepts all button element properties
+- [ToolTip] Component accepts all div element properties
 
 #### Fixed
 

--- a/packages/react/src/components/accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/accordion/Accordion.stories.tsx
@@ -4,7 +4,7 @@ import { IconAngleDown, IconAngleUp } from '../../icons';
 import { Button } from '../button';
 import { Card } from '../card';
 import { Select } from '../dropdown/select';
-import { Accordion } from './Accordion';
+import { Accordion, AccordionProps } from './Accordion';
 import { useAccordion } from './useAccordion';
 
 export default {
@@ -22,18 +22,18 @@ export default {
   },
 };
 
-export const Default = (args) => <Accordion {...args} />;
+export const Default = (args: AccordionProps) => <Accordion {...args} />;
 
-export const Small = (args) => <Accordion {...args} size="s" />;
+export const Small = (args: AccordionProps) => <Accordion {...args} size="s" />;
 
-export const Medium = (args) => <Accordion {...args} size="m" />;
+export const Medium = (args: AccordionProps) => <Accordion {...args} size="m" />;
 
-export const Large = (args) => <Accordion {...args} size="l" />;
+export const Large = (args: AccordionProps) => <Accordion {...args} size="l" />;
 
-export const WithoutCloseButton = (args) => <Accordion {...args} closeButton={false} />;
+export const WithoutCloseButton = (args: AccordionProps) => <Accordion {...args} closeButton={false} />;
 WithoutCloseButton.storyName = 'Without close button';
 
-export const StackedAccordionCards = (args) => (
+export const StackedAccordionCards = (args: AccordionProps) => (
   <>
     <h1>Stacked Accordions in Cards</h1>
     <Accordion {...args} card border style={{ maxWidth: '360px' }} />
@@ -44,10 +44,10 @@ export const StackedAccordionCards = (args) => (
 
 StackedAccordionCards.storyName = 'Stacked cards';
 
-export const InitiallyOpen = (args) => <Accordion {...args} initiallyOpen />;
+export const InitiallyOpen = (args: AccordionProps) => <Accordion {...args} initiallyOpen />;
 InitiallyOpen.storyName = 'Initially open';
 
-export const CardAccordion = (args) => (
+export const CardAccordion = (args: AccordionProps) => (
   <>
     <h2>Card</h2>
     <Accordion {...args} card />
@@ -64,7 +64,7 @@ CardAccordion.args = {
   style: { marginBottom: 'var(--spacing-m)', maxWidth: '360px' },
 };
 
-export const CustomTheme = (args) => (
+export const CustomTheme = (args: AccordionProps) => (
   <>
     <Accordion
       {...args}
@@ -81,7 +81,7 @@ export const CustomTheme = (args) => (
         '--header-line-height': 'var(--lineheight-s)',
         '--header-letter-spacing': '-0.4px',
         '--button-size': '28px',
-        '--button-border-color-hover': 'var(--color-coat-of-arms)',
+        '--close-button-border-color-hover': 'var(--color-coat-of-arms)',
         '--content-font-color': 'var(--color-black-90)',
         '--content-font-size': 'var(--fontsize-body-m)',
         '--content-line-height': 'var(--lineheight-l)',
@@ -102,7 +102,7 @@ export const CustomTheme = (args) => (
         '--header-letter-spacing': '0.2px',
         '--header-line-height': '1.4',
         '--button-size': '28px',
-        '--button-border-color-hover': 'var(--color-white)',
+        '--close-button-border-color-hover': 'var(--color-white)',
         '--content-font-color': 'var(--color-white)',
         '--content-font-size': 'var(--fontsize-body-m)',
         '--content-line-height': 'var(--lineheight-l)',

--- a/packages/react/src/components/accordion/Accordion.test.tsx
+++ b/packages/react/src/components/accordion/Accordion.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 
 import { Accordion } from './Accordion';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Accordion /> spec', () => {
   afterAll(() => {
@@ -19,6 +20,17 @@ describe('<Accordion /> spec', () => {
     const { container } = render(<Accordion heading="Foo">Bar</Accordion>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const divProps = { ...getCommonElementTestProps('div') };
+    const { getByTestId } = render(
+      <Accordion heading="Foo" {...divProps}>
+        Bar
+      </Accordion>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 
   it('should open the accordion when accordion header is clicked', async () => {

--- a/packages/react/src/components/accordion/Accordion.tsx
+++ b/packages/react/src/components/accordion/Accordion.tsx
@@ -9,6 +9,7 @@ import { useAccordion } from './useAccordion';
 import { useTheme } from '../../hooks/useTheme';
 import { Button } from '../button';
 import useHasMounted from '../../hooks/useHasMounted';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface AccordionCustomTheme {
   '--background-color'?: string;
@@ -115,7 +116,7 @@ export type CardAccordionProps = Omit<CommonAccordionProps, 'card' | 'border'> &
   card: true;
 };
 
-export type AccordionProps = CommonAccordionProps | CardAccordionProps;
+export type AccordionProps = AllElementPropsWithoutRef<'div'> & (CommonAccordionProps | CardAccordionProps);
 
 const getCloseMessage = (language: Language): string => {
   return {
@@ -138,14 +139,13 @@ export const Accordion = ({
   initiallyOpen = false,
   language = 'fi',
   size = 'm',
-  style,
   theme,
+  ...rest
 }: AccordionProps) => {
   const headerRef = useRef<HTMLDivElement>(null);
   const [beforeCloseButtonClick, setBeforeCloseButtonClick] = useState(false);
   // Create a unique id if not provided via prop
   const [accordionId] = useState(id || uniqueId('accordion-'));
-
   // Custom themes
   const sovereignThemeVariables = theme && {
     '--background-color': theme['--background-color'],
@@ -240,6 +240,7 @@ export const Accordion = ({
 
   return (
     <div
+      {...rest}
       className={classNames(
         styles.accordion,
         card && styles.card,
@@ -250,7 +251,6 @@ export const Accordion = ({
         sizeDependentThemeClass,
         className,
       )}
-      style={style}
       id={accordionId}
     >
       <div className={classNames(styles.accordionHeader)}>

--- a/packages/react/src/components/accordion/Accordion.tsx
+++ b/packages/react/src/components/accordion/Accordion.tsx
@@ -18,9 +18,12 @@ export interface AccordionCustomTheme {
   '--padding-vertical'?: string;
   '--header-font-color'?: string;
   '--header-font-size'?: string;
+  '--header-font-weight'?: string;
+  '--header-letter-spacing'?: string;
   '--header-line-height'?: string;
   '--button-size'?: string;
   '--header-focus-outline-color'?: string;
+  '--content-font-color'?: string;
   '--content-font-size'?: string;
   '--content-line-height'?: string;
   '--close-button-background-color-disabled'?: string;

--- a/packages/react/src/components/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/breadcrumb/Breadcrumb.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from '../header/Header';
-import { Breadcrumb } from './Breadcrumb';
+import { Breadcrumb, BreadcrumbProps } from './Breadcrumb';
 import { Link } from '../link';
 import { LanguageOption } from '../header/LanguageContext';
 import { Container } from '../container/Container';
@@ -32,9 +32,9 @@ const languages: LanguageOption[] = [
   { label: 'English', value: 'en' },
 ];
 
-export const Example = (args) => <Breadcrumb {...args} />;
+export const Example = (args: BreadcrumbProps) => <Breadcrumb {...args} />;
 
-export const ExampleInHeader = (args) => {
+export const ExampleInHeader = (args: BreadcrumbProps) => {
   return (
     <>
       <Header languages={languages}>
@@ -105,7 +105,7 @@ export const ExampleInHeader = (args) => {
 
 ExampleInHeader.storyName = 'Breadcrumb in header';
 
-export const LastItemIsLink = (args) => (
+export const LastItemIsLink = (args: BreadcrumbProps) => (
   <Breadcrumb
     {...args}
     list={[
@@ -120,7 +120,7 @@ export const LastItemIsLink = (args) => (
 
 LastItemIsLink.storyName = 'Last item a link';
 
-export const WithCustomTheme = (args) => (
+export const WithCustomTheme = (args: BreadcrumbProps) => (
   <Breadcrumb
     {...args}
     theme={{

--- a/packages/react/src/components/breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react/src/components/breadcrumb/Breadcrumb.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Breadcrumb, BreadcrumbProps } from './Breadcrumb';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Breadcrumb /> spec', () => {
   const defaultProps: BreadcrumbProps = {
@@ -24,6 +25,18 @@ describe('<Breadcrumb /> spec', () => {
     const { container } = render(<Breadcrumb {...defaultProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const navProps = getCommonElementTestProps<'nav'>('nav');
+    // BreadCrumb has prop "ariaLabel". It will override "aria-label".
+    navProps['aria-label'] = defaultProps.ariaLabel;
+    const expectedProps = {
+      ...navProps,
+      ...defaultProps,
+    };
+    const { getByTestId } = render(<Breadcrumb {...expectedProps} />);
+    const element = getByTestId(navProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, navProps)).toHaveLength(0);
   });
   it('Mobile view renders the last item with a path. That item is rendered twice: in the desktop and mobile views.', async () => {
     const { getAllByText, getByText, container } = render(<Breadcrumb {...defaultProps} />);

--- a/packages/react/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/Breadcrumb.tsx
@@ -6,6 +6,7 @@ import { Link } from '../link';
 import { IconAngleLeft, IconAngleRight } from '../../icons';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface BreadcrumbCustomTheme {
   /**
@@ -32,7 +33,7 @@ export interface BreadcrumbCustomTheme {
 }
 
 export type BreadcrumbListItem = { title: string; path: string | null };
-export type BreadcrumbProps = {
+export type BreadcrumbProps = AllElementPropsWithoutRef<'nav'> & {
   /**
    * Aria-label for the created <nav> element
    */
@@ -116,7 +117,7 @@ const getLastItemWithPath = (list: BreadcrumbListItem[]): BreadcrumbListItem | u
   }, undefined);
 };
 
-export const Breadcrumb = ({ list, ariaLabel, theme }: BreadcrumbProps) => {
+export const Breadcrumb = ({ list, ariaLabel, theme, className, ...rest }: BreadcrumbProps) => {
   const customThemeClass = useTheme<BreadcrumbCustomTheme>(styles.breadcrumb, theme);
   // The breadcrumb shows a list of links to parent pages and optionally can also show the title of the current page
   // If there are no items with paths, then the breadcrumb would only show the title of the current page
@@ -127,7 +128,7 @@ export const Breadcrumb = ({ list, ariaLabel, theme }: BreadcrumbProps) => {
   }
 
   return (
-    <nav aria-label={ariaLabel} className={classNames(styles.breadcrumb, customThemeClass)}>
+    <nav {...rest} aria-label={ariaLabel} className={classNames(styles.breadcrumb, customThemeClass, className)}>
       <DesktopListView list={list} />
       <MobileView item={lastItemWithPath} />
     </nav>

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { IconShare, IconAngleRight, IconFaceSmile, IconTrash } from '../../icons';
-import { Button } from './Button';
+import { Button, ButtonProps } from './Button';
 
 const onClick = action('button-click');
 
@@ -79,7 +79,7 @@ export const Loading = () => (
   </Button>
 );
 
-export const LoadingOnClick = (args) => {
+export const LoadingOnClick = (args: ButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const onButtonClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     setIsLoading(true);

--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Button } from './Button';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Button /> spec', () => {
   it('renders the component', () => {
@@ -21,5 +22,11 @@ describe('<Button /> spec', () => {
     const { container } = render(<Button>My Button</Button>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps<'button'>('button');
+    const { getByTestId } = render(<Button {...buttonProps}>My Button</Button>);
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -4,12 +4,13 @@ import '../../styles/base.module.css';
 import styles from './Button.module.scss';
 import { LoadingSpinner } from '../loadingSpinner';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type ButtonSize = 'default' | 'small';
 export type ButtonTheme = 'default' | 'coat' | 'black';
 export type ButtonVariant = 'primary' | 'secondary' | 'supplementary' | 'success' | 'danger';
 
-export type CommonButtonProps = {
+export type CommonButtonProps = AllElementPropsWithoutRef<'button'> & {
   /**
    * The content of the button
    */
@@ -54,7 +55,7 @@ export type CommonButtonProps = {
    * Loading text to show alongside loading spinner
    */
   loadingText?: string;
-} & React.ComponentPropsWithoutRef<'button'>;
+};
 
 // Supplementary variant requires iconLeft or iconRight
 export type SupplementaryButtonProps = Omit<CommonButtonProps, 'variant'> & {

--- a/packages/react/src/components/card/Card.stories.tsx
+++ b/packages/react/src/components/card/Card.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Card } from './Card';
+import { Card, CardProps } from './Card';
 import { Button } from '../button';
 
 export default {
@@ -11,28 +11,28 @@ export default {
   },
 };
 
-export const Empty = (args) => <Card {...args} />;
+export const Empty = (args: CardProps) => <Card {...args} />;
 
-export const WithBorder = (args) => <Card {...args} />;
+export const WithBorder = (args: CardProps) => <Card {...args} />;
 WithBorder.storyName = 'With border';
 WithBorder.args = {
   border: true,
 };
 
-export const WithBoxShadow = (args) => <Card {...args} />;
+export const WithBoxShadow = (args: CardProps) => <Card {...args} />;
 WithBoxShadow.storyName = 'With box shadow';
 WithBoxShadow.args = {
   boxShadow: true,
 };
 
-export const TextHeading = (args) => <Card {...args} />;
+export const TextHeading = (args: CardProps) => <Card {...args} />;
 TextHeading.storyName = 'With text & heading';
 TextHeading.args = {
   heading: 'Card',
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
 };
 
-export const WithOtherComponents = (args) => (
+export const WithOtherComponents = (args: CardProps) => (
   <Card {...args}>
     <Button variant="secondary" theme="black" role="link">
       Button
@@ -45,7 +45,7 @@ WithOtherComponents.args = {
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
 };
 
-export const WithCustomTheme = (args) => <Card {...args} />;
+export const WithCustomTheme = (args: CardProps) => <Card {...args} />;
 WithCustomTheme.storyName = 'With custom theme';
 WithCustomTheme.args = {
   border: true,

--- a/packages/react/src/components/card/Card.test.tsx
+++ b/packages/react/src/components/card/Card.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Card } from './Card';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Card /> spec', () => {
   it('renders the component', () => {
@@ -21,5 +22,15 @@ describe('<Card /> spec', () => {
       </Card>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <Card border heading="Foo" text="Bar" {...divProps}>
+        Baz
+      </Card>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/card/Card.tsx
+++ b/packages/react/src/components/card/Card.tsx
@@ -4,6 +4,7 @@ import '../../styles/base.module.css';
 import styles from './Card.module.scss';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface CardCustomTheme {
   '--background-color'?: string;
@@ -14,7 +15,7 @@ export interface CardCustomTheme {
   '--padding-vertical': string;
 }
 
-export type CardProps = {
+export type CardProps = AllElementPropsWithoutRef<'div'> & {
   /**
    * Boolean indicating whether Card will have box shadow or not.
    */
@@ -47,7 +48,7 @@ export type CardProps = {
    * Additional children to render inside the card.
    */
   children?: React.ReactNode;
-} & React.HTMLProps<HTMLDivElement>;
+};
 
 export const Card = ({
   border,

--- a/packages/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useReducer, useState } from 'react';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
-import { Checkbox } from './Checkbox';
+import { Checkbox, CheckboxProps } from './Checkbox';
 import { Fieldset } from '../fieldset';
 
 export default {
@@ -31,7 +31,7 @@ export const Indeterminate = () => (
 
 export const Disabled = () => <Checkbox id="disabled" label="Label" disabled />;
 
-export const Invalid = (args) => <Checkbox style={{ width: '300px' }} {...args} />;
+export const Invalid = (args: CheckboxProps) => <Checkbox style={{ width: '300px' }} {...args} />;
 Invalid.args = {
   id: 'Invalid',
   label: 'Label',
@@ -40,7 +40,7 @@ Invalid.args = {
 
 export const WithHelperText = () => <Checkbox id="helper-text" label="Label" helperText="Assistive text" />;
 
-export const WithTooltip = (args) => <Checkbox id="with-tooltip" {...args} />;
+export const WithTooltip = (args: CheckboxProps) => <Checkbox {...args} id="with-tooltip" />;
 WithTooltip.args = {
   label: 'Label',
   tooltipText: 'Tooltip text',
@@ -229,7 +229,7 @@ export const WithExternalLabel = () => {
   );
 };
 
-export const Playground = (args) => {
+export const Playground = (args: Record<string, string>) => {
   const [checkedItems, setCheckedItems] = useState({});
   const options = ['Option 1', 'Option 2', 'Option 3'];
 

--- a/packages/react/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Checkbox, CheckboxProps } from './Checkbox';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Checkbox /> spec', () => {
   const checkboxProps: CheckboxProps = {
@@ -10,6 +11,12 @@ describe('<Checkbox /> spec', () => {
     id: 'test',
     helperText: 'Helper text',
     errorText: 'Error text',
+    'data-testid': 'testId',
+    onChange: (e: React.ChangeEvent) => {
+      if (e) {
+        //
+      }
+    },
   };
 
   it('renders the component', () => {
@@ -20,5 +27,14 @@ describe('<Checkbox /> spec', () => {
     const { container } = render(<Checkbox {...checkboxProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps<'input', { value: string }>('input');
+    const { getByTestId } = render(<Checkbox {...checkboxProps} {...inputProps} />);
+    const element = getByTestId(inputProps['data-testid']);
+    // className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, { ...inputProps, style: undefined, className: undefined }),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -6,65 +6,69 @@ import classNames from '../../utils/classNames';
 import mergeRefWithInternalRef from '../../utils/mergeRefWithInternalRef';
 import { Tooltip } from '../tooltip';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
-export type CheckboxProps = {
-  /**
-   * If `true`, the component is checked
-   */
-  checked?: boolean;
-  /**
-   * Additional class names to apply to the checkbox
-   */
-  className?: string;
-  /**
-   * If `true`, the checkbox will be disabled
-   */
-  disabled?: boolean;
-  /**
-   * The error text content that will be shown below the checkbox
-   */
-  errorText?: string;
-  /**
-   * The helper text content that will be shown below the checkbox
-   */
-  helperText?: string;
-  /**
-   * The id of the input element
-   */
-  id: string;
-  /**
-   * Boolean indicating indeterminate status of the checkbox
-   */
-  indeterminate?: boolean;
-  /**
-   * The label for the checkbox
-   */
-  label?: string | React.ReactNode;
-  /**
-   * Callback fired when the state is changed
-   */
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-  /**
-   * The value of the component
-   */
-  value?: string;
-  /**
-   * Tooltip text for the checkbox
-   */
-  tooltipText?: string;
-  /**
-   * Aria-label text for the tooltip
-   */
-  tooltipLabel?: string;
-  /**
-   * Aria-label text for the tooltip trigger button
-   */
-  tooltipButtonLabel?: string;
-} & React.ComponentPropsWithoutRef<'input'>;
+export type CheckboxProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'input'>,
+  {
+    /**
+     * If `true`, the component is checked
+     */
+    checked?: boolean;
+    /**
+     * Additional class names to apply to the checkbox
+     */
+    className?: string;
+    /**
+     * If `true`, the checkbox will be disabled
+     */
+    disabled?: boolean;
+    /**
+     * The error text content that will be shown below the checkbox
+     */
+    errorText?: string;
+    /**
+     * The helper text content that will be shown below the checkbox
+     */
+    helperText?: string;
+    /**
+     * The id of the input element
+     */
+    id: string;
+    /**
+     * Boolean indicating indeterminate status of the checkbox
+     */
+    indeterminate?: boolean;
+    /**
+     * The label for the checkbox
+     */
+    label?: string | React.ReactNode;
+    /**
+     * Callback fired when the state is changed
+     */
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    style?: React.CSSProperties;
+    /**
+     * The value of the component
+     */
+    value?: string;
+    /**
+     * Tooltip text for the checkbox
+     */
+    tooltipText?: string;
+    /**
+     * Aria-label text for the tooltip
+     */
+    tooltipLabel?: string;
+    /**
+     * Aria-label text for the tooltip trigger button
+     */
+    tooltipButtonLabel?: string;
+  }
+>;
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (
@@ -88,7 +92,6 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     ref: React.Ref<HTMLInputElement>,
   ) => {
     const inputRef = useRef<HTMLInputElement>(null);
-
     useEffect(() => {
       if (ref) {
         /**

--- a/packages/react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<Checkbox /> spec renders the component 1`] = `
     <input
       aria-describedby="test-helper test-error"
       class="input"
+      data-testid="testId"
       id="test"
       type="checkbox"
       value=""

--- a/packages/react/src/components/columns/Columns.test.tsx
+++ b/packages/react/src/components/columns/Columns.test.tsx
@@ -3,15 +3,22 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Columns } from './Columns';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Columns /> spec', () => {
   it('renders the component', () => {
-    const { asFragment } = render(<Columns />);
+    const { asFragment } = render(<Columns className="extra-class" />);
     expect(asFragment()).toMatchSnapshot();
   });
   it('should not have basic accessibility issues', async () => {
-    const { container } = render(<Columns />);
+    const { container } = render(<Columns className="extra-class" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<Columns className="extra-class" {...divProps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/columns/Columns.tsx
+++ b/packages/react/src/components/columns/Columns.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 
 import '../../styles/base.module.css';
 import styles from './Columns.module.css';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
+import classNames from '../../utils/classNames';
 
-export type ColumnsProps = React.PropsWithChildren<Record<string, unknown>>;
+export type ColumnsProps = React.PropsWithChildren<AllElementPropsWithoutRef<'div'>>;
 
-export const Columns = ({ children }: ColumnsProps) => <div className={styles.columns}>{children}</div>;
+export const Columns = ({ children, className, ...rest }: ColumnsProps) => (
+  <div className={classNames(styles.columns, className)} {...rest}>
+    {children}
+  </div>
+);

--- a/packages/react/src/components/columns/__snapshots__/Columns.test.tsx.snap
+++ b/packages/react/src/components/columns/__snapshots__/Columns.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Columns /> spec renders the component 1`] = `
 <DocumentFragment>
   <div
-    class="columns"
+    class="columns extra-class"
   />
 </DocumentFragment>
 `;

--- a/packages/react/src/components/container/Container.stories.tsx
+++ b/packages/react/src/components/container/Container.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Container } from './Container';
+import { Container, ContainerProps } from './Container';
 import { Header } from '../header';
 import { Logo, logoFi } from '../logo';
 import { IconUser } from '../../icons';
@@ -11,7 +11,7 @@ export default {
   args: {},
 };
 
-export const Example = (args) => (
+export const Example = (args: ContainerProps) => (
   <Container {...args}>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -22,7 +22,7 @@ export const Example = (args) => (
   </Container>
 );
 
-export const AlignsWithHeader = (args) => {
+export const AlignsWithHeader = (args: ContainerProps) => {
   return (
     <>
       <Header>
@@ -88,7 +88,7 @@ AlignsWithHeader.parameters = {
   layout: 'fullscreen',
 };
 
-export const AlignsWitCustomWidthHeader = (args) => {
+export const AlignsWitCustomWidthHeader = (args: ContainerProps) => {
   return (
     <>
       <style>

--- a/packages/react/src/components/container/Container.test.tsx
+++ b/packages/react/src/components/container/Container.test.tsx
@@ -3,15 +3,34 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Container } from './Container';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Container /> spec', () => {
   it('renders the component', () => {
-    const { asFragment } = render(<Container>Foo</Container>);
+    const { asFragment } = render(
+      <Container className="extra-class" alignWithHeader>
+        Foo
+      </Container>,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
   it('should not have basic accessibility issues', async () => {
-    const { container } = render(<Container>Foo</Container>);
+    const { container } = render(
+      <Container className="extra-class" alignWithHeader>
+        Foo
+      </Container>,
+    );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <Container className="extra-class" alignWithHeader {...divProps}>
+        Bar
+      </Container>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/container/Container.tsx
+++ b/packages/react/src/components/container/Container.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import '../../styles/base.module.css';
 import styles from './Container.module.scss';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-export type ContainerProps = React.PropsWithChildren<React.HTMLProps<HTMLDivElement>> & {
+export type ContainerProps = React.PropsWithChildren<AllElementPropsWithoutRef<'div'>> & {
   /**
    * Match the container's alignment and spacings with the HDS Header.
    */

--- a/packages/react/src/components/container/__snapshots__/Container.test.tsx.snap
+++ b/packages/react/src/components/container/__snapshots__/Container.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Container /> spec renders the component 1`] = `
 <DocumentFragment>
   <div
-    class="container"
+    class="container extra-class alignWithHeader"
   >
     Foo
   </div>

--- a/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
+++ b/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
@@ -10,6 +10,8 @@ import { Accordion } from '../accordion';
 import { useCookies } from './useCookies';
 import { CookieModal } from './cookieModal/CookieModal';
 
+type StoryArgs = Record<string | number | symbol, unknown>;
+
 export default {
   component: CookieModal,
   title: 'Components/CookieConsent',
@@ -31,7 +33,7 @@ const ForcePageScrollBarForModalTesting = () => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const EnglishModalVersion = (args) => {
+export const EnglishModalVersion = (args: StoryArgs) => {
   const [language, setLanguage] = useState<SupportedLanguage>('en');
   const onLanguageChange = (newLang) => setLanguage(newLang);
   const contentSource: CookieContentSource = {
@@ -329,7 +331,7 @@ export const EnglishModalVersion = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const FinnishModalVersion = (args) => {
+export const FinnishModalVersion = (args: StoryArgs) => {
   const [language, setLanguage] = useState<SupportedLanguage>('fi');
   const onLanguageChange = (newLang) => setLanguage(newLang);
   const contentSource: CookieContentSource = {
@@ -630,9 +632,9 @@ export const FinnishModalVersion = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const SimpleModalVersion = (args) => {
+export const SimpleModalVersion = (args: StoryArgs) => {
   const [language, setLanguage] = useState<SupportedLanguage>('en');
-  const onLanguageChange = (newLang) => setLanguage(newLang);
+  const onLanguageChange = (newLang: string) => setLanguage(newLang as SupportedLanguage);
   const contentSource: CookieContentSource = {
     siteName: `Site title ${language}`,
     currentLanguage: language,
@@ -675,7 +677,7 @@ export const SimpleModalVersion = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const PageVersion = (args) => {
+export const PageVersion = (args: StoryArgs) => {
   const contentSource: CookieContentSource = {
     siteName: 'Test website',
     currentLanguage: 'en',
@@ -779,7 +781,7 @@ export const PageVersion = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomContentVersion = (args) => {
+export const CustomContentVersion = (args: StoryArgs) => {
   const contentSource: CookieContentSource = {
     siteName: 'Not shown if main title is overridden',
     currentLanguage: 'en',
@@ -916,7 +918,7 @@ export const CustomContentVersion = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const DebugVersion = (args) => {
+export const DebugVersion = (args: StoryArgs) => {
   const contentSource: CookieContentSource = {
     siteName: 'Cookie consent debugging',
     currentLanguage: 'fi',
@@ -1041,7 +1043,7 @@ DebugVersion.parameters = {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const TunnistamoLoginCookies = (args) => {
+export const TunnistamoLoginCookies = (args: StoryArgs) => {
   const [language, setLanguage] = useState<SupportedLanguage>('en');
   const onLanguageChange = (newLang) => setLanguage(newLang);
   const contentSource: CookieContentSource = {

--- a/packages/react/src/components/dateInput/DateInput.stories.tsx
+++ b/packages/react/src/components/dateInput/DateInput.stories.tsx
@@ -42,11 +42,11 @@ export default {
   },
 };
 
-export const Default = (args) => {
+export const Default = (args: DateInputProps) => {
   return <DateInput {...args} />;
 };
 
-export const WithMinAndMaxDate = (args) => {
+export const WithMinAndMaxDate = (args: DateInputProps) => {
   const minDate = new Date();
   minDate.setDate(4);
   const maxDate = addMonths(new Date(), 4);
@@ -55,7 +55,7 @@ export const WithMinAndMaxDate = (args) => {
 
 WithMinAndMaxDate.parameters = { loki: { skip: true } };
 
-export const WithoutConfirmation = (args) => {
+export const WithoutConfirmation = (args: DateInputProps) => {
   return <DateInput {...args} />;
 };
 WithoutConfirmation.storyName = 'Without confirmation';
@@ -63,7 +63,7 @@ WithoutConfirmation.args = {
   disableConfirmation: true,
 };
 
-export const Localisation = (args) => {
+export const Localisation = (args: DateInputProps) => {
   const bottomMargin = { marginBottom: 'var(--spacing-m)' };
   return (
     <div>
@@ -98,7 +98,7 @@ export const Localisation = (args) => {
   );
 };
 
-export const WithoutDatePicker = (args) => {
+export const WithoutDatePicker = (args: DateInputProps) => {
   return <DateInput {...args} />;
 };
 WithoutDatePicker.storyName = 'Without date picker';
@@ -106,7 +106,7 @@ WithoutDatePicker.args = {
   disableDatePicker: true,
 };
 
-export const WithExternalClearValueButton = (args) => {
+export const WithExternalClearValueButton = (args: DateInputProps) => {
   const [value, setValue] = useState<string>('10.2.2022');
   return (
     <div className="date-input--external-clear-value-button">
@@ -119,7 +119,7 @@ export const WithExternalClearValueButton = (args) => {
 };
 WithExternalClearValueButton.storyName = 'With external clear value button';
 
-export const WithDisabledDates = (args) => {
+export const WithDisabledDates = (args: DateInputProps) => {
   const [value, setValue] = useState<string>('');
   const [errorText, setErrorText] = useState<string | undefined>(undefined);
   const dateHelperText = 'Only weekdays are available.';
@@ -153,7 +153,7 @@ export const WithDisabledDates = (args) => {
 WithDisabledDates.storyName = 'With disabled dates';
 WithDisabledDates.parameters = { loki: { skip: true } };
 
-export const WithSelectedDisabledDates = (args) => {
+export const WithSelectedDisabledDates = (args: DateInputProps) => {
   const dateFormat = 'dd.M.yyyy';
   const dateValue = new Date(2021, 10, 12);
   const [value, setValue] = useState<string>(format(dateValue, dateFormat));
@@ -193,7 +193,7 @@ export const WithSelectedDisabledDates = (args) => {
 WithSelectedDisabledDates.storyName = 'With selected disabled dates';
 WithSelectedDisabledDates.parameters = { loki: { skip: true } };
 
-export const Invalid = (args) => {
+export const Invalid = (args: DateInputProps) => {
   return <DateInput {...args} />;
 };
 Invalid.args = {
@@ -202,7 +202,7 @@ Invalid.args = {
   errorText: 'Date invalid',
 };
 
-export const Success = (args) => {
+export const Success = (args: DateInputProps) => {
   return <DateInput {...args} />;
 };
 Success.args = {
@@ -273,7 +273,7 @@ export const WithCustomDayStyles = (args: DateInputProps) => {
 WithCustomDayStyles.storyName = 'With custom day styles';
 WithCustomDayStyles.parameters = { loki: { skip: true } };
 
-export const WithRange = (args) => {
+export const WithRange = (args: DateInputProps) => {
   const [range, setRange] = useState<Array<Date | null>>([null, null]);
   const [errors, setErrors] = useState<Array<string>>(['', '']);
   const storeDate = (index: number, date: Date | null) => {

--- a/packages/react/src/components/dateInput/DateInput.test.tsx
+++ b/packages/react/src/components/dateInput/DateInput.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-classes-per-file */
-import React, { useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -8,7 +8,8 @@ import '@testing-library/jest-dom/extend-expect';
 import { axe } from 'jest-axe';
 import isWeekend from 'date-fns/isWeekend';
 
-import { DateInput } from './DateInput';
+import { DateInput, DateInputProps } from './DateInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<DateInput /> spec', () => {
   const RealDate = Date;
@@ -74,6 +75,31 @@ describe('<DateInput /> spec', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps<
+      'input',
+      { defaultValue: string; value: string; onChange: DateInputProps['onChange']; id: string }
+    >('input');
+    const { getByTestId } = render(<DateInput label="Foo" {...inputProps} value="11.11.2012" />);
+    const element = getByTestId(inputProps['data-testid']);
+    // className and style props are applied to a wrapper element and not testable
+    const inputElementProps = {
+      ...inputProps,
+      style: undefined,
+      className: undefined,
+    };
+    expect(
+      getElementAttributesMisMatches(element, inputElementProps as unknown as HTMLAttributes<HTMLInputElement>),
+    ).toHaveLength(0);
+    const wrapper = (element.parentElement as HTMLElement).parentElement as HTMLElement;
+    expect(
+      getElementAttributesMisMatches(wrapper, {
+        style: inputProps.style,
+        className: inputProps.className,
+      }),
+    ).toHaveLength(0);
+  });
+
   it('opens and closes the date picker', async () => {
     render(<DateInput id="date" label="Foo" />);
 
@@ -108,7 +134,7 @@ describe('<DateInput /> spec', () => {
     expect(screen.getByLabelText('Year')).toHaveValue('2021');
 
     // Get the current date cell
-    const cellElement = container.querySelector('td[aria-current="date"]');
+    const cellElement = container.querySelector('td[aria-current="date"]') as HTMLElement;
 
     // Current date cell should have a button with the current date as content
     expect(cellElement.querySelectorAll('button > span')[0]).toHaveTextContent('17');
@@ -131,7 +157,7 @@ describe('<DateInput /> spec', () => {
     expect(container.querySelector('td[aria-current="date"]')).toBeNull();
 
     // Select the date 2022-02-10
-    userEvent.click(container.querySelector('button[data-date="2022-02-10"]'));
+    userEvent.click(container.querySelector('button[data-date="2022-02-10"]') as HTMLButtonElement);
 
     // The button should now have aria-pressed="true" attribute and selected class
     const currentDateButton = container.querySelector('button[data-date="2022-02-10"]');
@@ -152,7 +178,7 @@ describe('<DateInput /> spec', () => {
     userEvent.selectOptions(screen.getByLabelText('Year'), '2022');
 
     // Select the date 2022-02-10
-    userEvent.click(container.querySelector('button[data-date="2022-02-10"]'));
+    userEvent.click(container.querySelector('button[data-date="2022-02-10"]') as HTMLButtonElement);
 
     // Confirm the date selection by clicking the Select button
     userEvent.click(screen.getByTestId('selectButton'));
@@ -177,7 +203,7 @@ describe('<DateInput /> spec', () => {
     userEvent.selectOptions(screen.getByLabelText('Year'), '2022');
 
     // Select the date 2022-02-10
-    userEvent.click(container.querySelector('button[data-date="2022-02-10"]'));
+    userEvent.click(container.querySelector('button[data-date="2022-02-10"]') as HTMLButtonElement);
 
     // Close with the Close button
     userEvent.click(screen.getByTestId('closeButton'));
@@ -202,7 +228,7 @@ describe('<DateInput /> spec', () => {
     userEvent.selectOptions(screen.getByLabelText('Year'), '2022');
 
     // Select the date 2022-02-10
-    userEvent.click(container.querySelector('button[data-date="2022-02-10"]'));
+    userEvent.click(container.querySelector('button[data-date="2022-02-10"]') as HTMLButtonElement);
 
     // Click outside the calendar
     await act(async () => {
@@ -229,7 +255,7 @@ describe('<DateInput /> spec', () => {
     userEvent.selectOptions(screen.getByLabelText('Year'), '2022');
 
     // Select the date 2022-02-10
-    userEvent.click(container.querySelector('button[data-date="2022-02-10"]'));
+    userEvent.click(container.querySelector('button[data-date="2022-02-10"]') as HTMLButtonElement);
 
     // Calendar should become hidden
     expect(screen.queryByRole('dialog')).toBeNull();

--- a/packages/react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/dialog/Dialog.stories.tsx
@@ -3,7 +3,7 @@ import React, { useRef, useState } from 'react';
 import { Button } from '../button/Button';
 import { TextArea } from '../textarea/TextArea';
 import { TextInput } from '../textInput/TextInput';
-import { Dialog } from './Dialog';
+import { Dialog, DialogProps } from './Dialog';
 import { IconAlertCircle, IconInfoCircle, IconPlusCircle, IconTrash } from '../../icons';
 import { DateInput } from '../dateInput';
 
@@ -33,7 +33,7 @@ export default {
   argTypes,
 };
 
-export const Default = (args) => {
+export const Default = (args: DialogProps) => {
   const openButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(false);
   const close = () => setOpen(false);
@@ -52,7 +52,7 @@ export const Default = (args) => {
         theme={args.theme}
         style={args.style}
         variant={args.variant}
-        closeButtonLabelText={args.closeButtonLabelText}
+        closeButtonLabelText={args.closeButtonLabelText as string}
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
         isOpen={open}
@@ -100,8 +100,8 @@ export const Default = (args) => {
 };
 
 // This dialog story is part of Loki's visual regression tests. It is open by default, and it is not part of the Storybooks' docs section.
-export const WithBoxShadow = (args) => {
-  const dialogTargetElement = document.getElementById('root'); // Because of the story regression tests, we need to render the dialog into the root element
+export const WithBoxShadow = (args: DialogProps) => {
+  const dialogTargetElement = document.getElementById('root') as HTMLElement; // Because of the story regression tests, we need to render the dialog into the root element
   const openButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
@@ -177,8 +177,8 @@ WithBoxShadow.parameters = {
 };
 
 // This dialog story is part of Loki's visual regression tests. It is open by default, and it is not part of the Storybooks' docs section.
-export const Confirmation = (args) => {
-  const dialogTargetElement = document.getElementById('root'); // Because of the story regression tests, we need to render the dialog into the root element
+export const Confirmation = (args: DialogProps) => {
+  const dialogTargetElement = document.getElementById('root') as HTMLElement; // Because of the story regression tests, we need to render the dialog into the root element
   const openConfirmationButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
@@ -241,8 +241,8 @@ Confirmation.parameters = {
 };
 
 // This dialog story is part of Loki's visual regression tests. It is open by default, and it is not part of the Storybooks' docs section.
-export const Danger = (args) => {
-  const dialogTargetElement = document.getElementById('root'); // Because of the story regression tests, we need to render the dialog into the root element
+export const Danger = (args: DialogProps) => {
+  const dialogTargetElement = document.getElementById('root') as HTMLElement; // Because of the story regression tests, we need to render the dialog into the root element
   const openDangerButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
@@ -308,8 +308,8 @@ Danger.parameters = {
 };
 
 // This dialog story is part of Loki's visual regression tests. It is open by default, and it is not part of the Storybooks' docs section.
-export const ScrollableConfirmation = (args) => {
-  const dialogTargetElement = document.getElementById('root'); // Because of the story regression tests, we need to render the dialog into the root element
+export const ScrollableConfirmation = (args: DialogProps) => {
+  const dialogTargetElement = document.getElementById('root') as HTMLElement; // Because of the story regression tests, we need to render the dialog into the root element
   const openScrollableConfirmationButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
@@ -443,8 +443,8 @@ ScrollableConfirmation.parameters = {
 };
 
 // This dialog story is part of Loki's visual regression tests. It is open by default, and it is not part of the Storybooks' docs section.
-export const LongButtonLabels = (args) => {
-  const dialogTargetElement = document.getElementById('root'); // Because of the story regression tests, we need to render the dialog into the root element
+export const LongButtonLabels = (args: DialogProps) => {
+  const dialogTargetElement = document.getElementById('root') as HTMLElement; // Because of the story regression tests, we need to render the dialog into the root element
   const openDialogButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(true);
   const close = () => setOpen(false);
@@ -503,7 +503,7 @@ LongButtonLabels.parameters = {
 };
 
 // This dialog story is not part of the Storybooks' docs section.
-export const ConfirmationWithTerms = (args) => {
+export const ConfirmationWithTerms = (args: DialogProps & { termsId: string }) => {
   const openConfirmationButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(false);
   const [termsOpen, setTermsOpen] = useState<boolean>(false);
@@ -625,7 +625,7 @@ ConfirmationWithTerms.parameters = {
   },
 };
 
-export const WithControlledContent = (args) => {
+export const WithControlledContent = (args: DialogProps) => {
   const openButtonRef = useRef(null);
   const [open, setOpen] = useState<boolean>(false);
   const close = () => setOpen(false);

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -9,6 +9,7 @@ import { DialogActionButtons } from './dialogActionButtons/DialogActionButtons';
 import { DialogHeader } from './dialogHeader/DialogHeader';
 import { DialogContent } from './dialogContent/DialogContent';
 import { DialogContext, DialogContextProps } from './DialogContext';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface DialogCustomTheme {
   '--accent-line-color'?: string;
@@ -84,8 +85,8 @@ type DialogCloseProps =
       closeButtonLabelText?: undefined;
     };
 
-export type DialogProps = React.PropsWithChildren<
-  {
+export type DialogProps = AllElementPropsWithoutRef<'div'> &
+  React.PropsWithChildren<{
     /**
      * The id of the dialog element.
      */
@@ -138,12 +139,11 @@ export type DialogProps = React.PropsWithChildren<
      * Target element where dialog is rendered. The dialog is rendered into the document.body by default.
      */
     targetElement?: HTMLElement;
-  } & DialogCloseProps
->;
+  }> &
+  DialogCloseProps;
 
 export const Dialog = ({
   boxShadow = false,
-  id,
   isOpen,
   children,
   close,
@@ -152,11 +152,10 @@ export const Dialog = ({
   focusAfterCloseRef,
   scrollable,
   variant = 'primary',
-  style,
   theme,
   className,
   targetElement,
-  ...props
+  ...rest
 }: DialogProps) => {
   const [isReadyToShowDialog, setIsReadyToShowDialog] = useState<boolean>(false);
   const dialogContextProps: DialogContextProps = { isReadyToShowDialog, scrollable, close, closeButtonLabelText };
@@ -180,8 +179,6 @@ export const Dialog = ({
     // Returning null from useEffect is prohibited, but undefined is fine
     return undefined;
   }, [dialogRef, isOpen]);
-
-  const { 'aria-labelledby': ariaLabelledby, 'aria-describedby': ariaDescribedby } = props;
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent): void => {
@@ -231,10 +228,10 @@ export const Dialog = ({
         <ContentTabBarrier onFocus={() => focusToDialogElement(TabBarrierPosition.bottom, dialogRef.current)} />
         <div tabIndex={-1} className={styles.dialogBackdrop} />
         <div
+          {...rest}
           ref={dialogRef}
           role="dialog"
           aria-modal="true"
-          id={id}
           className={classNames(
             styles.dialog,
             isReadyToShowDialog && styles.dialogVisible,
@@ -243,9 +240,6 @@ export const Dialog = ({
             boxShadow && styles.boxShadow,
             className,
           )}
-          style={style}
-          aria-labelledby={ariaLabelledby}
-          aria-describedby={ariaDescribedby}
         >
           {children}
         </div>

--- a/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -22,11 +22,16 @@ exports[`<Dialog /> spec renders the component 1`] = `
     />
     <div
       aria-describedby="test-dialog-description-id"
+      aria-label="aria-label"
       aria-labelledby="test-dialog-title-id"
       aria-modal="true"
-      class="dialog dialogVisible primary"
+      class="dialog dialogVisible primary test-class-name"
+      data-hds-prop="hdsProp"
+      data-testid="testId"
       id="test-dialog-id"
       role="dialog"
+      style="padding: 100px;"
+      tabindex="100"
     >
       <div
         class="dialogHeader"
@@ -56,8 +61,10 @@ exports[`<Dialog /> spec renders the component 1`] = `
             </svg>
           </button>
           <h2
+            aria-label="dialog-header"
             class="dialogTitle"
-            id="test-dialog-title-id"
+            data-testid="dialog-header-test-id"
+            id="dialog-header-id"
             tabindex="-1"
           >
             <span
@@ -85,7 +92,10 @@ exports[`<Dialog /> spec renders the component 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="content-label"
         class="dialogContent"
+        data-testid="dialog-content-test-id"
+        id="dialog-content-id"
       >
         <p
           id="test-dialog-description-id"
@@ -94,7 +104,10 @@ exports[`<Dialog /> spec renders the component 1`] = `
         </p>
       </div>
       <div
+        aria-labelledby="buttons-label"
         class="dialogActionButtons"
+        data-testid="dialog-buttons-test-id"
+        id="dialog-buttons-id"
       >
         <button
           type="button"

--- a/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.tsx
+++ b/packages/react/src/components/dialog/dialogActionButtons/DialogActionButtons.tsx
@@ -2,16 +2,23 @@ import React from 'react';
 
 import styles from './DialogActionButtons.module.scss';
 import classNames from '../../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../../utils/elementTypings';
 
-export type DialogActionButtonProps = React.PropsWithChildren<{
-  /**
-   * className for custom styling
-   */
-  className?: string;
-}>;
+export type DialogActionButtonProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * className for custom styling
+     */
+    className?: string;
+  }
+>;
 
-export const DialogActionButtons = ({ children, className }: DialogActionButtonProps) => {
-  return <div className={classNames(styles.dialogActionButtons, className)}>{children}</div>;
+export const DialogActionButtons = ({ children, className, ...rest }: DialogActionButtonProps) => {
+  return (
+    <div className={classNames(styles.dialogActionButtons, className)} {...rest}>
+      {children}
+    </div>
+  );
 };
 
 DialogActionButtons.componentName = 'DialogActionButtons';

--- a/packages/react/src/components/dialog/dialogContent/DialogContent.tsx
+++ b/packages/react/src/components/dialog/dialogContent/DialogContent.tsx
@@ -3,19 +3,24 @@ import React, { useContext } from 'react';
 import styles from './DialogContent.module.scss';
 import classNames from '../../../utils/classNames';
 import { DialogContext } from '../DialogContext';
+import { AllElementPropsWithoutRef } from '../../../utils/elementTypings';
 
-export type DialogContentProps = React.PropsWithChildren<{
-  /**
-   * The id of the content element.
-   */
-  id?: string;
-}>;
-
-export const DialogContent = ({ id, children }: DialogContentProps) => {
+export type DialogContentProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * The id of the content element.
+     */
+    id?: string;
+  }
+>;
+export const DialogContent = ({ children, className, ...rest }: DialogContentProps) => {
   const { scrollable } = useContext(DialogContext);
 
   return (
-    <div id={id} className={classNames(styles.dialogContent, scrollable && styles.dialogContentScrollable)}>
+    <div
+      className={classNames(styles.dialogContent, scrollable && styles.dialogContentScrollable, className)}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/packages/react/src/components/dialog/dialogHeader/DialogHeader.tsx
+++ b/packages/react/src/components/dialog/dialogHeader/DialogHeader.tsx
@@ -3,8 +3,10 @@ import React, { RefObject, useContext, useEffect } from 'react';
 import styles from './DialogHeader.module.scss';
 import { IconCross } from '../../../icons';
 import { DialogContext } from '../DialogContext';
+import { AllElementPropsWithRef } from '../../../utils/elementTypings';
+import classNames from '../../../utils/classNames';
 
-export type DialogHeaderProps = {
+export type DialogHeaderProps = AllElementPropsWithRef<'h2'> & {
   /**
    * The id of the heading element.
    */
@@ -19,7 +21,7 @@ export type DialogHeaderProps = {
   iconLeft?: React.ReactNode;
 };
 
-export const DialogHeader = ({ id, title, iconLeft }: DialogHeaderProps) => {
+export const DialogHeader = ({ title, iconLeft, className, ...rest }: DialogHeaderProps) => {
   const { close, closeButtonLabelText, isReadyToShowDialog } = useContext(DialogContext);
   const titleRef: RefObject<HTMLHeadingElement> = React.useRef();
 
@@ -42,7 +44,7 @@ export const DialogHeader = ({ id, title, iconLeft }: DialogHeaderProps) => {
             <IconCross aria-hidden="true" />
           </button>
         )}
-        <h2 id={id} tabIndex={-1} className={styles.dialogTitle} ref={titleRef}>
+        <h2 tabIndex={-1} className={classNames(styles.dialogTitle, className)} ref={titleRef} {...rest}>
           {iconLeft && (
             <span className={styles.dialogTitleLeftIcon} aria-hidden="true">
               {iconLeft}

--- a/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/dropdown/combobox/Combobox.stories.tsx
@@ -3,10 +3,28 @@ import { action } from '@storybook/addon-actions';
 import { uniqueId } from 'lodash';
 
 import { Button } from '../../button';
-import { Combobox } from './Combobox';
+import { Combobox, ComboboxProps } from './Combobox';
 import { IconFaceSmile, IconLocation } from '../../../icons';
+import { MultiSelectProps } from '../select';
 
 type Option = { label: string };
+type MultiSelectEssentials = Pick<MultiSelectProps<Option>, 'onChange' | 'multiselect'>;
+// when aria-labelledby is set, label must be undefined
+type MultiSelectArgsWithLabel = ComboboxProps<Option> & { 'aria-labelledby': undefined } & MultiSelectEssentials;
+type DefaultArgs = Pick<
+  Required<ComboboxProps<Option>>,
+  | 'id'
+  | 'label'
+  | 'helper'
+  | 'placeholder'
+  | 'clearButtonAriaLabel'
+  | 'options'
+  | 'onBlur'
+  | 'onFocus'
+  | 'toggleButtonAriaLabel'
+> & { multiselect: false; onChange: (option: Option | Option[]) => void };
+
+type StoryArgs = DefaultArgs & Partial<ComboboxProps<Option>>;
 
 function getId(): string {
   return uniqueId('hds-combobox-');
@@ -61,19 +79,19 @@ export default {
     onChange: (change) => action('onChange')(change),
     onFocus: action('onFocus'),
     toggleButtonAriaLabel: 'Open the combobox',
-  },
+  } as DefaultArgs,
 };
 
-export const Default = (args) => <Combobox {...args} />;
+export const Default = (args: StoryArgs) => <Combobox {...args} />;
 
-export const WithClearButton = (args) => <Combobox {...args} />;
+export const WithClearButton = (args: StoryArgs) => <Combobox {...args} />;
 WithClearButton.storyName = 'With clear button';
 WithClearButton.args = {
   clearable: true,
 };
 WithClearButton.parameters = { loki: { skip: true } };
 
-export const Multiselect = (args) => <Combobox {...args} />;
+export const Multiselect = (args: StoryArgs) => <Combobox {...args} />;
 Multiselect.storyName = 'Multi-select';
 Multiselect.args = {
   multiselect: true,
@@ -81,27 +99,27 @@ Multiselect.args = {
   selectedItemRemoveButtonAriaLabel: 'Remove {value}',
 };
 
-export const Invalid = (args) => <Combobox {...args} />;
+export const Invalid = (args: StoryArgs) => <Combobox {...args} />;
 Invalid.args = {
   invalid: true,
   error: 'Wrong item!',
 };
 
-export const Disabled = (args) => <Combobox {...args} />;
+export const Disabled = (args: StoryArgs) => <Combobox {...args} />;
 Disabled.args = {
   disabled: true,
 };
 
-export const Controlled = (args) => {
-  const [selectedItem, setSelectedItem] = useState(null);
-  const [selectedItems, setSelectedItems] = useState(null);
+export const Controlled = (args: StoryArgs) => {
+  const [selectedItem, setSelectedItem] = useState<Option | null>(null);
+  const [selectedItems, setSelectedItems] = useState<Option[] | null>(null);
 
-  const handleChange = (item) => {
+  const handleChange = (item: Option) => {
     action('onChange')(item);
     setSelectedItem(item);
   };
 
-  const handleMultiSelectChange = (item) => {
+  const handleMultiSelectChange = (item: Option[]) => {
     action('onChange')(item);
     setSelectedItems(item);
   };
@@ -113,12 +131,13 @@ export const Controlled = (args) => {
         Select first option
       </Button>
       <Combobox
-        {...args}
+        {...(args as DefaultArgs)}
         id={getId()}
         label="Combobox"
         onChange={handleChange}
         value={selectedItem}
         style={{ marginTop: 'var(--spacing-s)' }}
+        toggleButtonAriaLabel="Open the combobox"
       />
 
       <Button onClick={() => setSelectedItems(null)} style={{ marginTop: 'var(--spacing-l)' }}>
@@ -131,7 +150,7 @@ export const Controlled = (args) => {
         Select all
       </Button>
       <Combobox
-        {...args}
+        {...(args as unknown as MultiSelectArgsWithLabel)}
         id={getId()}
         label="Multi-select combobox"
         multiselect
@@ -144,14 +163,14 @@ export const Controlled = (args) => {
   );
 };
 
-export const DisabledOptions = (args) => {
-  const getIsDisabled = (item, index): boolean => index % 2 === 1;
+export const DisabledOptions = (args: StoryArgs) => {
+  const getIsDisabled = (item: Option, index: number): boolean => index % 2 === 1;
 
   return (
     <>
-      <Combobox {...args} id={getId()} label="Combobox" isOptionDisabled={getIsDisabled} />
+      <Combobox {...(args as DefaultArgs)} id={getId()} label="Combobox" isOptionDisabled={getIsDisabled} />
       <Combobox
-        {...args}
+        {...(args as unknown as MultiSelectArgsWithLabel)}
         id={getId()}
         label="Multi-select combobox"
         multiselect
@@ -164,10 +183,10 @@ export const DisabledOptions = (args) => {
 };
 DisabledOptions.storyName = 'With disabled options';
 
-export const Icon = (args) => <Combobox {...args} icon={<IconFaceSmile />} />;
+export const Icon = (args: ComboboxProps<Option>) => <Combobox {...args} icon={<IconFaceSmile />} />;
 Icon.storyName = 'With icon';
 
-export const MultiselectWithIcon = (args) => <Combobox {...args} icon={<IconLocation />} />;
+export const MultiselectWithIcon = (args: ComboboxProps<Option>) => <Combobox {...args} icon={<IconLocation />} />;
 MultiselectWithIcon.storyName = 'Multi-select with icon';
 MultiselectWithIcon.args = {
   multiselect: true,
@@ -177,7 +196,7 @@ MultiselectWithIcon.args = {
 
 MultiselectWithIcon.parameters = { loki: { skip: true } };
 
-export const Tooltip = (args) => <Combobox {...args} />;
+export const Tooltip = (args: ComboboxProps<Option>) => <Combobox {...args} />;
 Tooltip.storyName = 'With tooltip';
 Tooltip.args = {
   tooltipLabel: 'Tooltip',
@@ -186,8 +205,12 @@ Tooltip.args = {
     'Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.',
 };
 
-export const CustomTheme = (args) => (
-  <Combobox {...args} multiselect selectedItemRemoveButtonAriaLabel="Remove {value}" />
+export const CustomTheme = (args: StoryArgs) => (
+  <Combobox
+    {...(args as unknown as MultiSelectArgsWithLabel)}
+    multiselect
+    selectedItemRemoveButtonAriaLabel="Remove {value}"
+  />
 );
 CustomTheme.storyName = 'With custom theme';
 CustomTheme.args = {
@@ -230,20 +253,22 @@ CustomTheme.args = {
   },
 };
 
-export const ComboboxExample = (args) => {
+export const ComboboxExample = (args: ComboboxProps<Option>) => {
   return (
-    <Combobox<Option>
+    <Combobox
       {...args}
       placeholder="Type to search"
-      getA11yComboboxionMessage={({ selectedItem }) => `${selectedItem.label} selected`}
+      getA11ySelectionMessage={({ selectedItem }) => {
+        return selectedItem ? `${selectedItem.label} selected` : '';
+      }}
     />
   );
 };
 ComboboxExample.storyName = 'Combobox example';
 
-export const MultiSelectExample = (args) => {
+export const MultiSelectExample = (args: MultiSelectArgsWithLabel) => {
   return (
-    <Combobox<Option>
+    <Combobox
       {...args}
       label="Items"
       helper="Choose items"
@@ -253,13 +278,14 @@ export const MultiSelectExample = (args) => {
       selectedItemRemoveButtonAriaLabel="Remove {value}"
       selectedItemSrLabel="Selected item {value}"
       getA11yRemovalMessage={({ removedSelectedItem }) => `${removedSelectedItem.label} was removed`}
+      toggleButtonAriaLabel="Open the combobox"
     />
   );
 };
 MultiSelectExample.storyName = 'Multi-select combobox example';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const WithExternalLabel = (args) => {
+export const WithExternalLabel = (args: ComboboxProps<Option>) => {
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr' }}>
       <p id="externalLabelId">External label for the combobox</p>
@@ -282,7 +308,7 @@ export const WithExternalLabel = (args) => {
 WithExternalLabel.storyName = 'With external label';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const MultiSelectWithDefaultValue = (args) => {
+export const MultiSelectWithDefaultValue = (args: DefaultArgs) => {
   // this story also tests very long labels are displayed correctly.
   const optionsWithLongText = [
     { label: 'This is a long text that is wider than the container, but should still be visible' },

--- a/packages/react/src/components/dropdown/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdown/select/Select.stories.tsx
@@ -3,10 +3,28 @@ import { action } from '@storybook/addon-actions';
 import { uniqueId } from 'lodash';
 
 import { Button } from '../../button';
-import { Select } from './Select';
+import { MultiSelectProps, Select } from './Select';
 import { IconFaceSmile, IconLocation } from '../../../icons';
+import { ComboboxProps } from '../combobox/Combobox';
 
 type Option = { label: string };
+type MultiSelectEssentials = Pick<MultiSelectProps<Option>, 'onChange' | 'multiselect'>;
+// when aria-labelledby is set, label must be undefined
+type MultiSelectArgsWithLabel = ComboboxProps<Option> & { 'aria-labelledby': undefined } & MultiSelectEssentials;
+type DefaultArgs = Pick<
+  Required<ComboboxProps<Option>>,
+  | 'id'
+  | 'label'
+  | 'helper'
+  | 'placeholder'
+  | 'clearButtonAriaLabel'
+  | 'options'
+  | 'onBlur'
+  | 'onFocus'
+  | 'toggleButtonAriaLabel'
+> & { multiselect: false; onChange: (option: Option | Option[]) => void };
+
+type StoryArgs = DefaultArgs & Partial<ComboboxProps<Option>>;
 
 function getId(): string {
   return uniqueId('hds-select-');
@@ -52,43 +70,43 @@ export default {
   },
 };
 
-export const Default = (args) => <Select {...args} />;
+export const Default = (args: StoryArgs) => <Select {...args} />;
 
-export const WithClearButton = (args) => <Select {...args} />;
+export const WithClearButton = (args: StoryArgs) => <Select {...args} />;
 WithClearButton.storyName = 'With clear button';
 WithClearButton.args = {
   clearable: true,
 };
 WithClearButton.parameters = { loki: { skip: true } };
 
-export const Multiselect = (args) => <Select {...args} />;
+export const Multiselect = (args: StoryArgs) => <Select {...args} />;
 Multiselect.storyName = 'Multi-select';
 Multiselect.args = {
   multiselect: true,
   selectedItemRemoveButtonAriaLabel: 'Remove {value}',
 };
 
-export const Invalid = (args) => <Select {...args} />;
+export const Invalid = (args: StoryArgs) => <Select {...args} />;
 Invalid.args = {
   invalid: true,
   error: 'Wrong item!',
 };
 
-export const Disabled = (args) => <Select {...args} />;
+export const Disabled = (args: StoryArgs) => <Select {...args} />;
 Disabled.args = {
   disabled: true,
 };
 
-export const Controlled = (args) => {
-  const [selectedItem, setSelectedItem] = useState(null);
-  const [selectedItems, setSelectedItems] = useState(null);
+export const Controlled = (args: StoryArgs) => {
+  const [selectedItem, setSelectedItem] = useState<Option | null>(null);
+  const [selectedItems, setSelectedItems] = useState<Option[] | null>(null);
 
-  const handleChange = (item) => {
+  const handleChange = (item: Option) => {
     action('onChange')(item);
     setSelectedItem(item);
   };
 
-  const handleMultiSelectChange = (item) => {
+  const handleMultiSelectChange = (item: Option[]) => {
     action('onChange')(item);
     setSelectedItems(item);
   };
@@ -100,7 +118,7 @@ export const Controlled = (args) => {
         Select first option
       </Button>
       <Select
-        {...args}
+        {...(args as DefaultArgs)}
         id={getId()}
         label="Select"
         onChange={handleChange}
@@ -118,7 +136,7 @@ export const Controlled = (args) => {
         Select all
       </Button>
       <Select
-        {...args}
+        {...(args as unknown as MultiSelectArgsWithLabel)}
         id={getId()}
         label="Multi-select"
         multiselect
@@ -131,14 +149,14 @@ export const Controlled = (args) => {
   );
 };
 
-export const DisabledOptions = (args) => {
+export const DisabledOptions = (args: StoryArgs) => {
   const getIsDisabled = (item, index): boolean => index % 2 === 1;
 
   return (
     <>
-      <Select {...args} id={getId()} label="Select" isOptionDisabled={getIsDisabled} />
+      <Select {...(args as DefaultArgs)} id={getId()} label="Select" isOptionDisabled={getIsDisabled} />
       <Select
-        {...args}
+        {...(args as unknown as MultiSelectArgsWithLabel)}
         id={getId()}
         label="Multi-select"
         multiselect
@@ -151,10 +169,10 @@ export const DisabledOptions = (args) => {
 };
 DisabledOptions.storyName = 'With disabled options';
 
-export const Icon = (args) => <Select {...args} icon={<IconFaceSmile />} />;
+export const Icon = (args: StoryArgs) => <Select {...args} icon={<IconFaceSmile />} />;
 Icon.storyName = 'With icon';
 
-export const MultiselectWithIcon = (args) => <Select {...args} icon={<IconLocation />} />;
+export const MultiselectWithIcon = (args: StoryArgs) => <Select {...args} icon={<IconLocation />} />;
 MultiselectWithIcon.storyName = 'Multi-select with icon';
 MultiselectWithIcon.args = {
   multiselect: true,
@@ -162,7 +180,7 @@ MultiselectWithIcon.args = {
 };
 MultiselectWithIcon.parameters = { loki: { skip: true } };
 
-export const Tooltip = (args) => <Select {...args} />;
+export const Tooltip = (args: StoryArgs) => <Select {...args} />;
 Tooltip.storyName = 'With tooltip';
 Tooltip.args = {
   tooltipLabel: 'Tooltip',
@@ -171,7 +189,9 @@ Tooltip.args = {
     'Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.',
 };
 
-export const CustomTheme = (args) => <Select {...args} multiselect />;
+export const CustomTheme = (args: StoryArgs) => (
+  <Select {...(args as unknown as MultiSelectArgsWithLabel)} multiselect />
+);
 CustomTheme.storyName = 'With custom theme';
 CustomTheme.args = {
   theme: {
@@ -213,8 +233,15 @@ CustomTheme.args = {
   },
 };
 
-export const SelectExample = (args) => {
-  return <Select<Option> {...args} getA11ySelectionMessage={({ selectedItem }) => `${selectedItem.label} selected`} />;
+export const SelectExample = (args: StoryArgs) => {
+  return (
+    <Select<Option>
+      {...args}
+      getA11ySelectionMessage={({ selectedItem }) => {
+        return selectedItem ? `${selectedItem.label} selected` : '';
+      }}
+    />
+  );
 };
 SelectExample.storyName = 'Select example';
 
@@ -245,7 +272,7 @@ export const MultiSelectExample = ({ options: itemOptions, ...args }) => {
 MultiSelectExample.storyName = 'Multi-select example';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const WithExternalLabel = (args) => {
+export const WithExternalLabel = (args: StoryArgs) => {
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr' }}>
       <p id="externalLabelId">External label for the select</p>

--- a/packages/react/src/components/errorSummary/ErrorSummary.stories.tsx
+++ b/packages/react/src/components/errorSummary/ErrorSummary.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ErrorSummary } from './ErrorSummary';
+import { ErrorSummary, ErrorSummaryProps } from './ErrorSummary';
 
 export default {
   component: ErrorSummary,
@@ -14,7 +14,7 @@ export default {
   },
 };
 
-export const Default = (args) => (
+export const Default = (args: ErrorSummaryProps) => (
   <ErrorSummary {...args}>
     <ul>
       <li>
@@ -30,7 +30,7 @@ export const Default = (args) => (
   </ErrorSummary>
 );
 
-export const Large = (args) => <Default {...args} />;
+export const Large = (args: ErrorSummaryProps) => <Default {...args} />;
 Large.args = {
   size: 'large',
 };

--- a/packages/react/src/components/errorSummary/ErrorSummary.test.tsx
+++ b/packages/react/src/components/errorSummary/ErrorSummary.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { ErrorSummary } from './ErrorSummary';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<ErrorSummary /> spec', () => {
   it('renders the component', () => {
@@ -26,5 +27,15 @@ describe('<ErrorSummary /> spec', () => {
       </ErrorSummary>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <ErrorSummary {...divProps} label="Form contains following errors" size="default">
+        <ul />
+      </ErrorSummary>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/errorSummary/ErrorSummary.tsx
+++ b/packages/react/src/components/errorSummary/ErrorSummary.tsx
@@ -5,34 +5,37 @@ import errorSummaryStyles from './ErrorSummary.module.scss';
 import notificationStyles from '../notification/Notification.module.css';
 import { IconErrorFill } from '../../icons';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type ErrorSummarySize = 'default' | 'large';
 
-export type ErrorSummaryProps = React.PropsWithChildren<{
-  /**
-   * Automatically focus the label of the error summary
-   */
-  autofocus?: boolean;
-  /**
-   * Additional class names to apply to the error summary
-   */
-  className?: string;
-  /**
-   * The label of the error summary.
-   */
-  label: string | React.ReactNode;
-  /**
-   * The size of the error summary
-   */
-  size?: ErrorSummarySize;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-}>;
+export type ErrorSummaryProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * Automatically focus the label of the error summary
+     */
+    autofocus?: boolean;
+    /**
+     * Additional class names to apply to the error summary
+     */
+    className?: string;
+    /**
+     * The label of the error summary.
+     */
+    label: string | React.ReactNode;
+    /**
+     * The size of the error summary
+     */
+    size?: ErrorSummarySize;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    style?: React.CSSProperties;
+  }
+>;
 
 export const ErrorSummary = React.forwardRef<HTMLDivElement, ErrorSummaryProps>(
-  ({ autofocus = false, className, label, size = 'default', style, children }: ErrorSummaryProps, ref) => {
+  ({ autofocus = false, className, label, size = 'default', children, ...rest }: ErrorSummaryProps, ref) => {
     const labelRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -50,9 +53,9 @@ export const ErrorSummary = React.forwardRef<HTMLDivElement, ErrorSummaryProps>(
           notificationStyles.error,
           className,
         )}
-        style={style}
         aria-label="Error summary"
         aria-atomic="true"
+        {...rest}
       >
         <div className={notificationStyles.content}>
           <div

--- a/packages/react/src/components/fieldset/Fieldset.stories.tsx
+++ b/packages/react/src/components/fieldset/Fieldset.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Fieldset } from './Fieldset';
+import { Fieldset, FieldsetProps } from './Fieldset';
 import { TextInput } from '../textInput/TextInput';
 import { RadioButton } from '../radioButton/RadioButton';
 import { SelectionGroup } from '../selectionGroup/SelectionGroup';
@@ -18,7 +18,7 @@ export default {
   },
 };
 
-export const Default = (args) => {
+export const Default = (args: FieldsetProps) => {
   return (
     <Fieldset heading={args.heading} border={args.border}>
       <div
@@ -43,7 +43,7 @@ export const Default = (args) => {
   );
 };
 
-export const WithBorder = (args) => {
+export const WithBorder = (args: FieldsetProps) => {
   return (
     <Fieldset heading={args.heading} border={args.border}>
       <div
@@ -76,7 +76,7 @@ WithBorder.args = {
   border: true,
 };
 
-export const WithSelectionGroup = (args) => {
+export const WithSelectionGroup = (args: FieldsetProps) => {
   const fileFormats = [
     { label: 'Text', value: 'txt' },
     { label: 'CSV', value: 'csv' },
@@ -109,7 +109,7 @@ WithSelectionGroup.args = {
   heading: 'File information',
 };
 
-export const WithTooltip = (args) => {
+export const WithTooltip = (args: FieldsetProps) => {
   return (
     <Fieldset {...args}>
       <div
@@ -144,7 +144,7 @@ WithTooltip.args = {
   tooltipButtonLabel: 'tooltip button aria label',
 };
 
-export const WithHelperText = (args) => {
+export const WithHelperText = (args: FieldsetProps) => {
   return (
     <Fieldset {...args}>
       <div

--- a/packages/react/src/components/fieldset/Fieldset.test.tsx
+++ b/packages/react/src/components/fieldset/Fieldset.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Fieldset } from './Fieldset';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Fieldset /> spec', () => {
   it('renders the component', () => {
@@ -13,5 +14,11 @@ describe('<Fieldset /> spec', () => {
     const { container } = render(<Fieldset heading="Test fieldset" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const fieldsetProps = getCommonElementTestProps<'fieldset'>('fieldset');
+    const { getByTestId } = render(<Fieldset {...fieldsetProps} heading="Test fieldset" />);
+    const element = getByTestId(fieldsetProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, fieldsetProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/fieldset/Fieldset.tsx
+++ b/packages/react/src/components/fieldset/Fieldset.tsx
@@ -4,8 +4,9 @@ import '../../styles/base.module.css';
 import styles from './Fieldset.module.scss';
 import classNames from '../../utils/classNames';
 import { Tooltip } from '../tooltip';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-export type FieldsetProps = {
+export type FieldsetProps = AllElementPropsWithoutRef<'fieldset'> & {
   /**
    * Heading text inside legend element
    */
@@ -34,7 +35,7 @@ export type FieldsetProps = {
    * Aria-label text for the tooltip trigger button
    */
   tooltipButtonLabel?: string;
-} & React.HTMLProps<HTMLFieldSetElement>;
+};
 
 export const Fieldset = ({
   heading,

--- a/packages/react/src/components/fileInput/FileInput.stories.tsx
+++ b/packages/react/src/components/fileInput/FileInput.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { FileInput } from './FileInput';
+import { FileInput, FileInputProps } from './FileInput';
 
 const onFilesChanged = (files: File[] | undefined) => action('filesChanged')(files);
 
@@ -22,7 +22,7 @@ export default {
   },
 };
 
-export const Single = (args) => {
+export const Single = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -33,7 +33,7 @@ Single.args = {
   label: 'Choose a file',
 };
 
-export const Multiple = (args) => {
+export const Multiple = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -44,7 +44,7 @@ Multiple.args = {
   multiple: true,
 };
 
-export const WithDefaultValue = (args) => {
+export const WithDefaultValue = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -60,7 +60,7 @@ WithDefaultValue.args = {
   multiple: true,
 };
 
-export const WithDragAndDrop = (args) => {
+export const WithDragAndDrop = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -72,7 +72,7 @@ WithDragAndDrop.args = {
   dragAndDrop: true,
 };
 
-export const WithTooltip = (args) => {
+export const WithTooltip = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -85,7 +85,7 @@ WithTooltip.args = {
   tooltipText: 'The file input will accept most of the known image formats. Please notice the size limit.',
 };
 
-export const Disabled = (args) => {
+export const Disabled = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -98,7 +98,7 @@ Disabled.args = {
   accept: '.png,.jpg,.pdf,.json',
 };
 
-export const DisabledDragAndDrop = (args) => {
+export const DisabledDragAndDrop = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -112,7 +112,7 @@ DisabledDragAndDrop.args = {
   accept: '.png,.jpg,.pdf,.json',
 };
 
-export const Required = (args) => {
+export const Required = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
@@ -124,7 +124,7 @@ Required.args = {
   accept: 'image/*',
 };
 
-export const Playground = (args) => {
+export const Playground = (args: FileInputProps) => {
   const onChange = (files) => {
     onFilesChanged(files);
   };
@@ -169,7 +169,7 @@ Playground.argTypes = {
   },
 };
 
-export const Invalid = (args) => {
+export const Invalid = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 

--- a/packages/react/src/components/fileInput/FileInput.test.tsx
+++ b/packages/react/src/components/fileInput/FileInput.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { act } from 'react-dom/test-utils';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
-import { FileInput, formatBytes } from './FileInput';
+import { FileInput, FileInputProps, formatBytes } from './FileInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<FileInput /> spec', () => {
   const defaultInputProps: Parameters<typeof FileInput>[0] = {
@@ -25,6 +26,19 @@ describe('<FileInput /> spec', () => {
     const { container } = render(<FileInput {...defaultInputProps} errorText="Error text" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps<'div', Pick<FileInputProps, 'onChange' | 'defaultValue'>>('div');
+    const { getByTestId } = render(<FileInput {...divProps} {...defaultInputProps} errorText="Error text" />);
+    const element = getByTestId(divProps['data-testid']);
+    // id is set to the input element, others to wrapper
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...(divProps as unknown as HTMLAttributes<HTMLDivElement>),
+        id: undefined,
+      }),
+    ).toHaveLength(0);
   });
 
   it('should not have accessibility issues when there are files added', async () => {

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -7,11 +7,11 @@ import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 import classNames from '../../utils/classNames';
 import { Button } from '../button';
 import { IconPlus, IconPhoto, IconCross, IconDocument, IconUpload } from '../../icons';
-import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
+import { InputWrapper, InputWrapperProps } from '../../internal/input-wrapper/InputWrapper';
 
 type Language = 'en' | 'fi' | 'sv';
 
-type FileInputProps = {
+export type FileInputProps = Omit<InputWrapperProps, 'onChange'> & {
   /**
    * A comma-separated list of unique file type specifiers describing file types to allow. If present, the filename extension or filetype property is validated against the list. If the file(s) do not match the acceptance criteria, the component will not add the file(s), and it will show an error message with the file name.
    */
@@ -390,6 +390,7 @@ export const FileInput = ({
   tooltipLabel,
   tooltipButtonLabel,
   tooltipText,
+  ...restWrapperProps
 }: FileInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const didMountRef = useRef<boolean>(false);
@@ -415,7 +416,8 @@ export const FileInput = ({
   const errorTextToUse = errorText || invalidText;
   const infoTextToUse = infoText || inputStateText;
 
-  const wrapperProps = {
+  const wrapperProps: InputWrapperProps = {
+    ...restWrapperProps,
     className,
     helperText: helperTextToUse,
     successText: successTextToUse,

--- a/packages/react/src/components/footer/Footer.stories.tsx
+++ b/packages/react/src/components/footer/Footer.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Footer } from './Footer';
+import { Footer, FooterProps } from './Footer';
 import { IconFacebook, IconInstagram, IconLinkedin, IconTiktok, IconTwitter, IconYoutube } from '../../icons';
 import { FooterGroupHeading } from './components/footerGroupHeading/FooterGroupHeading';
 import { FooterLink } from './components/footerLink/FooterLink';
@@ -121,7 +121,7 @@ export default {
   },
 };
 
-export const NoNav = (args) => (
+export const NoNav = (args: FooterProps) => (
   <Footer {...args}>
     <Utilities />
     <Base />
@@ -129,7 +129,7 @@ export const NoNav = (args) => (
 );
 NoNav.storyName = 'No navigation';
 
-export const CustomTheme = (args) => (
+export const CustomTheme = (args: FooterProps) => (
   <Footer {...args}>
     <Footer.Navigation>
       {createArray(8).map((index) => (
@@ -157,7 +157,7 @@ CustomTheme.argTypes = {
   },
 };
 
-export const Sitemap = (args) => (
+export const Sitemap = (args: FooterProps) => (
   <Footer {...args}>
     <Footer.Navigation>
       {createArray(4).map((index) => (
@@ -184,7 +184,7 @@ export const Sitemap = (args) => (
   </Footer>
 );
 
-export const Example = (args) => (
+export const Example = (args: FooterProps) => (
   <Footer footerProps={{ lang: 'fi' }} {...args}>
     <Footer.Navigation>
       <Footer.Link href="https://asiointi.hel.fi/wps/portal/login?locale=fi" label="Sähköinen asiointi" />
@@ -270,7 +270,7 @@ export const Example = (args) => (
   </Footer>
 );
 
-export const UtilityGroups = (args) => (
+export const UtilityGroups = (args: FooterProps) => (
   <Footer footerProps={{ lang: 'fi' }} {...args}>
     <Footer.Navigation>
       <Footer.Link href="https://asiointi.hel.fi/wps/portal/login?locale=fi" label="Sähköinen asiointi" />
@@ -362,7 +362,7 @@ export const UtilityGroups = (args) => (
   </Footer>
 );
 
-export const CustomSection = (args) => (
+export const CustomSection = (args: FooterProps) => (
   <Footer {...args}>
     <Footer.Navigation>
       {createArray(8).map((index) => (
@@ -385,7 +385,7 @@ export const CustomSection = (args) => (
   </Footer>
 );
 
-export const Minimal = (args) => (
+export const Minimal = (args: FooterProps) => (
   <Footer {...args}>
     <Footer.Base backToTopLabel="Back to top" logo={<Logo src={logoFi} size="medium" alt="Helsingin kaupunki" />} />
   </Footer>

--- a/packages/react/src/components/footer/Footer.test.tsx
+++ b/packages/react/src/components/footer/Footer.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 
 import { Footer } from './Footer';
 import { Logo } from '../logo';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Footer /> spec', () => {
   it('renders the component', () => {
@@ -23,5 +24,16 @@ describe('<Footer /> spec', () => {
     const { container } = render(<Footer title="Bar" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const footerProps = getCommonElementTestProps<'footer'>('footer');
+    // footer has "ariaLabel", which should override "aria-label"
+    footerProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <Footer footerProps={footerProps} aria-label="Is overridden" ariaLabel="Real ariaLabel" title="Bar" />,
+    );
+    const element = getByTestId(footerProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, footerProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/Footer.tsx
+++ b/packages/react/src/components/footer/Footer.tsx
@@ -14,6 +14,7 @@ import { FooterBase } from './components/footerBase/FooterBase';
 import { FooterCustom } from './components/footerCustom/FooterCustom';
 import { FooterTheme } from './Footer.interface';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type FooterProps = React.PropsWithChildren<{
   /**
@@ -27,7 +28,7 @@ export type FooterProps = React.PropsWithChildren<{
   /**
    * Props that will be passed to the native `<footer>` element.
    */
-  footerProps?: React.ComponentPropsWithoutRef<'footer'>;
+  footerProps?: AllElementPropsWithoutRef<'footer'>;
   /**
    * Koros type to use in the footer.
    * @default 'basic'
@@ -64,6 +65,7 @@ export const Footer = ({
         styles.footer,
         typeof theme === 'string' && styles[`theme-${theme}`],
         customThemeClass,
+        footerProps && footerProps.className,
         className,
       )}
       aria-label={ariaLabel}

--- a/packages/react/src/components/footer/components/footerBase/FooterBase.test.tsx
+++ b/packages/react/src/components/footer/components/footerBase/FooterBase.test.tsx
@@ -7,6 +7,7 @@ import { FooterWrapper } from '../../../../utils/test-utils';
 import { Footer } from '../../Footer';
 import { FooterVariant } from '../../Footer.interface';
 import { Logo } from '../../../logo';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.Base /> spec', () => {
   const mockDate = new Date(2020, 1, 1);
@@ -55,6 +56,33 @@ describe('<Footer.Base /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    divProps.role = 'role';
+    // element has "ariaLabel", which should override "aria-label"
+    divProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <FooterBase
+        {...divProps}
+        copyrightHolder="Copyright"
+        copyrightText="All rights reserved"
+        backToTopLabel="Ylös"
+        logo={<Logo alt="Helsingin kaupunki" size="medium" src="dummyPath" />}
+        aria-label="Is overridden"
+        ariaLabel="Real ariaLabel"
+      >
+        <Footer.Link label="Link 1" variant={FooterVariant.Base} />
+        <Footer.Link label="Link 2" variant={FooterVariant.Base} />
+        <Footer.Link label="Link 3" variant={FooterVariant.Base} />
+      </FooterBase>,
+      {
+        wrapper: FooterWrapper,
+      },
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 
   it('should scroll to top', () => {

--- a/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
+++ b/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
@@ -9,53 +9,57 @@ import { FooterLink } from '../footerLink/FooterLink';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 import { FooterVariant } from '../../Footer.interface';
 import { useCallbackIfDefined } from '../../../../utils/useCallback';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
+import classNames from '../../../../utils/classNames';
 
-export type FooterBaseProps = React.PropsWithChildren<{
-  /**
-   * aria-label for describing Footer.Base.
-   */
-  ariaLabel?: string;
-  /**
-   * Label for the "Back to top" button.
-   */
-  backToTopLabel?: string | React.ReactNode;
-  /**
-   * Text to be displayed next to the copyright symbol.
-   */
-  copyrightHolder?: React.ReactNode;
-  /**
-   * Text to be displayed after the copyright holder text.
-   */
-  copyrightText?: React.ReactNode;
-  /**
-   * Link for the logo. Should direct to the main page.
-   */
-  logoHref?: string;
-  /**
-   * Logo to use
-   */
-  logo: React.ReactElement<typeof Logo>;
-  /**
-   * Callback fired when the "Back to top" button is clicked.
-   */
-  onBackToTopClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  /**
-   * Callback fired when the logo is clicked.
-   */
-  onLogoClick?: MouseEventHandler;
-  /**
-   * ARIA role to describe the contents.
-   */
-  role?: string;
-  /**
-   * Whether the "Back to top" button should be shown.
-   */
-  showBackToTopButton?: boolean;
-  /**
-   * Set the year for copyright text. This can be useful in automated tests when a static year is set so the tests don't fail after a new year.
-   */
-  year?: number;
-}>;
+export type FooterBaseProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * aria-label for describing Footer.Base.
+     */
+    ariaLabel?: string;
+    /**
+     * Label for the "Back to top" button.
+     */
+    backToTopLabel?: string | React.ReactNode;
+    /**
+     * Text to be displayed next to the copyright symbol.
+     */
+    copyrightHolder?: React.ReactNode;
+    /**
+     * Text to be displayed after the copyright holder text.
+     */
+    copyrightText?: React.ReactNode;
+    /**
+     * Link for the logo. Should direct to the main page.
+     */
+    logoHref?: string;
+    /**
+     * Logo to use
+     */
+    logo: React.ReactElement<typeof Logo>;
+    /**
+     * Callback fired when the "Back to top" button is clicked.
+     */
+    onBackToTopClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    /**
+     * Callback fired when the logo is clicked.
+     */
+    onLogoClick?: MouseEventHandler;
+    /**
+     * ARIA role to describe the contents.
+     */
+    role?: string;
+    /**
+     * Whether the "Back to top" button should be shown.
+     */
+    showBackToTopButton?: boolean;
+    /**
+     * Set the year for copyright text. This can be useful in automated tests when a static year is set so the tests don't fail after a new year.
+     */
+    year?: number;
+  }
+>;
 
 /**
  * Scrolls to the top of the page and puts the focus on the first focusable element in the DOM
@@ -77,14 +81,15 @@ export const FooterBase = ({
   logoHref,
   onBackToTopClick,
   onLogoClick,
-  role,
   showBackToTopButton = true,
   year = new Date().getFullYear(),
+  className,
+  ...rest
 }: FooterBaseProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   const handleLogoClick = useCallbackIfDefined(onLogoClick);
   return (
-    <div className={styles.base} aria-label={ariaLabel} role={role}>
+    <div {...rest} className={classNames(styles.base, className)} aria-label={ariaLabel}>
       <hr className={styles.divider} aria-hidden />
       <div className={styles.logoWrapper}>
         <FooterLink tabIndex={0} icon={logo} href={logoHref} onClick={handleLogoClick} />

--- a/packages/react/src/components/footer/components/footerCustom/FooterCustom.test.tsx
+++ b/packages/react/src/components/footer/components/footerCustom/FooterCustom.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 
 import { FooterCustom } from './FooterCustom';
 import { FooterWrapper } from '../../../../utils/test-utils';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.Custom /> spec', () => {
   it('renders the component', () => {
@@ -19,5 +20,18 @@ describe('<Footer.Custom /> spec', () => {
     });
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    // element has "ariaLabel", which should override "aria-label"
+    divProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <FooterCustom {...divProps} aria-label="Is overridden" ariaLabel="Real ariaLabel" />,
+      {
+        wrapper: FooterWrapper,
+      },
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerCustom/FooterCustom.tsx
+++ b/packages/react/src/components/footer/components/footerCustom/FooterCustom.tsx
@@ -3,29 +3,32 @@ import React from 'react';
 import '../../../../styles/base.module.css';
 import styles from './FooterCustom.module.scss';
 import classNames from '../../../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
-export type FooterCustomProps = React.PropsWithChildren<{
-  /**
-   * aria-label for describing Footer.Custom.
-   */
-  ariaLabel?: string;
-  /**
-   * Additional class names to apply.
-   */
-  className?: string;
-  /**
-   * ID of the navigation element.
-   */
-  id?: string;
-  /**
-   * ARIA role to describe the contents.
-   */
-  role?: string;
-}>;
+export type FooterCustomProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * aria-label for describing Footer.Custom.
+     */
+    ariaLabel?: string;
+    /**
+     * Additional class names to apply.
+     */
+    className?: string;
+    /**
+     * ID of the navigation element.
+     */
+    id?: string;
+    /**
+     * ARIA role to describe the contents.
+     */
+    role?: string;
+  }
+>;
 
-export const FooterCustom = ({ ariaLabel, children, className, id, role }: FooterCustomProps) => {
+export const FooterCustom = ({ ariaLabel, children, className, ...rest }: FooterCustomProps) => {
   return (
-    <div className={classNames(styles.custom, className)} id={id} aria-label={ariaLabel} role={role}>
+    <div {...rest} className={classNames(styles.custom, className)} aria-label={ariaLabel}>
       <hr className={styles.divider} aria-hidden />
       {children}
     </div>

--- a/packages/react/src/components/footer/components/footerGroupHeading/FooterGroupHeading.test.tsx
+++ b/packages/react/src/components/footer/components/footerGroupHeading/FooterGroupHeading.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import { FooterGroupHeading } from './FooterGroupHeading';
 import { FooterWrapper } from '../../../../utils/test-utils';
 import { FooterVariant } from '../../Footer.interface';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.FooterGroupHeading /> spec', () => {
   it('renders the component', () => {
@@ -26,5 +27,13 @@ describe('<Footer.FooterGroupHeading /> spec', () => {
   it('renders the navigation variant', () => {
     const { asFragment } = render(<FooterGroupHeading label="Test" variant={FooterVariant.Navigation} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('native html props are passed to the element', async () => {
+    const linkProps = getCommonElementTestProps<'a'>('a');
+    const { getByTestId } = render(
+      <FooterGroupHeading {...linkProps} label="Test" variant={FooterVariant.Navigation} />,
+    );
+    const element = getByTestId(linkProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, linkProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerGroupHeading/FooterGroupHeading.tsx
+++ b/packages/react/src/components/footer/components/footerGroupHeading/FooterGroupHeading.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import '../../../../styles/base.module.css';
 import styles from './FooterGroupHeading.module.scss';
-import { MergeElementProps } from '../../../../common/types';
 import classNames from '../../../../utils/classNames';
 import { FooterVariant } from '../../Footer.interface';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../../../utils/elementTypings';
 
 type ItemProps<T> = React.PropsWithChildren<{
   /**
@@ -30,7 +30,10 @@ type ItemProps<T> = React.PropsWithChildren<{
   variant?: FooterVariant.Navigation | FooterVariant.Utility;
 }>;
 
-export type FooterGroupHeadingProps<T extends React.ElementType = 'a'> = MergeElementProps<T, ItemProps<T>>;
+export type FooterGroupHeadingProps<T extends React.ElementType = 'a'> = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<T>,
+  ItemProps<T>
+>;
 
 export const FooterGroupHeading = <T extends React.ElementType = 'a'>({
   as: LinkComponent,

--- a/packages/react/src/components/footer/components/footerLink/FooterLink.test.tsx
+++ b/packages/react/src/components/footer/components/footerLink/FooterLink.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import { FooterLink } from './FooterLink';
 import { FooterWrapper } from '../../../../utils/test-utils';
 import { FooterVariant } from '../../Footer.interface';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Link /> spec', () => {
   it('renders the component', () => {
@@ -29,5 +30,11 @@ describe('<Link /> spec', () => {
   it('renders the base variant', () => {
     const { asFragment } = render(<FooterLink label="Link" variant={FooterVariant.Base} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('native html props are passed to the element', async () => {
+    const linkProps = getCommonElementTestProps<'a'>('a');
+    const { getByTestId } = render(<FooterLink {...linkProps} label="Test" variant={FooterVariant.Base} />);
+    const element = getByTestId(linkProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, linkProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerLink/FooterLink.tsx
+++ b/packages/react/src/components/footer/components/footerLink/FooterLink.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import '../../../../styles/base.module.css';
 import styles from './FooterLink.module.scss';
 import { Link } from '../../../link';
-import { MergeElementProps } from '../../../../common/types';
 import classNames from '../../../../utils/classNames';
 import { IconAngleRight, IconLinkExternal } from '../../../../icons';
 import { FooterVariant } from '../../Footer.interface';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../../../utils/elementTypings';
 
 type ItemProps<Element> = React.PropsWithChildren<{
   /**
@@ -58,7 +58,10 @@ type ItemProps<Element> = React.PropsWithChildren<{
   variant?: FooterVariant.Navigation | FooterVariant.Utility | FooterVariant.Base;
 }>;
 
-export type FooterLinkProps<Element extends React.ElementType = 'a'> = MergeElementProps<Element, ItemProps<Element>>;
+export type FooterLinkProps<T extends React.ElementType = 'a'> = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<T>,
+  ItemProps<T>
+>;
 
 export const FooterLink = <T extends React.ElementType = 'a'>({
   ariaLabel,
@@ -72,7 +75,6 @@ export const FooterLink = <T extends React.ElementType = 'a'>({
   ...rest
 }: FooterLinkProps<T>) => {
   const Item = React.isValidElement(LinkComponent) ? LinkComponent.type : LinkComponent;
-
   return (
     <Item
       aria-label={ariaLabel}

--- a/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.test.tsx
+++ b/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import { FooterNavigation } from './FooterNavigation';
 import { FooterWrapper } from '../../../../utils/test-utils';
 import { Footer } from '../../Footer';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.Navigation /> spec', () => {
   it('renders the component', () => {
@@ -29,5 +30,21 @@ describe('<Footer.Navigation /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    divProps.role = 'role';
+    // element has "ariaLabel", which should override "aria-label"
+    divProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <FooterNavigation {...divProps} aria-label="Is overridden" ariaLabel="Real ariaLabel">
+        <Footer.Link label="Link 1" />
+        <Footer.Link label="Link 2" />
+        <Footer.Link label="Link 3" />
+      </FooterNavigation>,
+      { wrapper: FooterWrapper },
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.tsx
+++ b/packages/react/src/components/footer/components/footerNavigation/FooterNavigation.tsx
@@ -4,21 +4,25 @@ import '../../../../styles/base.module.css';
 import styles from './FooterNavigation.module.scss';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 import { FooterVariant } from '../../Footer.interface';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
+import classNames from '../../../../utils/classNames';
 
-export type FooterNavigationProps = React.PropsWithChildren<{
-  /**
-   * aria-label for describing Footer.Navigation.
-   */
-  ariaLabel?: string;
-  /**
-   * ARIA role to describe the contents.
-   */
-  role?: string;
-}>;
-export const FooterNavigation = ({ ariaLabel, children, role }: FooterNavigationProps) => {
+export type FooterNavigationProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * aria-label for describing Footer.Navigation.
+     */
+    ariaLabel?: string;
+    /**
+     * ARIA role to describe the contents.
+     */
+    role?: string;
+  }
+>;
+export const FooterNavigation = ({ ariaLabel, children, className, ...rest }: FooterNavigationProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
-    <div className={styles.navigation} aria-label={ariaLabel} role={role}>
+    <div {...rest} className={classNames(styles.navigation, className)} aria-label={ariaLabel}>
       {childElements.map((child, childIndex) => {
         return (
           // eslint-disable-next-line react/no-array-index-key

--- a/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.test.tsx
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.test.tsx
@@ -2,15 +2,20 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { FooterNavigationGroup } from './FooterNavigationGroup';
+import { FooterNavigationGroup, FooterNavigationGroupProps } from './FooterNavigationGroup';
 import { FooterNavigationWrapper } from '../../../../utils/test-utils';
 import { Footer } from '../../Footer';
 import { FooterVariant } from '../../Footer.interface';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.NavigationGroup /> spec', () => {
-  it('renders the navigation groups', () => {
-    const { asFragment } = render(
+  // if only one FooterNavigationGroup is passed to the <FooterNavigationWrapper />
+  // the Footer.Navigation removes the FooterNavigationGroup and renders only its children.
+  // wrapping the <FooterNavigationGroup> with <TestContent> changes this behaviour.
+  const TestContent = (props?: Partial<FooterNavigationGroupProps>) => {
+    return (
       <FooterNavigationGroup
+        {...props}
         headingLink={
           <Footer.GroupHeading href="https://google.com" label="Main Page" variant={FooterVariant.Navigation} />
         }
@@ -18,25 +23,22 @@ describe('<Footer.NavigationGroup /> spec', () => {
         <Footer.Link label="Link 1" />
         <Footer.Link label="Link 2" />
         <Footer.Link label="Link 3" />
-      </FooterNavigationGroup>,
-      { wrapper: FooterNavigationWrapper },
+      </FooterNavigationGroup>
     );
+  };
+  it('renders the navigation groups', () => {
+    const { asFragment } = render(<TestContent />, { wrapper: FooterNavigationWrapper });
     expect(asFragment()).toMatchSnapshot();
   });
   it('should not have basic accessibility issues', async () => {
-    const { container } = render(
-      <FooterNavigationGroup
-        headingLink={
-          <Footer.GroupHeading href="https://google.com" label="Main Page" variant={FooterVariant.Navigation} />
-        }
-      >
-        <Footer.Link label="Link 1" />
-        <Footer.Link label="Link 2" />
-        <Footer.Link label="Link 3" />
-      </FooterNavigationGroup>,
-      { wrapper: FooterNavigationWrapper },
-    );
+    const { container } = render(<TestContent />, { wrapper: FooterNavigationWrapper });
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<TestContent {...divProps} />, { wrapper: FooterNavigationWrapper });
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.tsx
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/FooterNavigationGroup.tsx
@@ -6,17 +6,19 @@ import { FooterVariant } from '../../Footer.interface';
 import { useMediaQueryLessThan } from '../../../../hooks/useMediaQuery';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
-type FooterNavigationGroupProps = React.PropsWithChildren<{
-  /**
-   * Additional class names to apply.
-   */
-  className?: string;
-  /**
-   * ID of the navigation group element.
-   */
-  id?: string;
-  /**
+export type FooterNavigationGroupProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * Additional class names to apply.
+     */
+    className?: string;
+    /**
+     * ID of the navigation group element.
+     */
+    id?: string;
+    /**
    * Footer.GroupHeading component to display at the top of the group. On smaller screens only this will be displayed.
    * @example
    * ```ts
@@ -26,9 +28,10 @@ type FooterNavigationGroupProps = React.PropsWithChildren<{
       />}
     ```
    */
-  headingLink: React.ReactNode;
-}>;
-export const FooterNavigationGroup = ({ className, children, id, headingLink }: FooterNavigationGroupProps) => {
+    headingLink: React.ReactNode;
+  }
+>;
+export const FooterNavigationGroup = ({ className, children, headingLink, ...rest }: FooterNavigationGroupProps) => {
   // Show only main links in smaller screens
   const shouldRenderOnlyMainLinks = useMediaQueryLessThan('l');
   const childElements = getChildElementsEvenIfContainersInbetween(children);
@@ -41,12 +44,11 @@ export const FooterNavigationGroup = ({ className, children, id, headingLink }: 
     }
     return headingLink;
   };
-
   // Return headingLink inside a Fragment to avoid erronous return type 'Element | { headingLink: ReactNode; }'.
   return shouldRenderOnlyMainLinks ? (
     <>{renderHeading()}</>
   ) : (
-    <div id={id} className={classNames(styles.navigationGroup, className)}>
+    <div {...rest} className={classNames(styles.navigationGroup, className)}>
       <div className={styles.navigationGroupList}>
         {renderHeading()}
         {childElements.map((child, childIndex) => {

--- a/packages/react/src/components/footer/components/footerNavigationGroup/__snapshots__/FooterNavigationGroup.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerNavigationGroup/__snapshots__/FooterNavigationGroup.test.tsx.snap
@@ -52,27 +52,87 @@ exports[`<Footer.NavigationGroup /> spec renders the navigation groups 1`] = `
         <div
           class="navigation"
         >
-          <a
-            class="link linkM item navigation"
+          <div
+            class="navigationGroup"
+            variant="navigation"
           >
-            <span>
-              Link 1
-            </span>
-          </a>
-          <a
-            class="link linkM item navigation"
-          >
-            <span>
-              Link 2
-            </span>
-          </a>
-          <a
-            class="link linkM item navigation"
-          >
-            <span>
-              Link 3
-            </span>
-          </a>
+            <div
+              class="navigationGroupList"
+            >
+              <a
+                class="heading navigation"
+                href="https://google.com"
+              >
+                Main Page
+              </a>
+              <a
+                class="link linkM item subItem navigation"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-label="angle-right"
+                  class="icon s subItemIcon"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                <span>
+                  Link 1
+                </span>
+              </a>
+              <a
+                class="link linkM item subItem navigation"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-label="angle-right"
+                  class="icon s subItemIcon"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                <span>
+                  Link 2
+                </span>
+              </a>
+              <a
+                class="link linkM item subItem navigation"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-label="angle-right"
+                  class="icon s subItemIcon"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M13.5 12L8.5 7L10 5.5L16.5 12L10 18.5L8.5 17L13.5 12Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                <span>
+                  Link 3
+                </span>
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.test.tsx
+++ b/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import { FooterUtilities } from './FooterUtilities';
 import { FooterLink } from '../footerLink/FooterLink';
 import { FooterWrapper } from '../../../../utils/test-utils';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.Utilities /> spec', () => {
   it('renders the component', () => {
@@ -42,5 +43,27 @@ describe('<Footer.Utilities /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    divProps.role = 'role';
+    // element has "ariaLabel", which should override "aria-label"
+    divProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <FooterUtilities {...divProps} aria-label="Is overridden" ariaLabel="Real ariaLabel">
+        <FooterLink
+          href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/ota-yhteytta/ota-yhteytta"
+          label="Yhteystiedot"
+        />
+        <FooterLink
+          href="https://hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta"
+          label="Anna ja lue palautetta"
+        />
+        <FooterLink href="https://hel.fi/kanslia/neuvonta-fi" label="Chat-neuvonta" />
+      </FooterUtilities>,
+      { wrapper: FooterWrapper },
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.tsx
+++ b/packages/react/src/components/footer/components/footerUtilities/FooterUtilities.tsx
@@ -5,8 +5,9 @@ import styles from './FooterUtilities.module.scss';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 import { FooterVariant } from '../../Footer.interface';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
-export type FooterUtilitiesProps = {
+export type FooterUtilitiesProps = AllElementPropsWithoutRef<'div'> & {
   /**
    * aria-label for describing Footer.Utilities.
    */
@@ -30,10 +31,17 @@ export type FooterUtilitiesProps = {
   role?: string;
 };
 
-export const FooterUtilities = ({ ariaLabel, children, soMeLinks, soMeSectionProps, role }: FooterUtilitiesProps) => {
+export const FooterUtilities = ({
+  ariaLabel,
+  children,
+  soMeLinks,
+  soMeSectionProps,
+  className,
+  ...rest
+}: FooterUtilitiesProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
   return (
-    <div className={styles.utilities} aria-label={ariaLabel} role={role}>
+    <div {...rest} className={classNames(styles.utilities, className)} aria-label={ariaLabel}>
       <hr className={styles.divider} aria-hidden />
       <div className={classNames(styles.links, !soMeLinks && styles.widerLinks)}>
         {childElements.map((child, childIndex) => {

--- a/packages/react/src/components/footer/components/footerUtilityGroup/FooterUtilityGroup.test.tsx
+++ b/packages/react/src/components/footer/components/footerUtilityGroup/FooterUtilityGroup.test.tsx
@@ -6,6 +6,7 @@ import { Footer } from '../../Footer';
 import { FooterUtilitiesWrapper } from '../../../../utils/test-utils';
 import { FooterVariant } from '../../Footer.interface';
 import { IconFacebook } from '../../../../icons';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Footer.UtilityGroup /> spec', () => {
   it('renders the utility groups', () => {
@@ -98,5 +99,20 @@ describe('<Footer.UtilityGroup /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <Footer.UtilityGroup {...divProps}>
+        <Footer.GroupHeading
+          href="https://google.com"
+          onClick={(e) => e.preventDefault()}
+          label="Main Page"
+          variant={FooterVariant.Utility}
+        />
+      </Footer.UtilityGroup>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/footer/components/footerUtilityGroup/FooterUtilityGroup.tsx
+++ b/packages/react/src/components/footer/components/footerUtilityGroup/FooterUtilityGroup.tsx
@@ -5,17 +5,20 @@ import styles from './FooterUtilityGroup.module.scss';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
 import { FooterVariant } from '../../Footer.interface';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
+import { FooterLinkProps } from '../footerLink/FooterLink';
 
-type FooterUtilityGroupProps = React.PropsWithChildren<{
-  /**
-   * Additional class names to apply.
-   */
-  className?: string;
-  /**
-   * ID of the group element.
-   */
-  id?: string;
-  /**
+type FooterUtilityGroupProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * Additional class names to apply.
+     */
+    className?: string;
+    /**
+     * ID of the group element.
+     */
+    id?: string;
+    /**
    * FooterGroupHeading component to display at the top of the group.
    * @example
    * ```ts
@@ -25,12 +28,18 @@ type FooterUtilityGroupProps = React.PropsWithChildren<{
       />}
     ```
    */
-  headingLink?: React.ReactNode;
-}>;
-export const FooterUtilityGroup = ({ className, children, id, headingLink }: FooterUtilityGroupProps) => {
+    headingLink?: React.ReactNode;
+  }
+>;
+export const FooterUtilityGroup = ({ className, children, headingLink, ...rest }: FooterUtilityGroupProps) => {
   const childElements = getChildElementsEvenIfContainersInbetween(children);
+  // Footer.Utilities force-feeds "variant" prop to all its children.
+  // It will end up in HTML unless removed.
+  if ((rest as unknown as FooterLinkProps).variant) {
+    Reflect.deleteProperty(rest, 'variant');
+  }
   return (
-    <div id={id} className={classNames(styles.utilityGroup, className)}>
+    <div className={classNames(styles.utilityGroup, className)} {...rest}>
       <div className={styles.utilityGroup}>
         {isValidElement(headingLink)
           ? cloneElement(headingLink as React.ReactElement, {

--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -251,7 +251,7 @@ const FullFeaturedActionBar = ({ I18n, lang, theme }) => {
       <Header.LanguageSelector ariaLabel={I18n.ariaLanguageSelection} languageHeading={I18n.otherLanguages}>
         <Header.ActionBarSubItemGroup label={I18n.infoOtherLanguages}>
           <Header.ActionBarSubItem label={I18n.clearFinnish} external href="www.example.com" lang="fi" />
-          <Header.ActionBarSubItem label={I18n.signLanguage} external href="www.example.com" lang="fse" />
+          <Header.ActionBarSubItem label={I18n.signLanguage} external href="www.example.com" lang="se" />
         </Header.ActionBarSubItemGroup>
         <Header.ActionBarSubItemGroup label={I18n.forTravellers}>
           <Header.ActionBarSubItem label="MyHelsinki.fi" external href="www.example.com" lang="fi" />

--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { LanguageSelectorProps } from '.';
-import { Header } from './Header';
+import { Header, HeaderProps } from './Header';
 import { HeaderUniversalBar } from './components/headerUniversalBar/HeaderUniversalBar';
 import { HeaderActionBar } from './components/headerActionBar/HeaderActionBar';
 import { HeaderLink } from './components/headerLink/HeaderLink';
@@ -442,7 +442,7 @@ const FullFeaturedNavigationMenu = ({
   );
 };
 
-export const WithFullFeatures = (args) => {
+export const WithFullFeatures = (args: HeaderProps) => {
   const [href, setHref] = useState('');
   const [lang, setLang] = useState<string>('fi');
 
@@ -473,7 +473,7 @@ export const WithFullFeatures = (args) => {
   );
 };
 
-export const Minimal = (args) => {
+export const Minimal = (args: HeaderProps) => {
   const lang = 'fi';
   const I18n = translations[lang];
 
@@ -486,7 +486,12 @@ export const Minimal = (args) => {
           title={translations[lang].headerTitle}
           titleAriaLabel={translations[lang].headerAriaLabel}
           titleHref="https://hel.fi"
-          logo={<Logo src={logoSrcFromLanguageAndTheme(lang, args.theme)} alt={translations[lang].headerTitle} />}
+          logo={
+            <Logo
+              src={logoSrcFromLanguageAndTheme(lang, args.theme as HeaderTheme)}
+              alt={translations[lang].headerTitle}
+            />
+          }
           logoAriaLabel={I18n.ariaLogo}
         />
       </Header>
@@ -495,7 +500,7 @@ export const Minimal = (args) => {
   );
 };
 
-export const MinimalWithCustomLogo = (args) => {
+export const MinimalWithCustomLogo = (args: HeaderProps) => {
   const lang = 'fi';
   const I18n = translations[lang];
 
@@ -522,7 +527,7 @@ export const MinimalWithCustomLogo = (args) => {
   );
 };
 
-export const ManualLanguageSorting = (args) => {
+export const ManualLanguageSorting = (args: HeaderProps) => {
   const [href, setHref] = useState('');
   const [lang, setLang] = useState<string>('fi');
 
@@ -559,7 +564,7 @@ export const ManualLanguageSorting = (args) => {
         title={I18n.headerTitle}
         titleAriaLabel={I18n.headerTitle}
         titleHref="https://hel.fi"
-        logo={<Logo src={logoSrcFromLanguageAndTheme(lang, args.theme)} alt={I18n.headerTitle} />}
+        logo={<Logo src={logoSrcFromLanguageAndTheme(lang, args.theme as HeaderTheme)} alt={I18n.headerTitle} />}
       >
         <Header.LanguageSelector
           sortLanguageOptions={sortLanguageOptions}
@@ -597,7 +602,7 @@ export const ManualLanguageSorting = (args) => {
   );
 };
 
-export const ManualLanguageOptions = (args) => {
+export const ManualLanguageOptions = (args: HeaderProps) => {
   const [href, setHref] = useState('');
   const [lang, setLang] = useState<string>('fi');
 
@@ -619,7 +624,12 @@ export const ManualLanguageOptions = (args) => {
         title={translations[lang].headerTitle}
         titleAriaLabel={translations[lang].headerAriaLabel}
         titleHref="https://hel.fi"
-        logo={<Logo src={logoSrcFromLanguageAndTheme(lang, args.theme)} alt={translations[lang].headerTitle} />}
+        logo={
+          <Logo
+            src={logoSrcFromLanguageAndTheme(lang, args.theme as HeaderTheme)}
+            alt={translations[lang].headerTitle}
+          />
+        }
       >
         <Header.SimpleLanguageOptions languages={[languages[0], languages[1], languages[2]]} />
       </Header.ActionBar>
@@ -646,7 +656,7 @@ export const ManualLanguageOptions = (args) => {
   );
 };
 
-export const WithFullFeaturesCustomTheme = (args) => {
+export const WithFullFeaturesCustomTheme = (args: HeaderProps) => {
   const [href, setHref] = useState('');
   const [lang, setLang] = useState<string>('fi');
   const isSmallerThanLarge = useMediaQueryLessThan('l');
@@ -709,7 +719,7 @@ export const WithFullFeaturesCustomTheme = (args) => {
   );
 };
 
-export const WithUserMenu = (args) => {
+export const WithUserMenu = (args: HeaderProps) => {
   const lang = 'fi';
   const I18n = translations[lang];
 
@@ -722,7 +732,12 @@ export const WithUserMenu = (args) => {
           title={translations[lang].headerTitle}
           titleAriaLabel={translations[lang].headerAriaLabel}
           titleHref="https://hel.fi"
-          logo={<Logo src={logoSrcFromLanguageAndTheme(lang, args.theme)} alt={translations[lang].headerTitle} />}
+          logo={
+            <Logo
+              src={logoSrcFromLanguageAndTheme(lang, args.theme as HeaderTheme)}
+              alt={translations[lang].headerTitle}
+            />
+          }
           logoAriaLabel={I18n.ariaLogo}
         >
           <Header.ActionBarItem label="Testi Käyttäjänimi" avatar="TK" fixedRightPosition id="action-bar-login">

--- a/packages/react/src/components/header/Header.test.tsx
+++ b/packages/react/src/components/header/Header.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Header } from './Header';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Header /> spec', () => {
   it('renders the component', () => {
@@ -14,5 +15,13 @@ describe('<Header /> spec', () => {
     const { container } = render(<Header />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const headerProps = getCommonElementTestProps<'header'>('header');
+    // header has "ariaLabel", which should override "aria-label"
+    headerProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(<Header {...headerProps} aria-label="Is overridden" ariaLabel="Real ariaLabel" />);
+    const element = getByTestId(headerProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, headerProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/header/Header.tsx
+++ b/packages/react/src/components/header/Header.tsx
@@ -22,10 +22,11 @@ import { LanguageProvider, LanguageProviderProps } from './LanguageContext';
 import { SkipLink } from '../../internal/skipLink';
 import { styleBoundClassNames } from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithRef } from '../../utils/elementTypings';
 
 const classNames = styleBoundClassNames(styles);
 
-type HeaderAttributes = JSX.IntrinsicElements['header'];
+type HeaderAttributes = AllElementPropsWithRef<'header'>;
 
 export interface HeaderNodeProps extends HeaderAttributes {
   /**

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.test.tsx
@@ -7,6 +7,7 @@ import { HeaderWrapper } from '../../../../utils/test-utils';
 import { DEFAULT_LANGUAGE, LanguageOption, useActiveLanguage } from '../../LanguageContext';
 import { Header } from '../../Header';
 import { Logo, logoFi, logoSv } from '../../../logo';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../../../utils/testHelpers';
 
 type StrFn = (str: string) => string;
 
@@ -60,6 +61,28 @@ describe('<HeaderActionBar /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    // check that removed specific "role" props is still added in ...rest
+    divProps.role = 'role';
+    // header has "ariaLabel", which should override "aria-label"
+    divProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <HeaderActionBar
+        {...divProps}
+        title="Test"
+        logo={<Logo src="dummySrc" dataTestId="action-bar-logo" alt="Helsingin kaupunki" />}
+        frontPageLabel="Etusivu"
+        titleHref="#"
+        aria-label="Is overridden"
+        ariaLabel="Real ariaLabel"
+      />,
+      { wrapper: HeaderWrapper },
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 
   it('has a language context that correctly dispatches language change events', async () => {

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -24,6 +24,7 @@ import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/get
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import { HeaderActionBarItemProps } from '../headerActionBarItem/HeaderActionBarItem';
 import { IconCross, IconMenuHamburger } from '../../../../icons';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
 const classNames = styleBoundClassNames(styles);
 
@@ -104,76 +105,78 @@ export enum TitleStyleType {
   Bold = 'bold',
 }
 
-export type HeaderActionBarProps = PropsWithChildren<{
-  /**
-   * Aria-label for describing ActionBar.
-   */
-  ariaLabel?: string;
-  /**
-   * Additional class names to apply.
-   */
-  className?: string;
-  /**
-   * Label for front page link in mobile navigation menu.
-   */
-  frontPageLabel: string;
-  /**
-   * Logo to use
-   */
-  logo: React.ReactElement<typeof Logo>;
-  /**
-   * The aria-label for the logo to screen reader users.
-   */
-  logoAriaLabel?: string;
-  /**
-   * Link for the logo.
-   */
-  logoHref?: string;
-  /**
-   * The label for the menu button.
-   */
-  menuButtonLabel?: string;
-  /**
-   * The aria-label for the menu button to screen reader users.
-   */
-  menuButtonAriaLabel?: string;
-  /**
-   * Callback fired when the logo is clicked.
-   */
-  onLogoClick?: MouseEventHandler;
-  /**
-   * Callback fired when the mobile menu is clicked.
-   */
-  onMenuClick?: MouseEventHandler;
-  /**
-   * Callback fired when the title is clicked.
-   */
-  onTitleClick?: MouseEventHandler;
-  /**
-   * Aria-label for describing opening main navigation links into view in mobile navigation menu.
-   */
-  openFrontPageLinksAriaLabel?: string;
-  /**
-   * ARIA role to describe the contents.
-   */
-  role?: string;
-  /**
-   * Service name that is displayed next to the Helsinki logo.
-   */
-  title: string;
-  /**
-   * The aria-label for the title describing the service to screen reader users.
-   */
-  titleAriaLabel?: string;
-  /**
-   * Link for the title.
-   */
-  titleHref: string;
-  /**
-   * Style for title.
-   */
-  titleStyle?: TitleStyleType;
-}>;
+export type HeaderActionBarProps = PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * Aria-label for describing ActionBar.
+     */
+    ariaLabel?: string;
+    /**
+     * Additional class names to apply.
+     */
+    className?: string;
+    /**
+     * Label for front page link in mobile navigation menu.
+     */
+    frontPageLabel: string;
+    /**
+     * Logo to use
+     */
+    logo: React.ReactElement<typeof Logo>;
+    /**
+     * The aria-label for the logo to screen reader users.
+     */
+    logoAriaLabel?: string;
+    /**
+     * Link for the logo.
+     */
+    logoHref?: string;
+    /**
+     * The label for the menu button.
+     */
+    menuButtonLabel?: string;
+    /**
+     * The aria-label for the menu button to screen reader users.
+     */
+    menuButtonAriaLabel?: string;
+    /**
+     * Callback fired when the logo is clicked.
+     */
+    onLogoClick?: MouseEventHandler;
+    /**
+     * Callback fired when the mobile menu is clicked.
+     */
+    onMenuClick?: MouseEventHandler;
+    /**
+     * Callback fired when the title is clicked.
+     */
+    onTitleClick?: MouseEventHandler;
+    /**
+     * Aria-label for describing opening main navigation links into view in mobile navigation menu.
+     */
+    openFrontPageLinksAriaLabel?: string;
+    /**
+     * ARIA role to describe the contents.
+     */
+    role?: string;
+    /**
+     * Service name that is displayed next to the Helsinki logo.
+     */
+    title: string;
+    /**
+     * The aria-label for the title describing the service to screen reader users.
+     */
+    titleAriaLabel?: string;
+    /**
+     * Link for the title.
+     */
+    titleHref: string;
+    /**
+     * Style for title.
+     */
+    titleStyle?: TitleStyleType;
+  }
+>;
 
 export const HeaderActionBar = ({
   title,
@@ -191,9 +194,9 @@ export const HeaderActionBar = ({
   children,
   className,
   ariaLabel,
-  role,
   frontPageLabel,
   openFrontPageLinksAriaLabel,
+  ...rest
 }: HeaderActionBarProps) => {
   const handleClick = useCallbackIfDefined(onTitleClick);
   const handleLogoClick = useCallbackIfDefined(onLogoClick);
@@ -279,7 +282,7 @@ export const HeaderActionBar = ({
         className={classNames(styles.headerActionBarContainer, mobileMenuOpen && styles.mobileMenuContainer)}
         ref={actionBarRef}
       >
-        <div className={classNames(styles.headerActionBar, className)} role={role} aria-label={ariaLabel}>
+        <div {...rest} className={classNames(styles.headerActionBar, className)} aria-label={ariaLabel}>
           <HeaderActionBarLogo logo={logo} logoProps={logoProps} />
           {title && (
             <LinkItem {...titleProps}>

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBarNavigationMenu.tsx
@@ -1,5 +1,6 @@
 import React, {
   cloneElement,
+  HTMLAttributes,
   isValidElement,
   MouseEventHandler,
   TransitionEvent,
@@ -20,10 +21,15 @@ import HeaderActionBarLogo from './HeaderActionBarLogo';
 import { HeaderActionBarItemProps } from '../headerActionBarItem';
 import useForceRender from '../../../../hooks/useForceRender';
 
-type NavigationSectionType = {
+/**
+ * This HeaderActionBarNavigationMenu is used only internally in <HeaderActionBar />
+ * The component is not export to hds-react, so it does not need to have typings from AllElementPropsWithoutRef
+ */
+
+type NavigationSectionType = HTMLAttributes<HTMLElement> & {
   logo: React.ReactNode;
   universalLinks: React.ReactNode[];
-} & React.ComponentPropsWithoutRef<'section'>;
+};
 
 const NavigationSection = ({ children, className, logo, universalLinks, ...rest }: NavigationSectionType) => {
   return (

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.tsx
@@ -5,62 +5,64 @@ import classes from './HeaderActionBarItem.module.scss';
 import { HeaderActionBarItemButton, HeaderActionBarItemButtonProps } from './HeaderActionBarItemButton';
 import { useHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
+import { AllElementPropsWithRef } from '../../../../utils/elementTypings';
 
-export type HeaderActionBarItemProps = React.PropsWithChildren<{
-  /**
-   * Aria-label attribute for the dropdown button.
-   */
-  ariaLabel?: string;
-  /**
-   * An avatar which replaces the icon. Usually user's initials, but can be any Element.
-   */
-  avatar?: string | JSX.Element;
-  /**
-   * Icon for the action bar item when dropdown is open.
-   */
-  closeIcon?: JSX.Element;
-  /**
-   * Label for the action bar item when dropdown is open.
-   */
-  closeLabel?: string | JSX.Element;
-  /**
-   * Additional classname for the dropdown element.
-   */
-  dropdownClassName?: string;
-  /**
-   * Fix the item position to the right side of the action bar.
-   */
-  fixedRightPosition?: boolean;
-  /**
-   * Possibility to use a full-width version of the dropdown, for example in mobile use.
-   */
-  fullWidth?: boolean;
-  /**
-   * Icon for the action bar item.
-   */
-  icon?: JSX.Element;
-  /**
-   * Additional classname for the icon.
-   */
-  iconClassName?: string;
-  /**
-   * ID of the dropdown item.
-   */
-  id: string;
-  /**
-   * Label for the action bar item.
-   */
-  label?: string | JSX.Element;
-  /**
-   * Positions the label right side of the icon.
-   */
-  labelOnRight?: boolean;
-  /**
-   * Menu button resizing is prevented by rendering button's active state to a separate element.
-   */
-  preventButtonResize?: boolean;
-}> &
-  React.ComponentPropsWithoutRef<'div'>;
+export type HeaderActionBarItemProps = React.PropsWithChildren<
+  AllElementPropsWithRef<'div'> & {
+    /**
+     * Aria-label attribute for the dropdown button.
+     */
+    ariaLabel?: string;
+    /**
+     * An avatar which replaces the icon. Usually user's initials, but can be any Element.
+     */
+    avatar?: string | JSX.Element;
+    /**
+     * Icon for the action bar item when dropdown is open.
+     */
+    closeIcon?: JSX.Element;
+    /**
+     * Label for the action bar item when dropdown is open.
+     */
+    closeLabel?: string | JSX.Element;
+    /**
+     * Additional classname for the dropdown element.
+     */
+    dropdownClassName?: string;
+    /**
+     * Fix the item position to the right side of the action bar.
+     */
+    fixedRightPosition?: boolean;
+    /**
+     * Possibility to use a full-width version of the dropdown, for example in mobile use.
+     */
+    fullWidth?: boolean;
+    /**
+     * Icon for the action bar item.
+     */
+    icon?: JSX.Element;
+    /**
+     * Additional classname for the icon.
+     */
+    iconClassName?: string;
+    /**
+     * ID of the dropdown item.
+     */
+    id: string;
+    /**
+     * Label for the action bar item.
+     */
+    label?: string | JSX.Element;
+    /**
+     * Positions the label right side of the icon.
+     */
+    labelOnRight?: boolean;
+    /**
+     * Menu button resizing is prevented by rendering button's active state to a separate element.
+     */
+    preventButtonResize?: boolean;
+  }
+>;
 
 export const HeaderActionBarItem = (properties: HeaderActionBarItemProps) => {
   const {
@@ -79,7 +81,7 @@ export const HeaderActionBarItem = (properties: HeaderActionBarItemProps) => {
     fixedRightPosition,
     preventButtonResize,
     avatar,
-    ...props
+    ...rest
   } = properties;
   const dropdownContentElementRef = useRef<HTMLDivElement>(null);
   const containerElementRef = useRef<HTMLDivElement>(null);
@@ -146,7 +148,7 @@ export const HeaderActionBarItem = (properties: HeaderActionBarItemProps) => {
 
   /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
   return (
-    <div {...props} id={id} className={className} ref={containerElementRef} onBlur={handleBlur}>
+    <div {...rest} id={id} className={className} ref={containerElementRef} onBlur={handleBlur}>
       <HeaderActionBarItemButton
         className={iconClassName}
         onClick={handleButtonClick}

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemButton.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemButton.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { HeaderActionBarItemButton, HeaderActionBarItemButtonProps } from './HeaderActionBarItemButton';
+import { HeaderWrapper } from '../../../../utils/test-utils';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 const clickHandler = jest.fn();
 
@@ -35,7 +37,7 @@ const activeStateProps: Pick<HeaderActionBarItemButtonProps, 'activeStateIcon' |
 const RenderTestScenario = (props?: Partial<HeaderActionBarItemButtonProps> & JSX.IntrinsicElements['button']) => {
   const ref = useRef<HTMLButtonElement>(null);
   const combinedProps = { ...defaultProps, ...props };
-  return <HeaderActionBarItemButton {...combinedProps} ref={ref} data-testid="button" />;
+  return <HeaderActionBarItemButton ref={ref} data-testid="button" {...combinedProps} />;
 };
 
 describe('HeaderActionBarItemButton spec', () => {
@@ -50,6 +52,14 @@ describe('HeaderActionBarItemButton spec', () => {
     const { container } = render(<RenderTestScenario />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps<'button'>('button');
+    const { getByTestId } = render(<RenderTestScenario {...buttonProps} isActive labelOnRight fixedRightPosition />, {
+      wrapper: HeaderWrapper,
+    });
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 
   it('Label and icon are set', async () => {

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemButton.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemButton.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import { HeaderActionBarItemButton, HeaderActionBarItemButtonProps } from './HeaderActionBarItemButton';
 import { HeaderWrapper } from '../../../../utils/test-utils';
 import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
+import { AllElementPropsWithRef } from '../../../../utils/elementTypings';
 
 const clickHandler = jest.fn();
 
@@ -34,7 +35,7 @@ const activeStateProps: Pick<HeaderActionBarItemButtonProps, 'activeStateIcon' |
   activeStateIcon,
 };
 
-const RenderTestScenario = (props?: Partial<HeaderActionBarItemButtonProps> & JSX.IntrinsicElements['button']) => {
+const RenderTestScenario = (props?: Partial<HeaderActionBarItemButtonProps> & AllElementPropsWithRef<'button'>) => {
   const ref = useRef<HTMLButtonElement>(null);
   const combinedProps = { ...defaultProps, ...props };
   return <HeaderActionBarItemButton ref={ref} data-testid="button" {...combinedProps} />;

--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemButton.tsx
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItemButton.tsx
@@ -3,8 +3,9 @@ import React, { cloneElement, forwardRef, ReactNode, RefObject } from 'react';
 import classes from './HeaderActionBarItemButton.module.scss';
 import classNames from '../../../../utils/classNames';
 import { IconAngleDown, IconAngleUp } from '../../../../icons';
+import { AllElementPropsWithRef } from '../../../../utils/elementTypings';
 
-type ButtonAttributes = JSX.IntrinsicElements['button'];
+type ButtonAttributes = AllElementPropsWithRef<'button'>;
 
 /**
  * This component is internal and not exported as Header.xxxx

--- a/packages/react/src/components/header/components/headerActionBarSubItem/HeaderActionBarSubItem.test.tsx
+++ b/packages/react/src/components/header/components/headerActionBarSubItem/HeaderActionBarSubItem.test.tsx
@@ -1,0 +1,50 @@
+import React, { PropsWithChildren } from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { HeaderActionBarSubItem, HeaderActionBarSubItemProps } from './HeaderActionBarSubItem';
+import { Header } from '../../Header';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../../../utils/testHelpers';
+import { IconAlertCircle, IconAngleDown } from '../../../../icons';
+
+type WrapperProps = PropsWithChildren<Record<string, unknown>>;
+
+describe('<HeaderActionBarSubItem /> spec', () => {
+  const basicProps: HeaderActionBarSubItemProps = {
+    iconLeft: <IconAlertCircle />,
+    iconRight: <IconAngleDown />,
+    label: 'MyHelsinki.fi',
+    external: true,
+    href: 'www.example.com',
+    lang: 'fi',
+  };
+
+  const Wrapper = ({ children }: WrapperProps) => {
+    return (
+      <Header>
+        <Header.ActionBarItem label="label" id="actionBarItem-id">
+          <Header.ActionBarSubItemGroup label="label">{children}</Header.ActionBarSubItemGroup>
+        </Header.ActionBarItem>
+      </Header>
+    );
+  };
+  it('renders the component', () => {
+    const { asFragment } = render(<HeaderActionBarSubItem {...basicProps} />, { wrapper: Wrapper });
+    expect(asFragment()).toMatchSnapshot();
+  });
+  it('should not have basic accessibility issues', async () => {
+    const { container } = render(<HeaderActionBarSubItem {...basicProps} />, { wrapper: Wrapper });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps<'button'>('button');
+    // "." is added to aria-label inside the component if missing.
+    buttonProps['aria-label'] = 'Aria-label with comma.';
+    const { getByTestId } = render(<HeaderActionBarSubItem {...buttonProps} {...basicProps} external={false} />, {
+      wrapper: Wrapper,
+    });
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
+  });
+});

--- a/packages/react/src/components/header/components/headerActionBarSubItem/HeaderActionBarSubItem.tsx
+++ b/packages/react/src/components/header/components/headerActionBarSubItem/HeaderActionBarSubItem.tsx
@@ -13,8 +13,12 @@ import classes from './HeaderActionBarSubItem.module.scss';
 import classNames from '../../../../utils/classNames';
 import { IconLinkExternal } from '../../../../icons';
 import actionBarItemClasses from '../headerActionBarItem/HeaderActionBarItem.module.scss';
+import { CommonHTMLAttributes } from '../../../../utils/commonHTMLAttributes';
 
-export interface HeaderActionBarSubItemProps extends React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
+// AllElementPropsWithoutRef not used here, because intersection types cannot be extended and ts errors are shown
+type ElementProps = React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement> & CommonHTMLAttributes;
+
+export interface HeaderActionBarSubItemProps extends ElementProps {
   /**
    * Aria-label attribute for the action bar item.
    */

--- a/packages/react/src/components/header/components/headerActionBarSubItem/__snapshots__/HeaderActionBarSubItem.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBarSubItem/__snapshots__/HeaderActionBarSubItem.test.tsx.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<HeaderActionBarSubItem /> spec renders the component 1`] = `
+<DocumentFragment>
+  <header
+    class="hds-header header"
+  >
+    <div
+      class="headerBackgroundWrapper"
+    >
+      <div
+        class="container hasContent hasSubItems"
+        id="actionBarItem-id"
+      >
+        <button
+          aria-controls="actionBarItem-id-dropdown"
+          aria-expanded="false"
+          aria-label="label"
+          class="actionBarItemButton icon hasSubItems"
+          type="button"
+        >
+          <div
+            class="buttonContent"
+          >
+            <span>
+              <span
+                class="actionBarItemButtonLabel"
+              >
+                label
+              </span>
+            </span>
+            <svg
+              aria-hidden="true"
+              aria-label="angle-down"
+              class="icon s"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+        </button>
+        <div
+          class="dropdownWrapper"
+        >
+          <div
+            class="dropdown hasContent hasSubItems"
+            id="actionBarItem-id-dropdown"
+          >
+            <ul>
+              <li
+                class="dropdownSubItem"
+              >
+                <h4
+                  class="actionBarSubItem"
+                >
+                  <span
+                    class="actionBarSubItemLabel"
+                  >
+                    label
+                  </span>
+                </h4>
+                <ul>
+                  <li
+                    class="dropdownItem"
+                  >
+                    <a
+                      aria-label="MyHelsinki.fi. Siirtyy toiseen sivustoon."
+                      class="actionBarSubItem"
+                      href="www.example.com"
+                      lang="fi"
+                    >
+                      <span
+                        class="actionBarSubItemIcon actionBarSubItemIconLeft"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="alert-circle"
+                          class="icon s"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM13 16V18H11V16H13ZM13 6V14H11V6H13Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="actionBarSubItemLabel"
+                      >
+                        MyHelsinki.fi
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="icon s actionBarSubItemIcon"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+</DocumentFragment>
+`;

--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.test.tsx
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.test.tsx
@@ -13,10 +13,13 @@ import { Link } from '../../../link/Link';
 import {
   HeaderLanguageSelector,
   HeaderLanguageSelectorConsumer,
+  LanguageButton,
   LanguageSelectorProps,
+  SimpleLanguageOptions,
 } from './HeaderLanguageSelector';
 import { HeaderActionBar } from '../headerActionBar/HeaderActionBar';
 import { Logo } from '../../../logo/Logo';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 type StrFn = (str: string) => string;
 type TestScenarioProps = LanguageProviderProps &
@@ -79,6 +82,7 @@ const RenderTestScenario = ({
   doNotRenderMenuItems = false,
   renderActiveLanguage = false,
   consumerOnly = false,
+  ...rest
 }: TestScenarioProps) => {
   return (
     <LanguageProvider onDidChangeLanguage={onDidChangeLanguage} defaultLanguage={defaultLanguage} languages={languages}>
@@ -91,7 +95,7 @@ const RenderTestScenario = ({
           titleHref="https://hel.fi"
           logo={<Logo src="dummySrc" dataTestId="action-bar-logo" alt="Helsingin kaupunki" />}
         >
-          <HeaderLanguageSelector ariaLabel={ariaLabel}>
+          <HeaderLanguageSelector {...rest} ariaLabel={ariaLabel}>
             {!doNotRenderMenuItems && <MenuContent />}
           </HeaderLanguageSelector>
         </HeaderActionBar>
@@ -131,6 +135,32 @@ describe('<Header.LanguageSelector /> spec', () => {
     const { container } = render(<LanguageSelectorConsumerOnly />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<LanguageSelectorWithActionBar {...divProps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
+  });
+
+  it('Native html props are passed to the SimpleLanguageOptions element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <SimpleLanguageOptions
+        languages={[defaultLanguages[0], defaultLanguages[1], defaultLanguages[2]]}
+        {...divProps}
+      />,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
+  });
+
+  it('native html props are passed to the LanguageButton element', async () => {
+    const buttonProps = getCommonElementTestProps<'button', { value: string }>('button');
+    const { getByTestId } = render(<LanguageButton {...defaultLanguages[0]} {...buttonProps} />);
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 
   it('Language selector props and children are rendered by the consumers', async () => {

--- a/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.tsx
+++ b/packages/react/src/components/header/components/headerLanguageSelector/HeaderLanguageSelector.tsx
@@ -4,11 +4,12 @@ import classes from './HeaderLanguageSelector.module.scss';
 import { LanguageOption, useActiveLanguage, useAvailableLanguages, useSetLanguage } from '../../LanguageContext';
 import classNames from '../../../../utils/classNames';
 import { withDefaultPrevented } from '../../../../utils/useCallback';
-import { HeaderActionBarItem, HeaderActionBarSubItemGroup } from '../headerActionBarItem';
+import { HeaderActionBarItem, HeaderActionBarItemProps, HeaderActionBarSubItemGroup } from '../headerActionBarItem';
 import { HeaderActionBarSubItem } from '../headerActionBarSubItem';
 import { IconGlobe } from '../../../../icons';
 import { useHeaderContext } from '../../HeaderContext';
 import { getComponentFromChildren } from '../../../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
 /* eslint-disable react/no-unused-prop-types */
 type LanguageSelectorComponentProps = {
@@ -24,7 +25,7 @@ type LanguageSelectorComponentProps = {
    * Function for sorting language options into primary and secondary.
    */
   sortLanguageOptions?: (options: LanguageOption[], selectedLanguage: string) => [LanguageOption[], LanguageOption[]];
-};
+} & Partial<HeaderActionBarItemProps>;
 /* eslint-enable react/no-unused-prop-types */
 
 export type LanguageSelectorProps = PropsWithChildren<LanguageSelectorComponentProps>;
@@ -38,19 +39,28 @@ type LanguageSelectorConsumerProps = LanguageSelectorProps & {
   fullWidthForMobile?: boolean;
 };
 
-export const LanguageButton = ({ value, label }: LanguageOption) => {
+export const LanguageButton = ({
+  value,
+  label,
+  // isPrimary is picked so it won't be in ...rest and end up in the html
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isPrimary,
+  className,
+  ...rest
+}: LanguageOption & AllElementPropsWithoutRef<'button'>) => {
   const activeLanguage = useActiveLanguage();
   const setLanguage = useSetLanguage();
-  const className = classNames(classes.item, { [classes.activeItem]: activeLanguage === value });
+  const classList = classNames(classes.item, { [classes.activeItem]: activeLanguage === value }, className);
   const selectLanguage = withDefaultPrevented(() => setLanguage(value));
 
   return (
     <button
+      {...rest}
       key={value}
       lang={value}
       onClick={selectLanguage}
       type="button"
-      className={className}
+      className={classList}
       aria-current={activeLanguage === value}
     >
       <span>{label}</span>
@@ -63,9 +73,13 @@ const renderLanguageNode = (language: LanguageOption, primary: boolean) => {
   return primary ? Label : <HeaderActionBarSubItem label={Label} key={language.value} />;
 };
 
-export const SimpleLanguageOptions = ({ languages }: { languages: LanguageOption[] }) => {
+export const SimpleLanguageOptions = ({
+  languages,
+  className,
+  ...rest
+}: { languages: LanguageOption[] } & AllElementPropsWithoutRef<'div'>) => {
   return (
-    <div className={classNames(classes.languageNodes, classes.simpleLanguageNodes)}>
+    <div {...rest} className={classNames(classes.languageNodes, classes.simpleLanguageNodes, className)}>
       {languages.map((node) => renderLanguageNode(node, true))}
     </div>
   );

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.test.tsx
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 
 import { HeaderLink } from './HeaderLink';
 import { HeaderNavigationMenuWrapper } from '../../../../utils/test-utils';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<HeaderLink /> spec', () => {
   it('renders the component', () => {
@@ -16,6 +17,13 @@ describe('<HeaderLink /> spec', () => {
     const { container } = render(<HeaderLink href="#" label="Link" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const linkProps = getCommonElementTestProps<'a'>('a');
+    const { getByTestId } = render(<HeaderLink {...linkProps} label="Link" />);
+    const element = getByTestId(linkProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, linkProps)).toHaveLength(0);
   });
 
   it('should not open dropdown when the link is hovered', async () => {

--- a/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
+++ b/packages/react/src/components/header/components/headerLink/HeaderLink.tsx
@@ -7,8 +7,8 @@ import { styleBoundClassNames } from '../../../../utils/classNames';
 import { Link } from '../../../link';
 import { HeaderLinkDropdown, DropdownMenuPosition } from './headerLinkDropdown';
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
-import { MergeElementProps } from '../../../../common/types';
 import useIsomorphicLayoutEffect from '../../../../hooks/useIsomorphicLayoutEffect';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../../../utils/elementTypings';
 
 const classNames = styleBoundClassNames(styles);
 
@@ -93,9 +93,9 @@ export type NavigationLinkProps<ReactElement> = {
   wrapperClassName?: string;
 };
 
-export type HeaderNavigationLinkProps<ReactElement extends React.ElementType = 'a'> = MergeElementProps<
-  ReactElement,
-  NavigationLinkProps<ReactElement>
+export type HeaderNavigationLinkProps<T extends React.ElementType = 'a'> = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<T>,
+  NavigationLinkProps<T>
 >;
 
 export const HeaderLink = <T extends React.ElementType = 'a'>({

--- a/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.test.tsx
+++ b/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { HeaderNavigationMenu } from './HeaderNavigationMenu';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<HeaderNavigationMenu /> spec', () => {
   it('renders the component', () => {
@@ -14,5 +15,15 @@ describe('<HeaderNavigationMenu /> spec', () => {
     const { container } = render(<HeaderNavigationMenu />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const navProps = getCommonElementTestProps('nav');
+    // element has ariaLabel prop which overrides aria-label
+    navProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <HeaderNavigationMenu {...navProps} aria-label="Is overridden" ariaLabel="Real ariaLabel" />,
+    );
+    const element = getByTestId(navProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, navProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
+++ b/packages/react/src/components/header/components/headerNavigationMenu/HeaderNavigationMenu.tsx
@@ -5,21 +5,24 @@ import styles from './HeaderNavigationMenu.module.scss';
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween, getChildrenAsArray } from '../../../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
-export type HeaderNavigationMenuProps = React.PropsWithChildren<{
-  /**
-   * Aria-label for describing universal bar.
-   */
-  ariaLabel?: string;
-  /**
-   * Children are expected to be HeaderLink components or a container with HeaderLink components inside.
-   */
-  children?: React.ReactNode;
-  /**
-   * ID of the header element.
-   */
-  id?: string;
-}>;
+export type HeaderNavigationMenuProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'nav'> & {
+    /**
+     * Aria-label for describing universal bar.
+     */
+    ariaLabel?: string;
+    /**
+     * Children are expected to be HeaderLink components or a container with HeaderLink components inside.
+     */
+    children?: React.ReactNode;
+    /**
+     * ID of the header element.
+     */
+    id?: string;
+  }
+>;
 
 const renderHeaderNavigationMenuItem = (child, index, isSmallScreen) => {
   const linkContentClass = isSmallScreen
@@ -67,7 +70,7 @@ export const HeaderNavigationMenuContent = () => {
   );
 };
 
-export const HeaderNavigationMenu = ({ ariaLabel, children, id }: HeaderNavigationMenuProps) => {
+export const HeaderNavigationMenu = ({ ariaLabel, children, className, ...rest }: HeaderNavigationMenuProps) => {
   const { isSmallScreen } = useHeaderContext();
   const { setNavigationContent } = useSetHeaderContext();
 
@@ -80,7 +83,7 @@ export const HeaderNavigationMenu = ({ ariaLabel, children, id }: HeaderNavigati
 
   return (
     <div className={styles.headerNavigationMenuContainer}>
-      <nav aria-label={ariaLabel} id={id} className={styles.headerNavigationMenu}>
+      <nav {...rest} aria-label={ariaLabel} className={classNames(styles.headerNavigationMenu, className)}>
         <ul className={styles.headerNavigationMenuList}>
           <HeaderNavigationMenuContent />
         </ul>

--- a/packages/react/src/components/header/components/headerSearch/HeaderSearch.test.tsx
+++ b/packages/react/src/components/header/components/headerSearch/HeaderSearch.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { HeaderSearch } from './HeaderSearch';
+import { HeaderSearch, NavigationSearchProps } from './HeaderSearch';
 import { HeaderWrapper } from '../../../../utils/test-utils';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('<Header.HeaderSearch /> spec', () => {
   it('renders the component', () => {
@@ -14,5 +15,17 @@ describe('<Header.HeaderSearch /> spec', () => {
     const { container } = render(<HeaderSearch label="Haku" />, { wrapper: HeaderWrapper });
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps<'div', Pick<NavigationSearchProps, 'onSubmit' | 'onChange'>>('div');
+    // the role is fixed to "search" and should not be overwritten
+    const { getByTestId } = render(<HeaderSearch label="Haku" {...divProps} role="navigation" />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...(divProps as unknown as HTMLAttributes<HTMLDivElement>),
+        role: 'search',
+      }),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/header/components/headerSearch/HeaderSearch.tsx
+++ b/packages/react/src/components/header/components/headerSearch/HeaderSearch.tsx
@@ -2,23 +2,28 @@ import React, { useEffect, useState } from 'react';
 
 import styles from './HeaderSearch.module.scss';
 import { SearchInput } from '../../../searchInput';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../../../utils/elementTypings';
+import classNames from '../../../../utils/classNames';
 
-export type NavigationSearchProps = {
-  /**
-   * Callback fired when the search button or Enter key is pressed
-   */
-  onSubmit?: (inputValue: string) => void;
-  /**
-   * Callback fired when the search input value is changed
-   */
-  onChange?: (inputValue: string) => void;
-  /**
-   * Label for the search element.
-   */
-  label: string | JSX.Element;
-};
+export type NavigationSearchProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'div'>,
+  {
+    /**
+     * Callback fired when the search button or Enter key is pressed
+     */
+    onSubmit?: (inputValue: string) => void;
+    /**
+     * Callback fired when the search input value is changed
+     */
+    onChange?: (inputValue: string) => void;
+    /**
+     * Label for the search element.
+     */
+    label: string | JSX.Element;
+  }
+>;
 
-export const HeaderSearch = ({ onChange, onSubmit, label }: NavigationSearchProps) => {
+export const HeaderSearch = ({ onChange, onSubmit, label, className, ...rest }: NavigationSearchProps) => {
   // search is always active in mobile
   const [inputValue, setInputValue] = useState<string>('');
 
@@ -31,7 +36,7 @@ export const HeaderSearch = ({ onChange, onSubmit, label }: NavigationSearchProp
   };
 
   return (
-    <div className={styles.searchContainer} role="search">
+    <div {...rest} className={classNames(styles.searchContainer, className)} role="search">
       <SearchInput label={label} onSubmit={handleSubmit} onChange={setInputValue} />
     </div>
   );

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.test.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 
 import { HeaderUniversalBar } from './HeaderUniversalBar';
 import { Header } from '../../Header';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../../../utils/testHelpers';
 
 describe('<HeaderUniversalBar /> spec', () => {
   it('renders the component', () => {
@@ -23,5 +24,24 @@ describe('<HeaderUniversalBar /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    divProps.role = 'role';
+    // header has "ariaLabel", which should override "aria-label"
+    divProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <Header>
+        <HeaderUniversalBar
+          {...divProps}
+          primaryLinkText="hel.fi"
+          primaryLinkHref="#"
+          aria-label="Is overridden"
+          ariaLabel="Real ariaLabel"
+        />
+      </Header>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
+++ b/packages/react/src/components/header/components/headerUniversalBar/HeaderUniversalBar.tsx
@@ -6,46 +6,48 @@ import { HeaderLink } from '../headerLink/HeaderLink';
 import { useHeaderContext, useSetHeaderContext } from '../../HeaderContext';
 import classNames from '../../../../utils/classNames';
 import { getChildElementsEvenIfContainersInbetween } from '../../../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../../../utils/elementTypings';
 
-export type HeaderUniversalBarProps = React.PropsWithChildren<{
-  /**
-   * Aria-label for describing UniversalBar.
-   */
-  ariaLabel?: string;
-  /**
-   * Additional class names to apply.
-   */
-  className?: string;
-  /**
-   * Children are expected to be HeaderLink components or a container with HeaderLink components inside.
-   */
-  children?: React.ReactNode;
-  /**
-   * ID of the header element.
-   */
-  id?: string;
-  /**
-   * Hypertext reference of the primary link.
-   */
-  primaryLinkHref?: string;
-  /**
-   * Link text for the primary link.
-   */
-  primaryLinkText?: string;
-  /**
-   * ARIA role to describe the contents.
-   */
-  role?: string;
-}>;
+export type HeaderUniversalBarProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * Aria-label for describing UniversalBar.
+     */
+    ariaLabel?: string;
+    /**
+     * Additional class names to apply.
+     */
+    className?: string;
+    /**
+     * Children are expected to be HeaderLink components or a container with HeaderLink components inside.
+     */
+    children?: React.ReactNode;
+    /**
+     * ID of the header element.
+     */
+    id?: string;
+    /**
+     * Hypertext reference of the primary link.
+     */
+    primaryLinkHref?: string;
+    /**
+     * Link text for the primary link.
+     */
+    primaryLinkText?: string;
+    /**
+     * ARIA role to describe the contents.
+     */
+    role?: string;
+  }
+>;
 
 export const HeaderUniversalBar = ({
   ariaLabel,
   className,
   children,
-  id,
   primaryLinkHref,
   primaryLinkText,
-  role,
+  ...rest
 }: HeaderUniversalBarProps) => {
   const { isSmallScreen } = useHeaderContext();
   const childElements = getChildElementsEvenIfContainersInbetween(children);
@@ -60,7 +62,7 @@ export const HeaderUniversalBar = ({
 
   return (
     <div className={styles.headerUniversalBarContainer}>
-      <div role={role} aria-label={ariaLabel} id={id} className={classNames(styles.headerUniversalBar, className)}>
+      <div {...rest} aria-label={ariaLabel} className={classNames(styles.headerUniversalBar, className)}>
         <ul className={styles.headerUniversalBarList}>
           <li className={styles.universalBarMainLinkContainer}>
             <HeaderLink href={primaryLinkHref} label={primaryLinkText} className={styles.universalBarLink} />

--- a/packages/react/src/components/header/components/headerUserItems/HeaderLoginButton.test.tsx
+++ b/packages/react/src/components/header/components/headerUserItems/HeaderLoginButton.test.tsx
@@ -5,6 +5,7 @@ import { advanceUntilDoesNotThrow, advanceUntilPromiseResolved } from '../../../
 import { getActiveElement } from '../../../cookieConsent/test.util';
 import { HeaderLoginButton, HeaderLoginButtonProps } from './HeaderLoginButton';
 import { initTests, jestHelpers } from './test.util';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('HeaderLoginButton', () => {
   const props: HeaderLoginButtonProps = {
@@ -18,8 +19,8 @@ describe('HeaderLoginButton', () => {
   const Component = (componentProps) => {
     return <HeaderLoginButton {...componentProps} />;
   };
-  const initTestsWithComponent = (isUserAuthenticated = false) => {
-    return initTests(props, Component, isUserAuthenticated);
+  const initTestsWithComponent = (isUserAuthenticated = false, extraProps?: Partial<HeaderLoginButtonProps>) => {
+    return initTests({ ...props, ...extraProps }, Component, isUserAuthenticated);
   };
 
   beforeEach(() => {
@@ -37,6 +38,15 @@ describe('HeaderLoginButton', () => {
   it('The button is not rendered if user is logged in', async () => {
     const { getButtonElement } = initTestsWithComponent(true);
     expect(getButtonElement()).toBeNull();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps<'button'>('button');
+    // aria-label is constructed inside the component
+    buttonProps['aria-label'] = undefined;
+    const { getByTestId } = initTestsWithComponent(false, buttonProps);
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 
   it('Click calls oidcClient.login(). Loading is indicated', async () => {

--- a/packages/react/src/components/header/components/headerUserItems/HeaderLogoutSubmenuButton.test.tsx
+++ b/packages/react/src/components/header/components/headerUserItems/HeaderLogoutSubmenuButton.test.tsx
@@ -7,6 +7,7 @@ import { HeaderLogoutSubmenuButton, HeaderLogoutSubmenuButtonProps } from './Hea
 import { initTests, jestHelpers } from './test.util';
 import { HeaderActionBarItem } from '../headerActionBarItem';
 import { HeaderUserMenuButton } from './HeaderUserMenuButton';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('HeaderLogoutSubmenuButton', () => {
   const props: HeaderLogoutSubmenuButtonProps = {
@@ -26,8 +27,8 @@ describe('HeaderLogoutSubmenuButton', () => {
       </HeaderUserMenuButton>
     );
   };
-  const initTestsWithComponent = (isUserAuthenticated = true) => {
-    return initTests(props, Component, isUserAuthenticated);
+  const initTestsWithComponent = (isUserAuthenticated = true, extraProps?: Partial<HeaderLogoutSubmenuButtonProps>) => {
+    return initTests({ ...props, ...extraProps }, Component, isUserAuthenticated);
   };
 
   beforeEach(() => {
@@ -40,6 +41,15 @@ describe('HeaderLogoutSubmenuButton', () => {
   it('The button is rendered', async () => {
     const { getButtonElement } = initTestsWithComponent();
     expect(getButtonElement()).toMatchSnapshot();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps<'button'>('button');
+    // "." is added to aria-label inside the component if missing.
+    buttonProps['aria-label'] = 'Aria-label with comma.';
+    const { getByTestId } = initTestsWithComponent(true, buttonProps);
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 
   it('Click calls oidcClient.logout(). Loading is indicated', async () => {

--- a/packages/react/src/components/header/components/headerUserItems/HeaderUserMenuButton.test.tsx
+++ b/packages/react/src/components/header/components/headerUserItems/HeaderUserMenuButton.test.tsx
@@ -2,19 +2,26 @@ import { fireEvent, act, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { initTests, jestHelpers } from './test.util';
-import { HeaderActionBarItem } from '../headerActionBarItem';
+import { HeaderActionBarItem, HeaderActionBarItemProps } from '../headerActionBarItem';
 import { HeaderUserMenuButton } from './HeaderUserMenuButton';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../../../utils/testHelpers';
 
 describe('HeaderLogoutSubmenuButton', () => {
   const defaultUserProfile = { given_name: 'ABC', family_name: 'ZYX', email: 'email@domain.com' };
-  const Component = () => {
-    return (
-      <HeaderUserMenuButton id="user-menu">
-        <HeaderActionBarItem id="item" />
-      </HeaderUserMenuButton>
-    );
-  };
-  const initTestsWithComponent = (isUserAuthenticated = true, user = {}) => {
+
+  const initTestsWithComponent = (
+    isUserAuthenticated = true,
+    user = {},
+    extraProps?: Partial<HeaderActionBarItemProps>,
+  ) => {
+    const Component = () => {
+      return (
+        <HeaderUserMenuButton id="user-menu" {...extraProps}>
+          <HeaderActionBarItem id="item" />
+        </HeaderUserMenuButton>
+      );
+    };
+
     return initTests({}, Component, isUserAuthenticated, { ...defaultUserProfile, ...user });
   };
 
@@ -40,6 +47,13 @@ describe('HeaderLogoutSubmenuButton', () => {
   it('The button is not rendered if user is not logged in', async () => {
     const { getUserMenuButton } = initTestsWithComponent(false);
     expect(getUserMenuButton()).toBeNull();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps('button');
+    const { getByTestId } = initTestsWithComponent(true, {}, buttonProps);
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 
   it('Initials are rendered', async () => {

--- a/packages/react/src/components/hero/Hero.stories.tsx
+++ b/packages/react/src/components/hero/Hero.stories.tsx
@@ -8,6 +8,7 @@ import { Logo, logoFi } from '../logo';
 import { Header } from '../header/Header';
 import { Section } from '../section/Section';
 import { LanguageOption } from '../header/LanguageContext';
+import { KorosType } from '../koros';
 
 export default {
   component: Hero,
@@ -78,8 +79,8 @@ const getDisabledControl = (control: string, notUsed?: boolean) => {
 };
 
 const getDefaultArgs = (variant: HeroProps['variant'], preset?: string): HeroProps => {
-  const defaultValuePicker = (args: Record<string, { defaultValue: unknown }>) => {
-    return Object.entries(args).reduce((currentObject, [prop, value]) => {
+  const defaultValuePicker = (values: Record<string, { defaultValue: unknown }>) => {
+    return Object.entries(values).reduce((currentObject, [prop, value]) => {
       if (value.defaultValue) {
         return {
           ...currentObject,
@@ -232,7 +233,7 @@ const NavigationComponent = () => (
   </Header>
 );
 
-export const ImageLeft = (args) => {
+export const ImageLeft = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent buttonTheme="black" />
@@ -245,7 +246,7 @@ ImageLeft.argTypes = {
   ...createVariantArg('imageLeft'),
 };
 
-export const ImageRight = (args) => {
+export const ImageRight = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent buttonTheme="black" />
@@ -259,7 +260,7 @@ ImageRight.argTypes = {
   ...createVariantArg('imageRight'),
 };
 
-export const WithoutImage = (args) => {
+export const WithoutImage = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent />
@@ -280,7 +281,7 @@ WithoutImage.argTypes = {
   ...createCenteredContentArg(true),
 };
 
-export const WithoutImageKorosOverlay = (args) => {
+export const WithoutImageKorosOverlay = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent buttonTheme="white" />
@@ -301,7 +302,7 @@ WithoutImageKorosOverlay.argTypes = {
   ...createCenteredContentArg(false),
 };
 
-export const WithoutImageAndKoros = (args) => {
+export const WithoutImageAndKoros = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent />
@@ -320,7 +321,7 @@ WithoutImageAndKoros.argTypes = {
   ...createCenteredContentArg(false),
 };
 
-export const BackgroundImage = (args) => {
+export const BackgroundImage = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent buttonTheme="black" />
@@ -336,7 +337,7 @@ BackgroundImage.argTypes = {
   ...createVariantArg('backgroundImage'),
 };
 
-export const DiagonalKoros = (args) => {
+export const DiagonalKoros = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent buttonTheme="black" />
@@ -353,7 +354,7 @@ DiagonalKoros.argTypes = {
   ...createVariantArg('diagonalKoros'),
 };
 
-export const ImageBottom = (args) => {
+export const ImageBottom = (args: HeroProps) => {
   return (
     <Hero {...args}>
       <DefaultContent />
@@ -370,7 +371,7 @@ ImageBottom.argTypes = {
   ...createVariantArg('imageBottom'),
 };
 
-export const PlaygroundForKoros = (args) => {
+export const PlaygroundForKoros = (args: HeroProps & Record<string, string> & { type: KorosType }) => {
   const heroProps: HeroProps = {
     koros: {
       type: args.type,
@@ -451,7 +452,7 @@ PlaygroundForKoros.argTypes = {
   ...createVariantArg('diagonalKoros'),
 };
 
-export const EmbeddedToPage = (args) => {
+export const EmbeddedToPage = (args: HeroProps & { preset: string }) => {
   const { preset, variant } = args;
   const props = getDefaultArgs(variant, preset);
   const NoImage = () => {
@@ -506,7 +507,7 @@ EmbeddedToPage.argTypes = {
 const demoPadding = '55px';
 const demoBgColor = '#f5a3c7';
 
-export const PlaygroundForTheme = (args) => {
+export const PlaygroundForTheme = (args: HeroProps & Record<string, string>) => {
   const argsAsTheme = {
     '--background-color': args.backgroundColor,
     '--color': args.color,

--- a/packages/react/src/components/hero/Hero.test.tsx
+++ b/packages/react/src/components/hero/Hero.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 
 import { Hero, HeroProps } from './Hero';
 import { Button } from '../button';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Hero /> spec', () => {
   const imageSrc = 'http://image.com/image.jpg';
@@ -55,5 +56,11 @@ describe('<Hero /> spec', () => {
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     }
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<HeroWithContent variant="backgroundImage" {...divProps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/hero/Hero.tsx
+++ b/packages/react/src/components/hero/Hero.tsx
@@ -9,11 +9,12 @@ import { getShapeHeight, Koros, KorosProps } from '../koros';
 import { Text } from './Text';
 import { Title } from './Title';
 import { IconArrowDown } from '../../icons';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-type HTMLElementAttributes = React.HtmlHTMLAttributes<HTMLDivElement>;
-type ImgElementAttributes = React.ImgHTMLAttributes<HTMLImageElement>;
+type DivElementAttributes = AllElementPropsWithoutRef<'div'>;
+type ImgElementAttributes = AllElementPropsWithoutRef<'img'>;
 export type HeroProps = React.PropsWithChildren<
-  HTMLElementAttributes & {
+  DivElementAttributes & {
     /**
      * Show arrow icon
      */
@@ -132,13 +133,13 @@ export const Hero = ({
   const customThemeClass = useTheme<HeroCustomTheme>(styles.hero, editableTheme);
   const korosStyle = { ...koros, style: { fill: 'var(--koros-color)' } };
 
-  const heroElementAttributes: HTMLElementAttributes = {
+  const heroElementAttributes: DivElementAttributes = {
     ...elementAttributes,
     className: classNames(
       styles.hero,
       customThemeClass,
       styles[currentVariant],
-      (elementAttributes as HTMLElementAttributes).className,
+      (elementAttributes as DivElementAttributes).className,
       showArrowIcon && styles.arrowIconSpacingAfter,
     ),
   };
@@ -193,9 +194,10 @@ export const Hero = ({
     const { inward, containerClassName, style, ...korosProps } = props;
     const className =
       containerClassName || (inward !== true ? styles.korosContainer : styles.korosContainerInwardKoros);
+    const mergedKorosProps: KorosProps = { ...korosProps, style };
     return (
       <div className={className}>
-        <Koros {...{ ...korosProps, style, shift: false, compact: false }} />
+        <Koros {...mergedKorosProps} />
       </div>
     );
   };

--- a/packages/react/src/components/hero/Text.test.tsx
+++ b/packages/react/src/components/hero/Text.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { Hero } from './Hero';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
+
+describe('<Hero.Text /> spec', () => {
+  const paragraphProps = getCommonElementTestProps('p');
+  // axe will complain if tabIndex > 0
+  paragraphProps.tabIndex = 0;
+  const Component = () => {
+    return (
+      <Hero.Text {...paragraphProps}>
+        Nullam ut nunc consectetur, accumsan nunc sed, luctus nisl. Curabitur lacinia!
+      </Hero.Text>
+    );
+  };
+
+  it('renders the component', () => {
+    const { asFragment } = render(<Component />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+  it('should not have basic accessibility issues', async () => {
+    const { container } = render(<Component />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const { getByTestId } = render(<Component />);
+    const element = getByTestId(paragraphProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, paragraphProps)).toHaveLength(0);
+  });
+});

--- a/packages/react/src/components/hero/Text.tsx
+++ b/packages/react/src/components/hero/Text.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 
 import styles from './Hero.module.scss';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-export const Text = (props: React.HtmlHTMLAttributes<HTMLParagraphElement>): React.ReactElement => {
+export const Text = (props: AllElementPropsWithoutRef<'p'>): React.ReactElement => {
   const { className, children, ...elementProps } = props;
   const classList = classNames(styles.text, className);
   return (

--- a/packages/react/src/components/hero/Title.test.tsx
+++ b/packages/react/src/components/hero/Title.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { Hero } from './Hero';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
+
+describe('<Hero.Title /> spec', () => {
+  const headingProps = getCommonElementTestProps('h1');
+  // axe will complain if tabIndex > 0
+  headingProps.tabIndex = 0;
+  const Component = () => {
+    return (
+      <Hero.Title headingLevel={3} {...headingProps}>
+        This is the heading
+      </Hero.Title>
+    );
+  };
+
+  it('renders the component', () => {
+    const { asFragment } = render(<Component />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+  it('should not have basic accessibility issues', async () => {
+    const { container } = render(<Component />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const { getByTestId } = render(<Component />);
+    const element = getByTestId(headingProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, headingProps)).toHaveLength(0);
+  });
+});

--- a/packages/react/src/components/hero/Title.tsx
+++ b/packages/react/src/components/hero/Title.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 
 import styles from './Hero.module.scss';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-export type TitleProps = React.HtmlHTMLAttributes<HTMLHeadingElement> & {
+export type TitleProps = AllElementPropsWithoutRef<'h1'> & {
   /**
    * Heading level
    * @default 1

--- a/packages/react/src/components/hero/__snapshots__/Text.test.tsx.snap
+++ b/packages/react/src/components/hero/__snapshots__/Text.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Hero.Text /> spec renders the component 1`] = `
+<DocumentFragment>
+  <p
+    aria-describedby="aria-describedby"
+    aria-label="aria-label"
+    class="text test-class-name"
+    data-hds-prop="hdsProp"
+    data-testid="testId"
+    id="element-id"
+    style="padding: 100px;"
+    tabindex="0"
+  >
+    Nullam ut nunc consectetur, accumsan nunc sed, luctus nisl. Curabitur lacinia!
+  </p>
+</DocumentFragment>
+`;

--- a/packages/react/src/components/hero/__snapshots__/Title.test.tsx.snap
+++ b/packages/react/src/components/hero/__snapshots__/Title.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Hero.Title /> spec renders the component 1`] = `
+<DocumentFragment>
+  <h3
+    aria-describedby="aria-describedby"
+    aria-label="aria-label"
+    class="title test-class-name"
+    data-hds-prop="hdsProp"
+    data-testid="testId"
+    id="element-id"
+    style="padding: 100px;"
+    tabindex="0"
+  >
+    This is the heading
+  </h3>
+</DocumentFragment>
+`;

--- a/packages/react/src/components/highlight/Highlight.stories.tsx
+++ b/packages/react/src/components/highlight/Highlight.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Highlight } from './Highlight';
+import { Highlight, HighlightProps } from './Highlight';
 
 export default {
   component: Highlight,
@@ -18,24 +18,24 @@ const highlightArgs = {
   text: 'You may select an highlight from the article to be displayed here. Select an excerpt that you want the user to pay attention to.',
 };
 
-export const DefaultHighlight = (args) => <Highlight {...args} />;
+export const DefaultHighlight = (args: HighlightProps) => <Highlight {...args} />;
 DefaultHighlight.args = {
   ...highlightArgs,
 };
 
-export const HighlightSmall = (args) => <Highlight {...args} />;
+export const HighlightSmall = (args: HighlightProps) => <Highlight {...args} />;
 HighlightSmall.args = {
   ...highlightArgs,
   size: 'small',
 };
 
-export const HighlightLarge = (args) => <Highlight {...args} />;
+export const HighlightLarge = (args: HighlightProps) => <Highlight {...args} />;
 HighlightLarge.args = {
   ...highlightArgs,
   size: 'l',
 };
 
-export const HighlightCustomAccentColor = (args) => <Highlight {...args} />;
+export const HighlightCustomAccentColor = (args: HighlightProps) => <Highlight {...args} />;
 HighlightCustomAccentColor.args = {
   ...highlightArgs,
   theme: {
@@ -43,7 +43,7 @@ HighlightCustomAccentColor.args = {
   },
 };
 
-export const HighlightCustomTextColor = (args) => <Highlight {...args} />;
+export const HighlightCustomTextColor = (args: HighlightProps) => <Highlight {...args} />;
 HighlightCustomTextColor.args = {
   ...highlightArgs,
   theme: {
@@ -51,24 +51,24 @@ HighlightCustomTextColor.args = {
   },
 };
 
-export const DefaultQuote = (args) => <Highlight {...args} />;
+export const DefaultQuote = (args: HighlightProps) => <Highlight {...args} />;
 DefaultQuote.args = {
   ...quoteArgs,
 };
 
-export const QuoteLarge = (args) => <Highlight {...args} />;
+export const QuoteLarge = (args: HighlightProps) => <Highlight {...args} />;
 QuoteLarge.args = {
   ...quoteArgs,
   size: 'l',
 };
 
-export const QuoteSmall = (args) => <Highlight {...args} />;
+export const QuoteSmall = (args: HighlightProps) => <Highlight {...args} />;
 QuoteSmall.args = {
   ...quoteArgs,
   size: 's',
 };
 
-export const QuoteCustomAccentColor = (args) => <Highlight {...args} />;
+export const QuoteCustomAccentColor = (args: HighlightProps) => <Highlight {...args} />;
 QuoteCustomAccentColor.args = {
   ...quoteArgs,
   theme: {
@@ -76,7 +76,7 @@ QuoteCustomAccentColor.args = {
   },
 };
 
-export const QuoteCustomTextColor = (args) => <Highlight {...args} />;
+export const QuoteCustomTextColor = (args: HighlightProps) => <Highlight {...args} />;
 QuoteCustomTextColor.args = {
   ...quoteArgs,
   theme: {

--- a/packages/react/src/components/highlight/Highlight.test.tsx
+++ b/packages/react/src/components/highlight/Highlight.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { Highlight } from './Highlight';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Highlight /> spec', () => {
   it('renders the Highlight', () => {
@@ -15,5 +16,18 @@ describe('<Highlight /> spec', () => {
       <Highlight text="Add an interesting quote here" type="quote" reference="First name Last name. Title." />,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('Native html props are passed to the element', async () => {
+    const elementProps = getCommonElementTestProps('all');
+    const { getByTestId } = render(
+      <Highlight
+        text="Add an interesting quote here"
+        type="quote"
+        reference="First name Last name. Title."
+        {...elementProps}
+      />,
+    );
+    const element = getByTestId(elementProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, elementProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/highlight/Highlight.tsx
+++ b/packages/react/src/components/highlight/Highlight.tsx
@@ -4,6 +4,7 @@ import '../../styles/base.module.css';
 import styles from './Highlight.module.scss';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface HighlightTheme {
   '--accent-line-color'?: string;
@@ -13,7 +14,7 @@ export interface HighlightTheme {
 export type HighlightType = 'highlight' | 'quote';
 export type HighlightSize = 's' | 'm' | 'l';
 
-export type HighlightProps = {
+export type HighlightProps = AllElementPropsWithoutRef<'figure'> & {
   /**
    * Highlight Theme
    */
@@ -36,13 +37,16 @@ export type HighlightProps = {
   reference?: string;
 };
 
-export const Highlight = ({ theme, size, type, text, reference }: HighlightProps) => {
+export const Highlight = ({ theme, size, type, text, reference, className, ...rest }: HighlightProps) => {
   // custom theme
   const customThemeClass = useTheme<HighlightTheme>(styles.highlight, theme || {});
   const isQuote = type && type === 'quote';
 
   return (
-    <figure className={classNames(styles.highlight, size && styles[`size-${size}`], customThemeClass)}>
+    <figure
+      {...rest}
+      className={classNames(styles.highlight, size && styles[`size-${size}`], customThemeClass, className)}
+    >
       <blockquote className={styles.highlightBlockquote}>
         <p className={classNames(styles.text, isQuote && styles.quote)}>{text}</p>
       </blockquote>

--- a/packages/react/src/components/imageWithCard/ImageWithCard.stories.tsx
+++ b/packages/react/src/components/imageWithCard/ImageWithCard.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ArgsTable, Title } from '@storybook/addon-docs/blocks';
 
-import { ImageWithCard } from './ImageWithCard';
+import { ImageWithCard, ImageWithCardProps } from './ImageWithCard';
 import imageFile from '../../assets/img/placeholder_1920x1080.jpg';
 
 const contentTitle = 'Lorem ipsum';
@@ -60,7 +60,7 @@ export const SplitFullWidth = () => (
 );
 SplitFullWidth.storyName = 'Split full width';
 
-export const Playground = (args) => (
+export const Playground = (args: ImageWithCardProps & Record<string, string>) => (
   <ImageWithCard
     color={args.color}
     cardAlignment={args.cardAlignment}

--- a/packages/react/src/components/imageWithCard/ImageWithCard.test.tsx
+++ b/packages/react/src/components/imageWithCard/ImageWithCard.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { ImageWithCard } from './ImageWithCard';
+import { ImageWithCard, ImageWithCardProps } from './ImageWithCard';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<ImageWithCard /> spec', () => {
   it('renders the component', () => {
@@ -13,5 +14,11 @@ describe('<ImageWithCard /> spec', () => {
     const { container } = render(<ImageWithCard src="" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const elementProps = getCommonElementTestProps<'div', Pick<ImageWithCardProps, 'color'>>('div');
+    const { getByTestId } = render(<ImageWithCard {...elementProps} src="" />);
+    const element = getByTestId(elementProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, elementProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/imageWithCard/ImageWithCard.tsx
+++ b/packages/react/src/components/imageWithCard/ImageWithCard.tsx
@@ -3,19 +3,22 @@ import React from 'react';
 import '../../styles/base.module.css';
 import styles from './ImageWithCard.module.css';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type ImageWithCardAlignment = 'left' | 'right';
 export type ImageWithCardLayout = 'hover' | 'split';
 export type ImageWithCardColor = 'primary' | 'secondary' | 'tertiary' | 'plain';
 
-export type ImageWithCardProps = React.PropsWithChildren<{
-  src: string;
-  fullWidth?: boolean;
-  cardAlignment?: ImageWithCardAlignment;
-  cardLayout?: ImageWithCardLayout;
-  color?: ImageWithCardColor;
-  className?: string;
-}>;
+export type ImageWithCardProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    src: string;
+    fullWidth?: boolean;
+    cardAlignment?: ImageWithCardAlignment;
+    cardLayout?: ImageWithCardLayout;
+    color?: ImageWithCardColor;
+    className?: string;
+  }
+>;
 
 export const ImageWithCard = ({
   src,
@@ -24,9 +27,11 @@ export const ImageWithCard = ({
   cardAlignment = 'left',
   color = 'plain',
   cardLayout = null,
-  className = null,
+  className,
+  ...rest
 }: ImageWithCardProps) => (
   <div
+    {...rest}
     className={classNames(
       styles.wrapper,
       styles[`${cardAlignment}Alignment`],

--- a/packages/react/src/components/koros/Koros.stories.tsx
+++ b/packages/react/src/components/koros/Koros.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
-import { getShapeHeight, Koros } from './Koros';
+import { getShapeHeight, Koros, KorosProps } from './Koros';
 
 export default {
   component: Koros,
@@ -46,7 +46,7 @@ export const Dense = () => (
   </>
 );
 
-export const Flipped = (args) => (
+export const Flipped = (args: KorosProps) => (
   <>
     <Koros flipVertical={args.flipVertical} />
     <br />
@@ -68,7 +68,9 @@ Flipped.args = {
   flipVertical: true,
 };
 
-export const Rotated = (args) => <Koros type={args.type} flipVertical={args.flipVertical} rotate={args.rotate} />;
+export const Rotated = (args: KorosProps) => (
+  <Koros type={args.type} flipVertical={args.flipVertical} rotate={args.rotate} />
+);
 
 Rotated.args = {
   type: 'basic',
@@ -115,7 +117,7 @@ export const RotatedInContainer = () => {
 
 export const CustomColor = () => <Koros style={{ fill: 'var(--color-coat-of-arms)' }} />;
 
-export const ExactFit = (args) => {
+export const ExactFit = (args: KorosProps) => {
   const korosProps = {
     style: { fill: 'var(--color-coat-of-arms)' },
     ...args,
@@ -136,7 +138,9 @@ export const ExactFit = (args) => {
   );
 };
 
-export const Playground = (args) => <Koros type={args.type} flipVertical={args.flipVertical} rotate={args.rotate} />;
+export const Playground = (args: KorosProps) => (
+  <Koros type={args.type} flipVertical={args.flipVertical} rotate={args.rotate} />
+);
 
 Playground.parameters = {
   previewTabs: {

--- a/packages/react/src/components/koros/Koros.test.tsx
+++ b/packages/react/src/components/koros/Koros.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Koros } from './Koros';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Koros /> spec', () => {
   it('renders the component', () => {
@@ -31,5 +32,11 @@ describe('<Koros /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<Koros type="basic" {...divProps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/koros/Koros.tsx
+++ b/packages/react/src/components/koros/Koros.tsx
@@ -4,12 +4,13 @@ import { uniqueId } from 'lodash';
 import '../../styles/base.module.css';
 import styles from './Koros.module.css';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type KorosType = 'basic' | 'beat' | 'pulse' | 'wave' | 'vibration' | 'calm';
 
 type RotateDegrees = '45deg' | '90deg' | '135deg' | '180deg' | '225deg' | '270deg' | '315deg';
 
-export type KorosProps = {
+export type KorosProps = AllElementPropsWithoutRef<'div'> & {
   /**
    * Whether to use dense variant
    * @default false
@@ -95,6 +96,7 @@ export const Koros = ({
   rotate,
   className = '',
   style,
+  ...rest
 }: KorosProps) => {
   const patternName = `koros_${type}`;
   const [id] = useState(uniqueId(`${patternName}-`));
@@ -103,6 +105,7 @@ export const Koros = ({
   );
   return (
     <div
+      {...rest}
       className={classNames(styles.koros, styles[type], rotate && styles.rotate, className)}
       style={{ ...style, ...(cssTransforms.length > 0 ? { transform: cssTransforms.join(' ') } : {}) }}
     >

--- a/packages/react/src/components/link/Link.stories.tsx
+++ b/packages/react/src/components/link/Link.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Link } from './Link';
+import { Link, LinkProps } from './Link';
 import { IconDocument, IconEnvelope, IconPhone, IconPhoto } from '../../icons';
 
 export default {
@@ -15,9 +15,9 @@ export default {
   },
 };
 
-export const Default = (args) => <Link {...args}>Default link</Link>;
+export const Default = (args: LinkProps) => <Link {...args}>Default link</Link>;
 
-export const InternalLinks = (args) => {
+export const InternalLinks = (args: LinkProps) => {
   return (
     <>
       <Link {...args} href={args.href} size="S">
@@ -46,7 +46,7 @@ InternalLinks.argTypes = {
   },
 };
 
-export const ExternalLinks = (args) => {
+export const ExternalLinks = (args: LinkProps) => {
   return (
     <>
       <Link
@@ -94,7 +94,7 @@ ExternalLinks.argTypes = {
   },
 };
 
-export const OpenInNewTabLink = (args) => (
+export const OpenInNewTabLink = (args: LinkProps) => (
   <Link
     {...args}
     href="https://hds.hel.fi"
@@ -114,7 +114,7 @@ OpenInNewTabLink.args = {
   external: true,
 };
 
-export const visitedStylesDisabled = (args) => (
+export const visitedStylesDisabled = (args: LinkProps) => (
   <Link {...args} href={args.href} disableVisitedStyles={args.disableVisitedStyles}>
     Link without visited styles
   </Link>
@@ -124,7 +124,7 @@ visitedStylesDisabled.args = {
   disableVisitedStyles: true,
 };
 
-export const inlineLinks = (args) => {
+export const inlineLinks = (args: LinkProps) => {
   return (
     <>
       <p style={{ fontSize: '14px' }}>
@@ -158,7 +158,7 @@ inlineLinks.argTypes = {
   },
 };
 
-export const standaloneLink = (args) => {
+export const standaloneLink = (args: LinkProps) => {
   return (
     <Link {...args} size="L" style={{ display: 'block', marginBottom: '20px', width: 'fit-content' }}>
       Standalone link
@@ -168,7 +168,7 @@ export const standaloneLink = (args) => {
 
 standaloneLink.storyName = 'Standalone link';
 
-export const withCustomIcon = (args) => {
+export const withCustomIcon = (args: LinkProps) => {
   return (
     <div style={{ display: 'grid', columnGap: '10px', gridTemplateColumns: '1fr 1fr 1fr' }}>
       <div>
@@ -245,7 +245,7 @@ withCustomIcon.argTypes = {
   },
 };
 
-export const withButtonStyles = (args) => {
+export const withButtonStyles = (args: LinkProps) => {
   return (
     <Link {...args} useButtonStyles>
       Link with button styles

--- a/packages/react/src/components/link/Link.test.tsx
+++ b/packages/react/src/components/link/Link.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Link } from './Link';
+import { Link, LinkProps } from './Link';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Link /> spec', () => {
   it('renders the component', () => {
@@ -27,5 +28,19 @@ describe('<Link /> spec', () => {
     expect(asFragment()).toMatchSnapshot();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const linkProps = getCommonElementTestProps<'a', Pick<LinkProps, 'href'>>('a');
+    linkProps.href = 'https://hds.hel.fi';
+    // Note: "...rest" in Link component is appened after other props
+    // so it overrides for example ariaLabel.
+    // Changing this would be a breaking change, so did not change it.
+    const { getByTestId } = render(
+      <Link {...linkProps} external openInNewTab>
+        Test link
+      </Link>,
+    );
+    const element = getByTestId(linkProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, linkProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/linkbox/Linkbox.test.tsx
+++ b/packages/react/src/components/linkbox/Linkbox.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Linkbox } from './Linkbox';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Linkbox /> spec', () => {
   it('renders the component', () => {
@@ -46,5 +47,23 @@ describe('<Linkbox /> spec', () => {
     expect(asFragment()).toMatchSnapshot();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const linkProps = getCommonElementTestProps<'a'>('a');
+    // className goes to main element, not to <a> where other props go
+    linkProps.className = undefined;
+    linkProps.href = 'https://hds.hel.fi';
+    const { getByTestId } = render(
+      <Linkbox
+        {...linkProps}
+        linkboxAriaLabel="Linkbox: HDS"
+        linkAriaLabel="HDS"
+        heading="Linkbox title"
+        text="Linkbox text"
+      />,
+    );
+    const element = getByTestId(linkProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, linkProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/loadingSpinner/LoadingSpinner.stories.tsx
+++ b/packages/react/src/components/loadingSpinner/LoadingSpinner.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { LoadingSpinner } from './LoadingSpinner';
+import { LoadingSpinner, LoadingSpinnerProps } from './LoadingSpinner';
 import { Button } from '../button';
 
 export default {
@@ -8,14 +8,14 @@ export default {
   title: 'Components/LoadingSpinner',
 };
 
-export const Default = (args) => <LoadingSpinner {...args} />;
+export const Default = (args: LoadingSpinnerProps) => <LoadingSpinner {...args} />;
 
-export const Small = (args) => <LoadingSpinner {...args} />;
+export const Small = (args: LoadingSpinnerProps) => <LoadingSpinner {...args} />;
 Small.args = {
   small: true,
 };
 
-export const CustomTheme = (args) => (
+export const CustomTheme = (args: LoadingSpinnerProps) => (
   <>
     <LoadingSpinner {...args} multicolor={false} />
     <br />
@@ -32,7 +32,7 @@ CustomTheme.args = {
   },
 };
 
-export const MultipleSpinners = (args) => {
+export const MultipleSpinners = (args: LoadingSpinnerProps) => {
   const [showSpinner1, setShowSpinner1] = useState(false);
   const [showSpinner2, setShowSpinner2] = useState(false);
   const [showSpinner3, setShowSpinner3] = useState(false);

--- a/packages/react/src/components/loadingSpinner/LoadingSpinner.test.tsx
+++ b/packages/react/src/components/loadingSpinner/LoadingSpinner.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { LoadingSpinner } from './LoadingSpinner';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<LoadingSpinner /> spec', () => {
   it('renders the component', () => {
@@ -13,5 +14,11 @@ describe('<LoadingSpinner /> spec', () => {
     const { container } = render(<LoadingSpinner />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<LoadingSpinner {...divProps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/logo/Logo.stories.tsx
+++ b/packages/react/src/components/logo/Logo.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Logo, logoFi, logoSv, logoRu } from './Logo';
+import { Logo, logoFi, logoSv, logoRu, LogoProps } from './Logo';
 
 export default {
   component: Logo,
@@ -10,7 +10,7 @@ export default {
   },
 };
 
-export const Playground = (args) => <Logo {...args} />;
+export const Playground = (args: LogoProps & Record<string, string>) => <Logo {...args} />;
 
 Playground.args = {
   size: 'full',

--- a/packages/react/src/components/logo/Logo.test.tsx
+++ b/packages/react/src/components/logo/Logo.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Logo } from './Logo';
+import { Logo, LogoProps } from './Logo';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Logo /> spec', () => {
   it('renders the component', () => {
@@ -13,5 +14,21 @@ describe('<Logo /> spec', () => {
     const { container } = render(<Logo src="dummyPath" alt="logo" title="Helsingin kaupunki" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    // "aria-hidden" and "alt" are linked in LogoProps. If alt is set, aria-hidden must be false/undefined
+    const imgProps = getCommonElementTestProps<'img', Pick<LogoProps, 'dataTestId'> & { 'aria-hidden': undefined }>(
+      'img',
+    );
+    // the component has "dataTestId" prop
+    imgProps.dataTestId = imgProps['data-testid'];
+    const { getByTestId } = render(<Logo {...imgProps} src="dummyPath" alt="logo" title="Helsingin kaupunki" />);
+    const element = getByTestId(imgProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...imgProps,
+        dataTestId: undefined,
+      } as HTMLAttributes<HTMLImageElement>),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/logo/Logo.tsx
+++ b/packages/react/src/components/logo/Logo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import styles from './Logo.module.css';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export const logoFi =
   'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoCiAgICAgICAgZD0iTTc1Ljc1MyAyLjI1MXYyMC43YzAgMy45NS0zLjI3NSA3LjE3OC03LjMxIDcuMTc4aC0yMi4yNmMtMi42NzQgMC01LjIwNS45Ni03LjE4MyAyLjczOWExMC43NDkgMTAuNzQ5IDAgMDAtNy4xODMtMi43NEg5LjUwOWMtNC4wMDMgMC03LjI0Ny0zLjIxLTcuMjQ3LTcuMTc3VjIuMjVoNzMuNDkxek00MC4xODcgMzQuODM1YTguNDcgOC40NyAwIDAxNi4wMTItMi40NzFoMjIuMjQ1YzUuMjY4IDAgOS41NTYtNC4yMTkgOS41NTYtOS40MTNWMEgwdjIyLjkzNWMwIDUuMTk0IDQuMjU2IDkuNDEzIDkuNTA5IDkuNDEzaDIyLjMwOGMyLjI2MyAwIDQuMzk4Ljg4MiA2LjAxMiAyLjQ3MUwzOS4wMTYgMzZsMS4xNy0xLjE2NXoiCiAgICAgICAgZmlsbD0iY3VycmVudENvbG9yIiAvPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg==';
@@ -47,44 +48,43 @@ interface LogoShown {
 
 type LogoHiddenOrShown = LogoHidden | LogoShown;
 
-export type LogoProps = LogoHiddenOrShown & {
-  /**
-   * Additional class names to apply to the logo
-   */
-  className?: string;
-  /**
-   * Adds a data-testid attribute to the root element with the given value
-   */
-  dataTestId?: string;
-  /**
-   * The size of the logo
-   * @default 'full'
-   */
-  size?: LogoSize;
-  /**
-   * Src of the logo. Data-url, locally imported image or a URL
-   */
-  src: HTMLImageElement['src'];
-  /**
-   * Title for the logo
-   */
-  title?: string;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-};
-
-/* & React.ComponentPropsWithoutRef<'svg'>; */
+export type LogoProps = AllElementPropsWithoutRef<'img'> &
+  LogoHiddenOrShown & {
+    /**
+     * Additional class names to apply to the logo
+     */
+    className?: string;
+    /**
+     * Adds a data-testid attribute to the root element with the given value
+     */
+    dataTestId?: string;
+    /**
+     * The size of the logo
+     * @default 'full'
+     */
+    size?: LogoSize;
+    /**
+     * Src of the logo. Data-url, locally imported image or a URL
+     */
+    src: HTMLImageElement['src'];
+    /**
+     * Title for the logo
+     */
+    title?: string;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    style?: React.CSSProperties;
+  };
 
 export const Logo = ({ alt, className, dataTestId, size = 'full', style, ...rest }: LogoProps) => {
   const props = {
+    ...rest,
     alt,
     size,
     className: classNames(styles.logo, size !== 'full' && styles[size], className),
     style,
     'data-testid': dataTestId,
-    ...rest,
   };
 
   return <img alt={alt} {...props} />;

--- a/packages/react/src/components/notification/Notification.stories.tsx
+++ b/packages/react/src/components/notification/Notification.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import { Notification, NotificationSizeInline, NotificationSizeToast } from './Notification';
+import { Notification, NotificationProps, NotificationSizeInline, NotificationSizeToast } from './Notification';
 import { Button } from '../button';
 
 const props = {
@@ -175,7 +175,7 @@ WithCustomHeadingLevel.parameters = {
 
 WithCustomHeadingLevel.storyName = 'With a custom aria-level';
 
-export const Playground = (args) => {
+export const Playground = (args: NotificationProps & Record<string, string>) => {
   const [open, setOpen] = useState(true);
 
   useEffect(() => {
@@ -212,7 +212,7 @@ export const Playground = (args) => {
           position={args.position}
           size={typedSize}
           dismissible={args.dismissible}
-          closeButtonLabelText={args.closeButtonLabelText}
+          closeButtonLabelText={args.closeButtonLabelText as string}
           headingLevel={args.headingLevel}
         >
           {args.body}

--- a/packages/react/src/components/notification/Notification.test.tsx
+++ b/packages/react/src/components/notification/Notification.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Notification } from './Notification';
+import { Notification, NotificationProps } from './Notification';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 const label = 'This is the label text';
 const body =
@@ -17,6 +18,23 @@ describe('<Notification /> spec', () => {
   it('renders the component without optional label', () => {
     const { asFragment } = render(<Notification>{body}</Notification>);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const sectionProps: NotificationProps = getCommonElementTestProps('section');
+    // the component has "dataTestId" prop
+    sectionProps.dataTestId = sectionProps['data-testid'];
+    // the component has "notificationAriaLabel" prop
+    sectionProps.notificationAriaLabel = sectionProps['aria-label'];
+    const { getByTestId } = render(<Notification {...sectionProps}>{body}</Notification>);
+    const element = getByTestId(sectionProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...sectionProps,
+        dataTestId: undefined,
+        notificationAriaLabel: undefined,
+      } as unknown as HTMLAttributes<HTMLElement>),
+    ).toHaveLength(0);
   });
 
   // Replaces aria-atomic with role=alert and removes heading props for a better screen reader support

--- a/packages/react/src/components/notification/Notification.tsx
+++ b/packages/react/src/components/notification/Notification.tsx
@@ -6,6 +6,7 @@ import '../../styles/base.module.css';
 import styles from './Notification.module.css';
 import classNames from '../../utils/classNames';
 import { IconInfoCircleFill, IconErrorFill, IconAlertCircleFill, IconCheckCircleFill, IconCross } from '../../icons';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type NotificationType = 'info' | 'error' | 'alert' | 'success';
 export type NotificationSizeInline = 'default' | 'small' | 'large';
@@ -20,73 +21,75 @@ export type NotificationPosition =
   | 'bottom-center'
   | 'bottom-right';
 
-type CommonProps = React.PropsWithChildren<{
-  /**
-   * Whether the notification should be closed automatically after a certain time
-   * @default false
-   */
-  autoClose?: boolean;
-  /**
-   * The duration before the notification is automatically closed. Used together with the `autoClose` prop.
-   * @default 6000
-   */
-  autoCloseDuration?: number;
-  /**
-   * Boolean indication whether notification has box shadow or not.
-   */
-  boxShadow?: boolean;
-  /**
-   * Additional class names to apply to the notification
-   */
-  className?: string;
-  /**
-   * Duration of the close fade-out animation
-   * @default 85
-   */
-  closeAnimationDuration?: number;
-  /**
-   * Value for the data-testid attribute that is applied to the root component.
-   */
-  dataTestId?: string;
-  /**
-   * Displays a progress bar on top of the notification when `true`
-   * @default true
-   */
-  displayAutoCloseProgress?: boolean;
-  /**
-   * Determines whether the notification should be visually hidden. Useful when notification should only be "seen" by screen readers.
-   * @default false
-   */
-  invisible?: boolean;
-  /**
-   * The label of the notification.
-   * Note: Labels are not displayed visually for small notifications, but they are still accessible to assistive technology. This could be used to help screen reader users to better understand the context of the notification.
-   */
-  label?: string | React.ReactNode;
-  /**
-   * The aria-label of the notification region
-   * @default "Notification"
-   */
-  notificationAriaLabel?: string;
-  /**
-   * Callback fired when the notification is closed
-   */
-  onClose?: () => void;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-  /**
-   * The type of the notification
-   * @default 'info'
-   */
-  type?: NotificationType;
-  /**
-   * The aria-level of the heading element
-   * @default 2
-   */
-  headingLevel?: number;
-}>;
+type CommonProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'section'> & {
+    /**
+     * Whether the notification should be closed automatically after a certain time
+     * @default false
+     */
+    autoClose?: boolean;
+    /**
+     * The duration before the notification is automatically closed. Used together with the `autoClose` prop.
+     * @default 6000
+     */
+    autoCloseDuration?: number;
+    /**
+     * Boolean indication whether notification has box shadow or not.
+     */
+    boxShadow?: boolean;
+    /**
+     * Additional class names to apply to the notification
+     */
+    className?: string;
+    /**
+     * Duration of the close fade-out animation
+     * @default 85
+     */
+    closeAnimationDuration?: number;
+    /**
+     * Value for the data-testid attribute that is applied to the root component.
+     */
+    dataTestId?: string;
+    /**
+     * Displays a progress bar on top of the notification when `true`
+     * @default true
+     */
+    displayAutoCloseProgress?: boolean;
+    /**
+     * Determines whether the notification should be visually hidden. Useful when notification should only be "seen" by screen readers.
+     * @default false
+     */
+    invisible?: boolean;
+    /**
+     * The label of the notification.
+     * Note: Labels are not displayed visually for small notifications, but they are still accessible to assistive technology. This could be used to help screen reader users to better understand the context of the notification.
+     */
+    label?: string | React.ReactNode;
+    /**
+     * The aria-label of the notification region
+     * @default "Notification"
+     */
+    notificationAriaLabel?: string;
+    /**
+     * Callback fired when the notification is closed
+     */
+    onClose?: () => void;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    style?: React.CSSProperties;
+    /**
+     * The type of the notification
+     * @default 'info'
+     */
+    type?: NotificationType;
+    /**
+     * The aria-level of the heading element
+     * @default 2
+     */
+    headingLevel?: number;
+  }
+>;
 
 type PositionAndSize =
   | { position?: 'inline'; size?: NotificationSizeInline }
@@ -202,6 +205,7 @@ export const Notification = React.forwardRef<HTMLDivElement, NotificationProps>(
       style,
       type = 'info',
       headingLevel = 2,
+      ...rest
     }: NotificationProps,
     ref,
   ) => {
@@ -252,6 +256,7 @@ export const Notification = React.forwardRef<HTMLDivElement, NotificationProps>(
     return (
       <ConditionalVisuallyHidden visuallyHidden={invisible}>
         <animated.section
+          {...rest}
           // there is an issue with react-spring -rc3 and a new version of @types/react: https://github.com/react-spring/react-spring/issues/1102
           // eslint-disable-next-line  @typescript-eslint/no-explicit-any
           style={{ ...notificationTransition, ...(style as any) }}

--- a/packages/react/src/components/numberInput/NumberInput.stories.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { NumberInput } from './NumberInput';
+import { NumberInput, NumberInputProps } from './NumberInput';
 
 export default {
   component: NumberInput,
@@ -18,12 +18,12 @@ export default {
   },
 };
 
-export const Default = (args) => <NumberInput {...args} />;
+export const Default = (args: NumberInputProps) => <NumberInput {...args} />;
 Default.args = {
   id: 'Default',
 };
 
-export const CustomStep = (args) => <NumberInput {...args} />;
+export const CustomStep = (args: NumberInputProps) => <NumberInput {...args} />;
 CustomStep.storyName = 'With a custom step value';
 CustomStep.args = {
   id: 'CustomStep',
@@ -34,7 +34,7 @@ CustomStep.args = {
   plusStepButtonAriaLabel: 'Increase by ten',
 };
 
-export const Disabled = (args) => <NumberInput {...args} />;
+export const Disabled = (args: NumberInputProps) => <NumberInput {...args} />;
 Disabled.storyName = 'Disabled';
 Disabled.args = {
   id: 'Disabled',
@@ -45,7 +45,7 @@ Disabled.args = {
   disabled: true,
 };
 
-export const WithMinAndMax = (args) => <NumberInput {...args} />;
+export const WithMinAndMax = (args: NumberInputProps) => <NumberInput {...args} />;
 WithMinAndMax.storyName = 'With min and max value';
 WithMinAndMax.args = {
   id: 'WithMinAndMax',
@@ -57,7 +57,7 @@ WithMinAndMax.args = {
   plusStepButtonAriaLabel: 'Increase by one',
 };
 
-export const WithDefaultValue = (args) => <NumberInput {...args} />;
+export const WithDefaultValue = (args: NumberInputProps) => <NumberInput {...args} />;
 WithDefaultValue.storyName = 'With a default value';
 WithDefaultValue.args = {
   id: 'WithDefaultValue',
@@ -68,14 +68,14 @@ WithDefaultValue.args = {
   plusStepButtonAriaLabel: 'Increase by ten',
 };
 
-export const Invalid = (args) => <NumberInput {...args} />;
+export const Invalid = (args: NumberInputProps) => <NumberInput {...args} />;
 Invalid.args = {
   id: 'Invalid',
   invalid: true,
   errorText: 'Invalid value',
 };
 
-export const Success = (args) => <NumberInput {...args} />;
+export const Success = (args: NumberInputProps) => <NumberInput {...args} />;
 Success.args = {
   id: 'Success',
   successText: 'Valid value',

--- a/packages/react/src/components/numberInput/NumberInput.test.tsx
+++ b/packages/react/src/components/numberInput/NumberInput.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import { act } from 'react-dom/test-utils';
 
 import { NumberInput, NumberInputProps } from './NumberInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<NumberInput /> spec', () => {
   const numberInputProps: NumberInputProps = {
@@ -38,6 +39,19 @@ describe('<NumberInput /> spec', () => {
     const { container } = render(<NumberInput step={10} {...numberInputProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps<
+      'input',
+      Pick<NumberInputProps, 'step' | 'max' | 'min' | 'value' | 'defaultValue'>
+    >('input');
+    const { getByTestId } = render(<NumberInput {...numberInputProps} {...inputProps} step={10} />);
+    const element = getByTestId(inputProps['data-testid']);
+    // id, className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, { ...inputProps, id: undefined, style: undefined, className: undefined }),
+    ).toHaveLength(0);
   });
 
   it('should increase value correct amount when user clicks step up button', async () => {

--- a/packages/react/src/components/pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/pagination/Pagination.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Pagination } from './Pagination';
+import { Pagination, PaginationProps } from './Pagination';
 
 export default {
   component: Pagination,
@@ -13,7 +13,7 @@ export default {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Basic = (args) => {
+export const Basic = (args: PaginationProps) => {
   const [pageIndex, setPageIndex] = useState<number>(0);
   return (
     <Pagination
@@ -32,7 +32,7 @@ export const Basic = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const WithTruncation = (args) => {
+export const WithTruncation = (args: PaginationProps) => {
   const [pageIndexPagination1, setPageIndexPagination1] = useState<number>(7);
   const [pageIndexPagination2, setPageIndexPagination2] = useState<number>(7);
   const [pageIndexPagination3, setPageIndexPagination3] = useState<number>(7);
@@ -82,7 +82,7 @@ WithTruncation.storyName = 'With truncation';
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const WithoutPrevAndNextButtons = (args) => {
+export const WithoutPrevAndNextButtons = (args: PaginationProps) => {
   const [pageIndex, setPageIndex] = useState<number>(7);
 
   return (
@@ -106,7 +106,7 @@ WithoutPrevAndNextButtons.storyName = 'Without prev and next buttons';
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomTheme = (args) => {
+export const CustomTheme = (args: PaginationProps) => {
   const theme = {
     '--active-page-background-color': 'var(--color-bus)',
   };
@@ -131,7 +131,7 @@ export const CustomTheme = (args) => {
 
 CustomTheme.storyName = 'Custom theme';
 
-export const Playground = (args) => {
+export const Playground = (args: PaginationProps) => {
   const [pageIndex, setPageIndex] = useState<number>(7);
 
   return (

--- a/packages/react/src/components/pagination/Pagination.test.tsx
+++ b/packages/react/src/components/pagination/Pagination.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { getAllByText, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Pagination } from './Pagination';
+import { Pagination, PaginationProps } from './Pagination';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 const renderPagination = ({ pageCount, pageIndex, siblingCount }) => {
   const { asFragment } = render(
@@ -39,6 +40,34 @@ describe('<Pagination /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const navProps = getCommonElementTestProps<'nav', Pick<PaginationProps, 'dataTestId' | 'paginationAriaLabel'>>(
+      'nav',
+    );
+    // the component has "dataTestId" prop
+    navProps.dataTestId = navProps['data-testid'];
+    // aria-label is from "paginationAriaLabel" prop
+    navProps.paginationAriaLabel = navProps['aria-label'] as string;
+    const { getByTestId } = render(
+      <Pagination
+        {...navProps}
+        onChange={() => null}
+        pageCount={68}
+        pageIndex={7}
+        pageHref={() => '#'}
+        language="en"
+      />,
+    );
+    const element = getByTestId(navProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...navProps,
+        dataTestId: undefined,
+        paginationAriaLabel: undefined,
+      } as HTMLAttributes<HTMLElement>),
+    ).toHaveLength(0);
   });
 
   it('should render null when pageCount is zero', () => {

--- a/packages/react/src/components/pagination/Pagination.tsx
+++ b/packages/react/src/components/pagination/Pagination.tsx
@@ -7,6 +7,7 @@ import classNames from '../../utils/classNames';
 import { Button } from '../button';
 import { IconAngleLeft, IconAngleRight } from '../../icons';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
 type Language = 'en' | 'fi' | 'sv';
 
@@ -134,56 +135,62 @@ export interface PaginationCustomTheme {
   '--active-page-background-color'?: string;
 }
 
-export type PaginationProps = {
-  /**
-   * Data test id of pagination
-   */
-  dataTestId?: string;
-  /**
-   * If true, hide the next-page button
-   * @default false
-   */
-  hideNextButton?: boolean;
-  /**
-   * If true, hide the previous-page button
-   * @default false
-   */
-  hidePrevButton?: boolean;
-  /**
-   * The language of the pagination component.
-   * @default fi
-   */
-  language?: Language;
-  /**
-   * Callback fired when the page is changed
-   */
-  onChange?: (event: React.MouseEvent<HTMLAnchorElement> | React.MouseEvent<HTMLButtonElement>, index: number) => void;
-  /**
-   * The total number of pages
-   */
-  pageCount: number;
-  /**
-   * A function for generating the href of pages
-   */
-  pageHref: (index: number) => string;
-  /**
-   * The active page index
-   */
-  pageIndex: number;
-  /**
-   * Aria-label for the pagination nav element
-   */
-  paginationAriaLabel: string;
-  /**
-   * Number of always visible pages before and after the current page
-   * @default 1
-   */
-  siblingCount?: number;
-  /**
-   * Theme prop for customisation of the Pagination component
-   */
-  theme?: PaginationCustomTheme;
-};
+export type PaginationProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'nav'>,
+  {
+    /**
+     * Data test id of pagination
+     */
+    dataTestId?: string;
+    /**
+     * If true, hide the next-page button
+     * @default false
+     */
+    hideNextButton?: boolean;
+    /**
+     * If true, hide the previous-page button
+     * @default false
+     */
+    hidePrevButton?: boolean;
+    /**
+     * The language of the pagination component.
+     * @default fi
+     */
+    language?: Language;
+    /**
+     * Callback fired when the page is changed
+     */
+    onChange?: (
+      event: React.MouseEvent<HTMLAnchorElement> | React.MouseEvent<HTMLButtonElement>,
+      index: number,
+    ) => void;
+    /**
+     * The total number of pages
+     */
+    pageCount: number;
+    /**
+     * A function for generating the href of pages
+     */
+    pageHref: (index: number) => string;
+    /**
+     * The active page index
+     */
+    pageIndex: number;
+    /**
+     * Aria-label for the pagination nav element
+     */
+    paginationAriaLabel: string;
+    /**
+     * Number of always visible pages before and after the current page
+     * @default 1
+     */
+    siblingCount?: number;
+    /**
+     * Theme prop for customisation of the Pagination component
+     */
+    theme?: PaginationCustomTheme;
+  }
+>;
 
 export const Pagination = ({
   dataTestId = 'hds-pagination',
@@ -197,6 +204,8 @@ export const Pagination = ({
   paginationAriaLabel,
   siblingCount = 1,
   theme,
+  className,
+  ...rest
 }: PaginationProps) => {
   const initialPageIndex = useRef(pageIndex);
   const [hasUserChangedPage, setHasUserChangedPage] = useState<boolean>(false);
@@ -223,7 +232,13 @@ export const Pagination = ({
   return (
     <div className={styles.container}>
       <nav
-        className={classNames(styles.pagination, customThemeClass, hideNextButton ? styles.hideNextButton : '')}
+        {...rest}
+        className={classNames(
+          styles.pagination,
+          customThemeClass,
+          hideNextButton ? styles.hideNextButton : '',
+          className,
+        )}
         role="navigation"
         aria-label={paginationAriaLabel}
         data-next={mapLangToNext(language)}

--- a/packages/react/src/components/passwordInput/PasswordInput.stories.tsx
+++ b/packages/react/src/components/passwordInput/PasswordInput.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { PasswordInput } from './PasswordInput';
+import { PasswordInput, PasswordInputProps } from './PasswordInput';
 import { Button } from '../button';
 import { IconEye, IconEyeCrossed } from '../../icons';
 
@@ -14,7 +14,7 @@ export default {
   args: {},
 };
 
-export const Default = (args) => <PasswordInput {...args} />;
+export const Default = (args: PasswordInputProps) => <PasswordInput {...args} />;
 Default.args = {
   id: 'Default',
   helperText: 'Assistive text',
@@ -23,7 +23,7 @@ Default.args = {
   concealPasswordButtonAriaLabel: 'Hide password',
 };
 
-export const Disabled = (args) => <PasswordInput {...args} />;
+export const Disabled = (args: PasswordInputProps) => <PasswordInput {...args} />;
 Disabled.storyName = 'Disabled';
 Disabled.args = {
   id: 'Disabled',
@@ -35,7 +35,7 @@ Disabled.args = {
   concealPasswordButtonAriaLabel: 'Hide password',
 };
 
-export const WithDefaultValue = (args) => <PasswordInput {...args} />;
+export const WithDefaultValue = (args: PasswordInputProps) => <PasswordInput {...args} />;
 WithDefaultValue.storyName = 'WithDefaultValue';
 WithDefaultValue.args = {
   id: 'WithDefaultValue',
@@ -46,7 +46,7 @@ WithDefaultValue.args = {
   concealPasswordButtonAriaLabel: 'Hide password',
 };
 
-export const InitiallyRevealed = (args) => <PasswordInput {...args} />;
+export const InitiallyRevealed = (args: PasswordInputProps) => <PasswordInput {...args} />;
 InitiallyRevealed.storyName = 'InitiallyRevealed';
 InitiallyRevealed.args = {
   id: 'InitiallyRevealed',
@@ -57,7 +57,7 @@ InitiallyRevealed.args = {
   revealPasswordButtonAriaLabel: 'Show password',
   concealPasswordButtonAriaLabel: 'Hide password',
 };
-export const AutoCompleteOn = (args) => <PasswordInput {...args} />;
+export const AutoCompleteOn = (args: PasswordInputProps) => <PasswordInput {...args} />;
 AutoCompleteOn.storyName = 'Autocomplete on';
 AutoCompleteOn.args = {
   id: 'Autocomplete on',
@@ -68,7 +68,7 @@ AutoCompleteOn.args = {
   concealPasswordButtonAriaLabel: 'Hide password',
 };
 
-export const Success = (args) => <PasswordInput {...args} />;
+export const Success = (args: PasswordInputProps) => <PasswordInput {...args} />;
 Success.storyName = 'Success';
 Success.args = {
   id: 'Success',
@@ -79,7 +79,7 @@ Success.args = {
   concealPasswordButtonAriaLabel: 'Hide password',
 };
 
-export const Invalid = (args) => <PasswordInput {...args} />;
+export const Invalid = (args: PasswordInputProps) => <PasswordInput {...args} />;
 Invalid.storyName = 'Invalid';
 Invalid.args = {
   id: 'Error',

--- a/packages/react/src/components/passwordInput/PasswordInput.test.tsx
+++ b/packages/react/src/components/passwordInput/PasswordInput.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react-dom/test-utils';
 import { axe } from 'jest-axe';
 
 import { PasswordInput, PasswordInputProps } from './PasswordInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<PasswordInput /> spec', () => {
   const defaultInputProps: PasswordInputProps = {
@@ -30,6 +31,16 @@ describe('<PasswordInput /> spec', () => {
     const { container } = render(<PasswordInput {...defaultInputProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('Native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps<'input', Pick<PasswordInputProps, 'value' | 'defaultValue'>>('input');
+    const { getByTestId } = render(<PasswordInput {...inputProps} step={10} {...defaultInputProps} />);
+    const element = getByTestId(inputProps['data-testid']);
+    // id, className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, { ...inputProps, id: undefined, style: undefined, className: undefined }),
+    ).toHaveLength(0);
   });
 
   it('should change input type when show password button is clicked', async () => {

--- a/packages/react/src/components/phoneInput/PhoneInput.stories.tsx
+++ b/packages/react/src/components/phoneInput/PhoneInput.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { PhoneInput } from './PhoneInput';
+import { PhoneInput, PhoneInputProps } from './PhoneInput';
 import { Combobox } from '../dropdown/combobox';
 
 export default {
@@ -14,14 +14,14 @@ export default {
   args: {},
 };
 
-export const Default = (args) => <PhoneInput {...args} />;
+export const Default = (args: PhoneInputProps) => <PhoneInput {...args} />;
 Default.args = {
   id: 'Default',
   helperText: 'Assistive text',
   label: 'Label',
 };
 
-export const Disabled = (args) => <PhoneInput {...args} />;
+export const Disabled = (args: PhoneInputProps) => <PhoneInput {...args} />;
 Disabled.storyName = 'Disabled';
 Disabled.args = {
   id: 'Disabled',
@@ -31,7 +31,7 @@ Disabled.args = {
   disabled: true,
 };
 
-export const WithDefaultValue = (args) => <PhoneInput {...args} />;
+export const WithDefaultValue = (args: PhoneInputProps) => <PhoneInput {...args} />;
 WithDefaultValue.storyName = 'With a default value';
 WithDefaultValue.args = {
   id: 'WithDefaultValue',
@@ -40,7 +40,7 @@ WithDefaultValue.args = {
   label: 'Label for default value',
 };
 
-export const WithCountryCode = (args) => {
+export const WithCountryCode = (args: PhoneInputProps) => {
   const options = [{ label: 'Finland (+358)' }, { label: 'UK (+46)' }];
   return (
     <>
@@ -77,7 +77,7 @@ WithCountryCode.args = {
 };
 WithCountryCode.decorators = [(storyFn) => <div style={{ maxWidth: '516px' }}>{storyFn()}</div>];
 
-export const Invalid = (args) => <PhoneInput {...args} />;
+export const Invalid = (args: PhoneInputProps) => <PhoneInput {...args} />;
 Invalid.args = {
   id: 'Invalid',
   invalid: true,
@@ -86,7 +86,7 @@ Invalid.args = {
   errorText: 'Invalid value',
 };
 
-export const Success = (args) => <PhoneInput {...args} />;
+export const Success = (args: PhoneInputProps) => <PhoneInput {...args} />;
 Success.args = {
   id: 'Default',
   helperText: 'Assistive text',

--- a/packages/react/src/components/phoneInput/PhoneInput.test.tsx
+++ b/packages/react/src/components/phoneInput/PhoneInput.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { PhoneInput } from './PhoneInput';
+import { PhoneInput, PhoneInputProps } from './PhoneInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<PhoneInput /> spec', () => {
   it('renders the component', () => {
@@ -13,5 +14,14 @@ describe('<PhoneInput /> spec', () => {
     const { container } = render(<PhoneInput id="phone-input" label="test label" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps<'input', Pick<PhoneInputProps, 'value' | 'defaultValue'>>('input');
+    const { getByTestId } = render(<PhoneInput {...inputProps} id="phone-input" label="test label" />);
+    const element = getByTestId(inputProps['data-testid']);
+    // id, className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, { ...inputProps, id: undefined, style: undefined, className: undefined }),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/radioButton/RadioButton.stories.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
-import { RadioButton } from './RadioButton';
+import { RadioButton, RadioButtonProps } from './RadioButton';
 
 export default {
   component: RadioButton,
@@ -66,7 +66,7 @@ Custom.storyName = 'With custom styles';
 
 export const WithHelperText = () => <RadioButton id="radio-with-helper" label="Label" helperText="Assistive text" />;
 
-export const Playground = (args) => {
+export const Playground = (args: RadioButtonProps & Record<string, string>) => {
   const [radioValue, setRadioValue] = useState('');
   const options = ['foo', 'bar', 'baz'];
 

--- a/packages/react/src/components/radioButton/RadioButton.test.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { RadioButton } from './RadioButton';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 const radioProps = {
   label: 'label text',
@@ -18,5 +19,14 @@ describe('<RadioButton /> spec', () => {
     const { container } = render(<RadioButton {...radioProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps('input');
+    const { getByTestId } = render(<RadioButton {...radioProps} {...inputProps} />);
+    const element = getByTestId(inputProps['data-testid']);
+    // className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, { ...inputProps, style: undefined, className: undefined }),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/radioButton/RadioButton.tsx
+++ b/packages/react/src/components/radioButton/RadioButton.tsx
@@ -3,45 +3,49 @@ import React from 'react';
 import '../../styles/base.module.css';
 import styles from './RadioButton.module.css';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
-export type RadioButtonProps = {
-  /**
-   * If `true`, the component is checked
-   */
-  checked?: boolean;
-  /**
-   * Additional class names to apply to the radio button
-   */
-  className?: string;
-  /**
-   * If `true`, the radio button will be disabled
-   */
-  disabled?: boolean;
-  /**
-   * The helper text content that will be shown below the input
-   */
-  helperText?: string;
-  /**
-   * The id of the input element
-   */
-  id: string;
-  /**
-   * The label for the radio button
-   */
-  label?: string | React.ReactNode;
-  /**
-   * Callback fired when the state is changed
-   */
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-  /**
-   * The value of the component
-   */
-  value?: string;
-} & React.ComponentPropsWithoutRef<'input'>;
+export type RadioButtonProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'input'>,
+  {
+    /**
+     * If `true`, the component is checked
+     */
+    checked?: boolean;
+    /**
+     * Additional class names to apply to the radio button
+     */
+    className?: string;
+    /**
+     * If `true`, the radio button will be disabled
+     */
+    disabled?: boolean;
+    /**
+     * The helper text content that will be shown below the input
+     */
+    helperText?: string;
+    /**
+     * The id of the input element
+     */
+    id: string;
+    /**
+     * The label for the radio button
+     */
+    label?: string | React.ReactNode;
+    /**
+     * Callback fired when the state is changed
+     */
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    style?: React.CSSProperties;
+    /**
+     * The value of the component
+     */
+    value?: string;
+  }
+>;
 
 export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
   (

--- a/packages/react/src/components/searchInput/SearchInput.stories.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.stories.tsx
@@ -2,8 +2,12 @@
 
 import React, { useRef, useState } from 'react';
 
-import { SearchInput } from './SearchInput';
+import { SearchInput, SearchInputProps } from './SearchInput';
 import { Button } from '../button';
+
+type SuggestionItemType = {
+  value: string;
+};
 
 export default {
   component: SearchInput,
@@ -64,7 +68,7 @@ const asynchronousSearchOperation = (inputValue: string, timeout = 0) => {
 
 const longLastingAsynchronousSearchOperation = (inputValue: string) => asynchronousSearchOperation(inputValue, 5000);
 
-export const Default = (args) => {
+export const Default = (args: SearchInputProps<string>) => {
   const onSubmit = (value: string) => {
     console.log('Search for:', value);
   };
@@ -76,7 +80,7 @@ Default.args = {
   placeholder: 'Placeholder',
 };
 
-export const WithCustomSearchButton = (args) => {
+export const WithCustomSearchButton = (args: SearchInputProps<string>) => {
   const currentValue = useRef<string>('');
 
   const onChange = (value: string) => {
@@ -130,11 +134,7 @@ export const WithCustomSearchButton = (args) => {
   );
 };
 
-export const WithSuggestions = (args) => {
-  type SuggestionItemType = {
-    value: string;
-  };
-
+export const WithSuggestions = (args: SearchInputProps<SuggestionItemType>) => {
   const getSuggestions = async (inputValue: string): Promise<SuggestionItemType[]> => {
     const suggestions = await asynchronousSearchOperation(inputValue);
     return suggestions;
@@ -160,11 +160,7 @@ WithSuggestions.args = {
   placeholder: 'Placeholder',
 };
 
-export const WithSuggestionsAndHighlighting = (args) => {
-  type SuggestionItemType = {
-    value: string;
-  };
-
+export const WithSuggestionsAndHighlighting = (args: SearchInputProps<SuggestionItemType>) => {
   const getSuggestions = async (inputValue: string): Promise<SuggestionItemType[]> => {
     const suggestions = await asynchronousSearchOperation(inputValue);
     return suggestions;
@@ -191,11 +187,7 @@ WithSuggestionsAndHighlighting.args = {
   placeholder: 'Placeholder',
 };
 
-export const WithSuggestionsSpinner = (args) => {
-  type SuggestionItemType = {
-    value: string;
-  };
-
+export const WithSuggestionsSpinner = (args: SearchInputProps<SuggestionItemType>) => {
   const getSuggestions = async (inputValue: string): Promise<SuggestionItemType[]> => {
     const suggestions = await longLastingAsynchronousSearchOperation(inputValue);
     return suggestions;
@@ -226,11 +218,8 @@ WithSuggestionsSpinner.args = {
   placeholder: 'Placeholder',
 };
 
-export const WithDefaultValue = (args) => {
-  type SuggestionItemType = {
-    value: string;
-  };
-  const [searchValue, setSearchValue] = useState<string>(args.value);
+export const WithDefaultValue = (args: SearchInputProps<SuggestionItemType> & Record<string, string>) => {
+  const [searchValue, setSearchValue] = useState<string>(args.value as string);
 
   const getSuggestions = async (inputValue: string): Promise<SuggestionItemType[]> => {
     const suggestions = await asynchronousSearchOperation(inputValue);

--- a/packages/react/src/components/searchInput/SearchInput.test.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.test.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 import { render, waitFor, screen, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { SearchInput, SearchInputProps } from './SearchInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 type SuggestionItemType = {
   value: string;
@@ -87,6 +88,32 @@ describe('<SearchInput /> spec', () => {
   it('renders the component', () => {
     const { asFragment } = render(<SearchInput label="Search" onSubmit={() => null} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const wrapperProps = getCommonElementTestProps<
+      'div',
+      Pick<SearchInputProps<SuggestionItemType>, 'onChange' | 'onSubmit'>
+    >('div');
+    wrapperProps['data-testid'] = 'wrapper-test-id';
+    const inputProps: SearchInputProps<SuggestionItemType>['inputProps'] = getCommonElementTestProps('input');
+    const { getByTestId } = render(
+      <SearchInput
+        {...wrapperProps}
+        label="Search"
+        onSubmit={() => null}
+        onChange={() => null}
+        inputProps={inputProps}
+      />,
+    );
+    const element = getByTestId(wrapperProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, wrapperProps as unknown as HTMLAttributes<HTMLDivElement>),
+    ).toHaveLength(0);
+
+    const inputElement = getByTestId(inputProps ? inputProps['data-testid'] : 'error');
+    // id is set by downshift
+    expect(getElementAttributesMisMatches(inputElement, { ...inputProps, id: undefined })).toHaveLength(0);
   });
 
   it('uncontrolled component calls onChange when input value changes', async () => {

--- a/packages/react/src/components/searchInput/SearchInput.tsx
+++ b/packages/react/src/components/searchInput/SearchInput.tsx
@@ -11,98 +11,117 @@ import { GetSuggestionsFunction, SUGGESTIONS_DEBOUNCE_VALUE, useSuggestions } fr
 import { DROPDOWN_MENU_ITEM_HEIGHT } from '../dropdown/dropdownUtils';
 import { useShowLoadingSpinner } from '../../hooks/useShowLoadingSpinner';
 import { LoadingSpinner } from '../loadingSpinner';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
-export type SearchInputProps<SuggestionItem> = {
-  /**
-   * Additional class names to add to the component.
-   */
-  className?: string;
-  /**
-   * The aria-label for the clear button.
-   * @default Clear
-   */
-  clearButtonAriaLabel?: string;
-  /**
-   * Callback function fired every time the input content changes. Receives the input value as a parameter. Must return a promise which resolves to an array of SuggestionItems.
-   */
-  getSuggestions?: GetSuggestionsFunction<SuggestionItem>;
-  /**
-   * The helper text content that will be shown below the input.
-   */
-  helperText?: string;
-  /**
-   * Should the matching part of a suggestion be highlighted.
-   * @default true
-   */
-  highlightSuggestions?: boolean;
-  /**
-   * The label for the search field.
-   */
-  label: React.ReactNode;
-  /**
-   * Text to show for screen readers when loading spinner is no longer visible.
-   * @default "Finished loading suggestions"
-   */
-  loadingSpinnerFinishedText?: string;
-  /**
-   * Text to show for screen readers when loading spinner is visible.
-   * @default "Loading suggestions"
-   */
-  loadingSpinnerText?: string;
-  /**
-   * Callback function fired after search is triggered.
-   */
-  onSubmit: (value: string) => void;
-  /**
-   * Callback function fired after input value has changed. Required for a controlled component.
-   */
-  onChange?: (value: string) => void;
-  /**
-   * Placeholder text for the search input.
-   */
-  placeholder?: string;
-  /**
-   * The aria-label for the search button.
-   * @default Search
-   */
-  searchButtonAriaLabel?: string;
-  /**
-   * Hides the search button.
-   * @default false
-   */
-  hideSearchButton?: boolean;
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Field of the SuggestionItem that represents the item key. Key needs to be unique between item.
-   * E.g. an `suggestionKeyField` value of `'bar'` and a suggestion item `{ foo: 'Label', bar: 'value' }`, would use `'value'` as the key in the menu for that specific item.
-   * Uses value of `suggestionLabelField` by default.
-   */
-  suggestionKeyField?: keyof SuggestionItem;
-  /**
-   * Field of the SuggestionItem that represents the item label.
-   * E.g. an `suggestionLabelField` value of `'foo'` and a suggestion item `{ foo: 'Label', bar: 'value' }`, would display `'Label'` in the menu for that specific suggestion.
-   */
-  suggestionLabelField?: keyof SuggestionItem;
-  /**
-   * The value of the input element, required for a controlled component. Remember to use onChange prop as well.
-   */
-  value?: string;
-  /**
-   * The number of suggestions that are visible in the menu before it becomes scrollable.
-   * @default 8
-   */
-  visibleSuggestions?: number;
-};
-
+export type SearchInputProps<SuggestionItem> = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'div'>,
+  {
+    /**
+     * Additional class names to add to the component.
+     */
+    className?: string;
+    /**
+     * The aria-label for the clear button.
+     * @default Clear
+     */
+    clearButtonAriaLabel?: string;
+    /**
+     * Callback function fired every time the input content changes. Receives the input value as a parameter. Must return a promise which resolves to an array of SuggestionItems.
+     */
+    getSuggestions?: GetSuggestionsFunction<SuggestionItem>;
+    /**
+     * The helper text content that will be shown below the input.
+     */
+    helperText?: string;
+    /**
+     * Should the matching part of a suggestion be highlighted.
+     * @default true
+     */
+    highlightSuggestions?: boolean;
+    /**
+     * The label for the search field.
+     */
+    label: React.ReactNode;
+    /**
+     * Text to show for screen readers when loading spinner is no longer visible.
+     * @default "Finished loading suggestions"
+     */
+    loadingSpinnerFinishedText?: string;
+    /**
+     * Text to show for screen readers when loading spinner is visible.
+     * @default "Loading suggestions"
+     */
+    loadingSpinnerText?: string;
+    /**
+     * Callback function fired after search is triggered.
+     */
+    onSubmit: (value: string) => void;
+    /**
+     * Callback function fired after input value has changed. Required for a controlled component.
+     */
+    onChange?: (value: string) => void;
+    /**
+     * Placeholder text for the search input.
+     */
+    placeholder?: string;
+    /**
+     * The aria-label for the search button.
+     * @default Search
+     */
+    searchButtonAriaLabel?: string;
+    /**
+     * Hides the search button.
+     * @default false
+     */
+    hideSearchButton?: boolean;
+    /**
+     * Props that will be passed to the `<input>` element. Some props are omitted, because the component needs to control the input and for accessibility reasons.
+     */
+    inputProps?: Omit<
+      AllElementPropsWithoutRef<'input'>,
+      | 'aria-expanded'
+      | 'aria-haspopup'
+      | 'aria-owns'
+      | 'id'
+      | 'onChange'
+      | 'onKeyDown'
+      | 'onKeyUp'
+      | 'placeholder'
+      | 'role'
+    >;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    style?: React.CSSProperties;
+    /**
+     * Field of the SuggestionItem that represents the item key. Key needs to be unique between item.
+     * E.g. an `suggestionKeyField` value of `'bar'` and a suggestion item `{ foo: 'Label', bar: 'value' }`, would use `'value'` as the key in the menu for that specific item.
+     * Uses value of `suggestionLabelField` by default.
+     */
+    suggestionKeyField?: keyof SuggestionItem;
+    /**
+     * Field of the SuggestionItem that represents the item label.
+     * E.g. an `suggestionLabelField` value of `'foo'` and a suggestion item `{ foo: 'Label', bar: 'value' }`, would display `'Label'` in the menu for that specific suggestion.
+     */
+    suggestionLabelField?: keyof SuggestionItem;
+    /**
+     * The value of the input element, required for a controlled component. Remember to use onChange prop as well.
+     */
+    value?: string;
+    /**
+     * The number of suggestions that are visible in the menu before it becomes scrollable.
+     * @default 8
+     */
+    visibleSuggestions?: number;
+  }
+>;
 export const SearchInput = <SuggestionItem,>({
   className,
   clearButtonAriaLabel = 'Clear',
   getSuggestions,
   helperText,
   highlightSuggestions = false,
+  inputProps,
   label,
   loadingSpinnerFinishedText = 'Finished loading suggestions',
   loadingSpinnerText = 'Loading suggestions',
@@ -110,12 +129,12 @@ export const SearchInput = <SuggestionItem,>({
   placeholder,
   searchButtonAriaLabel = 'Search',
   hideSearchButton = false,
-  style,
   suggestionKeyField,
   suggestionLabelField,
   visibleSuggestions = 8,
   onChange,
   value,
+  ...restWrapperProps
 }: SearchInputProps<SuggestionItem>) => {
   const didMount = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -251,10 +270,12 @@ export const SearchInput = <SuggestionItem,>({
   }, [onChange, inputValue]);
 
   return (
-    <div className={classNames(styles.root, isOpen && styles.open, className)} style={style}>
+    <div {...restWrapperProps} className={classNames(styles.root, isOpen && styles.open, className)}>
       {label && <FieldLabel label={label} {...getLabelProps()} />}
       <div className={classNames(styles.wrapper)} ref={getComboboxProps().ref}>
         <input
+          enterKeyHint="search"
+          {...inputProps}
           {...getInputProps({
             onKeyUp: onInputKeyUp,
             onKeyDown: onInputKeyDown,
@@ -265,9 +286,8 @@ export const SearchInput = <SuggestionItem,>({
             'aria-haspopup': getComboboxProps()['aria-haspopup'],
             'aria-owns': getComboboxProps()['aria-owns'],
           })}
-          className={classNames(styles.input)}
+          className={classNames(styles.input, inputProps && inputProps.className)}
           placeholder={placeholder}
-          enterKeyHint="search"
         />
         <div className={styles.buttons}>
           {inputValue.length > 0 && (

--- a/packages/react/src/components/section/Section.stories.tsx
+++ b/packages/react/src/components/section/Section.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ArgsTable, Title } from '@storybook/addon-docs/blocks';
 
-import { Section } from './Section';
+import { Section, SectionProps } from './Section';
 import imageFile from '../../assets/img/placeholder_1920x1080.jpg';
 
 const placeholderTitle = 'Lorem ipsum';
@@ -102,7 +102,7 @@ export const Multiple = () => (
 );
 Multiple.storyName = 'Multiple sections';
 
-export const Playground = (args) => (
+export const Playground = (args: SectionProps & Record<string, string | null>) => (
   <Section color={args.color} korosType={args.korosType}>
     <h1 className="heading-xl">{args.sectionTitle}</h1>
     {args.sectionText}

--- a/packages/react/src/components/section/Section.test.tsx
+++ b/packages/react/src/components/section/Section.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Section } from './Section';
+import { Section, SectionProps } from './Section';
+import { getElementAttributesMisMatches, getCommonElementTestProps } from '../../utils/testHelpers';
 
 describe('<Section /> spec', () => {
   it('renders the component', () => {
@@ -13,5 +14,11 @@ describe('<Section /> spec', () => {
     const { container } = render(<Section />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps<'div', Pick<SectionProps, 'color'>>('div');
+    const { getByTestId } = render(<Section {...divProps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/section/Section.tsx
+++ b/packages/react/src/components/section/Section.tsx
@@ -3,21 +3,24 @@ import React from 'react';
 import '../../styles/base.module.css';
 import styles from './Section.module.css';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 import { Koros, KorosType } from '../koros';
 
 export type SectionColor = 'primary' | 'secondary' | 'tertiary' | 'plain';
 
-export type SectionProps = React.PropsWithChildren<{
-  color?: SectionColor;
-  className?: string;
-  korosType?: KorosType;
-}>;
+export type SectionProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    color?: SectionColor;
+    className?: string;
+    korosType?: KorosType;
+  }
+>;
 
-export const Section = ({ children, className = '', color = 'plain', korosType = null }: SectionProps) => {
+export const Section = ({ children, className = '', color = 'plain', korosType = null, ...rest }: SectionProps) => {
   const withKoros = korosType !== null;
 
   return (
-    <div className={classNames(styles.section, styles[color], withKoros && styles.withKoros, className)}>
+    <div {...rest} className={classNames(styles.section, styles[color], withKoros && styles.withKoros, className)}>
       {withKoros && <Koros type={korosType} className={`${styles.koros} ${styles.topKoros} ${styles[korosType]}`} />}
       <div className={styles.content}>{children}</div>
       {withKoros && (

--- a/packages/react/src/components/selectionGroup/SelectionGroup.test.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 
 import { SelectionGroup } from './SelectionGroup';
 import { Checkbox } from '../checkbox';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<SelectionGroup /> spec', () => {
   it('renders the component', () => {
@@ -22,5 +23,15 @@ describe('<SelectionGroup /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const fieldSetProps = getCommonElementTestProps<'fieldset'>('fieldset');
+    const { getByTestId } = render(
+      <SelectionGroup {...fieldSetProps}>
+        <Checkbox id="checkbox" label="Foo" />
+      </SelectionGroup>,
+    );
+    const element = getByTestId(fieldSetProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, fieldSetProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/selectionGroup/SelectionGroup.tsx
+++ b/packages/react/src/components/selectionGroup/SelectionGroup.tsx
@@ -6,11 +6,12 @@ import classNames from '../../utils/classNames';
 import { RequiredIndicator } from '../../internal/required-indicator/RequiredIndicator';
 import { Tooltip } from '../tooltip';
 import { getChildrenAsArray } from '../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type Direction = 'vertical' | 'horizontal';
 
 export type SelectionGroupProps = React.PropsWithChildren<
-  {
+  AllElementPropsWithoutRef<'fieldset'> & {
     /**
      * The label for the selection group.
      */
@@ -47,7 +48,7 @@ export type SelectionGroupProps = React.PropsWithChildren<
      * Additional class names
      */
     className?: string;
-  } & React.HTMLProps<HTMLFieldSetElement>
+  }
 >;
 
 export const SelectionGroup = ({

--- a/packages/react/src/components/sideNavigation/SideNavigation.stories.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { SideNavigation } from './SideNavigation';
+import { SideNavigation, SideNavigationProps } from './SideNavigation';
 import { IconHome } from '../../icons';
 
 export default {
@@ -24,7 +24,7 @@ const handleClick = (setActive) => (ev) => {
   setActive(ev.currentTarget.getAttribute('href'));
 };
 
-export const Default = (args) => {
+export const Default = (args: SideNavigationProps) => {
   const [active, setActive] = React.useState('/sub-level-1');
 
   return (
@@ -107,7 +107,7 @@ export const Default = (args) => {
   );
 };
 
-export const WithIcons = (args) => {
+export const WithIcons = (args: SideNavigationProps) => {
   const [active, setActive] = React.useState('/sub-level-2');
 
   return (
@@ -204,7 +204,7 @@ const skipLinkTheme = {
   '--top': '0px',
 };
 
-export const WithSkipLink = (args) => {
+export const WithSkipLink = (args: SideNavigationProps) => {
   const [active, setActive] = React.useState('/sub-level-1');
 
   return (
@@ -289,7 +289,7 @@ export const WithSkipLink = (args) => {
   );
 };
 
-export const CustomTheme = (args) => Default(args);
+export const CustomTheme = (args: SideNavigationProps) => Default(args);
 CustomTheme.args = {
   theme: {
     '--side-navigation-background-color': 'var(--color-white)',

--- a/packages/react/src/components/sideNavigation/SideNavigation.test.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
-import { SideNavigation } from './SideNavigation';
+import { SideNavigation, SideNavigationProps } from './SideNavigation';
 import { IconHome } from '../../icons';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 const labels = {
   mainLevel1: 'Main level 1',
@@ -50,6 +51,25 @@ describe('<SideNavigation /> spec', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps<'nav', Pick<SideNavigationProps, 'ariaLabel' | 'id'>>('nav');
+    // Element has prop "ariaLabel". It will override "aria-label".
+    divProps.ariaLabel = 'Real aria-label';
+    const { getByTestId } = render(
+      <SideNavigation {...divProps} toggleButtonLabel={labels.toggleButton} aria-label="This will be overridden">
+        <p>Hello</p>
+      </SideNavigation>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...divProps,
+        ariaLabel: undefined,
+        'aria-label': divProps.ariaLabel,
+      } as HTMLAttributes<HTMLElement>),
+    ).toHaveLength(0);
+  });
+
   it('should show sub level when main level is clicked', () => {
     render(
       <SideNavigation id="sideNavigation" toggleButtonLabel={labels.toggleButton}>
@@ -60,7 +80,7 @@ describe('<SideNavigation /> spec', () => {
     );
 
     expect(queryLink('subLevel1')).not.toBeInTheDocument();
-    userEvent.click(queryButton('mainLevel1'));
+    userEvent.click(queryButton('mainLevel1') as HTMLButtonElement);
     expect(queryLink('subLevel1')).toBeInTheDocument();
   });
 
@@ -115,22 +135,22 @@ describe('<SideNavigation /> spec', () => {
     expect(queryLink('subLevel1')).not.toBeInTheDocument();
     expect(queryLink('subLevel2')).not.toBeInTheDocument();
 
-    userEvent.click(mainLevelButton1);
+    userEvent.click(mainLevelButton1 as HTMLButtonElement);
     expect(mainLevelButton1).toHaveAttribute('aria-expanded', 'true');
     expect(queryLink('subLevel1')).toBeInTheDocument();
     expect(queryLink('subLevel2')).not.toBeInTheDocument();
 
-    userEvent.click(mainLevelButton2);
+    userEvent.click(mainLevelButton2 as HTMLButtonElement);
     expect(mainLevelButton2).toHaveAttribute('aria-expanded', 'true');
     expect(queryLink('subLevel1')).toBeInTheDocument();
     expect(queryLink('subLevel2')).toBeInTheDocument();
 
-    userEvent.click(mainLevelButton2);
+    userEvent.click(mainLevelButton2 as HTMLButtonElement);
     expect(mainLevelButton2).toHaveAttribute('aria-expanded', 'false');
     expect(queryLink('subLevel1')).toBeInTheDocument();
     expect(queryLink('subLevel2')).not.toBeInTheDocument();
 
-    userEvent.click(mainLevelButton1);
+    userEvent.click(mainLevelButton1 as HTMLButtonElement);
     expect(mainLevelButton1).toHaveAttribute('aria-expanded', 'false');
     expect(queryLink('subLevel1')).not.toBeInTheDocument();
     expect(queryLink('subLevel2')).not.toBeInTheDocument();

--- a/packages/react/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/sideNavigation/SideNavigation.tsx
@@ -13,6 +13,7 @@ import { MainLevel } from './mainLevel/MainLevel';
 import { SubLevel } from './subLevel/SubLevel';
 import { useTheme } from '../../hooks/useTheme';
 import { getChildrenAsArray } from '../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface SideNavigationCustomTheme {
   '--side-navigation-background-color'?: string;
@@ -31,36 +32,39 @@ export interface SideNavigationCustomTheme {
   '--side-navigation-mobile-menu-z-index'?: number;
 }
 
-export type SideNavigationProps = React.PropsWithChildren<{
-  /**
-   * Additional class names to apply to the side navigation
-   */
-  className?: string;
-  /**
-   * Default value for open main levels
-   */
-  defaultOpenMainLevels?: number[];
-  /**
-   * The id of the side navigation.
-   */
-  id: string;
-  /**
-   * aria-label for helping screen reader users to distinguish SideNavigation from other navigational components
-   */
-  ariaLabel?: string;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-  /**
-   * Custom theme styles
-   */
-  theme?: SideNavigationCustomTheme;
-  /**
-   * label for the mobile menu toggle button
-   */
-  toggleButtonLabel: string;
-}>;
+export type SideNavigationProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'nav'> & {
+    /**
+     * Additional class names to apply to the side navigation
+     */
+    className?: string;
+    /**
+     * Default value for open main levels
+     */
+    defaultOpenMainLevels?: number[];
+    /**
+     * The id of the side navigation.
+     */
+    id: string;
+    /**
+     * aria-label for helping screen reader users to distinguish SideNavigation from other navigational components
+     */
+    ariaLabel?: string;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    // eslint-disable-next-line react/no-unused-prop-types
+    style?: React.CSSProperties;
+    /**
+     * Custom theme styles
+     */
+    theme?: SideNavigationCustomTheme;
+    /**
+     * label for the mobile menu toggle button
+     */
+    toggleButtonLabel: string;
+  }
+>;
 
 export const SideNavigation = ({
   children,
@@ -68,9 +72,9 @@ export const SideNavigation = ({
   defaultOpenMainLevels = [],
   id,
   ariaLabel,
-  style,
   theme,
   toggleButtonLabel,
+  ...rest
 }: SideNavigationProps) => {
   const container = React.useRef<HTMLDivElement>(null);
   const customThemeClass = useTheme<SideNavigationCustomTheme>(styles.sideNavigation, theme);
@@ -137,11 +141,11 @@ export const SideNavigation = ({
       }}
     >
       <nav
+        {...rest}
         className={classNames(styles.sideNavigation, customThemeClass, className)}
         id={id}
         aria-label={ariaLabel}
         ref={container}
-        style={style}
       >
         {skipLink && skipLink}
         {/* Toggle button is visible only on small screen size */}

--- a/packages/react/src/components/statusLabel/StatusLabel.stories.tsx
+++ b/packages/react/src/components/statusLabel/StatusLabel.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StatusLabel } from './StatusLabel';
+import { StatusLabel, StatusLabelProps } from './StatusLabel';
 import { IconCheckCircle, IconInfoCircle, IconAlertCircle, IconError } from '../../icons';
 
 export default {
@@ -47,7 +47,9 @@ export const Icons = () => (
   </>
 );
 
-export const Playground = (args) => <StatusLabel type={args.type}>{args.label}</StatusLabel>;
+export const Playground = (args: StatusLabelProps & { label: string }) => (
+  <StatusLabel type={args.type}>{args.label}</StatusLabel>
+);
 
 Playground.parameters = {
   previewTabs: {

--- a/packages/react/src/components/statusLabel/StatusLabel.test.tsx
+++ b/packages/react/src/components/statusLabel/StatusLabel.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { StatusLabel, StatusLabelType } from './StatusLabel';
+import { StatusLabel, StatusLabelProps, StatusLabelType } from './StatusLabel';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<StatusLabel /> spec', () => {
   it('renders the component', () => {
@@ -13,6 +14,20 @@ describe('<StatusLabel /> spec', () => {
     const { container } = render(<StatusLabel />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const spanProps = getCommonElementTestProps<'span', Pick<StatusLabelProps, 'dataTestId'>>('span');
+    // Element has prop "dataTestId", but ..rest is applied after it so, data-testid will override it.
+    spanProps.dataTestId = 'This is overridden';
+    const { getByTestId } = render(<StatusLabel {...spanProps} />);
+    const element = getByTestId(spanProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...spanProps,
+        dataTestId: undefined,
+      } as unknown as HTMLAttributes<HTMLSpanElement>),
+    ).toHaveLength(0);
   });
 
   (['neutral', 'info', 'success', 'alert', 'error'] as StatusLabelType[]).map((status) =>

--- a/packages/react/src/components/statusLabel/StatusLabel.tsx
+++ b/packages/react/src/components/statusLabel/StatusLabel.tsx
@@ -3,28 +3,30 @@ import React from 'react';
 import '../../styles/base.module.css';
 import styles from './StatusLabel.module.css';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type StatusLabelType = 'neutral' | 'info' | 'success' | 'alert' | 'error';
 
-export type StatusLabelProps = React.PropsWithChildren<{
-  /**
-   * Additional class names to apply to the status label
-   */
-  className?: string;
-  /**
-   * Adds a data-testid attribute to the root element with the given value
-   */
-  dataTestId?: string;
-  /**
-   * The type of the status label
-   */
-  type?: StatusLabelType;
-  /**
-   * Element placed on the left side of the status label
-   */
-  iconLeft?: React.ReactNode;
-}>;
-
+export type StatusLabelProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'span'> & {
+    /**
+     * Additional class names to apply to the status label
+     */
+    className?: string;
+    /**
+     * Adds a data-testid attribute to the root element with the given value
+     */
+    dataTestId?: string;
+    /**
+     * The type of the status label
+     */
+    type?: StatusLabelType;
+    /**
+     * Element placed on the left side of the status label
+     */
+    iconLeft?: React.ReactNode;
+  }
+>;
 const IconElement = ({ icon }: { icon: React.ReactNode }) => (
   <span className={styles.statusLabelIcon} aria-hidden="true">
     {icon}

--- a/packages/react/src/components/stepByStep/StepByStep.stories.tsx
+++ b/packages/react/src/components/stepByStep/StepByStep.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StepByStep } from './StepByStep';
+import { StepByStep, StepByStepProps } from './StepByStep';
 
 export default {
   component: StepByStep,
@@ -51,14 +51,14 @@ export default {
   },
 };
 
-export const NumberedStepByStep = (args) => <StepByStep numberedList {...args} />;
+export const NumberedStepByStep = (args: StepByStepProps) => <StepByStep numberedList {...args} />;
 
 NumberedStepByStep.args = {
   title: 'Numbered step by step component',
   helpText: 'Numbered component is suitable for cases where the order of the steps is important.',
 };
 
-export const RegularStepByStep = (args) => <StepByStep {...args} />;
+export const RegularStepByStep = (args: StepByStepProps) => <StepByStep {...args} />;
 
 RegularStepByStep.args = {
   title: 'Numbered step by step component',

--- a/packages/react/src/components/stepByStep/StepByStep.test.tsx
+++ b/packages/react/src/components/stepByStep/StepByStep.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { StepByStep } from './StepByStep';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 const steps = [
   {
@@ -37,5 +38,11 @@ describe('<StepByStep /> spec', () => {
     const { container } = render(<StepByStep steps={steps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(<StepByStep {...divProps} steps={steps} />);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, { ...divProps })).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/stepByStep/StepByStep.tsx
+++ b/packages/react/src/components/stepByStep/StepByStep.tsx
@@ -5,6 +5,7 @@ import styles from './StepByStep.module.scss';
 import { Button, ButtonProps } from '../button';
 import classNames from '../../utils/classNames';
 import { Link, LinkProps } from '../link';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 type StepType = {
   /**
@@ -30,7 +31,7 @@ type StepType = {
   title: string;
 };
 
-type StepByStepPropsType = {
+type StepByStepProps = AllElementPropsWithoutRef<'div'> & {
   /**
    * Additional class names to apply to the container element.
    */
@@ -103,7 +104,7 @@ const StepComponent = ({ title, description, buttons = [], links = [] }: StepTyp
   );
 };
 
-export const StepByStep: FC<StepByStepPropsType> = ({
+export const StepByStep: FC<StepByStepProps> = ({
   className,
   title,
   helpText,
@@ -111,13 +112,14 @@ export const StepByStep: FC<StepByStepPropsType> = ({
   numberedList = false,
   headerClassName,
   headerLevel = 2,
+  ...rest
 }) => {
   const wrapperClassName = classNames(styles.container, className);
   const titleComponent =
     title && React.createElement(`h${headerLevel}`, { className: classNames(styles.title, headerClassName) }, title);
 
   return (
-    <div className={wrapperClassName}>
+    <div {...rest} className={wrapperClassName}>
       <div>
         {titleComponent}
         <p className={styles.description}>{helpText}</p>

--- a/packages/react/src/components/stepByStep/StepByStep.tsx
+++ b/packages/react/src/components/stepByStep/StepByStep.tsx
@@ -31,7 +31,7 @@ type StepType = {
   title: string;
 };
 
-type StepByStepProps = AllElementPropsWithoutRef<'div'> & {
+export type StepByStepProps = AllElementPropsWithoutRef<'div'> & {
   /**
    * Additional class names to apply to the container element.
    */

--- a/packages/react/src/components/stepper/Stepper.stories.tsx
+++ b/packages/react/src/components/stepper/Stepper.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useReducer, useRef } from 'react';
 
 import styles from './Stepper.module.scss';
-import { Stepper } from './Stepper';
+import { Stepper, StepperProps } from './Stepper';
 import { Step, StepState } from './Step';
 import { Button } from '../button';
 import { IconArrowLeft, IconArrowRight } from '../../icons';
@@ -80,7 +80,7 @@ const commonReducer = (stepsTotal) => (state, action) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Default = (args) => {
+export const Default = (args: StepperProps) => {
   const reducer = commonReducer(5);
 
   const initialState = {
@@ -162,7 +162,7 @@ Default.parameters = {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Small = (args) => {
+export const Small = (args: StepperProps) => {
   const reducer = commonReducer(5);
 
   const initialState = {
@@ -238,7 +238,7 @@ export const Small = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const WithStepHeading = (args) => {
+export const WithStepHeading = (args: StepperProps) => {
   const reducer = commonReducer(5);
 
   const initialState = {
@@ -316,7 +316,7 @@ export const WithStepHeading = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Overflow = (args) => {
+export const Overflow = (args: StepperProps) => {
   const reducer = commonReducer(12);
 
   const initialState = {
@@ -419,7 +419,7 @@ export const Overflow = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const WithCustomTheme = (args) => {
+export const WithCustomTheme = (args: StepperProps) => {
   const reducer = commonReducer(5);
 
   const initialState = {
@@ -511,7 +511,7 @@ WithCustomTheme.parameters = {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const SimpleFormExample = (args) => {
+export const SimpleFormExample = (args: StepperProps) => {
   const initialState = {
     showErrorSummary: false,
     activeStepIndex: 0,
@@ -725,6 +725,7 @@ export const SimpleFormExample = (args) => {
         onStepClick={(event, stepIndex) => {
           if (state.showErrorSummary && stepIndex !== state.activeStepIndex) {
             // focus to error summary label
+            // @ts-ignore
             errorRef.current.children[0].children[0].focus();
           }
           dispatch({ type: 'setActive', payload: stepIndex });
@@ -768,9 +769,9 @@ export const SimpleFormExample = (args) => {
               label="First name"
               invalid={state.fields.firstName.value.length === 0 && state.fields.firstName.visited === true}
               errorText={
-                state.fields.firstName.value.length === 0 &&
-                state.fields.firstName.visited === true &&
-                'Please enter your first name'
+                state.fields.firstName.value.length === 0 && state.fields.firstName.visited === true
+                  ? 'Please enter your first name'
+                  : ''
               }
               value={state.fields.firstName.value}
               onChange={(event) =>
@@ -786,9 +787,9 @@ export const SimpleFormExample = (args) => {
               label="Last name"
               invalid={state.fields.lastName.value.length === 0 && state.fields.lastName.visited === true}
               errorText={
-                state.fields.lastName.value.length === 0 &&
-                state.fields.lastName.visited === true &&
-                'Please enter your last name'
+                state.fields.lastName.value.length === 0 && state.fields.lastName.visited === true
+                  ? 'Please enter your last name'
+                  : ''
               }
               value={state.fields.lastName.value}
               onChange={(event) =>
@@ -806,9 +807,9 @@ export const SimpleFormExample = (args) => {
                 (!state.fields.age.value || state.fields.age.value.length === 0) && state.fields.age.visited === true
               }
               errorText={
-                (!state.fields.age.value || state.fields.age.value.length === 0) &&
-                state.fields.age.visited === true &&
-                'Please enter your age'
+                (!state.fields.age.value || state.fields.age.value.length === 0) && state.fields.age.visited === true
+                  ? 'Please enter your age'
+                  : ''
               }
               value={state.fields.age.value}
               onChange={(event) => dispatch({ type: 'changeField', fieldName: 'age', newValue: event.target.value })}
@@ -824,8 +825,9 @@ export const SimpleFormExample = (args) => {
               language="en"
               errorText={
                 (!state.fields.files.value || state.fields.files.value.length === 0) &&
-                state.fields.files.visited === true &&
-                'Please updload a file'
+                state.fields.files.visited === true
+                  ? 'Please updload a file'
+                  : ''
               }
               onChange={(event) => dispatch({ type: 'changeField', fieldName: 'files', newValue: event })}
             />
@@ -859,6 +861,7 @@ export const SimpleFormExample = (args) => {
           onClick={() => {
             if (state.showErrorSummary) {
               // focus to error summary label
+              // @ts-ignore
               errorRef.current.children[0].children[0].focus();
             }
             dispatch({ type: 'setActive', payload: state.activeStepIndex - 1 });
@@ -873,6 +876,7 @@ export const SimpleFormExample = (args) => {
           onClick={() => {
             if (state.showErrorSummary) {
               // focus to error summary label
+              // @ts-ignore
               errorRef.current.children[0].children[0].focus();
             }
             dispatch({ type: 'completeStep', payload: state.activeStepIndex });
@@ -889,7 +893,7 @@ export const SimpleFormExample = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const States = (args) => {
+export const States = (args: StepperProps) => {
   return (
     <div className={styles.stepperContainer}>
       <div
@@ -934,7 +938,7 @@ export const States = (args) => {
   );
 };
 
-export const Playground = (args) => {
+export const Playground = (args: StepperProps & { activeStepIndex: number } & Record<string, string>) => {
   const reducer = commonReducer(5);
 
   const [state, dispatch] = useReducer(reducer, {

--- a/packages/react/src/components/stepper/Stepper.test.tsx
+++ b/packages/react/src/components/stepper/Stepper.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Stepper } from './Stepper';
+import { Stepper, StepperProps } from './Stepper';
 import { StepState } from './Step';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Stepper /> spec', () => {
   let state;
@@ -85,5 +86,22 @@ describe('<Stepper /> spec', () => {
     const { container } = render(<Stepper language="en" steps={state.steps} selectedStep={state.activeStepIndex} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps<'div', Pick<StepperProps, 'dataTestId'>>('div');
+    // the component has "dataTestId" prop
+    divProps.dataTestId = divProps['data-testid'];
+    const { getByTestId } = render(
+      <Stepper language="en" steps={state.steps} selectedStep={state.activeStepIndex} {...divProps} />,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    // className is applied to another element
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...divProps,
+        dataTestId: undefined,
+        className: undefined,
+      } as HTMLAttributes<HTMLDivElement>),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/stepper/Stepper.tsx
+++ b/packages/react/src/components/stepper/Stepper.tsx
@@ -6,6 +6,7 @@ import { Step, StepState } from './Step';
 import classNames from '../../utils/classNames';
 import { IconAngleLeft, IconAngleRight } from '../../icons';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 type Language = 'en' | 'fi' | 'sv' | string;
 
@@ -55,7 +56,7 @@ type Steps = {
   label: string;
 }[];
 
-export type StepperProps = {
+export type StepperProps = AllElementPropsWithoutRef<'div'> & {
   /**
    * A custom className passed to stepper
    */
@@ -113,7 +114,6 @@ export type StepperProps = {
    */
   theme?: StepperCustomTheme; // Custom theme styles
 };
-
 const getStepHeading = (language: Language, stepIndex: number, totalNumberOfSteps: number, label: string) => {
   return {
     en: `Step ${stepIndex + 1}/${totalNumberOfSteps}: ${label}`,
@@ -137,6 +137,7 @@ export const Stepper = ({
   renderCustomStepHeading,
   steps,
   theme,
+  ...rest
 }: StepperProps) => {
   const stepsTotal = steps.length;
   const initialRender = useRef(true);
@@ -186,7 +187,12 @@ export const Stepper = ({
   }, [selectedStep]);
 
   return (
-    <div lang={language} className={classNames(styles.stepperContainer, customThemeClass)} data-testid={dataTestId}>
+    <div
+      {...rest}
+      lang={language}
+      className={classNames(styles.stepperContainer, customThemeClass)}
+      data-testid={dataTestId}
+    >
       {showPreviousButton && (
         <div className={classNames(styles.scrollButton, styles.scrollButtonPrevious)} aria-hidden="true">
           {/*  eslint-disable-next-line jsx-a11y/control-has-associated-label */}

--- a/packages/react/src/components/table/Table.stories.tsx
+++ b/packages/react/src/components/table/Table.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { parse, isBefore, isSameDay } from 'date-fns';
 
-import { Table } from './Table';
+import { Table, TableProps } from './Table';
 import workTrial from './story-example-work-trial.json';
 import { Button } from '../button';
 import { IconTrash } from '../../icons';
@@ -18,7 +18,7 @@ export default {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Default = (args) => {
+export const Default = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -55,7 +55,7 @@ export const Default = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Light = (args) => {
+export const Light = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -92,7 +92,7 @@ export const Light = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Dense = (args) => {
+export const Dense = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -129,7 +129,7 @@ export const Dense = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Zebra = (args) => {
+export const Zebra = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -206,7 +206,7 @@ export const Zebra = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const VerticalLines = (args) => {
+export const VerticalLines = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -243,7 +243,7 @@ export const VerticalLines = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const VerticalHeaders = (args) => {
+export const VerticalHeaders = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: '8-12', headerName: '8-12' },
@@ -291,7 +291,7 @@ export const VerticalHeaders = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const Sorting = (args) => {
+export const Sorting = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name', isSortable: true },
@@ -340,7 +340,7 @@ export const Sorting = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const SortingLightVariant = (args) => {
+export const SortingLightVariant = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name', isSortable: true },
@@ -390,7 +390,7 @@ export const SortingLightVariant = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const InitiallySortedBy = (args) => {
+export const InitiallySortedBy = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name', isSortable: true },
@@ -441,7 +441,7 @@ export const InitiallySortedBy = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomSortFunction = (args) => {
+export const CustomSortFunction = (args: TableProps) => {
   const cols = [
     { key: 'Paikka-ID', headerName: 'Paikka-ID', isSortable: true },
     { key: 'Paikan tyyppi', headerName: 'Paikan tyyppi', isSortable: false },
@@ -517,7 +517,7 @@ export const CustomSortFunction = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const SortingSideEffects = (args) => {
+export const SortingSideEffects = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name', isSortable: true },
@@ -589,7 +589,7 @@ SortingSideEffects.parameters = {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CheckboxSelection = (args) => {
+export const CheckboxSelection = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -611,7 +611,7 @@ export const CheckboxSelection = (args) => {
     { id: 1003, firstName: 'Osku', surname: 'Rausku', age: 18, profession: 'Mail Carrier' },
   ];
 
-  const [selectedRows, setSelectedRows] = useState([]);
+  const [selectedRows, setSelectedRows] = useState<Array<string | number>>([]);
 
   return (
     <div style={{ maxWidth: '640px' }}>
@@ -635,7 +635,7 @@ export const CheckboxSelection = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CheckboxSelectionDense = (args) => {
+export const CheckboxSelectionDense = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -657,7 +657,7 @@ export const CheckboxSelectionDense = (args) => {
     { id: 1003, firstName: 'Osku', surname: 'Rausku', age: 18, profession: 'Mail Carrier' },
   ];
 
-  const [selectedRows, setSelectedRows] = useState([]);
+  const [selectedRows, setSelectedRows] = useState<Array<string | number>>([]);
 
   return (
     <div style={{ maxWidth: '500px' }}>
@@ -682,7 +682,7 @@ export const CheckboxSelectionDense = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const InitiallySelectedRows = (args) => {
+export const InitiallySelectedRows = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -704,7 +704,7 @@ export const InitiallySelectedRows = (args) => {
     { id: 1003, firstName: 'Osku', surname: 'Rausku', age: 18, profession: 'Mail Carrier' },
   ];
 
-  const [selectedRows, setSelectedRows] = useState([1002, 1003]);
+  const [selectedRows, setSelectedRows] = useState<Array<string | number>>([1002, 1003]);
 
   return (
     <div style={{ maxWidth: '640px' }}>
@@ -729,7 +729,7 @@ export const InitiallySelectedRows = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const WithCustomActions = (args) => {
+export const WithCustomActions = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -754,7 +754,7 @@ export const WithCustomActions = (args) => {
   ];
 
   const [tableRows, setTableRows] = useState(rows);
-  const [selectedRows, setSelectedRows] = useState([]);
+  const [selectedRows, setSelectedRows] = useState<Array<string | number>>([]);
 
   const deleteSelectedButton = (
     <Button
@@ -829,7 +829,7 @@ export const WithCustomActions = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CheckboxSelectionWithSorting = (args) => {
+export const CheckboxSelectionWithSorting = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name', isSortable: true },
@@ -854,7 +854,7 @@ export const CheckboxSelectionWithSorting = (args) => {
     { id: 1004, firstName: 'Linda', surname: 'Koululainen', age: 8, profession: 'School student' },
   ];
 
-  const [selectedRows, setSelectedRows] = useState([]);
+  const [selectedRows, setSelectedRows] = useState<Array<string | number>>([]);
 
   return (
     <div style={{ maxWidth: '640px' }}>
@@ -881,7 +881,7 @@ export const CheckboxSelectionWithSorting = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomBackgroundColorsForDarkVariant = (args) => {
+export const CustomBackgroundColorsForDarkVariant = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },
@@ -931,7 +931,7 @@ export const CustomBackgroundColorsForDarkVariant = (args) => {
 
 // args is required for docs tab to show source code
 // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-export const CustomBackgroundColorsForLightVariant = (args) => {
+export const CustomBackgroundColorsForLightVariant = (args: TableProps) => {
   const cols = [
     { key: 'id', headerName: 'Not rendered' },
     { key: 'firstName', headerName: 'First name' },

--- a/packages/react/src/components/table/Table.test.tsx
+++ b/packages/react/src/components/table/Table.test.tsx
@@ -1,9 +1,10 @@
 import { screen, render } from '@testing-library/react';
-import React, { useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 
-import { Table } from './Table';
+import { Table, TableProps } from './Table';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Table /> spec', () => {
   let cols;
@@ -67,6 +68,22 @@ describe('<Table /> spec', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('native html props are passed to the element', async () => {
+    const tableProps = getCommonElementTestProps<'table', Pick<TableProps, 'dataTestId'>>('table');
+    // the component has "dataTestId" prop
+    tableProps.dataTestId = tableProps['data-testid'];
+    const { getByTestId } = render(
+      <Table {...tableProps} caption={caption} cols={cols} rows={rows} indexKey={indexKey} renderIndexCol />,
+    );
+    const element = getByTestId(tableProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...tableProps,
+        dataTestId: undefined,
+      } as HTMLAttributes<HTMLTableElement>),
+    ).toHaveLength(0);
+  });
+
   it('Should successfully sort the table', () => {
     const colsWithSorting = [
       { key: 'id', headerName: 'Not rendered' },
@@ -97,7 +114,7 @@ describe('<Table /> spec', () => {
     );
     const ageOfFirstRow = container.querySelector('[data-testid="age-0"] > div');
     expect(ageOfFirstRow).toHaveTextContent('39');
-    userEvent.click(container.querySelector('[data-testid="hds-table-sorting-header-age"]'));
+    userEvent.click(container.querySelector('[data-testid="hds-table-sorting-header-age"]') as HTMLButtonElement);
     const ageOfSortedTableFirstRow = container.querySelector('[data-testid="age-0"] > div');
     expect(ageOfSortedTableFirstRow).toHaveTextContent('8');
   });
@@ -134,14 +151,14 @@ describe('<Table /> spec', () => {
       />,
     );
 
-    userEvent.click(container.querySelector('[data-testid="hds-table-sorting-header-age"]'));
+    userEvent.click(container.querySelector('[data-testid="hds-table-sorting-header-age"]') as HTMLButtonElement);
 
     expect(mockOnSort).toHaveBeenCalledTimes(1);
   });
 
   it('Should successfully select and deselect a single row', () => {
     const TableWithSelection = () => {
-      const [selectedRows, setSelectedRows] = useState([]);
+      const [selectedRows, setSelectedRows] = useState<Array<string | number>>([]);
       return (
         <Table
           checkboxSelection
@@ -161,16 +178,16 @@ describe('<Table /> spec', () => {
 
     expect(container.querySelector('[id="hds-table-id-checkbox-1000"]')).not.toBeChecked();
 
-    userEvent.click(container.querySelector('[id="hds-table-id-checkbox-1000"]'));
+    userEvent.click(container.querySelector('[id="hds-table-id-checkbox-1000"]') as HTMLButtonElement);
     expect(container.querySelector('[id="hds-table-id-checkbox-1000"]')).toBeChecked();
 
-    userEvent.click(container.querySelector('[id="hds-table-id-checkbox-1000"]'));
+    userEvent.click(container.querySelector('[id="hds-table-id-checkbox-1000"]') as HTMLButtonElement);
     expect(container.querySelector('[id="hds-table-id-checkbox-1000"]')).not.toBeChecked();
   });
 
   it('Should successfully select all and deselect all rows', () => {
     const TableWithSelection = () => {
-      const [selectedRows, setSelectedRows] = useState([]);
+      const [selectedRows, setSelectedRows] = useState<Array<string | number>>([]);
       return (
         <Table
           checkboxSelection
@@ -192,12 +209,18 @@ describe('<Table /> spec', () => {
       expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).not.toBeChecked();
     });
 
-    userEvent.click(container.querySelector('[data-testid="hds-table-select-all-button-hds-table-data-testid"]'));
+    userEvent.click(
+      container.querySelector('[data-testid="hds-table-select-all-button-hds-table-data-testid"]') as HTMLButtonElement,
+    );
     rows.forEach((row) => {
       expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).toBeChecked();
     });
 
-    userEvent.click(container.querySelector('[data-testid="hds-table-deselect-all-button-hds-table-data-testid"]'));
+    userEvent.click(
+      container.querySelector(
+        '[data-testid="hds-table-deselect-all-button-hds-table-data-testid"]',
+      ) as HTMLButtonElement,
+    );
     rows.forEach((row) => {
       expect(container.querySelector(`[id="hds-table-id-checkbox-${row.id}"]`)).not.toBeChecked();
     });

--- a/packages/react/src/components/table/Table.tsx
+++ b/packages/react/src/components/table/Table.tsx
@@ -11,6 +11,7 @@ import { Checkbox } from '../checkbox';
 import { useTheme } from '../../hooks/useTheme';
 import { Button } from '../button';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 type Header = {
   /**
@@ -50,7 +51,7 @@ export interface TableCustomTheme {
 
 type SelectedRow = string | number;
 
-export type TableProps = {
+export type TableProps = AllElementPropsWithoutRef<'table'> & {
   /**
    * Aria-label for checkbox selection.
    * @default 'Rivin valinta'
@@ -194,7 +195,7 @@ export type TableProps = {
    * Boolean indicating whether the table has alternating row colors zebra style.
    */
   zebra?: boolean;
-} & React.ComponentPropsWithoutRef<'table'>;
+};
 
 const processRows = (rows, order, sorting, cols) => {
   const sortingEnabled = cols.some((column) => {

--- a/packages/react/src/components/tabs/Tabs.test.tsx
+++ b/packages/react/src/components/tabs/Tabs.test.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import React from 'react';
 
-import { Tabs } from './Tabs';
-import { TabList } from './TabList';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 import { Tab } from './Tab';
+import { TabList } from './TabList';
 import { TabPanel } from './TabPanel';
+import { Tabs } from './Tabs';
 
 describe('<Tabs /> spec', () => {
   it('renders the component', () => {
@@ -36,6 +37,17 @@ describe('<Tabs /> spec', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <Tabs {...divProps}>
+        <TabPanel>Buzz</TabPanel>
+      </Tabs>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 
   it('should call onClick when user clicks tab', () => {

--- a/packages/react/src/components/tabs/Tabs.tsx
+++ b/packages/react/src/components/tabs/Tabs.tsx
@@ -10,6 +10,7 @@ import { TabList } from './TabList';
 import { TabPanel } from './TabPanel';
 import { Tab } from './Tab';
 import { getChildElementsEvenIfContainersInbetween } from '../../utils/getChildren';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export interface TabsCustomTheme {
   '--tablist-border-color'?: string;
@@ -25,23 +26,25 @@ export interface TabsCustomTheme {
   '--tab-focus-outline-color'?: string;
 }
 
-export type TabsProps = React.PropsWithChildren<{
-  /**
-   * The initially active tab
-   */
-  initiallyActiveTab?: number;
-  /**
-   * Use the small variant
-   * @default false
-   */
-  small?: boolean;
-  /**
-   * Defines the tabs theme
-   */
-  theme?: TabsCustomTheme;
-}>;
+export type TabsProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * The initially active tab
+     */
+    initiallyActiveTab?: number;
+    /**
+     * Use the small variant
+     * @default false
+     */
+    small?: boolean;
+    /**
+     * Defines the tabs theme
+     */
+    theme?: TabsCustomTheme;
+  }
+>;
 
-export const Tabs = ({ children, initiallyActiveTab = 0, small = false, theme }: TabsProps) => {
+export const Tabs = ({ children, initiallyActiveTab = 0, small = false, theme, className, ...rest }: TabsProps) => {
   const [activeTab, setActiveTab] = useState<number>(initiallyActiveTab);
   const [focusedTab, setFocusedTab] = useState<number>(null);
   // custom theme class that is applied to the root element
@@ -74,7 +77,7 @@ export const Tabs = ({ children, initiallyActiveTab = 0, small = false, theme }:
 
   return (
     <TabsContext.Provider value={{ activeTab, setActiveTab, focusedTab, setFocusedTab }}>
-      <div className={classNames(styles.tabs, small && styles.small, theme && customThemeClass)}>
+      <div {...rest} className={classNames(styles.tabs, small && styles.small, theme && customThemeClass, className)}>
         {tabList}
         {tabPanels}
       </div>

--- a/packages/react/src/components/tag/Tag.stories.tsx
+++ b/packages/react/src/components/tag/Tag.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { Tag } from './Tag';
+import { Tag, TagProps } from './Tag';
 
 export default {
   component: Tag,
@@ -14,16 +14,15 @@ export default {
   },
 };
 
-export const DefaultTag = (args) => <Tag {...args} />;
+export const DefaultTag = (args: TagProps) => <Tag {...args} />;
 
-export const DefaultTagClickable = (args) => (
+export const DefaultTagClickable = (args: TagProps) => (
   <>
-    <Tag {...args} label="Link" role="link" id="link" onClick={() => action(`Click: ${args.children}`)()}>
+    <Tag {...args} role="link" id="link" onClick={() => action(`Click: ${args.children}`)()}>
       {args.children}
     </Tag>
     <Tag
       {...args}
-      label="Button"
       role="button"
       id="button"
       style={{ marginLeft: 'var(--spacing-s)' }}
@@ -34,12 +33,12 @@ export const DefaultTagClickable = (args) => (
   </>
 );
 
-export const DefaultTagDeletable = (args) => {
+export const DefaultTagDeletable = (args: TagProps) => {
   return (
     <Tag
       {...args}
       deleteButtonAriaLabel={`Delete item: ${args.children}`}
-      srOnlyLabel
+      srOnlyLabel="Tag label for screen readers"
       onDelete={() => action(`Delete item: ${args.children}`)()}
     >
       {args.children}
@@ -47,7 +46,7 @@ export const DefaultTagDeletable = (args) => {
   );
 };
 
-export const DefaultTagWithCustomTheme = (args) => (
+export const DefaultTagWithCustomTheme = (args: TagProps) => (
   <Tag {...args} onClick={() => action(`Click: ${args.children}`)()}>
     {args.children}
   </Tag>
@@ -61,7 +60,7 @@ DefaultTagWithCustomTheme.args = {
   },
 };
 
-export const LargeTag = (args) => {
+export const LargeTag = (args: TagProps) => {
   return (
     <Tag {...args} size="l">
       {args.children}
@@ -69,7 +68,7 @@ export const LargeTag = (args) => {
   );
 };
 
-export const LargeTagDeletable = (args) => {
+export const LargeTagDeletable = (args: TagProps) => {
   return (
     <Tag
       {...args}
@@ -82,13 +81,13 @@ export const LargeTagDeletable = (args) => {
   );
 };
 
-export const DefaultTagWithLongText = (args) => (
+export const DefaultTagWithLongText = (args: TagProps) => (
   <Tag {...args} style={{ maxWidth: '300px' }}>
     Label - This is a tag with a very long text which is not advisable and might span into multiple lines
   </Tag>
 );
 
-export const DefaultTagWithLongTextAndDeletable = (args) => (
+export const DefaultTagWithLongTextAndDeletable = (args: TagProps) => (
   <Tag
     {...args}
     style={{ maxWidth: '300px' }}
@@ -99,13 +98,13 @@ export const DefaultTagWithLongTextAndDeletable = (args) => (
   </Tag>
 );
 
-export const LargeTagWithLongText = (args) => (
+export const LargeTagWithLongText = (args: TagProps) => (
   <Tag {...args} size="l" style={{ maxWidth: '300px' }}>
     Label - This is a tag with a very long text which is not advisable and might span into multiple lines
   </Tag>
 );
 
-export const LargeTagWithLongTextAndDeletable = (args) => (
+export const LargeTagWithLongTextAndDeletable = (args: TagProps) => (
   <Tag
     {...args}
     size="l"

--- a/packages/react/src/components/tag/Tag.test.tsx
+++ b/packages/react/src/components/tag/Tag.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
-import { Tag } from './Tag';
+import { Tag, TagProps } from './Tag';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Tag /> spec', () => {
   it('renders the component', () => {
@@ -30,5 +31,11 @@ describe('<Tag /> spec', () => {
     const { container } = render(<Tag>Foo</Tag>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps<'div', Pick<TagProps, 'onClick' | 'role'>>('div');
+    const { getByTestId } = render(<Tag {...divProps}>Foo</Tag>);
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/tag/Tag.tsx
+++ b/packages/react/src/components/tag/Tag.tsx
@@ -5,6 +5,7 @@ import styles from './Tag.module.scss';
 import { IconCross } from '../../icons';
 import classNames from '../../utils/classNames';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
 export interface TagCustomTheme {
   '--tag-background'?: string;
@@ -12,71 +13,73 @@ export interface TagCustomTheme {
   '--tag-focus-outline-color'?: string;
 }
 
-export type TagProps = {
-  /**
-   * The label for the tag
-   */
-  children: React.ReactNode;
-  /**
-   * Additional class names to apply to the tag
-   */
-  className?: string;
-  /**
-   * The aria-label for the delete button
-   * @deprecated Will be removed in the next major release.
-   */
-  deleteButtonAriaLabel?: string;
-  /**
-   * Prop will be passed to the delete button `<button>` element. It also hides the default label from screen readers to prevent confusion with labels when present.
-   * @deprecated Will be removed in the next major release.
-   */
-  deleteButtonProps?: React.ComponentPropsWithoutRef<'button'>;
-  /**
-   * Used to generate the first part of the id on the elements.
-   * Default value `hds-tag` will be removed in the next major release.
-   */
-  id?: string;
-  /**
-   * Additional class names to apply to the tag's label element
-   * @deprecated Will be removed in the next major release.
-   */
-  labelClassName?: string;
-  /**
-   * Props that will be passed to the label `<span>` element.
-   * @deprecated Will be removed in the next major release.
-   */
-  labelProps?: React.ComponentPropsWithoutRef<'span'>;
-  /**
-   * Callback function fired when the tag is clicked. If set, the tag will be clickable.
-   */
-  onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>) => void;
-  /**
-   * Callback function fired when the delete icon is clicked. If set, a delete button will be shown.
-   */
-  onDelete?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  /**
-   * Sets the role of the tag when it's clickable. Uses 'link' by default.
-   * @deprecated Usage will change in the next major release.
-   */
-  role?: 'link' | 'button';
-  /**
-   * Size variant for the Tag.
-   * @default 'm'
-   * @deprecated Will change in the next major release.
-   */
-  size?: 'm' | 'l';
-  /**
-   * The label is only visible to screen readers. Can be used to give screen reader users additional information about the tag.
-   * @deprecated Will be removed in the next major release.
-   */
-  srOnlyLabel?: string;
-  /**
-   * Custom theme styles
-   * Will contain more properties in the next major release.
-   */
-  theme?: TagCustomTheme;
-};
-
+export type TagProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'div'>,
+  {
+    /**
+     * The label for the tag
+     */
+    children: React.ReactNode;
+    /**
+     * Additional class names to apply to the tag
+     */
+    className?: string;
+    /**
+     * The aria-label for the delete button
+     * @deprecated Will be removed in the next major release.
+     */
+    deleteButtonAriaLabel?: string;
+    /**
+     * Prop will be passed to the delete button `<button>` element. It also hides the default label from screen readers to prevent confusion with labels when present.
+     * @deprecated Will be removed in the next major release.
+     */
+    deleteButtonProps?: React.ComponentPropsWithoutRef<'button'>;
+    /**
+     * Used to generate the first part of the id on the elements.
+     * Default value `hds-tag` will be removed in the next major release.
+     */
+    id?: string;
+    /**
+     * Additional class names to apply to the tag's label element
+     * @deprecated Will be removed in the next major release.
+     */
+    labelClassName?: string;
+    /**
+     * Props that will be passed to the label `<span>` element.
+     * @deprecated Will be removed in the next major release.
+     */
+    labelProps?: React.ComponentPropsWithoutRef<'span'>;
+    /**
+     * Callback function fired when the tag is clicked. If set, the tag will be clickable.
+     */
+    onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>) => void;
+    /**
+     * Callback function fired when the delete icon is clicked. If set, a delete button will be shown.
+     */
+    onDelete?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    /**
+     * Sets the role of the tag when it's clickable. Uses 'link' by default.
+     * @deprecated Usage will change in the next major release.
+     */
+    role?: 'link' | 'button';
+    /**
+     * Size variant for the Tag.
+     * @default 'm'
+     * @deprecated Will change in the next major release.
+     */
+    size?: 'm' | 'l';
+    /**
+     * The label is only visible to screen readers. Can be used to give screen reader users additional information about the tag.
+     * @deprecated Will be removed in the next major release.
+     */
+    srOnlyLabel?: string;
+    /**
+     * Custom theme styles
+     * Will contain more properties in the next major release.
+     */
+    theme?: TagCustomTheme;
+  }
+>;
 export const Tag = forwardRef<HTMLDivElement, TagProps>(
   (
     {

--- a/packages/react/src/components/textInput/TextInput.stories.tsx
+++ b/packages/react/src/components/textInput/TextInput.stories.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 
-import { TextInput } from './TextInput';
+import { TextInput, TextInputProps } from './TextInput';
 import { Button } from '../button';
 import { IconSearch } from '../../icons';
 
@@ -73,7 +73,7 @@ export const UsingRef = () => {
 };
 UsingRef.storyName = 'Using ref';
 
-export const Playground = (args) => (
+export const Playground = (args: TextInputProps & { tooltipButtonAriaLabelText: string }) => (
   <TextInput
     id={args.id}
     label={args.label}
@@ -118,8 +118,8 @@ Playground.args = {
   tooltipButtonAriaLabelText: 'Tooltip',
 };
 
-export const SimpleSearchInput = (args) => {
-  const [inputValue, setInputValue] = React.useState('');
+export const SimpleSearchInput = (args: TextInputProps) => {
+  const [inputValue, setInputValue] = React.useState<string>('');
   const ref = useRef<HTMLInputElement>(null);
 
   const doSearch = (value: string | undefined) => {
@@ -158,7 +158,7 @@ export const SimpleSearchInput = (args) => {
 
 SimpleSearchInput.storyName = 'As search input';
 
-export const SimpleSearchInputWithDefaultValue = (args) => {
+export const SimpleSearchInputWithDefaultValue = (args: TextInputProps) => {
   return <SimpleSearchInput {...args} defaultValue="test input" />;
 };
 

--- a/packages/react/src/components/textInput/TextInput.test.tsx
+++ b/packages/react/src/components/textInput/TextInput.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react-dom/test-utils';
 
 import { TextInput, TextInputProps } from './TextInput';
 import { IconSearch } from '../../icons';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<TextInput /> spec', () => {
   const textInputProps: TextInputProps = {
@@ -22,6 +23,15 @@ describe('<TextInput /> spec', () => {
     const { container } = render(<TextInput {...textInputProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+  it('Native html props are passed to the element', async () => {
+    const inputProps = getCommonElementTestProps<'input', { defaultValue: string; value: string }>('input');
+    const { getByTestId } = render(<TextInput {...textInputProps} {...inputProps} />);
+    const element = getByTestId(inputProps['data-testid']);
+    // id, className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, { ...inputProps, id: undefined, style: undefined, className: undefined }),
+    ).toHaveLength(0);
   });
   it('renders the component with tooltip', () => {
     const { asFragment } = render(

--- a/packages/react/src/components/textInput/TextInput.tsx
+++ b/packages/react/src/components/textInput/TextInput.tsx
@@ -6,122 +6,126 @@ import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
 import classNames from '../../utils/classNames';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
 import { IconCrossCircle } from '../../icons';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
-export type TextInputProps = {
-  /**
-   * Additional class names to apply to the text input
-   */
-  className?: string;
-  /**
-   * The aria-label for the clear button.
-   * @default 'Clear'
-   */
-  clearButtonAriaLabel?: string;
-  /**
-   * Use clear button
-   */
-  clearButton?: boolean;
-  /**
-   * Additional children to render after the input.
-   */
-  children?: React.ReactNode;
-  /**
-   * The default input element value. Use when the component is not controlled
-   */
-  defaultValue?: string;
-  /**
-   * If `true`, the input will be disabled
-   */
-  disabled?: boolean;
-  /**
-   * The error text content that will be shown below the input
-   */
-  errorText?: string;
-  /**
-   * The helper text content that will be shown below the input
-   */
-  helperText?: string;
-  /**
-   * Hides the label above the input
-   */
-  hideLabel?: boolean;
-  /**
-   * The id of the input element
-   */
-  id: string;
-  /**
-   * If `true`, the input will be displayed in an invalid state.
-   */
-  invalid?: boolean;
-  /**
-   * The label for the input
-   */
-  label?: string | React.ReactNode;
-  /**
-   * Callback fired when the state is changed
-   */
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  /**
-   * Button click callback
-   */
-  onButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
-  /**
-   * Short hint displayed in the input before the user enters a value
-   */
-  placeholder?: string;
-  /**
-   * If `true`, prevents the user from changing the value of the field (not from interacting with the field)
-   */
-  readOnly?: boolean;
-  /**
-   * If `true`, the label is displayed as required and the `input` element will be required
-   */
-  required?: boolean;
-  /**
-   * Override or extend the styles applied to the component
-   */
-  style?: React.CSSProperties;
-  /**
-   * The success text content that will be shown below the input
-   */
-  successText?: string;
-  /**
-   * The info text content that will be shown below the input
-   */
-  infoText?: string;
-  /**
-   * Aria-label text for the tooltip
-   */
-  tooltipLabel?: string;
-  /**
-   * Aria-label text for the tooltip trigger button
-   */
-  tooltipButtonLabel?: string;
-  /**
-   * The text content of the tooltip
-   */
-  tooltipText?: string;
-  /**
-   * Type of the input element
-   */
-  type?: string;
-  /**
-   * The value of the input element, required for a controlled component
-   */
-  value?: string;
-  /**
-   * The `ref` is forwarded to the native input element.
-   */
-  ref?: React.Ref<HTMLInputElement>;
-  /**
-   * Button icon
-   */
-  buttonIcon?: React.ReactNode;
-  /**
-   * Button aria-label
-   */
-  buttonAriaLabel?: string;
-} & React.ComponentPropsWithoutRef<'input'>;
+export type TextInputProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'input'>,
+  {
+    /**
+     * Additional class names to apply to the text input
+     */
+    className?: string;
+    /**
+     * The aria-label for the clear button.
+     * @default 'Clear'
+     */
+    clearButtonAriaLabel?: string;
+    /**
+     * Use clear button
+     */
+    clearButton?: boolean;
+    /**
+     * Additional children to render after the input.
+     */
+    children?: React.ReactNode;
+    /**
+     * The default input element value. Use when the component is not controlled
+     */
+    defaultValue?: string;
+    /**
+     * If `true`, the input will be disabled
+     */
+    disabled?: boolean;
+    /**
+     * The error text content that will be shown below the input
+     */
+    errorText?: string;
+    /**
+     * The helper text content that will be shown below the input
+     */
+    helperText?: string;
+    /**
+     * Hides the label above the input
+     */
+    hideLabel?: boolean;
+    /**
+     * The id of the input element
+     */
+    id: string;
+    /**
+     * If `true`, the input will be displayed in an invalid state.
+     */
+    invalid?: boolean;
+    /**
+     * The label for the input
+     */
+    label?: string | React.ReactNode;
+    /**
+     * Callback fired when the state is changed
+     */
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    /**
+     * Button click callback
+     */
+    onButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
+    /**
+     * Short hint displayed in the input before the user enters a value
+     */
+    placeholder?: string;
+    /**
+     * If `true`, prevents the user from changing the value of the field (not from interacting with the field)
+     */
+    readOnly?: boolean;
+    /**
+     * If `true`, the label is displayed as required and the `input` element will be required
+     */
+    required?: boolean;
+    /**
+     * Override or extend the styles applied to the component
+     */
+    style?: React.CSSProperties;
+    /**
+     * The success text content that will be shown below the input
+     */
+    successText?: string;
+    /**
+     * The info text content that will be shown below the input
+     */
+    infoText?: string;
+    /**
+     * Aria-label text for the tooltip
+     */
+    tooltipLabel?: string;
+    /**
+     * Aria-label text for the tooltip trigger button
+     */
+    tooltipButtonLabel?: string;
+    /**
+     * The text content of the tooltip
+     */
+    tooltipText?: string;
+    /**
+     * Type of the input element
+     */
+    type?: string;
+    /**
+     * The value of the input element, required for a controlled component
+     */
+    value?: string;
+    /**
+     * The `ref` is forwarded to the native input element.
+     */
+    ref?: React.Ref<HTMLInputElement>;
+    /**
+     * Button icon
+     */
+    buttonIcon?: React.ReactNode;
+    /**
+     * Button aria-label
+     */
+    buttonAriaLabel?: string;
+  }
+>;
 
 export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   (

--- a/packages/react/src/components/textarea/TextArea.stories.tsx
+++ b/packages/react/src/components/textarea/TextArea.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
-import { TextArea } from './TextArea';
+import { TextArea, TextAreaProps } from './TextArea';
 
 const textAreaProps = {
   helperText: 'Assistive text',
@@ -55,7 +55,7 @@ export const WithTooltip = () => (
 );
 WithTooltip.storyName = 'With tooltip';
 
-export const Playground = (args) => (
+export const Playground = (args: TextAreaProps & Record<string, string>) => (
   <TextArea
     id={args.id}
     label={args.label}

--- a/packages/react/src/components/textarea/TextArea.test.tsx
+++ b/packages/react/src/components/textarea/TextArea.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { TextArea, TextAreaProps } from './TextArea';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<Textarea /> spec', () => {
   const textAreaProps: TextAreaProps = {
@@ -27,5 +28,17 @@ describe('<Textarea /> spec', () => {
       <TextArea tooltipText="Tooltip text" tooltipLabel="Tooltip label" {...textAreaProps} />,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('native html props are passed to the element', async () => {
+    const textAreaAdditionalProps = getCommonElementTestProps<
+      'textarea',
+      Pick<TextAreaProps, 'value' | 'onChange' | 'defaultValue'>
+    >('textarea');
+    const { getByTestId } = render(<TextArea {...textAreaProps} {...textAreaAdditionalProps} />);
+    const element = getByTestId(textAreaAdditionalProps['data-testid']);
+    // className and style is set to the input element, others to wrapper
+    expect(
+      getElementAttributesMisMatches(element, { ...textAreaAdditionalProps, className: undefined, style: undefined }),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/textarea/TextArea.tsx
+++ b/packages/react/src/components/textarea/TextArea.tsx
@@ -4,89 +4,93 @@ import '../../styles/base.module.css';
 import styles from '../textInput/TextInput.module.css';
 import { InputWrapper } from '../../internal/input-wrapper/InputWrapper';
 import composeAriaDescribedBy from '../../utils/composeAriaDescribedBy';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
-export type TextAreaProps = {
-  /**
-   * Additional class names to apply to the textarea
-   */
-  className?: string;
-  /**
-   * The default textarea element value. Use when the component is not controlled
-   */
-  defaultValue?: string;
-  /**
-   * If `true`, the textarea will be disabled
-   */
-  disabled?: boolean;
-  /**
-   * The error text content that will be shown below the textarea
-   */
-  errorText?: string;
-  /**
-   * The helper text content that will be shown below the textarea
-   */
-  helperText?: string;
-  /**
-   * Hides the label above the textarea
-   */
-  hideLabel?: boolean;
-  /**
-   * The id of the textarea element
-   */
-  id: string;
-  /**
-   * If `true`, the textarea and `helperText` will be displayed in an invalid state.
-   */
-  invalid?: boolean;
-  /**
-   * The label for the textarea
-   */
-  label?: string | React.ReactNode;
-  /**
-   * Callback fired when the state is changed
-   */
-  onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
-  /**
-   * Short hint displayed in the textarea before the user enters a value
-   */
-  placeholder?: string;
-  /**
-   * If `true`, the label is displayed as required and the `textarea` element will be required
-   */
-  required?: boolean;
-  /**
-   * Override or extend the styles applied to the component. See text field [tokens](https://city-of-helsinki.github.io/helsinki-design-system/components/text-field#tokens) for available CSS variables
-   */
-  style?: React.CSSProperties;
-  /**
-   * The success text content that will be shown below the text area
-   */
-  successText?: string;
-  /**
-   * The info text content that will be shown below the text area
-   */
-  infoText?: string;
-  /**
-   * Aria-label text for the tooltip
-   */
-  tooltipLabel?: string;
-  /**
-   * Aria-label text for the tooltip trigger button
-   */
-  tooltipButtonLabel?: string;
-  /**
-   * The text content of the tooltip
-   */
-  tooltipText?: string;
-  /**
-   * The value of the textarea element, required for a controlled component
-   */
-  value?: string;
-  /**
-   * The `ref` is forwarded to the native textarea element.
-   */
-  ref?: React.Ref<HTMLTextAreaElement>;
-} & React.ComponentPropsWithoutRef<'textarea'>;
+export type TextAreaProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'textarea'>,
+  {
+    /**
+     * Additional class names to apply to the textarea
+     */
+    className?: string;
+    /**
+     * The default textarea element value. Use when the component is not controlled
+     */
+    defaultValue?: string;
+    /**
+     * If `true`, the textarea will be disabled
+     */
+    disabled?: boolean;
+    /**
+     * The error text content that will be shown below the textarea
+     */
+    errorText?: string;
+    /**
+     * The helper text content that will be shown below the textarea
+     */
+    helperText?: string;
+    /**
+     * Hides the label above the textarea
+     */
+    hideLabel?: boolean;
+    /**
+     * The id of the textarea element
+     */
+    id: string;
+    /**
+     * If `true`, the textarea and `helperText` will be displayed in an invalid state.
+     */
+    invalid?: boolean;
+    /**
+     * The label for the textarea
+     */
+    label?: string | React.ReactNode;
+    /**
+     * Callback fired when the state is changed
+     */
+    onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
+    /**
+     * Short hint displayed in the textarea before the user enters a value
+     */
+    placeholder?: string;
+    /**
+     * If `true`, the label is displayed as required and the `textarea` element will be required
+     */
+    required?: boolean;
+    /**
+     * Override or extend the styles applied to the component. See text field [tokens](https://city-of-helsinki.github.io/helsinki-design-system/components/text-field#tokens) for available CSS variables
+     */
+    style?: React.CSSProperties;
+    /**
+     * The success text content that will be shown below the text area
+     */
+    successText?: string;
+    /**
+     * The info text content that will be shown below the text area
+     */
+    infoText?: string;
+    /**
+     * Aria-label text for the tooltip
+     */
+    tooltipLabel?: string;
+    /**
+     * Aria-label text for the tooltip trigger button
+     */
+    tooltipButtonLabel?: string;
+    /**
+     * The text content of the tooltip
+     */
+    tooltipText?: string;
+    /**
+     * The value of the textarea element, required for a controlled component
+     */
+    value?: string;
+    /**
+     * The `ref` is forwarded to the native textarea element.
+     */
+    ref?: React.Ref<HTMLTextAreaElement>;
+  }
+>;
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (

--- a/packages/react/src/components/timeInput/TimeInput.stories.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { TimeInput } from './TimeInput';
+import { TimeInput, TimeInputProps } from './TimeInput';
 
 export default {
   component: TimeInput,
@@ -20,18 +20,18 @@ export default {
   },
 };
 
-export const Default = (args) => {
+export const Default = (args: TimeInputProps) => {
   return <TimeInput {...args} />;
 };
 
-export const Invalid = (args) => <TimeInput {...args} />;
+export const Invalid = (args: TimeInputProps) => <TimeInput {...args} />;
 Invalid.args = {
   id: 'Invalid',
   invalid: true,
   errorText: 'Invalid value',
 };
 
-export const Success = (args) => <TimeInput {...args} />;
+export const Success = (args: TimeInputProps) => <TimeInput {...args} />;
 Success.args = {
   id: 'Default',
   successText: 'Valid value',

--- a/packages/react/src/components/timeInput/TimeInput.test.tsx
+++ b/packages/react/src/components/timeInput/TimeInput.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 import { TimeInput, TimeInputProps } from './TimeInput';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<TimeInput /> spec', () => {
   const inputProps: TimeInputProps = {
@@ -30,6 +31,23 @@ describe('<TimeInput /> spec', () => {
     const { container } = render(<TimeInput {...inputProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const additionalInputProps = getCommonElementTestProps<'input', Pick<TimeInputProps, 'value' | 'defaultValue'>>(
+      'input',
+    );
+    const { getByTestId } = render(<TimeInput {...additionalInputProps} {...inputProps} />);
+    const element = getByTestId(additionalInputProps['data-testid']);
+    // id, className and style are set to the wrapper element, others to input
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...additionalInputProps,
+        id: undefined,
+        style: undefined,
+        className: undefined,
+      }),
+    ).toHaveLength(0);
   });
 
   it('should use value property as input value', async () => {

--- a/packages/react/src/components/toggleButton/ToggleButton.stories.tsx
+++ b/packages/react/src/components/toggleButton/ToggleButton.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { ToggleButton } from './ToggleButton';
+import { ToggleButton, ToggleButtonProps } from './ToggleButton';
 
 export default {
   component: ToggleButton,
@@ -16,7 +16,7 @@ export default {
   },
 };
 
-export const Default = (args) => {
+export const Default = (args: ToggleButtonProps) => {
   const [checked, setChecked] = useState<boolean>(args.checked);
   const [oppositeChecked, setOppositeChecked] = useState<boolean>(!args.checked);
   return (
@@ -34,7 +34,7 @@ export const Default = (args) => {
   );
 };
 
-export const Disabled = (args) => {
+export const Disabled = (args: ToggleButtonProps) => {
   const [checked, setChecked] = useState(false);
   const [oppositeChecked, setOppositeChecked] = useState<boolean>(!args.checked);
 
@@ -57,7 +57,7 @@ Disabled.args = {
   disabled: true,
 };
 
-export const WithTooltip = (args) => {
+export const WithTooltip = (args: ToggleButtonProps) => {
   const [checked, setChecked] = useState<boolean>(args.checked);
   return <ToggleButton {...args} label="Allow notifications" checked={checked} onChange={() => setChecked(!checked)} />;
 };
@@ -71,7 +71,7 @@ WithTooltip.args = {
 
 WithTooltip.storyName = 'With tooltip';
 
-export const Inline = (args) => {
+export const Inline = (args: ToggleButtonProps) => {
   const [checked, setChecked] = useState<boolean>(args.checked);
   const [checkedWithTooltip, setCheckedWithTooltip] = useState<boolean>(args.checked);
 
@@ -109,7 +109,7 @@ Inline.args = {
 
 WithTooltip.storyName = 'With tooltip';
 
-export const CustomTheme = (args) => {
+export const CustomTheme = (args: ToggleButtonProps) => {
   const customThemes = [
     {
       id: 'error',
@@ -159,8 +159,8 @@ CustomTheme.args = {
 
 CustomTheme.storyName = 'Custom theme';
 
-export const Playground = (args) => {
-  const [checked, setChecked] = useState(args.value);
+export const Playground = (args: ToggleButtonProps) => {
+  const [checked, setChecked] = useState(!!args.value);
 
   return (
     <ToggleButton

--- a/packages/react/src/components/toggleButton/ToggleButton.test.tsx
+++ b/packages/react/src/components/toggleButton/ToggleButton.test.tsx
@@ -3,7 +3,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
-import { ToggleButton } from './ToggleButton';
+import { ToggleButton, ToggleButtonProps } from './ToggleButton';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<ToggleButton /> spec', () => {
   it('renders the component', () => {
@@ -52,5 +53,11 @@ describe('<ToggleButton /> spec', () => {
     const button = screen.getByRole('button', { pressed: false });
     userEvent.click(button);
     expect(checked).toBeTruthy();
+  });
+  it('native html props are passed to the element', async () => {
+    const buttonProps = getCommonElementTestProps<'button', Pick<ToggleButtonProps, 'id'>>('button');
+    const { getByTestId } = render(<ToggleButton {...buttonProps} checked onChange={() => null} label="Test label" />);
+    const element = getByTestId(buttonProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, buttonProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/toggleButton/ToggleButton.tsx
+++ b/packages/react/src/components/toggleButton/ToggleButton.tsx
@@ -6,6 +6,7 @@ import classNames from '../../utils/classNames';
 import { IconCrossCircleFill, IconCheckCircleFill } from '../../icons';
 import { Tooltip } from '../tooltip/Tooltip';
 import { useTheme } from '../../hooks/useTheme';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 export type ToggleButtonVariant = 'default' | 'inline';
 
@@ -14,7 +15,7 @@ export interface ToggleButtonCustomTheme {
   '--toggle-button-hover-color'?: string;
 }
 
-export type ToggleButtonProps = {
+export type ToggleButtonProps = AllElementPropsWithoutRef<'button'> & {
   /**
    * The id of the button element
    */
@@ -70,6 +71,8 @@ export const ToggleButton = React.forwardRef<HTMLButtonElement, ToggleButtonProp
       tooltipText,
       variant = 'default',
       theme,
+      className,
+      ...rest
     }: ToggleButtonProps,
     ref: React.Ref<HTMLButtonElement>,
   ) => {
@@ -99,13 +102,14 @@ export const ToggleButton = React.forwardRef<HTMLButtonElement, ToggleButtonProp
           )}
         </div>
         <button
+          {...rest}
           id={id}
           ref={ref}
           disabled={disabled}
           type="button"
           aria-pressed={checked}
           aria-labelledby={labelId}
-          className={styles.toggleButton}
+          className={classNames(styles.toggleButton, className)}
           onClick={() => {
             onChange(checked);
           }}

--- a/packages/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Tooltip } from './Tooltip';
+import { Tooltip, TooltipProps } from './Tooltip';
 
 export default {
   component: Tooltip,
@@ -10,19 +10,19 @@ export default {
   },
 };
 
-export const Default = (args) => (
+export const Default = (args: TooltipProps) => (
   <Tooltip {...args}>
     Tooltips contain &quot;nice to have&quot; information. Default Tooltip contents should not be longer than two to
     three sentences. For longer descriptions, provide a link to a separate page.
   </Tooltip>
 );
 
-export const Small = (args) => <Tooltip {...args}>Less than five words long</Tooltip>;
+export const Small = (args: TooltipProps) => <Tooltip {...args}>Less than five words long</Tooltip>;
 Small.args = {
   small: true,
 };
 
-export const WithBoxShadow = (args) => (
+export const WithBoxShadow = (args: TooltipProps) => (
   <Tooltip {...args} boxShadow>
     Tooltips contain &quot;nice to have&quot; information. Default Tooltip contents should not be longer than two to
     three sentences. For longer descriptions, provide a link to a separate page.

--- a/packages/react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import { Tooltip } from './Tooltip';
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 
 describe('<TooltipNew /> spec', () => {
   it('renders the component', () => {
@@ -37,5 +38,23 @@ describe('<TooltipNew /> spec', () => {
     fireEvent.click(getByRole('button'));
     waitFor(() => getByRole('section'));
     expect(asFragment()).toMatchSnapshot();
+  });
+  it('native html props are passed to the element', async () => {
+    const divProps = getCommonElementTestProps('div');
+    const { getByTestId } = render(
+      <Tooltip
+        {...divProps}
+        small
+        placement="auto"
+        buttonLabel="Tooltip button"
+        tooltipLabel="Tooltip label"
+        buttonClassName="buttonClassName"
+        tooltipClassName="tooltipClassName"
+      >
+        Tooltip content
+      </Tooltip>,
+    );
+    const element = getByTestId(divProps['data-testid']);
+    expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/tooltip/Tooltip.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.tsx
@@ -6,41 +6,44 @@ import '../../styles/base.module.css';
 import styles from './Tooltip.module.scss';
 import { IconQuestionCircle } from '../../icons/IconQuestionCircle';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-type TooltipProps = React.PropsWithChildren<{
-  /**
-   * Boolean indicating whether tooltip has box shadow or not.
-   */
-  boxShadow?: boolean;
-  /**
-   * The placement of the tooltip.
-   */
-  placement?: Placement;
-  /**
-   * Use the small tooltip variant.
-   */
-  small?: boolean;
-  /**
-   * Aria-label text for the tooltip trigger button.
-   */
-  buttonLabel?: string;
-  /**
-   * Aria-label text for the tooltip.
-   */
-  tooltipLabel?: string;
-  /**
-   * Additional wrapper class names.
-   */
-  className?: string;
-  /**
-   * Additional button class names.
-   */
-  buttonClassName?: string;
-  /**
-   * Additional tooltip class names.
-   */
-  tooltipClassName?: string;
-}>;
+export type TooltipProps = React.PropsWithChildren<
+  AllElementPropsWithoutRef<'div'> & {
+    /**
+     * Boolean indicating whether tooltip has box shadow or not.
+     */
+    boxShadow?: boolean;
+    /**
+     * The placement of the tooltip.
+     */
+    placement?: Placement;
+    /**
+     * Use the small tooltip variant.
+     */
+    small?: boolean;
+    /**
+     * Aria-label text for the tooltip trigger button.
+     */
+    buttonLabel?: string;
+    /**
+     * Aria-label text for the tooltip.
+     */
+    tooltipLabel?: string;
+    /**
+     * Additional wrapper class names.
+     */
+    className?: string;
+    /**
+     * Additional button class names.
+     */
+    buttonClassName?: string;
+    /**
+     * Additional tooltip class names.
+     */
+    tooltipClassName?: string;
+  }
+>;
 
 export const Tooltip = ({
   boxShadow = false,
@@ -52,6 +55,7 @@ export const Tooltip = ({
   className,
   buttonClassName,
   tooltipClassName,
+  ...rest
 }: TooltipProps) => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -118,7 +122,7 @@ export const Tooltip = ({
   });
 
   return (
-    <div className={classNames(styles.root, className)}>
+    <div {...rest} className={classNames(styles.root, className)}>
       <button
         ref={buttonRef}
         type="button"

--- a/packages/react/src/internal/input-wrapper/InputWrapper.tsx
+++ b/packages/react/src/internal/input-wrapper/InputWrapper.tsx
@@ -3,8 +3,9 @@ import React, { FocusEvent } from 'react';
 import styles from '../../components/textInput/TextInput.module.css';
 import classNames from '../../utils/classNames';
 import { FieldLabel } from '../field-label/FieldLabel';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
-type InputWrapperProps = {
+export type InputWrapperProps = AllElementPropsWithoutRef<'div'> & {
   children?: React.ReactNode;
   className?: string;
   errorText?: string;
@@ -24,7 +25,7 @@ type InputWrapperProps = {
   tooltipText?: string;
   tooltipButtonLabel?: string;
   ref?: React.Ref<HTMLDivElement>;
-} & React.ComponentPropsWithoutRef<'div'>;
+};
 
 export const InputWrapper = React.forwardRef<HTMLDivElement, InputWrapperProps>(
   (

--- a/packages/react/src/internal/skipLink/SkipLink.test.tsx
+++ b/packages/react/src/internal/skipLink/SkipLink.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { AnchorHTMLAttributes } from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { getCommonElementTestProps, getElementAttributesMisMatches } from '../../utils/testHelpers';
 import { SkipLink } from './SkipLink';
 
 describe('<SkipToContentLink /> spec', () => {
@@ -15,5 +16,27 @@ describe('<SkipToContentLink /> spec', () => {
     userEvent.tab();
     expect(asFragment()).toMatchSnapshot();
     expect(getByText(/skip to content/)).toBeVisible();
+  });
+
+  it('native html props are passed to the element', async () => {
+    const linkProps = getCommonElementTestProps<'a'>('a');
+    // SkipLink has "ariaLabel", which should override "aria-label"
+    linkProps['aria-label'] = 'Real ariaLabel';
+    const { getByTestId } = render(
+      <SkipLink
+        skipTo="content"
+        label="skip to content"
+        aria-label="Is overridden"
+        ariaLabel="Real ariaLabel"
+        {...linkProps}
+      />,
+    );
+    const element = getByTestId(linkProps['data-testid']);
+    expect(
+      getElementAttributesMisMatches(element, {
+        ...linkProps,
+        href: '#content',
+      } as AnchorHTMLAttributes<HTMLAnchorElement>),
+    ).toHaveLength(0);
   });
 });

--- a/packages/react/src/internal/skipLink/SkipLink.tsx
+++ b/packages/react/src/internal/skipLink/SkipLink.tsx
@@ -4,6 +4,7 @@ import '../../styles/base.module.css';
 import styles from './SkipLink.module.scss';
 import { useTheme } from '../../hooks/useTheme';
 import classNames from '../../utils/classNames';
+import { AllElementPropsWithoutRef } from '../../utils/elementTypings';
 
 // custom theme for skip link position
 export interface SkipLinkTheme {
@@ -11,7 +12,7 @@ export interface SkipLinkTheme {
   '--top'?: string;
 }
 
-export type SkipLinkProps = {
+export type SkipLinkProps = AllElementPropsWithoutRef<'a'> & {
   /**
    * aria-label for describing SkipLink for screen readers.
    */
@@ -29,12 +30,17 @@ export type SkipLinkProps = {
    */
   theme?: SkipLinkTheme;
 };
-export const SkipLink = ({ ariaLabel, label, skipTo, theme }: SkipLinkProps) => {
+export const SkipLink = ({ ariaLabel, label, skipTo, theme, className, ...rest }: SkipLinkProps) => {
   const href = skipTo.startsWith('#') ? skipTo : `#${skipTo}`;
   const customThemeClass = useTheme<SkipLinkTheme>(styles.skipLink, theme);
 
   return (
-    <a href={href} aria-label={ariaLabel} className={classNames(styles.skipLink, customThemeClass)}>
+    <a
+      {...rest}
+      href={href}
+      aria-label={ariaLabel}
+      className={classNames(styles.skipLink, customThemeClass, className)}
+    >
       <span className={styles.skipLinkLabel}>{label}</span>
     </a>
   );

--- a/packages/react/src/utils/commonHTMLAttributes.ts
+++ b/packages/react/src/utils/commonHTMLAttributes.ts
@@ -1,0 +1,3 @@
+export type CommonHTMLAttributes = {
+  [key: `data-${string}`]: string;
+};

--- a/packages/react/src/utils/elementTypings.ts
+++ b/packages/react/src/utils/elementTypings.ts
@@ -1,0 +1,17 @@
+import React, { ElementType } from 'react';
+
+import { CommonHTMLAttributes } from './commonHTMLAttributes';
+
+// Good explanation about types: https://mortenbarklund.com/blog/react-typescript-props-spread/
+export type AllElementPropsWithoutRef<E extends ElementType> = React.ComponentPropsWithoutRef<E> & CommonHTMLAttributes;
+// Use "AllElementPropsWithRef" instead of "JSX.IntrinsicElements"
+// Note: JSX.IntrinsicElements always passes a ref as a prop which has the LegacyRef type rather than Ref
+export type AllElementPropsWithRef<E extends ElementType> = React.ComponentProps<E> & CommonHTMLAttributes;
+/** 
+ * example:
+  type Base = { a: undefined; b: boolean; c: string };
+  type Overrides = { a: string; b: string; d: string; e: number };
+  type Result = MergeAndOverrideProps<Base, Overrides>;
+  const test: Result = { a: 'a', b: 'f', c: 'c', d: 'd', e: 1 };
+ */
+export type MergeAndOverrideProps<E, C> = Omit<E, keyof C> & C;

--- a/packages/react/src/utils/testHelpers.ts
+++ b/packages/react/src/utils/testHelpers.ts
@@ -1,4 +1,4 @@
-import { ElementType, HTMLAttributes, HTMLProps } from 'react';
+import { ElementType, AnchorHTMLAttributes, HTMLAttributes, HTMLProps } from 'react';
 
 import { CommonHTMLAttributes } from './commonHTMLAttributes';
 import { AllElementPropsWithoutRef, MergeAndOverrideProps } from './elementTypings';
@@ -80,6 +80,7 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
     div: HTMLAttributes<HTMLDivElement>;
     // HTMLAttributes<HTMLInput> does not work properly.
     input: HTMLProps<'input'>;
+    a: AnchorHTMLAttributes<HTMLAnchorElement>;
   } = {
     all: {
       'data-testid': 'testId',
@@ -96,6 +97,11 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
       maxLength: 10,
       pattern: '[A-Za-z]{3}',
       required: true,
+    },
+    a: {
+      href: 'href',
+      target: '_blank',
+      rel: 'rel',
     },
   };
   return { ...nativeProps.all, ...nativeProps[elem.toLowerCase()], ...extraTestAttributes };

--- a/packages/react/src/utils/testHelpers.ts
+++ b/packages/react/src/utils/testHelpers.ts
@@ -1,4 +1,4 @@
-import { ElementType, AnchorHTMLAttributes, HTMLAttributes, HTMLProps } from 'react';
+import { ElementType, AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, HTMLProps } from 'react';
 
 import { CommonHTMLAttributes } from './commonHTMLAttributes';
 import { AllElementPropsWithoutRef, MergeAndOverrideProps } from './elementTypings';
@@ -49,7 +49,7 @@ export function getElementAttributesMisMatches<T = HTMLElement>(
       // <input required=""> matches required:true
       const attributeValueAsBoolean = attributeValue === '' || !!attributeValue;
       if (attributeValueAsBoolean !== value) {
-        mismatches.push(`Attribute "${key}" value "${attributeValue}" mismatches expected value  ${value}.`);
+        mismatches.push(`Attribute "${key}" value "${attributeValue}" mismatches expected value  "${value}".`);
       }
     } else if (key === 'className') {
       if (!String(elem.getAttribute('class')).includes(value)) {
@@ -78,6 +78,7 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
   const nativeProps: {
     all: HTMLAttributes<HTMLElement> & CommonHTMLAttributes;
     div: HTMLAttributes<HTMLDivElement>;
+    button: ButtonHTMLAttributes<HTMLButtonElement>;
     // HTMLAttributes<HTMLInput> does not work properly.
     input: HTMLProps<'input'>;
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
@@ -102,6 +103,10 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
       href: 'href',
       target: '_blank',
       rel: 'rel',
+    },
+    button: {
+      type: 'button',
+      name: 'buttonName',
     },
   };
   return { ...nativeProps.all, ...nativeProps[elem.toLowerCase()], ...extraTestAttributes };

--- a/packages/react/src/utils/testHelpers.ts
+++ b/packages/react/src/utils/testHelpers.ts
@@ -88,6 +88,7 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
     button: ButtonHTMLAttributes<HTMLButtonElement>;
     // HTMLAttributes<HTMLInput> does not work properly.
     input: HTMLProps<'input'>;
+    textarea: HTMLProps<'textarea'>;
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
     img: ImgHTMLAttributes<HTMLImageElement>;
   } = {
@@ -105,6 +106,10 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
     input: {
       maxLength: 10,
       pattern: '[A-Za-z]{3}',
+      required: true,
+    },
+    textarea: {
+      maxLength: 500,
       required: true,
     },
     a: {

--- a/packages/react/src/utils/testHelpers.ts
+++ b/packages/react/src/utils/testHelpers.ts
@@ -1,4 +1,11 @@
-import { ElementType, AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, HTMLProps } from 'react';
+import {
+  ElementType,
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  HTMLProps,
+  ImgHTMLAttributes,
+} from 'react';
 
 import { CommonHTMLAttributes } from './commonHTMLAttributes';
 import { AllElementPropsWithoutRef, MergeAndOverrideProps } from './elementTypings';
@@ -82,6 +89,7 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
     // HTMLAttributes<HTMLInput> does not work properly.
     input: HTMLProps<'input'>;
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
+    img: ImgHTMLAttributes<HTMLImageElement>;
   } = {
     all: {
       'data-testid': 'testId',
@@ -107,6 +115,12 @@ export function getCommonElementTestProps<T extends ElementType = 'div', C = unk
     button: {
       type: 'button',
       name: 'buttonName',
+    },
+    img: {
+      height: 100,
+      width: 100,
+      loading: 'lazy',
+      useMap: '#mapName',
     },
   };
   return { ...nativeProps.all, ...nativeProps[elem.toLowerCase()], ...extraTestAttributes };

--- a/site/src/components/NativeElementPropsInfo.js
+++ b/site/src/components/NativeElementPropsInfo.js
@@ -1,0 +1,132 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ExternalLink from './ExternalLink';
+
+/**
+ * Helper component to display information about native element props the component supports.
+ * Some attributes may be omitted and those can be listed with "notAllowed".
+ *
+ * Can also show information when a prop overrides a native prop. Some components use "ariaLabel" or "dataTestId" custom props.
+ * Most used prop overrides are pre-set as constants "ariaLabel"/"dataTestId". Other overrides can be added by providing the data in format "used/overwritten".
+ *
+ * Some components have element props that are not all set to one element. That may be confusing, so information about it should be shown.
+ *
+ */
+
+const NativeElementPropsInfo = ({ nodeName, splitProps, overlappingProps, notAllowed }) => {
+  const ElementInfo = () => (
+    <p>
+      This component also accepts all native
+      <ExternalLink href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${nodeName}#attributes`}>
+        <code>{nodeName}</code> element props
+      </ExternalLink>
+      {notAllowed && notAllowed.length ? (
+        <>
+          , except{' '}
+          {notAllowed.map((attr, index) => (
+            <>
+              <code>{attr}</code>
+              <>{index < notAllowed.length - 1 ? ', ' : ''}</>
+            </>
+          ))}{' '}
+          attribute(s)
+        </>
+      ) : (
+        ''
+      )}
+      .
+    </p>
+  );
+
+  const SplitTags = () => {
+    if (splitProps.length === 0) {
+      return '';
+    }
+    const propList = splitProps.join(', ');
+    return (
+      <>
+        {' '}
+        (<code>{propList}</code>){' '}
+      </>
+    );
+  };
+
+  const SplitInfo = () => {
+    // if splitProps are defined, but array is empty, the text is displayed but tag list is not seen.
+    if (splitProps) {
+      return (
+        <p>
+          {' '}
+          Some native element props <SplitTags /> are split into multiple children in the component.
+        </p>
+      );
+    }
+    return null;
+  };
+
+  const Overlaps = () => {
+    const getPropTuple = (prop) => {
+      if (prop === 'ariaLabel') {
+        return {
+          used: 'ariaLabel',
+          overwritten: 'aria-label',
+        };
+      }
+      if (prop === 'dataTestId') {
+        return {
+          used: 'dataTestId',
+          overwritten: 'data-testid',
+        };
+      }
+      const [used, overwritten] = prop.split('/');
+      return {
+        used,
+        overwritten,
+      };
+    };
+    return (
+      <ul>
+        {overlappingProps.map((prop) => {
+          const { used, overwritten } = getPropTuple(prop);
+          if (!used || !overwritten) {
+            return null;
+          }
+          return (
+            <li>
+              <code>{used}</code> overrides the <code>{overwritten}</code>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  const OverlapInfo = () => {
+    if (overlappingProps && overlappingProps.length) {
+      return (
+        <p>
+          Following component properties override their native counterparts: <Overlaps />
+        </p>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <>
+      <ElementInfo />
+      <OverlapInfo />
+      <SplitInfo />
+    </>
+  );
+};
+
+NativeElementPropsInfo.propTypes = {
+  nodeName: PropTypes.string.isRequired,
+  notAllowed: PropTypes.arrayOf(PropTypes.string),
+  splitProps: PropTypes.arrayOf(PropTypes.string),
+  overlappingProps: PropTypes.oneOf('ariaLabel', 'dataTestId', PropTypes.string),
+};
+
+export default NativeElementPropsInfo;

--- a/site/src/docs/components/accordion/code.mdx
+++ b/site/src/docs/components/accordion/code.mdx
@@ -5,6 +5,7 @@ title: 'Accordion - Code'
 
 import { Accordion, useAccordion, Button, Card, Select, IconAngleDown, IconAngleUp } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -184,3 +185,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `card`          | If set to true, the accordion will use HDS Card as its background element.     | `boolean` | false         |
 | `closeButton`   | If set to true, a close button is shown at the bottom of an expanded accordion | `boolean` | true          |
 | `initiallyOpen` | If set to true, the accordion will be initially opened.                        | `boolean` | false         |
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/accordion/customisation.mdx
+++ b/site/src/docs/components/accordion/customisation.mdx
@@ -24,6 +24,8 @@ You can use the `theme` property to customise the component. See all available t
 | <code>--content-line-height</code>        | Line height of the accordion content.           |
 | <code>--header-font-color</code>          | Font colour of the accordion header.            |
 | <code>--header-font-size</code>           | Font size of the accodion header.               |
+| <code>--header-font-weight</code>         | Font weight of the accodion header.             |
+| <code>--header-letter-spacing</code>      | Letter spacing of the accodion header.          |
 | <code>--header-line-height</code>         | Line height of the accordion header.            |
 | <code>--padding-horizontal</code>         | Left and right padding of the accordion.        |
 | <code>--padding-vertical</code>           | Top and bottom padding of the accordion.        |

--- a/site/src/docs/components/breadcrumb/code.mdx
+++ b/site/src/docs/components/breadcrumb/code.mdx
@@ -5,6 +5,8 @@ title: 'Breadcrumb - Code'
 
 import { Breadcrumb, IconDocument, IconEnvelope, IconPhone, IconPhoto } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
+
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -78,3 +80,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | ----------- | ------------------------------------------------------------------------- | ---------------------- | ------------- |
 | `ariaLabel` | `aria-label` of the `<nav>` element created by the component              | `string`               | -             |
 | `list`      | Array of breadcrumb items. Each item is an object with `title` and `path` | `BreadcrumbListItem[]` | -             |
+
+<NativeElementPropsInfo
+  nodeName="nav"
+  overlappingProps={['ariaLabel']}
+/>

--- a/site/src/docs/components/buttons/code.mdx
+++ b/site/src/docs/components/buttons/code.mdx
@@ -5,6 +5,7 @@ title: 'Button - Code'
 
 import { Button, IconTrash, IconAngleRight, Notification, IconShare, IconSaveDisketteFill } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -289,3 +290,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `fullWidth`   | If set to true, the button will take full width of its container. | `boolean`                                                          | false         |
 | `isLoading`   | If set to true, a loading spinner is displayed inside the button. | `boolean`                                                          | false         |
 | `loadingText` | Visible loading text to be shown next to the loading spinner.     | `string`                                                           | -             |
+
+<NativeElementPropsInfo nodeName="button" />

--- a/site/src/docs/components/card/code.mdx
+++ b/site/src/docs/components/card/code.mdx
@@ -5,6 +5,7 @@ title: 'Card - Code'
 
 import { Button, Card } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -161,6 +162,12 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 
 | Property  | Description                                             | Values      | Default value |
 | --------- | ------------------------------------------------------- | ----------- | ------------- |
-| `heading` | Heading of the Card (uses the built-in heading)         | -           | -             |
-| `text`    | Content text of the Card (uses the built-in text)       | -           | -             |
-| `border`  | If set to true, a border will be drawn around the card. | true, false | false         |
+| `border`  | If set to true, a border will be drawn around the card. | boolean | false         |
+| `boxShadow `  | Boolean indicating whether Card will have box shadow or not. | boolean | false         
+| `heading` | Heading of the Card (uses the built-in heading)         | string           | -             |
+| `headingAriaLevel `  | Heading aria-level. | string | -         |
+| `theme `  | Custom theme styles | CardTheme | -     
+| `text`    | Content text of the Card (uses the built-in text)       | string           | -             |
+
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/checkbox/code.mdx
+++ b/site/src/docs/components/checkbox/code.mdx
@@ -6,6 +6,7 @@ title: 'Checkbox - Code'
 import { useReducer } from 'react';
 import { Checkbox, Fieldset, SelectionGroup } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -281,3 +282,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `tooltipButtonLabel`       | The aria-label text for the tooltip trigger button.                        | `string`    | -             |
 | `tooltipText`              | The text content of the tooltip.                                           | `string`    | -             |
 | `onChange`                 | Callback fired when the state is changed.                                  | `function`  | -             |
+
+<NativeElementPropsInfo
+  nodeName="input"
+  splitProps={['className', 'style']}
+/>

--- a/site/src/docs/components/date-input/code.mdx
+++ b/site/src/docs/components/date-input/code.mdx
@@ -6,6 +6,7 @@ title: 'DateInput - Code'
 import { DateInput } from 'hds-react';
 import { format, addDays, subDays, parse, isWeekend, isValid } from 'date-fns';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -325,3 +326,5 @@ Also, note that this component is an input. All features supported by the HDS Te
 | `relatedClassName`              | Class name for the legend item element so it has the same styles as the related date. | `string`  | -             |
 | `selected`                      | Set to `true` and provide `label` prop to explain selected date's background colour.  | `boolean` | -             |
 | [Table 2:LegendItem properties] |                                                                                       |           |               |
+
+<NativeElementPropsInfo nodeName="input" />

--- a/site/src/docs/components/dialog/code.mdx
+++ b/site/src/docs/components/dialog/code.mdx
@@ -6,6 +6,8 @@ title: 'Dialog - Code'
 import { Dialog, Button, IconAlertCircle, IconInfoCircle, IconQuestionCircle, IconTrash, TextArea, TextInput } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
+
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -375,3 +377,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `variant`                | Defines the dialog variant.                                                                           | primary, danger | primary       |
 | `close`                  | A function called when a dialog close button is pressed. The button if shown if this property exists. | `function`      | -             |
 | `closeButtonLabelText`   | The aria-label for the close button. Required with `close` property.                                  | `string`        | -             |
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/error-summary/code.mdx
+++ b/site/src/docs/components/error-summary/code.mdx
@@ -5,6 +5,7 @@ title: 'ErrorSummary - Code'
 
 import { ErrorSummary } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -79,3 +80,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `autofocus` | Automatically focus the label of the error summary.   | `boolean`   | false         |
 | `label`   | The label of the error summary.                         | `string`    | -             |
 | `size`    | The size of the error summary.                          | `"default"`, `"large"` | `"default"` |
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/fieldset/code.mdx
+++ b/site/src/docs/components/fieldset/code.mdx
@@ -4,6 +4,8 @@ title: 'Fieldset - Code'
 ---
 import { Fieldset, TextInput } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
+
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -241,3 +243,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `tooltipLabel`        | The aria-label text for the tooltip.                                 | `string`  | -             |
 | `tooltipButtonLabel`  | The aria-label text for the tooltip trigger button.                  | `string`  | -             |
 | `tooltipText`         | The text content of the tooltip.                                     | `string`  | -             |
+
+<NativeElementPropsInfo nodeName="fieldset" />

--- a/site/src/docs/components/file-input/code.mdx
+++ b/site/src/docs/components/file-input/code.mdx
@@ -5,6 +5,7 @@ title: 'FileInput - Code'
 
 import { FileInput } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -104,3 +105,8 @@ Also, note that this component is an input. All features supported by the HDS Te
 | `language`    | The language of the component. It affects which language is used to present component-specific messages, labels, and aria-labels.                                            | `string` (fi, en, sv) | fi            |
 | `maxSize`     | Maximum file size in bytes.                                                                                                                                                  | `number`              | -             |
 | `multiple`    | If set to true, the input allows selecting multiple files.                                                                                                                   | `boolean`             | false         |
+
+<NativeElementPropsInfo
+  nodeName="div"
+  splitProps={['id']}
+/>

--- a/site/src/docs/components/footer/code.mdx
+++ b/site/src/docs/components/footer/code.mdx
@@ -16,6 +16,8 @@ import {
 } from 'hds-react';
 
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
+
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -337,11 +339,21 @@ import { Link } from 'gatsby';
 | `title`                     | Service name.                               | `string`                              | -             |
 | [Table 1:Footer properties] |
 
+<NativeElementPropsInfo
+  nodeName="footer"
+  overlappingProps={['ariaLabel']}
+/>
+
 | Property                               | Description                               | Values   | Default value |
 | -------------------------------------- | ----------------------------------------- | -------- | ------------- |
 | `ariaLabel`                            | Aria-label for describing the navigation. | `string` | -             |
 | `role`                                 | ARIA role to describe the contents.       | `string` | -             |
 | [Table 2:Footer.Navigation properties] |
+
+<NativeElementPropsInfo
+  nodeName="div"
+  overlappingProps={['ariaLabel']}
+/>
 
 | Property                         | Description                                                            | Values      | Default value                                           |
 | -------------------------------- | ---------------------------------------------------------------------- | ----------- | ------------------------------------------------------- |
@@ -356,12 +368,22 @@ import { Link } from 'gatsby';
 | `openInExternalDomainAriaLabel`  | Aria-label for opening link in an external domain.                     | `string`    | -                                                       |
 | [Table 3:Footer.Link properties] |
 
+<NativeElementPropsInfo
+  nodeName="a"
+  overlappingProps={['ariaLabel']}
+/>
+
 | Property                                    | Description                                                                                                       | Values                | Default value |
 | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------- | ------------- |
 | `className`                                 | Additional classNames for the element.                                                                            | `string`              | -             |
 | `id`                                        | ID for the element.                                                                                               | `string`              | -             |
 | `headingLink`                               | Footer.GroupHeading component to display at the top of the group. On smaller screens only this will be displayed. | `Footer.GroupHeading` | -             |
 | [Table 4:Footer.NavigationGroup properties] |
+
+<NativeElementPropsInfo
+  nodeName="div"
+/>
+
 
 | Property                                 | Description                                                                                        | Values    | Default value |
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------- | --------- | ------------- |
@@ -371,6 +393,10 @@ import { Link } from 'gatsby';
 | `label`                                  | Label for the heading.                                                                             | `string`  | -             |
 | [Table 5:Footer.GroupHeading properties] |
 
+<NativeElementPropsInfo
+  nodeName="a"
+/>
+
 | Property                              | Description                                                                     | Values                    | Default value |
 | ------------------------------------- | ------------------------------------------------------------------------------- | ------------------------- | ------------- |
 | `ariaLabel`                           | Aria-label for describing the utilities.                                        | `string`                  | -             |
@@ -379,12 +405,21 @@ import { Link } from 'gatsby';
 | `role`                                | ARIA role to describe the contents.                                             | `string`                  | -             |
 | [Table 6:Footer.Utilities properties] |
 
+<NativeElementPropsInfo
+  nodeName="div"
+  overlappingProps={['ariaLabel']}
+/>
+
 | Property                                 | Description                                                       | Values                | Default value |
 | ---------------------------------------- | ----------------------------------------------------------------- | --------------------- | ------------- |
 | `className`                              | Additional classNames for the element.                            | `string`              | -             |
 | `id`                                     | ID for the element.                                               | `string`              | -             |
 | `headingLink`                            | Footer.GroupHeading component to display at the top of the group. | `Footer.GroupHeading` | -             |
 | [Table 7:Footer.UtilityGroup properties] |
+
+<NativeElementPropsInfo
+  nodeName="div"
+/>
 
 | Property                           | Description                                | Values   | Default value |
 | ---------------------------------- | ------------------------------------------ | -------- | ------------- |
@@ -393,6 +428,11 @@ import { Link } from 'gatsby';
 | `id`                               | ID for the element.                        | `string` | -             |
 | `role`                             | ARIA role to describe the contents.        | `string` | -             |
 | [Table 8:Footer.Custom properties] |
+
+<NativeElementPropsInfo
+  nodeName="div"
+  overlappingProps={['ariaLabel']}
+/>
 
 | Property                         | Description                                                         | Values               | Default value |
 | -------------------------------- | ------------------------------------------------------------------- | -------------------- | ------------- |
@@ -408,3 +448,8 @@ import { Link } from 'gatsby';
 | `showBackToTopButton`            | Boolean for whether the "Back to top" button should be shown.       | `boolean`            | -             |
 | `year`                           | The year for copyright text. This can be useful in automated tests. | `string`             | -             |
 | [Table 9:Footer.Base properties] |
+
+<NativeElementPropsInfo
+  nodeName="div"
+  overlappingProps={['ariaLabel']}
+/>

--- a/site/src/docs/components/header/code.mdx
+++ b/site/src/docs/components/header/code.mdx
@@ -19,6 +19,7 @@ import ExternalLink from '../../../components/ExternalLink';
 import AnchorLink from '../../../components/AnchorLink';
 import Notification from '../../../components/Notification';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -584,6 +585,8 @@ import { Header, Logo, logoFiDark } from 'hds-react';
 
 The `languages` property is an array of `LanguageOption` objects. If `LanguageOption.isPrimary` is `true`, the option is shown outside of the dropdown, unless a non-primary language is selected.
 
+<NativeElementPropsInfo nodeName="header" overlappingProps={['ariaLabel']} />
+
 <IndexLink anchor="example">Header</IndexLink>
 ### Header.SkipLink
 
@@ -596,6 +599,8 @@ The `languages` property is an array of `LanguageOption` objects. If `LanguageOp
 | `skipTo`                             | Id of the element where the SkipLink jumps to.     | `string`        | -             |
 | `theme`                              | Custom styling for SkipLink.                       | `SkipLinkTheme` | -             |
 | [Table 2:Header.SkipLink properties] |
+
+<NativeElementPropsInfo nodeName="a" overlappingProps={['ariaLabel']} />
 
 <IndexLink anchor="with-skip-link">Header.SkipLink</IndexLink>
 
@@ -614,6 +619,8 @@ Note: Under large sized screens (992px and down) the Header.UniversalBar is hidd
 | `primaryLinkText`                        | Link text for the primary link            | `string` | -             |
 | `role`                                   | ARIA role to describe the contents.       | `string` | -             |
 | [Table 3:Header.UniversalBar properties] |
+
+<NativeElementPropsInfo nodeName="div" overlappingProps={['ariaLabel']} />
 
 <IndexLink anchor="with-universal-bar">Header.UniversalBar</IndexLink>
 
@@ -642,6 +649,8 @@ Note: Under large sized screens (992px and down) the Header.UniversalBar is hidd
 | `titleHref`                           | URL for the title.                                                                       | `string`                                      | -             |
 | [Table 4:Header.ActionBar properties] |
 
+<NativeElementPropsInfo nodeName="div" overlappingProps={['ariaLabel']} />
+
 <IndexLink anchor="with-action-bar">Header.ActionBar</IndexLink>
 
 ### Header.ActionBarItem
@@ -665,6 +674,8 @@ Note: Under large sized screens (992px and down) the Header.UniversalBar is hidd
 | `preventButtonResize`                     | If true, menu button resizing is prevented by rendering button's active state to a separate element.                                 | `boolean`              | `false`       |
 | [Table 5:Header.ActionBarItem properties] |
 
+<NativeElementPropsInfo nodeName="div" overlappingProps={['ariaLabel']} />
+
 <IndexLink anchor="actionbaritem-and-actionbarbutton">Header.ActionBarItem</IndexLink>
 
 ### Header.ActionBarButton
@@ -681,6 +692,8 @@ Note: Under large sized screens (992px and down) the Header.UniversalBar is hidd
 | `ref`                                       | `RefObject` to store the element.                                                                                                    | `RefObject`            | -             |
 | [Table 6:Header.ActionBarButton properties] |
 
+<NativeElementPropsInfo nodeName="button" />
+
 <IndexLink anchor="actionbaritem-and-actionbarbutton">Header.ActionBarButton</IndexLink>
 
 ### Header.LanguageSelector
@@ -696,6 +709,8 @@ Language options, the default language, and a change listener are passed to the 
 | `sortLanguageOptions`                        | Function for sorting language options into primary and secondary. By default, all primary `LanguageOptions` as shown. If a secondary `LanguageOption` is selected, only that one is shown. | `(options: LanguageOption[], selectedLanguage: string) => [LanguageOption[], LanguageOption[]]` | -             |
 | [Table 7:Header.LanguageSelector properties] |
 
+<NativeElementPropsInfo nodeName="button" />
+
 <IndexLink anchor="with-language-selector">Header.LanguageSelector</IndexLink>
 
 ### Header.SimpleLanguageOptions
@@ -708,6 +723,8 @@ Language options, the default language, and a change listener are passed to the 
 | ------------------------------------------------- | ----------------------------- | ------------------ | ------------- |
 | `languages`                                       | Array of languages to render. | `LanguageOption[]` | -             |
 | [Table 8:Header.SimpleLanguageOptions properties] |
+
+<NativeElementPropsInfo nodeName="div" />
 
 <IndexLink anchor="simple-language-options">Header.SimpleLanguageOptions</IndexLink>
 
@@ -722,6 +739,8 @@ Language options, the default language, and a change listener are passed to the 
 | `onSubmit`                         | Callback function for when input is submitted. | `(inputValue: string) => void` | -             |
 | [Table 9:Header.Search properties] |
 
+<NativeElementPropsInfo nodeName="div" />
+
 <IndexLink anchor="with-search">Header.Search</IndexLink>
 
 ### Header.NavigationMenu
@@ -733,6 +752,8 @@ Language options, the default language, and a change listener are passed to the 
 | `ariaLabel`                                 | Aria-label for describing NavigationMenu. | `string` | -             |
 | `id`                                        | ID for the NavigationMenu.                | `string` | -             |
 | [Table 10:Header.NavigationMenu properties] |
+
+<NativeElementPropsInfo nodeName="section" />
 
 <IndexLink anchor="with-navigation-menu">Header.NavigationMenu</IndexLink>
 
@@ -864,6 +885,8 @@ import { Link } from 'gatsby';
 | `wrapperClassName`                | Additional classNames for the element wrapping the link.                    | `string`          | -                                                           |
 | [Table 11:Header.Link properties] |
 
+<NativeElementPropsInfo nodeName="a" />
+
 ### Header.ActionBarSubItem
 
 #### Properties
@@ -882,6 +905,8 @@ import { Link } from 'gatsby';
 | `openInExternalDomainAriaLabel`               | The aria-label for opening link in an external domain.                 | `string`               | -             |
 | [Table 12:Header.ActionBarSubItem properties] |
 
+<NativeElementPropsInfo nodeName="a" />
+
 <IndexLink anchor="actionbarsubitem-and-actionbarsubitemgroup">Header.ActionBarSubItem</IndexLink>
 
 ### Header.ActionBarSubItemGroup
@@ -892,6 +917,8 @@ import { Link } from 'gatsby';
 | ----------------------------------------------------------------------------------------- | --- |
 | Same properties as the Header.ActionBarSubItem. The component sets `isHeading` to `true`. |
 | [Table 13:Header.ActionBarSubItemGroup properties]                                        |
+
+<NativeElementPropsInfo nodeName="a" />
 
 <IndexLink anchor="actionbarsubitem-and-actionbarsubitemgroup">Header.ActionBarSubItemGroup</IndexLink>
 
@@ -917,6 +944,8 @@ import { Link } from 'gatsby';
 | `& Header.ActionBarItemButton properties` | Extends properties of the Header.ActionBarItemButton.     | -                               | -                                              |
 | [Table 14:Header.LoginButton properties]  |
 
+<NativeElementPropsInfo nodeName="a" />{' '}
+
 <IndexLink>Header.LoginButton</IndexLink>
 
 ### Header.LogoutSubmenuButton
@@ -935,6 +964,8 @@ import { Link } from 'gatsby';
 | `& Header.ActionBarItemButton properties`        | Extends properties of the Header.ActionBarItemButton.     | -                               | -                                              |
 | [Table 15:Header.LogoutSubmenuButton properties] |
 
+<NativeElementPropsInfo nodeName="a" />{' '}
+
 <IndexLink>Header.LogoutSubmenuButton</IndexLink>
 
 ### Header.UserMenuButton
@@ -947,6 +978,8 @@ This component uses the <AnchorLink>Header.ActionBarItem</AnchorLink> and automa
 | ------------------------------------------------------------------ | --- |
 | No properties to set. User data is picked from the Login Provider. |
 | [Table 16:Header.UserMenuButton properties]                        |
+
+<NativeElementPropsInfo nodeName="a" />
 
 <IndexLink>Header.UserMenuButton</IndexLink>
 

--- a/site/src/docs/components/hero/code.mdx
+++ b/site/src/docs/components/hero/code.mdx
@@ -5,6 +5,7 @@ title: 'Hero - Code'
 
 import { Button, Hero } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -217,8 +218,6 @@ import { Fieldset, TextInput } from 'hds-react';
 
 ### Properties
 
-Note! You can find the full list of properties in the <Link openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="/storybook/react/?path=/story/components-hero--diagonal-koros">React Storybook.</Link>
-
 | Property        | Description                                                                                                        | Values                                                                       | Default value                                                        |
 | --------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | `theme`         | Theme prop for customisation of the Hero component.                                                                | `object`                                                                     | <Link href="/components/hero/customisation">See customisation</Link> |
@@ -227,3 +226,27 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `centerContent` | Should the text be aligned to center                                                                               | `boolean`                                                                    | false                                                                |
 | `variant`       | Which variant to render. The default value is `noImage` if `imageSrc` is not set. Otherwise default is `imageLeft` | `imageLeft, imageRight, backgroundImage, imageBottom,diagonalKoros, noImage` | `noImage` or `imageLeft`                                             |
 | `showArrowIcon` | Adds the arrow icon in the bottom left corner, slightly overlapping the Hero                                       | `boolean`                                                                    | false                                                                |
+| [Table 1:Hero properties] |
+
+<NativeElementPropsInfo
+  nodeName="div"
+/>  
+
+| Property        | Description                                                                                                        | Values                                                                       | Default value                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `headingLevel`      | Heading level of the title.                                                                                                   | `number`                                                                     | 1                                                                    |
+| [Table 2:Hero.Title properties] |
+
+<NativeElementPropsInfo
+  nodeName="h1"
+/>  
+
+| Property        | Description                                                                                                        | Values                                                                       | Default value                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| -      | Only native element properties                                                                                                   | -                                                                     | -                                                                   |
+| [Table 3:Hero.Text properties] |
+
+
+<NativeElementPropsInfo
+  nodeName="p"
+/> 

--- a/site/src/docs/components/koros/code.mdx
+++ b/site/src/docs/components/koros/code.mdx
@@ -5,6 +5,7 @@ title: 'Koros - Code'
 
 import { Koros } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -284,3 +285,6 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `flipVertical`   | If set to true, the koro shape will be flipped vertically.   | `boolean`                                                                        | false         |
 | `rotate`         | Controls the rotation of the koro shape.                     | `"45deg"`, `"90deg"`, `"135deg"`, `"180deg"`, `"225deg"`, `"270deg"`, `"315deg"` | -             |
 | `type`           | Controls the type (shape) of the koro.                       | `"basic"`, `"beat"`, `"pulse"`, `"wave"`, `"vibration"`, `"calm"`                    | `"basic"`     |
+| [Table 1:Koros properties] |
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/link/code.mdx
+++ b/site/src/docs/components/link/code.mdx
@@ -5,6 +5,7 @@ title: 'Link - Code'
 
 import { IconDocument, IconEnvelope, IconPhone, IconPhoto, Link } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -248,3 +249,9 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `openInNewTabAriaLabel`         | Aria-label which is read if the link is opened in a new tab.                   | `string`            | -             |
 | `size`                          | Controls the size of the link.                                                 | `"S"`, `"M"`, `"L"` | `"S"`         |
 | `useButtonStyles`               | Change the appearance to button.                                               | `boolean`           | false         |
+
+<NativeElementPropsInfo
+  nodeName="a"
+  notAllowed={["target", "onPointerEnterCapture", "onPointerLeaveCapture"]}
+  overlappingProps={['ariaLabel']}
+/>

--- a/site/src/docs/components/linkbox/code.mdx
+++ b/site/src/docs/components/linkbox/code.mdx
@@ -6,6 +6,7 @@ title: 'Linkbox - Code'
 import { Linkbox } from 'hds-react';
 import { withPrefix } from "gatsby"
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -232,3 +233,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `linkAriaLabel`                 | Aria-label for the link (arrow or external icon) that is located at the bottom of the linkbox.                                                                          | `string`                         | -             |
 | `linkboxAriaLabel`              | Aria label for the whole linkbox region. Remember to tell users of assistive technology that they are inside a linkbox. Check storybook examples on how it can be done. | `string`                         | -             |
 | `border`                    | If set to true, a border will be drawn around the card.                                                                                                                 | `boolean`                        | false         |
+
+<NativeElementPropsInfo
+  nodeName="a"
+  notAllowed={["tabIndex"]}
+/> 

--- a/site/src/docs/components/loading-spinner/code.mdx
+++ b/site/src/docs/components/loading-spinner/code.mdx
@@ -5,6 +5,7 @@ title: 'LoadingSpinner - Code'
 
 import { LoadingSpinner } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -60,3 +61,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `small`               | If set to true, the small variant is used.               | `boolean` | false                       |
 | `loadingText`         | Text to show for screen readers when spinner is visible. | `string`  | "Page is loading"          |
 | `loadingFinishedText` | Text to show for screen readers when spinner is removed. | `string`  | "Page has finished loading" |
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/logo/code.mdx
+++ b/site/src/docs/components/logo/code.mdx
@@ -6,6 +6,7 @@ title: 'Logo - Code'
 import { Link, Logo, logoFi, logoFiDark, logoSv, logoSvDark, logoRu, logoRuDark } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -61,3 +62,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | --------------------- | --------------------------------| ------------------------------------------ | -------------- |
 | `src`                 | Src of the logo. Can be base64-encoded, locally imported image or a URL.      | `string`                     | `-`         |
 | `size`                | Size of the logo.               | `"small"`, `"medium"`, `"large"`, `"full"` | `"full"`       |
+
+<NativeElementPropsInfo
+  nodeName="img"
+  overlappingProps={['dataTestId']}
+/>

--- a/site/src/docs/components/notification/code.mdx
+++ b/site/src/docs/components/notification/code.mdx
@@ -6,6 +6,7 @@ title: 'Notification - Code'
 import { Button, Notification } from 'hds-react';
 import { useState } from 'react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -243,3 +244,9 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `dismissible`              | If set to true, the notification can be closed.                                                                             | `boolean`                                                                                                     | false            |
 | `closeButtonLabelText`     | The aria-label and title for the close button.                                                                              | `string`                                                                                                      | -                |
 [Table 1:Notification properties]|
+
+<NativeElementPropsInfo
+  nodeName="section"
+  notAllowed={['role']}
+  overlappingProps={['dataTestId','notificationAriaLabel/aria-label']}
+/>

--- a/site/src/docs/components/number-input/code.mdx
+++ b/site/src/docs/components/number-input/code.mdx
@@ -5,6 +5,7 @@ title: 'NumberInput - Code'
 
 import { NumberInput } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -165,3 +166,8 @@ Also, note that this component is an input. All features supported by the HDS Te
 | `plusStepButtonAriaLabel`        | The aria label for plus step button.                                       | `string` | -             |
 | `unit`                           | Unit characters of the input. Example: €                                   | `string` | -             |
 | [Table 1:NumberInput properties] |
+
+<NativeElementPropsInfo
+  nodeName="input"
+  splitProps={['id', 'className', 'style']}
+/>

--- a/site/src/docs/components/pagination/code.mdx
+++ b/site/src/docs/components/pagination/code.mdx
@@ -5,6 +5,7 @@ title: 'Pagination - Code'
 import { Pagination } from 'hds-react';
 import { useState } from 'react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -242,3 +243,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `paginationAriaLabel` | Aria-label for the pagination nav element.                        | `string`   | -              |
 | `siblingCount`        | Number of always visible pages before and after the current page. | `number`   | 1              |
 | `theme`               | Theme prop for customisation of the Pagination component.         | `object`   | -              |
+
+<NativeElementPropsInfo
+  nodeName="nav"
+  overlappingProps={['dataTestId', 'paginationAriaLabel/aria-label']}
+/>

--- a/site/src/docs/components/password-input/code.mdx
+++ b/site/src/docs/components/password-input/code.mdx
@@ -5,6 +5,7 @@ title: 'PasswordInput - Code'
 
 import { Button, PasswordInput, IconEye, IconEyeCrossed } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -116,4 +117,9 @@ Also, note that this component is an input. All features supported by the HDS Te
 | `initiallyRevealed`              | If set to true, the component will initially reveal the password. Only applied when `includeShowPasswordButton` is true.                                                                       | `boolean` | false         |
 | `revealPasswordButtonAriaLabel`  | The aria-label for the reveal password button.                                                                                                                                                 | `string`  | -             |
 [Table 1:PasswordInput properties]|
+
+<NativeElementPropsInfo
+  nodeName="input"
+  splitProps={['id', 'className', 'style']}
+/>
 

--- a/site/src/docs/components/phone-input/code.mdx
+++ b/site/src/docs/components/phone-input/code.mdx
@@ -5,6 +5,7 @@ title: 'PhoneInput - Code'
 
 import { PhoneInput, Combobox } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -105,3 +106,9 @@ Also, note that this component is an input. All features supported by the HDS Te
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------- |
 | `label`                          | The label for the input.                                                                                                                                                                       | `string`  | -             |
 [Table 1:PhoneInput properties]|
+
+<NativeElementPropsInfo
+  nodeName="input"
+  splitProps={['id', 'className', 'style']}
+/>
+

--- a/site/src/docs/components/radio-button/code.mdx
+++ b/site/src/docs/components/radio-button/code.mdx
@@ -6,6 +6,7 @@ title: 'RadioButton - Code'
 import { RadioButton, SelectionGroup } from 'hds-react';
 import { useState } from 'react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -126,3 +127,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `label`                          | The label for the input.                                          | `string` | -             |
 | `helperText`                     | The helper text content that will be shown below the radiobutton. | `string` | -             |
 | [Table 1:RadioButton properties] |
+
+<NativeElementPropsInfo
+  nodeName="input"
+  splitProps={['className', 'style']}
+/>

--- a/site/src/docs/components/search-input/code.mdx
+++ b/site/src/docs/components/search-input/code.mdx
@@ -5,6 +5,7 @@ title: 'SearchInput - Code'
 
 import { SearchInput } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -150,5 +151,9 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `searchButtonAriaLabel`      | The aria-label for the search button.                                                                                                                                                                                                 | `string`                   | "Search"                       |
 | `hideSearchButton`           | If set to true, the search button will be hidden.                                                                                                                                                                                     | `boolean`                  | false                          |
 | `suggestionLabelField`       | Field of the SuggestionItem that represents the item label. E.g. an `suggestionLabelField` value of `'foo'` and a suggestion item `{ foo: 'Label', bar: 'value' }`, would display `'Label'` in the menu for that specific suggestion. | `string` `number` `symbol` | false                          |
-| `visibleSuggestions`         | The number of suggestions that are visible in the menu before it becomes scrollable.                                                                                                                                                  | `number`                   | 8                              |
+| `visibleSuggestions`         | The number of suggestions that are visible in the menu before it becomes scrollable.                                                                                                                                                  | `number`                   | 8     
+| `inputProps`                     | Props that will be passed to the `<input>` element. Some props are omitted, because the component needs to control the input and for accessibility reasons.                                                                           | `React.ComponentPropsWithoutRef<'input'>`                   | -                              |
+|                          |
 [Table 1:SearchInput properties]|
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/selection-group/code.mdx
+++ b/site/src/docs/components/selection-group/code.mdx
@@ -6,6 +6,7 @@ title: 'SelectionGroup - Code'
 import { SelectionGroup, Checkbox, RadioButton } from 'hds-react';
 import { useState } from 'react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -244,3 +245,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `direction` | The direction in which child components should be rendered in.              | `"vertical"` `"horizontal"` | `"vertical"`  |
 | `helperText`| The help text content that will be shown below the selection group content. | `string`                    | -             |
 [Table 1:SelectionGroup properties]|
+
+<NativeElementPropsInfo nodeName="fieldset" />

--- a/site/src/docs/components/side-navigation/code.mdx
+++ b/site/src/docs/components/side-navigation/code.mdx
@@ -6,6 +6,7 @@ title: 'SideNavigation - Code'
 import { SideNavigation, IconHome, IconMap, IconCogwheel } from 'hds-react';
 import { useState } from 'react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -248,3 +249,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `toggleButtonLabel`     | The label for the mobile menu toggle button                                                                      | `string`   | -             |
 | `ariaLabel`             | The aria-label for helping screen reader users to distinguish navigation row from other navigational components  | `string`   | -             |
 [Table 1:SideNavigation properties]|
+
+<NativeElementPropsInfo
+  nodeName="nav"
+  overlappingProps={['ariaLabel']}
+/>

--- a/site/src/docs/components/status-label/code.mdx
+++ b/site/src/docs/components/status-label/code.mdx
@@ -5,6 +5,7 @@ title: 'StatusLabel - Code'
 
 import { StatusLabel, IconInfoCircle, IconCheckCircle, IconAlertCircle, IconError } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -111,3 +112,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `type`     | The type of the status label.                        | `"neutral"` `"success"` `"info"` `"alert"` `"error"` | `"neutral"`   |
 | `iconLeft` | Element placed on the left side of the status label. | `ReactNode`                                          | -             |
 [Table 1:StatusLabel properties]|
+
+<NativeElementPropsInfo
+  nodeName="span"
+  overlappingProps={['native data-testid/dataTestId']}
+/>

--- a/site/src/docs/components/step-by-step/code.mdx
+++ b/site/src/docs/components/step-by-step/code.mdx
@@ -5,6 +5,7 @@ title: 'StepByStep - Code'
 
 import { StepByStep } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -222,3 +223,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `links`                       | List of HDS link objects for the step.                                        | `Array<LinkProps>`      | -             |
 | `title`                       | Step title.                                                                   | `string`                | -             |
 | [Table 1:StepType properties] |
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/stepper/code.mdx
+++ b/site/src/docs/components/stepper/code.mdx
@@ -5,8 +5,8 @@ title: 'Stepper - Code'
 
 import { useReducer } from 'react';
 import { Button, Stepper, StepState, IconArrowLeft, IconArrowRight } from 'hds-react';
-
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -568,3 +568,10 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `stepHeadingAriaLevel` | A step heading aria level.                                 | `number`             | 2             |
 | `steps`                | The steps of the stepper.                                  | `Steps`              | -             |
 [Table 1:Stepper properties]|
+
+<NativeElementPropsInfo
+  nodeName="div"
+  splitProps={['className']}
+  overlappingProps={['dataTestId']}
+/>
+

--- a/site/src/docs/components/table/code.mdx
+++ b/site/src/docs/components/table/code.mdx
@@ -6,6 +6,8 @@ title: 'Table - Code'
 import { useState } from 'react';
 import { Table } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
+
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -737,3 +739,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `verticalLines`                 | If set to true, the table displays vertical lines on columns.                                                                                                 | `boolean`          | false                                 |
 | `zebra`                         | If set to true, the table uses alternating row colors zebra style.                                                                                            | `boolean`          | false                                 |
 | [Table 1:Table properties]      |
+
+<NativeElementPropsInfo nodeName="table" />

--- a/site/src/docs/components/tabs/code.mdx
+++ b/site/src/docs/components/tabs/code.mdx
@@ -5,6 +5,8 @@ title: 'Tabs - Code'
 
 import { Tabs } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
+
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -142,3 +144,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | ---------------------- | ---------------------------------------------------------- | -------------------- | ------------- |
 | `small`                | If set to true, the small tabs variant is used.            | `boolean`            | false         |
 [Table 1:Tabs properties]|
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/tag/code.mdx
+++ b/site/src/docs/components/tag/code.mdx
@@ -5,6 +5,7 @@ title: 'Tag - Code'
 
 import { Tag } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -198,3 +199,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `size`                  | Sets the size of the Tag.                                                                                                      | `"m"` `"l"`         | `"m"`         |
 | `srOnlyLabel`           | Label that is only visible to screen readers. Can be used to to give screen reader users additional information about the tag. | `string`            | -             |
 [Table 1:Tag properties]|
+
+<NativeElementPropsInfo nodeName="div" />

--- a/site/src/docs/components/text-area/code.mdx
+++ b/site/src/docs/components/text-area/code.mdx
@@ -5,6 +5,7 @@ title: 'TextArea - Code'
 
 import { TextArea } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -126,3 +127,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `tooltipButtonLabel` | The aria-label text for the tooltip trigger button.              | `string`    | -             |
 | `tooltipText`        | The text content of the tooltip.                                 | `string`    | -             |
 [Table 1:TextArea properties]|
+
+<NativeElementPropsInfo
+  nodeName="textarea"
+  splitProps={['className', 'style']}
+/>

--- a/site/src/docs/components/text-input/code.mdx
+++ b/site/src/docs/components/text-input/code.mdx
@@ -5,6 +5,7 @@ title: 'TextInput - Code'
 
 import { TextInput } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -159,3 +160,8 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `buttonAriaLabel`    | The aria-label for the button.                                   | `string`    | -             |
 | `onButtonClick`      | Callback called when the button is pressed.                      | `function`  | -             |
 [Table 1:TextInput properties]|
+
+<NativeElementPropsInfo
+  nodeName="input"
+  splitProps={['className', 'id', 'style']}
+/>

--- a/site/src/docs/components/time-input/code.mdx
+++ b/site/src/docs/components/time-input/code.mdx
@@ -5,6 +5,7 @@ title: 'TimeInput - Code'
 
 import { TimeInput, Select } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -77,3 +78,8 @@ Also, note that this component is an input. All features supported by the HDS Te
 | `hoursLabel`   | A visually hidden label for the hours. Helps to navigate the component with screen readers.   | `string`    | -             |
 | `minutesLabel` | A visually hidden label for the minutes. Helps to navigate the component with screen readers. | `string`    | -             |
 [Table 1:TimeInput properties]|
+
+<NativeElementPropsInfo 
+  nodeName="input" 
+  splitProps={['id', 'className', 'style']}
+/>

--- a/site/src/docs/components/toggle-button/code.mdx
+++ b/site/src/docs/components/toggle-button/code.mdx
@@ -5,6 +5,7 @@ title: 'ToggleButton - Code'
 
 import { ToggleButton } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -88,3 +89,5 @@ Also, note that this component is an input. Most features supported by the HDS T
 | `checked` | If set to true, the toggle button state will be "On". | `boolean`              | false         |
 | `variant` | Defines the toggle button variant.                    | `"default"` `"inline"` | `"default"`   |
 [Table 1:ToggleButton properties]|
+
+<NativeElementPropsInfo nodeName="button" />

--- a/site/src/docs/components/tooltip/code.mdx
+++ b/site/src/docs/components/tooltip/code.mdx
@@ -5,6 +5,7 @@ title: 'Tooltip - Code'
 
 import { Tooltip, IconCheckCircleFill, IconCrossCircle } from 'hds-react';
 import TabsLayout from './tabs.mdx';
+import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
 
@@ -82,3 +83,5 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `buttonLabel`  | Aria-label text for the tooltip trigger button.              | `string`                                                                                                                                                                                       | "Tooltip"     |
 | `tooltipLabel` | Aria-label text for the tooltip.                             | `string`                                                                                                                                                                                       | "Tooltip"     |
 [Table 1:Tooltip properties]|
+
+<NativeElementPropsInfo nodeName="div" />


### PR DESCRIPTION
## Description

Allow native element props to all components. For example `data-testid` is not allowed in all components or `aria-*`. 

Added also tests and new documentation component.

**Recommended to review commit by commit, because they are in logical groups.**

## Related Issue

Closes [HDS-2269](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2269)

## How Has This Been Tested?

Added tests.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [ x] Added needed line to changelog


[HDS-2269]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ