### PR TITLE
Release-4.0.0: (HDS-2198) Update line-height docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Changes that are not related to specific components
 - [Notification] Changed according to new size enum.
 - [ErrorSummary] Changed according to new size enum.
 - [Icon] Document the size prop as enum usage.
+- Changes to the line-heights in foundation/typography.
 
 #### Fixed
 

--- a/site/src/docs/foundation/design-tokens/typography/index.mdx
+++ b/site/src/docs/foundation/design-tokens/typography/index.mdx
@@ -4,7 +4,7 @@ title: 'Typography tokens - Usage'
 navTitle: 'Typography'
 ---
 
-import ExternalLink from '../../../../components/ExternalLink'
+import ExternalLink from '../../../../components/ExternalLink';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -16,81 +16,89 @@ Typography can be used to organise information and help users find their way aro
 Typography is also an essential part of the City of Helsinki's brand identity. Helsinki Design system typography is based on the proprietary <strong>Helsinki Grotesk</strong> typeface. Preferably, no other typefaces should be used. The font licenses can be purchased from the <ExternalLink href="https://camelot-typefaces.com/helsinki-grotesk">Camelot Typefaces website</ExternalLink>.
 
 ## Principles
+
 - **Use black (`--color-black-90`) or white (`--color-white`) text colour** depending on the background. Other text colours should be used intentionally, if at all.
 - **Use typography consistently** throughout your service, to ensure that the content hierarchy and structure are clear and easily understandable.
 - **Use heading levels semantically.** For example after **h1**, next heading on the same page should be **h2**, not **h3**. If needed, the appearance and visual hierarchy of headings can be altered separately from the semantic structure with the font size tokens.
 
 ## Accessibility
+
 - Always check that sufficient colour contrast between text and its background is maintained. All colour choices should comply with <ExternalLink href="https://www.w3.org/TR/WCAG21/#contrast-minimum">WCAG 2.1 Standard at AA Level contrast ratios</ExternalLink>.
 - Avoid placing text over images, especially in small sizes.
 
 ## Usage
+
 The HDS offers two different sets of font size tokens for heading and body text. The tokens define the font size in rem values.
 
 ### Heading sizes
+
 The heading font size tokens are heading level agnostic. This allows you to fit the **heading scale** to the specific needs of the service. In addition to predefined _default_ and _small_ heading scales, custom scales can be also used.
 
 You can use <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/utils/helpers.css">helper classes provided in the Core package</ExternalLink> to match each heading size with the correct line height and letter spacing.
 
-| Heading size          | PX value | REM value | Example                                                                                                   |
-| --------------------- | -------: | --------: | --------------------------------------------------------------------------------------------------------- |
-| **Heading XXL**       | 64px     | 4rem      | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL</div>                    |
-| **Heading XL**        | 48px     | 3rem      | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL</div>                       |
-| **Heading XL Mobile** | 40px     | 2.5rem    | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XL Mobile</div> |
-| **Heading L**         | 32px     | 2rem      | <div class="heading-l" aria-label="Visualised heading L example">Heading L</div>                          |
-| **Heading M**         | 24px     | 1.5rem    | <div class="heading-m" aria-label="Visualised heading M example">Heading M</div>                          |
-| **Heading S**         | 20px     | 1.25rem   | <div class="heading-s" aria-label="Visualised heading S example">Heading S</div>                          |
-| **Heading XS**        | 18px     | 1.125rem  | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS</div>                       |
-| **Heading XXS**       | 16px     | 1rem      | <div class="heading-xxs" aria-label="Visualised heading XXS example">Heading XSS</div>                    |
-[Table 1:Heading sizes] |
+| Heading size            | PX value | REM value | Example                                                                                                  |
+| ----------------------- | -------: | --------: | -------------------------------------------------------------------------------------------------------- |
+| **Heading XXL**         |     64px |      4rem | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL</div>                   |
+| **Heading XL**          |     48px |      3rem | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL</div>                      |
+| **Heading XL Mobile**   |     40px |    2.5rem | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XL Mobile</div> |
+| **Heading L**           |     32px |      2rem | <div class="heading-l" aria-label="Visualised heading L example">Heading L</div>                         |
+| **Heading M**           |     24px |    1.5rem | <div class="heading-m" aria-label="Visualised heading M example">Heading M</div>                         |
+| **Heading S**           |     20px |   1.25rem | <div class="heading-s" aria-label="Visualised heading S example">Heading S</div>                         |
+| **Heading XS**          |     18px |  1.125rem | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS</div>                      |
+| **Heading XXS**         |     16px |      1rem | <div class="heading-xxs" aria-label="Visualised heading XXS example">Heading XSS</div>                   |
+| [Table 1:Heading sizes] |
 
 ### Heading scales
+
 The heading font size tokens allow two different heading scales to be used. The **default heading scale** is suitable for desktop screen sizes. The **small heading scale** is used on mobile devices and it can be also used on information-heavy user interfaces (e.g. admin panels).
 
-| Heading level         | Default scale                                   | Small scale                                                 |
-| --------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
-| Heading 1 (`h1`)      | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL (64px)</div> | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XL-Mobile (40px)</div> |
-| Heading 2 (`h2`)      | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL (48px)</div>   | <div class="heading-l" aria-label="Visualised heading L example">Heading L (32px)</div>                 |
-| Heading 3 (`h3`)      | <div class="heading-l" aria-label="Visualised heading L example">Heading L (32px)</div>     | <div class="heading-m" aria-label="Visualised heading M example">Heading M (24px)</div>                 |
-| Heading 4 (`h4`)      | <div class="heading-m" aria-label="Visualised heading M example">Heading M (24px)</div>     | <div class="heading-s" aria-label="Visualised heading S example">Heading S (20px)</div>                 |
-| Heading 5 (`h5`)      | <div class="heading-s" aria-label="Visualised heading S example">Heading S (20px)</div>     | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS (18px)</div>               |
-| Heading 6 (`h6`)      | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS (18px)</div>   | <div class="heading-xxs" aria-label="Visualised heading XXS example">Heading XXS (16px)</div>             |
-[Table 2:Heading scales]|
+| Heading level            | Default scale                                                                                 | Small scale                                                                                                     |
+| ------------------------ | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Heading 1 (`h1`)         | <div class="heading-xxl" aria-label="Visualised heading XXL example">Heading XXL (64px)</div> | <div class="heading-xl-mobile" aria-label="Visualised heading XL Mobile example">Heading XL-Mobile (40px)</div> |
+| Heading 2 (`h2`)         | <div class="heading-xl" aria-label="Visualised heading XL example">Heading XL (48px)</div>    | <div class="heading-l" aria-label="Visualised heading L example">Heading L (32px)</div>                         |
+| Heading 3 (`h3`)         | <div class="heading-l" aria-label="Visualised heading L example">Heading L (32px)</div>       | <div class="heading-m" aria-label="Visualised heading M example">Heading M (24px)</div>                         |
+| Heading 4 (`h4`)         | <div class="heading-m" aria-label="Visualised heading M example">Heading M (24px)</div>       | <div class="heading-s" aria-label="Visualised heading S example">Heading S (20px)</div>                         |
+| Heading 5 (`h5`)         | <div class="heading-s" aria-label="Visualised heading S example">Heading S (20px)</div>       | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS (18px)</div>                      |
+| Heading 6 (`h6`)         | <div class="heading-xs" aria-label="Visualised heading XS example">Heading XS (18px)</div>    | <div class="heading-xxs" aria-label="Visualised heading XXS example">Heading XXS (16px)</div>                   |
+| [Table 2:Heading scales] |
 
 ### Body text sizes
+
 Body font size tokens allow more subtle variations of body text sizes for improved content hierarchy and legibility.
 
-| Heading size | PX value | REM value | Usage                                                                                                                                                                |
-| ------------ | -------: | --------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Body XL**  |    20 px |      1.25 | Emphasising short introductory texts and other subtitles.                                                                                                            |
-| **Body L**   |    18 px |     1.125 | **Body text default for desktop screens.** Improving legibility of essential components, e.g. Text input and other form fields.                                      |
-| **Body M**   |    16 px |         1 | **Body text default for mobile screens.** Can also be used on text-heavy user interfaces as the default desktop body text size.                                      |
-| **Body S**   |    14 px |     0.875 | Conserving space in data-heavy layouts and small components, e.g. Status label.                                                                                      |
-[Table 3:Body text sizes]|
+| Heading size              | PX value | REM value | Usage                                                                                                                           |
+| ------------------------- | -------: | --------: | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Body XL**               |    20 px |      1.25 | Emphasising short introductory texts and other subtitles.                                                                       |
+| **Body L**                |    18 px |     1.125 | **Body text default for desktop screens.** Improving legibility of essential components, e.g. Text input and other form fields. |
+| **Body M**                |    16 px |         1 | **Body text default for mobile screens.** Can also be used on text-heavy user interfaces as the default desktop body text size. |
+| **Body S**                |    14 px |     0.875 | Conserving space in data-heavy layouts and small components, e.g. Status label.                                                 |
+| [Table 3:Body text sizes] |
 
 When choosing the body text size, start with the default `Body M (16 px)` token. It is a good starting point for most text-heavy user interfaces. This is also the minimum for the body text size in Helsinki services. This body text size can be used on all screen sizes.
 
-The smaller `Body S (14px)` token should only be used in secondary text content and inside components. 
+The smaller `Body S (14px)` token should only be used in secondary text content and inside components.
 
 If your service is not text-heavy, you can experiment with using the `Body L, 18px` token as the default body text size. In this case, it is recommended to use a smaller `Body M (16 px)` token for mobile breakpoints `breakpoint-s` and `breakpoint-xs`.
 
 ### Line height
+
 Line height tokens can be used to control the spacing between lines of text. The tokens define the ratio between line height and element font size. Note that HDS heading and text tokens use their line-height values to ensure line-height applies to 4 point grid. You can use <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/tree/master/packages/core/src/utils/helpers.css">helper classes provided in the Core package</ExternalLink> to match each heading and body text style with the correct line-height.
 
-| Line height size   | Ratio | Usage                                                                            |
-| ------------------ | ----: |--------------------------------------------------------------------------------- |
-| **Line height S**  | 1     | Buttons, navigation, and other UI components.                                     |
-| **Line height M**  | 1.2   | Lead texts and short paragraphs (no longer than 2-3 sentences).                  |
-| **Line height L**  | 1.5   | Optimal for longer text content and extended reading.                            |
-| **Line height XL** | 1.75  | Smaller text sizes or if you need to emphasise text (i.e. quotes).               |
-[Table 4:Line height sizes]|
+| Line height size            | Ratio | Usage                                                                                                                 |
+| --------------------------- | ----: | --------------------------------------------------------------------------------------------------------------------- |
+| **Line height S**           |     1 | Large headings and UI component texts that remain on a single line.                                                   |
+| **Line height M**           |   1.2 | Lead texts and short paragraphs (no longer than 2-3 sentences).                                                       |
+| **Line height L**           |   1.5 | Optimal for longer text content and extended reading. Use also with UI component texts that spread on multiple lines. |
+| **Line height XL**          |  1.75 | Smaller text sizes or if you need to emphasise text (i.e. quotes).                                                    |
+| [Table 4:Line height sizes] |
 
 ### Font weights
+
 HDS typography uses three font weights.
 
-| Weight name | CSS font-weight | Usage                                                          |
-| ----------- | --------------: |--------------------------------------------------------------- |
-| **Regular** | 400             | Body text default.                                             |
-| **Medium**  | 500             | Used for labels in components e.g. Button and form components. |
-| **Bold**    | 700             | Used to emphasise text.                                        |
-[Table 5:Font weights]|
+| Weight name            | CSS font-weight | Usage                                                          |
+| ---------------------- | --------------: | -------------------------------------------------------------- |
+| **Regular**            |             400 | Body text default.                                             |
+| **Medium**             |             500 | Used for labels in components e.g. Button and form components. |
+| **Bold**               |             700 | Used to emphasise text.                                        |
+| [Table 5:Font weights] |


### PR DESCRIPTION
## Description

Changed two lines. Lots of auto-formatting that haven't been applied before.

## Related Issue

Closes [HDS-2198](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2198)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments.

[Direct link to changed part
](https://city-of-helsinki.github.io/hds-demo/preview_1329/foundation/design-tokens/typography/#line-height)
## Screenshots (if appropriate):

## Add to changelog

- [ x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2198]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ