### PR TITLE
fix: use default touch-action on Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes that are not related to specific components
 
 - [Header] Fixed an issue with ActionBarItem dropdowns not inside the menu in mobile
 - [Header] Fix broken layout in mobile menu animations
+- [Dialog] Fix broken scrolling and zooming in mobile devices
 
 ### Core
 

--- a/packages/react/src/components/dialog/Dialog.module.scss
+++ b/packages/react/src/components/dialog/Dialog.module.scss
@@ -34,7 +34,6 @@
   -webkit-overflow-scrolling: unset;
   overscroll-behavior: none;
   position: fixed;
-  touch-action: none;
   z-index: 800;
 
   .dialogBackdrop {


### PR DESCRIPTION
## Description

`touch-action: none` -css rule in the Dialog component disabled default scrolling and zooming on mobile devices. Sometimes dialogs are so large (for mobile) that they need to be scrollable. I removed this rule to make scrolling work.

## Related Issue

Closes [HDS-2120](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2120)

## Motivation and Context

Sometimes dialogs are so large (for mobile) that they need to be scrollable.

## How Has This Been Tested?

There were doubts that this problematic rule was originally added to solve some issue with iOS devices. So I tested different use cases of the Dialog component in generic mobile devices and in iOS devices (in BrowserStack). I didn't found any problem after this fix.  

## Add to changelog

- [x] Added needed line to changelog


[HDS-2120]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ