### PR TITLE
release-4.0.0 HDS-2358 button content align fix

### DIFF
--- a/packages/core/src/components/button/button.css
+++ b/packages/core/src/components/button/button.css
@@ -58,6 +58,7 @@
   overflow-wrap: anywhere;
   padding: var(--padding);
   position: relative;
+  text-align: center;
   text-decoration: none;
   text-transform: none;
   vertical-align: top;


### PR DESCRIPTION
## Description

Fix issue where Link styled as a button has wrong text alignment

## Related Issue

Closes [HDS-2358](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2358)

## How Has This Been Tested?

- local machine running tests

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/4331e224-ab2a-40eb-a63d-2e7e807937e6)


## Add to changelog

Not needed, just a small tweak

[HDS-2358]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ