### PR TITLE
(hds-2354) Mark props deprecated for v4

### DIFF
--- a/packages/react/src/components/accordion/Accordion.tsx
+++ b/packages/react/src/components/accordion/Accordion.tsx
@@ -16,32 +16,53 @@ export interface AccordionCustomTheme {
   '--border-color'?: string;
   '--padding-horizontal'?: string;
   '--padding-vertical'?: string;
+  /**
+   * @deprecated Will be replaced with --header-color in the next major release
+   */
   '--header-font-color'?: string;
   '--header-font-size'?: string;
   '--header-font-weight'?: string;
   '--header-letter-spacing'?: string;
   '--header-line-height'?: string;
+  /**
+   * @deprecated Will be replaced with --icon-size in the next major release
+   */
   '--button-size'?: string;
+  /**
+   * @deprecated Will be replaced with --header-outline-color-focus in the next major release
+   */
   '--header-focus-outline-color'?: string;
   '--content-font-color'?: string;
   '--content-font-size'?: string;
   '--content-line-height'?: string;
   '--close-button-background-color-disabled'?: string;
   '--close-button-background-color-focus'?: string;
+  /**
+   * @deprecated Will be removed in the next major release
+   */
   '--close-button-background-color-hover-focus'?: string;
   '--close-button-background-color-hover'?: string;
   '--close-button-background-color'?: string;
   '--close-button-border-color-active'?: string;
   '--close-button-border-color-disabled'?: string;
   '--close-button-border-color-focus'?: string;
+  /**
+   * @deprecated Will be removed in the next major release
+   */
   '--close-button-border-color-hover-focus'?: string;
   '--close-button-border-color-hover'?: string;
   '--close-button-border-color'?: string;
   '--close-button-color-disabled'?: string;
   '--close-button-color-focus'?: string;
+  /**
+   * @deprecated Will be removed in the next major release
+   */
   '--close-button-color-hover-focus'?: string;
   '--close-button-color-hover'?: string;
   '--close-button-color'?: string;
+  /**
+   * @deprecated Will be replaced with --close-button-outline-color-focus in the next major release
+   */
   '--close-button-focus-outline-color'?: string;
 }
 

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -37,10 +37,12 @@ export type CommonButtonProps = AllElementPropsWithoutRef<'button'> & {
   fullWidth?: boolean;
   /**
    * Element placed on the left side of the button label
+   * @deprecated Will be replaced with iconStart in the next major release.
    */
   iconLeft?: React.ReactNode;
   /**
    * Element placed on the right side of the button label
+   * @deprecated Will be replaced with iconEnd in the next major release.
    */
   iconRight?: React.ReactNode;
   /**
@@ -49,10 +51,12 @@ export type CommonButtonProps = AllElementPropsWithoutRef<'button'> & {
   size?: ButtonSize;
   /**
    * If `true` a loading spinner is displayed inside the button along `loadingText`
+   * @deprecated Will be removed in the next major release
    */
   isLoading?: boolean;
   /**
    * Loading text to show alongside loading spinner
+   * @deprecated Will be removed in the next major release
    */
   loadingText?: string;
 };

--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -31,6 +31,7 @@ export type LinkProps = {
   href: string;
   /**
    * Element placed on the left side of the link text
+   * @deprecated Will be replaced with iconStart in the next major release.
    */
   iconLeft?: React.ReactNode;
   /**


### PR DESCRIPTION
## Description

Release-4.0.0 has some prop changes that are not marked as deprecated in development branch for v3.10.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2354](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2354)

## How Has This Been Tested?

No code changes.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

No code changes.


[HDS-2354]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ