### PR TITLE
Release-4.0.0: (HDS-2060)  change pagination active item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Dialog] heading typography changes
 - [CookieConsent] heading typography changes
 - [Accordion] heading typography changes
+- [Pagination] Active element changed from "a" element to "span" element
 
 #### Added
 
@@ -61,6 +62,7 @@ Changes that are not related to specific components
 - [StepByStep] heading typography changes
 - [Notification] heading typography changes
 - [Highlight] heading typography changes
+- [Pagination] Active element changed from "a" element to "span" element
 
 #### Added
 

--- a/packages/core/src/components/pagination/pagination.stories.js
+++ b/packages/core/src/components/pagination/pagination.stories.js
@@ -14,9 +14,9 @@ export const Basic = () => `
     </button>
     <ul class="hds-pagination__pages">
       <li>
-        <a class="hds-pagination__item-link hds-pagination__item-link--active" href="#" title="Current page" aria-label="Page 1" aria-current="page">
+        <span class="hds-pagination__item-link hds-pagination__item-link--active" title="Current page" aria-label="Page 1" aria-current="page">
           1
-        </a>
+        </span>
       </li>
       <li>
         <a class="hds-pagination__item-link" href="#" aria-label="Page 2" title="Go to page 2">
@@ -96,9 +96,9 @@ export const WithTruncation = () => `
         </a>
       </li>
       <li>
-        <a class="hds-pagination__item-link hds-pagination__item-link--active" href="#" aria-label="Page 66" title="Current page" aria-current="page">
+        <span class="hds-pagination__item-link hds-pagination__item-link--active" aria-label="Page 66" title="Current page" aria-current="page">
           66
-        </a>
+        </span>
       </li>
       <li>
         <a class="hds-pagination__item-link" href="#" aria-label="Page 67" title="Go to page 67">
@@ -136,9 +136,9 @@ export const WithTruncation = () => `
         </a>
       </li>
       <li>
-        <a class="hds-pagination__item-link hds-pagination__item-link--active" href="#" title="Current page" aria-label="Page 3" aria-current="page">
+        <span class="hds-pagination__item-link hds-pagination__item-link--active" title="Current page" aria-label="Page 3" aria-current="page">
           3
-        </a>
+        </span>
       </li>
       <li>
         <a class="hds-pagination__item-link" href="#" title="Go to page 4" aria-label="Page 4">
@@ -196,9 +196,9 @@ export const WithTruncation = () => `
         </a>
       </li>
       <li>
-        <a class="hds-pagination__item-link hds-pagination__item-link--active" href="#" title="Current page" aria-label="Page 32" aria-current="page">
+        <span class="hds-pagination__item-link hds-pagination__item-link--active" title="Current page" aria-label="Page 32" aria-current="page">
           32
-        </a>
+        </span>
       </li>
       <li>
         <a class="hds-pagination__item-link" href="#" title="Go to page 33" aria-label="Page 33">
@@ -245,9 +245,9 @@ export const CustomActivePageColor = () => `
       </button>
       <ul class="hds-pagination__pages">
         <li>
-          <a class="hds-pagination__item-link hds-pagination__item-link--active" href="#" title="Current page" aria-label="Page 1" aria-current="page">
+          <span class="hds-pagination__item-link hds-pagination__item-link--active" title="Current page" aria-label="Page 1" aria-current="page">
             1
-          </a>
+          </span>
         </li>
         <li>
           <a class="hds-pagination__item-link" href="#" aria-label="Page 2" title="Go to page 2">
@@ -302,15 +302,14 @@ export const CustomActivePageColor = () => `
 
 CustomActivePageColor.storyName = 'Custom active page color';
 
-
 export const States = () => `
 <p>Selected</p>
 <nav class="hds-pagination" aria-label="Pagination 1">
   <ul class="hds-pagination__pages">
     <li>
-      <a class="hds-pagination__item-link hds-pagination__item-link--active" href="#" title="Current page" aria-label="Page 1">
+      <span class="hds-pagination__item-link hds-pagination__item-link--active" title="Current page" aria-label="Page 1">
         1
-      </a>
+      </span>
     </li>
   </ul>
 </nav>
@@ -324,4 +323,4 @@ export const States = () => `
     </li>
   </ul>
 </nav>
-`
+`;

--- a/packages/react/src/components/pagination/Pagination.tsx
+++ b/packages/react/src/components/pagination/Pagination.tsx
@@ -70,7 +70,7 @@ const mapLangToOpenedPage = (pageNumber: number, language: Language): string => 
   return openedPage[language];
 };
 
-const range = (start, end) => {
+const range = (start: number, end: number): number[] => {
   const length = end - start + 1;
   return Array.from({ length }, (_, i) => start + i);
 };
@@ -114,14 +114,14 @@ const createPaginationItemList = ({
     ...startPages,
     // start ellipsis
     // eslint-disable-next-line no-nested-ternary
-    ...(siblingsStart > 3 ? ['start-ellipsis'] : pageCount - 1 > 2 ? [2] : []),
+    ...(siblingsStart > 3 ? [Ellipsis.start] : pageCount - 1 > 2 ? [2] : []),
 
     // Sibling pages
     ...range(siblingsStart, siblingsEnd),
 
     // End ellipsis
     // eslint-disable-next-line no-nested-ternary
-    ...(siblingsEnd < pageCount - 2 ? ['end-ellipsis'] : pageCount - 1 > 1 ? [pageCount - 1] : []),
+    ...(siblingsEnd < pageCount - 2 ? [Ellipsis.end] : pageCount - 1 > 1 ? [pageCount - 1] : []),
 
     ...endPages,
   ];

--- a/packages/react/src/components/pagination/Pagination.tsx
+++ b/packages/react/src/components/pagination/Pagination.tsx
@@ -258,19 +258,31 @@ export const Pagination = ({
               );
             }
 
+            const isCurrent = pageIndex + 1 === pageItem;
+
             return (
               <li key={pageItem}>
-                <a
-                  className={classNames(styles.itemLink, pageIndex + 1 === pageItem ? styles.itemLinkActive : '')}
-                  data-testid={dataTestId ? `${dataTestId}-page-${pageItem}` : undefined}
-                  href={pageHref(pageItem as number)}
-                  onClick={onChange ? (event) => onChange(event, (pageItem as number) - 1) : undefined}
-                  title={mapLangToPageTitle(pageItem as number, language, pageItem === pageIndex + 1)}
-                  aria-label={mapLangToPageAriaLabel(pageItem as number, language)}
-                  aria-current={pageIndex + 1 === pageItem ? 'page' : false}
-                >
-                  {pageItem}
-                </a>
+                {isCurrent ? (
+                  <span
+                    className={classNames(styles.itemLink, styles.itemLinkActive)}
+                    data-testid={dataTestId ? `${dataTestId}-page-${pageItem}` : undefined}
+                    aria-label={`${mapLangToPageAriaLabel(pageItem, language)}. ${mapLangToPageTitle(pageItem, language, true)}.`}
+                    aria-current="page"
+                  >
+                    {pageItem}
+                  </span>
+                ) : (
+                  <a
+                    className={classNames(styles.itemLink)}
+                    data-testid={dataTestId ? `${dataTestId}-page-${pageItem}` : undefined}
+                    href={pageHref(pageItem)}
+                    onClick={onChange ? (event) => onChange(event, pageItem - 1) : undefined}
+                    title={mapLangToPageTitle(pageItem, language, false)}
+                    aria-label={mapLangToPageAriaLabel(pageItem, language)}
+                  >
+                    {pageItem}
+                  </a>
+                )}
               </li>
             );
           })}

--- a/packages/react/src/components/pagination/Pagination.tsx
+++ b/packages/react/src/components/pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 
 import '../../styles/base.module.css';
@@ -199,7 +199,20 @@ export const Pagination = ({
   theme,
 }: PaginationProps) => {
   const initialPageIndex = useRef(pageIndex);
+  const activeItemRef = useRef<HTMLSpanElement>();
+  const userSelectedIndex = useRef(-1);
   const [hasUserChangedPage, setHasUserChangedPage] = useState<boolean>(false);
+
+  const onChangeWithInternalHandler = useCallback(
+    (event, index, wasButtonClick = false) => {
+      // do not shift focus away from buttons
+      userSelectedIndex.current = wasButtonClick ? -1 : index;
+      if (onChange) {
+        onChange(event, index);
+      }
+    },
+    [onChange],
+  );
 
   useEffect(() => {
     if (hasUserChangedPage === false) {
@@ -208,6 +221,14 @@ export const Pagination = ({
       }
     }
   }, [pageIndex, hasUserChangedPage]);
+
+  useEffect(() => {
+    if (userSelectedIndex.current > -1 && activeItemRef.current) {
+      // Active element changes from <a> to <span>, so focus is lost after re-render.
+      // Move it back manually
+      activeItemRef.current.focus();
+    }
+  }, [userSelectedIndex.current]);
 
   const itemList = useMemo(
     () => createPaginationItemList({ pageCount, pageIndex, siblingCount }),
@@ -240,7 +261,7 @@ export const Pagination = ({
             data-testid={dataTestId ? `${dataTestId}-previous-button` : undefined}
             disabled={pageIndex === 0 || pageCount === 1}
             aria-disabled={pageIndex === 0 || pageCount === 1 || undefined}
-            onClick={(event) => onChange(event, pageIndex - 1)}
+            onClick={(event) => onChangeWithInternalHandler(event, pageIndex - 1, true)}
             variant={ButtonVariant.Supplementary}
             theme={ButtonPresetTheme.Black}
             iconStart={<IconAngleLeft />}
@@ -268,6 +289,8 @@ export const Pagination = ({
                     data-testid={dataTestId ? `${dataTestId}-page-${pageItem}` : undefined}
                     aria-label={`${mapLangToPageAriaLabel(pageItem, language)}. ${mapLangToPageTitle(pageItem, language, true)}.`}
                     aria-current="page"
+                    tabIndex={-1}
+                    ref={activeItemRef}
                   >
                     {pageItem}
                   </span>
@@ -276,7 +299,7 @@ export const Pagination = ({
                     className={classNames(styles.itemLink)}
                     data-testid={dataTestId ? `${dataTestId}-page-${pageItem}` : undefined}
                     href={pageHref(pageItem)}
-                    onClick={onChange ? (event) => onChange(event, pageItem - 1) : undefined}
+                    onClick={(event) => onChangeWithInternalHandler(event, pageItem - 1)}
                     title={mapLangToPageTitle(pageItem, language, false)}
                     aria-label={mapLangToPageAriaLabel(pageItem, language)}
                   >
@@ -293,7 +316,7 @@ export const Pagination = ({
             data-testid={dataTestId ? `${dataTestId}-next-button` : undefined}
             disabled={pageIndex === pageCount - 1 || pageCount === 1}
             aria-disabled={pageIndex === pageCount - 1 || pageCount === 1 || undefined}
-            onClick={(event) => onChange(event, pageIndex + 1)}
+            onClick={(event) => onChangeWithInternalHandler(event, pageIndex + 1, true)}
             variant={ButtonVariant.Supplementary}
             theme={ButtonPresetTheme.Black}
             iconEnd={<IconAngleRight className={styles.angleRightIcon} />}

--- a/packages/react/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/__snapshots__/Pagination.test.tsx.snap
@@ -54,7 +54,6 @@ exports[`<Pagination /> spec renders the component 1`] = `
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -73,7 +72,6 @@ exports[`<Pagination /> spec renders the component 1`] = `
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 7"
             class="itemLink"
             data-testid="hds-pagination-page-7"
@@ -84,20 +82,18 @@ exports[`<Pagination /> spec renders the component 1`] = `
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 8"
+            aria-label="Page 8. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-8"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             8
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 9"
             class="itemLink"
             data-testid="hds-pagination-page-9"
@@ -116,7 +112,6 @@ exports[`<Pagination /> spec renders the component 1`] = `
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 68"
             class="itemLink"
             data-testid="hds-pagination-page-68"
@@ -217,7 +212,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -236,7 +230,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 28"
             class="itemLink"
             data-testid="hds-pagination-page-28"
@@ -248,7 +241,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 29"
             class="itemLink"
             data-testid="hds-pagination-page-29"
@@ -260,7 +252,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -359,7 +350,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -378,7 +368,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 26"
             class="itemLink"
             data-testid="hds-pagination-page-26"
@@ -390,7 +379,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 27"
             class="itemLink"
             data-testid="hds-pagination-page-27"
@@ -402,7 +390,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 28"
             class="itemLink"
             data-testid="hds-pagination-page-28"
@@ -414,7 +401,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 29"
             class="itemLink"
             data-testid="hds-pagination-page-29"
@@ -425,16 +411,15 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 30"
+            aria-label="Page 30. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-30"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             30
-          </a>
+          </span>
         </li>
       </ul>
       <button
@@ -527,7 +512,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -546,7 +530,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 24"
             class="itemLink"
             data-testid="hds-pagination-page-24"
@@ -558,7 +541,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 25"
             class="itemLink"
             data-testid="hds-pagination-page-25"
@@ -570,7 +552,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 26"
             class="itemLink"
             data-testid="hds-pagination-page-26"
@@ -582,7 +563,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 27"
             class="itemLink"
             data-testid="hds-pagination-page-27"
@@ -594,7 +574,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 28"
             class="itemLink"
             data-testid="hds-pagination-page-28"
@@ -605,20 +584,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 29"
+            aria-label="Page 29. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-29"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             29
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -717,7 +694,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -736,7 +712,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 22"
             class="itemLink"
             data-testid="hds-pagination-page-22"
@@ -748,7 +723,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 23"
             class="itemLink"
             data-testid="hds-pagination-page-23"
@@ -760,7 +734,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 24"
             class="itemLink"
             data-testid="hds-pagination-page-24"
@@ -772,7 +745,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 25"
             class="itemLink"
             data-testid="hds-pagination-page-25"
@@ -784,7 +756,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 26"
             class="itemLink"
             data-testid="hds-pagination-page-26"
@@ -796,7 +767,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 27"
             class="itemLink"
             data-testid="hds-pagination-page-27"
@@ -807,20 +777,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 28"
+            aria-label="Page 28. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-28"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             28
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 29"
             class="itemLink"
             data-testid="hds-pagination-page-29"
@@ -832,7 +800,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -931,7 +898,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -950,7 +916,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 20"
             class="itemLink"
             data-testid="hds-pagination-page-20"
@@ -962,7 +927,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 21"
             class="itemLink"
             data-testid="hds-pagination-page-21"
@@ -974,7 +938,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 22"
             class="itemLink"
             data-testid="hds-pagination-page-22"
@@ -986,7 +949,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 23"
             class="itemLink"
             data-testid="hds-pagination-page-23"
@@ -998,7 +960,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 24"
             class="itemLink"
             data-testid="hds-pagination-page-24"
@@ -1010,7 +971,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 25"
             class="itemLink"
             data-testid="hds-pagination-page-25"
@@ -1022,7 +982,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 26"
             class="itemLink"
             data-testid="hds-pagination-page-26"
@@ -1033,20 +992,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 27"
+            aria-label="Page 27. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-27"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             27
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 28"
             class="itemLink"
             data-testid="hds-pagination-page-28"
@@ -1058,7 +1015,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 29"
             class="itemLink"
             data-testid="hds-pagination-page-29"
@@ -1070,7 +1026,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -1169,7 +1124,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -1188,7 +1142,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 18"
             class="itemLink"
             data-testid="hds-pagination-page-18"
@@ -1200,7 +1153,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 19"
             class="itemLink"
             data-testid="hds-pagination-page-19"
@@ -1212,7 +1164,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 20"
             class="itemLink"
             data-testid="hds-pagination-page-20"
@@ -1224,7 +1175,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 21"
             class="itemLink"
             data-testid="hds-pagination-page-21"
@@ -1236,7 +1186,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 22"
             class="itemLink"
             data-testid="hds-pagination-page-22"
@@ -1248,7 +1197,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 23"
             class="itemLink"
             data-testid="hds-pagination-page-23"
@@ -1260,7 +1208,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 24"
             class="itemLink"
             data-testid="hds-pagination-page-24"
@@ -1272,7 +1219,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 25"
             class="itemLink"
             data-testid="hds-pagination-page-25"
@@ -1283,20 +1229,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 26"
+            aria-label="Page 26. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-26"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             26
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 27"
             class="itemLink"
             data-testid="hds-pagination-page-27"
@@ -1308,7 +1252,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 28"
             class="itemLink"
             data-testid="hds-pagination-page-28"
@@ -1320,7 +1263,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 29"
             class="itemLink"
             data-testid="hds-pagination-page-29"
@@ -1332,7 +1274,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -1431,7 +1372,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -1449,16 +1389,15 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </span>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 16"
+            aria-label="Page 16. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-16"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             16
-          </a>
+          </span>
         </li>
         <li>
           <span
@@ -1469,7 +1408,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -1568,7 +1506,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -1587,7 +1524,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 15"
             class="itemLink"
             data-testid="hds-pagination-page-15"
@@ -1598,20 +1534,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 16"
+            aria-label="Page 16. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-16"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             16
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 17"
             class="itemLink"
             data-testid="hds-pagination-page-17"
@@ -1630,7 +1564,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -1729,7 +1662,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -1748,7 +1680,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 14"
             class="itemLink"
             data-testid="hds-pagination-page-14"
@@ -1760,7 +1691,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 15"
             class="itemLink"
             data-testid="hds-pagination-page-15"
@@ -1771,20 +1701,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 16"
+            aria-label="Page 16. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-16"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             16
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 17"
             class="itemLink"
             data-testid="hds-pagination-page-17"
@@ -1796,7 +1724,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 18"
             class="itemLink"
             data-testid="hds-pagination-page-18"
@@ -1815,7 +1742,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -1914,7 +1840,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -1933,7 +1858,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 13"
             class="itemLink"
             data-testid="hds-pagination-page-13"
@@ -1945,7 +1869,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 14"
             class="itemLink"
             data-testid="hds-pagination-page-14"
@@ -1957,7 +1880,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 15"
             class="itemLink"
             data-testid="hds-pagination-page-15"
@@ -1968,20 +1890,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 16"
+            aria-label="Page 16. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-16"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             16
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 17"
             class="itemLink"
             data-testid="hds-pagination-page-17"
@@ -1993,7 +1913,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 18"
             class="itemLink"
             data-testid="hds-pagination-page-18"
@@ -2005,7 +1924,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 19"
             class="itemLink"
             data-testid="hds-pagination-page-19"
@@ -2024,7 +1942,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -2123,7 +2040,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -2142,7 +2058,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 12"
             class="itemLink"
             data-testid="hds-pagination-page-12"
@@ -2154,7 +2069,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 13"
             class="itemLink"
             data-testid="hds-pagination-page-13"
@@ -2166,7 +2080,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 14"
             class="itemLink"
             data-testid="hds-pagination-page-14"
@@ -2178,7 +2091,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 15"
             class="itemLink"
             data-testid="hds-pagination-page-15"
@@ -2189,20 +2101,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 16"
+            aria-label="Page 16. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-16"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             16
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 17"
             class="itemLink"
             data-testid="hds-pagination-page-17"
@@ -2214,7 +2124,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 18"
             class="itemLink"
             data-testid="hds-pagination-page-18"
@@ -2226,7 +2135,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 19"
             class="itemLink"
             data-testid="hds-pagination-page-19"
@@ -2238,7 +2146,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 20"
             class="itemLink"
             data-testid="hds-pagination-page-20"
@@ -2257,7 +2164,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -2356,7 +2262,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -2375,7 +2280,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 11"
             class="itemLink"
             data-testid="hds-pagination-page-11"
@@ -2387,7 +2291,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 12"
             class="itemLink"
             data-testid="hds-pagination-page-12"
@@ -2399,7 +2302,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 13"
             class="itemLink"
             data-testid="hds-pagination-page-13"
@@ -2411,7 +2313,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 14"
             class="itemLink"
             data-testid="hds-pagination-page-14"
@@ -2423,7 +2324,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 15"
             class="itemLink"
             data-testid="hds-pagination-page-15"
@@ -2434,20 +2334,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 16"
+            aria-label="Page 16. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-16"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             16
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 17"
             class="itemLink"
             data-testid="hds-pagination-page-17"
@@ -2459,7 +2357,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 18"
             class="itemLink"
             data-testid="hds-pagination-page-18"
@@ -2471,7 +2368,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 19"
             class="itemLink"
             data-testid="hds-pagination-page-19"
@@ -2483,7 +2379,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 20"
             class="itemLink"
             data-testid="hds-pagination-page-20"
@@ -2495,7 +2390,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 21"
             class="itemLink"
             data-testid="hds-pagination-page-21"
@@ -2514,7 +2408,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -2613,7 +2506,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -2624,20 +2516,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 2"
+            aria-label="Page 2. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-2"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             2
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 3"
             class="itemLink"
             data-testid="hds-pagination-page-3"
@@ -2656,7 +2546,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -2755,7 +2644,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -2767,7 +2655,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 2"
             class="itemLink"
             data-testid="hds-pagination-page-2"
@@ -2778,20 +2665,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 3"
+            aria-label="Page 3. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-3"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             3
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 4"
             class="itemLink"
             data-testid="hds-pagination-page-4"
@@ -2803,7 +2688,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 5"
             class="itemLink"
             data-testid="hds-pagination-page-5"
@@ -2822,7 +2706,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -2921,7 +2804,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -2933,7 +2815,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 2"
             class="itemLink"
             data-testid="hds-pagination-page-2"
@@ -2945,7 +2826,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 3"
             class="itemLink"
             data-testid="hds-pagination-page-3"
@@ -2956,20 +2836,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 4"
+            aria-label="Page 4. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-4"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             4
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 5"
             class="itemLink"
             data-testid="hds-pagination-page-5"
@@ -2981,7 +2859,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 6"
             class="itemLink"
             data-testid="hds-pagination-page-6"
@@ -2993,7 +2870,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 7"
             class="itemLink"
             data-testid="hds-pagination-page-7"
@@ -3012,7 +2888,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -3111,7 +2986,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -3123,7 +2997,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 2"
             class="itemLink"
             data-testid="hds-pagination-page-2"
@@ -3135,7 +3008,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 3"
             class="itemLink"
             data-testid="hds-pagination-page-3"
@@ -3147,7 +3019,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 4"
             class="itemLink"
             data-testid="hds-pagination-page-4"
@@ -3158,20 +3029,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 5"
+            aria-label="Page 5. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-5"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             5
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 6"
             class="itemLink"
             data-testid="hds-pagination-page-6"
@@ -3183,7 +3052,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 7"
             class="itemLink"
             data-testid="hds-pagination-page-7"
@@ -3195,7 +3063,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 8"
             class="itemLink"
             data-testid="hds-pagination-page-8"
@@ -3207,7 +3074,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 9"
             class="itemLink"
             data-testid="hds-pagination-page-9"
@@ -3226,7 +3092,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -3325,7 +3190,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -3337,7 +3201,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 2"
             class="itemLink"
             data-testid="hds-pagination-page-2"
@@ -3349,7 +3212,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 3"
             class="itemLink"
             data-testid="hds-pagination-page-3"
@@ -3361,7 +3223,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 4"
             class="itemLink"
             data-testid="hds-pagination-page-4"
@@ -3373,7 +3234,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 5"
             class="itemLink"
             data-testid="hds-pagination-page-5"
@@ -3384,20 +3244,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 6"
+            aria-label="Page 6. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-6"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             6
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 7"
             class="itemLink"
             data-testid="hds-pagination-page-7"
@@ -3409,7 +3267,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 8"
             class="itemLink"
             data-testid="hds-pagination-page-8"
@@ -3421,7 +3278,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 9"
             class="itemLink"
             data-testid="hds-pagination-page-9"
@@ -3433,7 +3289,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 10"
             class="itemLink"
             data-testid="hds-pagination-page-10"
@@ -3445,7 +3300,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 11"
             class="itemLink"
             data-testid="hds-pagination-page-11"
@@ -3464,7 +3318,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -3563,7 +3416,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"
@@ -3575,7 +3427,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 2"
             class="itemLink"
             data-testid="hds-pagination-page-2"
@@ -3587,7 +3438,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 3"
             class="itemLink"
             data-testid="hds-pagination-page-3"
@@ -3599,7 +3449,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 4"
             class="itemLink"
             data-testid="hds-pagination-page-4"
@@ -3611,7 +3460,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 5"
             class="itemLink"
             data-testid="hds-pagination-page-5"
@@ -3623,7 +3471,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 6"
             class="itemLink"
             data-testid="hds-pagination-page-6"
@@ -3634,20 +3481,18 @@ exports[`<Pagination /> spec should render pagination correctly with different s
           </a>
         </li>
         <li>
-          <a
+          <span
             aria-current="page"
-            aria-label="Page 7"
+            aria-label="Page 7. Current page."
             class="itemLink itemLinkActive"
             data-testid="hds-pagination-page-7"
-            href="#"
-            title="Current page"
+            tabindex="-1"
           >
             7
-          </a>
+          </span>
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 8"
             class="itemLink"
             data-testid="hds-pagination-page-8"
@@ -3659,7 +3504,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 9"
             class="itemLink"
             data-testid="hds-pagination-page-9"
@@ -3671,7 +3515,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 10"
             class="itemLink"
             data-testid="hds-pagination-page-10"
@@ -3683,7 +3526,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 11"
             class="itemLink"
             data-testid="hds-pagination-page-11"
@@ -3695,7 +3537,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 12"
             class="itemLink"
             data-testid="hds-pagination-page-12"
@@ -3707,7 +3548,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 13"
             class="itemLink"
             data-testid="hds-pagination-page-13"
@@ -3726,7 +3566,6 @@ exports[`<Pagination /> spec should render pagination correctly with different s
         </li>
         <li>
           <a
-            aria-current="false"
             aria-label="Page 30"
             class="itemLink"
             data-testid="hds-pagination-page-30"
@@ -3827,7 +3666,6 @@ exports[`<Pagination /> spec should return only first page when page count is 1 
       >
         <li>
           <a
-            aria-current="false"
             aria-label="Page 1"
             class="itemLink"
             data-testid="hds-pagination-page-1"

--- a/site/src/docs/components/pagination/accessibility.mdx
+++ b/site/src/docs/components/pagination/accessibility.mdx
@@ -21,3 +21,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 - Provide a screen reader notification (`aria-live` and `aria-atomic`) when a user changes a page. Especially this is
   important when the user changes the page by using the component's previous or next buttons. If you use the HDS React
   component of the pagination, this feature is automatically provided.
+
+### Issues
+
+There is an issue with this component when using Talkback with Firefox. The `aria-live` content is not read aloud when the user changes the selected item. When an `<a>` element is clicked, the focus jumps to the `<body>` element and is then moved to the selected item. Talkback seems to lose track of changes.


### PR DESCRIPTION
## Description

Pagination's active element should be `<span>`, not `<a>`.

Accessibility check done.

## Related Issue

Closes [HDS-2060](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2060)

## How Has This Been Tested?

Updated snapshot + manual testing

## Demos:

Links to demos are in the comments

## Add to changelog

- [x ] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2060]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ