### PR TITLE
Release-4.0.0 HDS-2423 enable playwright test separate running and write instructions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,68 @@
+# E2E Testing README
+
+This document provides instructions on how to use the `run.sh` and `update-snapshots.sh` scripts located in the `docker` directory as well as give some hints how to write tests (ongoing process).
+
+## Prerequisites
+
+- Docker installed on your machine
+- Necessary permissions to execute shell scripts
+
+## Usage
+
+Before running the tests build the corresponding Storybooks which the tests are ran against.
+
+### Running Tests
+
+To run all the end-to-end tests, use the `run.sh` script:
+
+```sh
+cd docker
+./run.sh
+```
+
+If you wish to run only certain package's tests (core for example):
+
+```sh
+cd docker
+./run.sh core
+```
+
+Or if you want to run only a certain component's tests (react button for example):
+
+```sh
+cd docker
+./run.sh react button
+```
+
+
+These scripts run the Docker container, executing the tests inside the container.
+
+### Updating Snapshots
+
+If you need to update the snapshots, use the `update-snapshots.sh` script:
+
+```sh
+cd docker
+./update-snapshots.sh
+```
+
+If you with to be more precise, use same targetting manner as in running the tests (for example update only core tag reference images):
+
+```sh
+cd docker
+./update-snapshots.sh core tag
+```
+
+This script will update the snapshot files used in the tests.
+
+## Writing tests
+
+- To be implemented....
+
+## Notes
+
+- Do not run the scripts in `package.json` locally since the screenshots will most likely differ from the ones created in CI and will cause the tests to fail.
+
+- If you need to update Playwright version in the project, you need to match the versions in `package.json`'s `devDependencies` and the docker scripts (used Docker images).
+
+For further assistance, refer to the project documentation or contact the development team.

--- a/e2e/docker/run.sh
+++ b/e2e/docker/run.sh
@@ -1,4 +1,28 @@
 
 #!/bin/sh
 HDS_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )"
-docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.45.1-jammy /bin/bash -c "cd /helsinki-design-system/e2e && yarn start"
+
+PACKAGE=$1
+COMPONENT=$2
+COMMAND=""
+
+# PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshot:react
+
+# if packaga and component are not provided, run all snapshots
+if [ -z "$PACKAGE" ] && [ -z "$COMPONENT" ]; then
+    COMMAND="yarn start"
+fi
+
+# if only package is provided, run snapshots for that package
+if [ -n "$PACKAGE" ] && [ -z "$COMPONENT" ]; then
+    COMMAND="PACKAGE=${PACKAGE} yarn start-package"
+fi
+
+# if both package and component are provided, run snapshots for that component
+if [ -n "$PACKAGE" ] && [ -n "$COMPONENT" ]; then
+    COMMAND="PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn start-component"
+fi
+
+docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.45.1-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
+
+# --update-snapshots

--- a/e2e/docker/update-snapshots.sh
+++ b/e2e/docker/update-snapshots.sh
@@ -1,4 +1,28 @@
 
 #!/bin/sh
 HDS_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )"
-docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.45.1-jammy /bin/bash -c "cd /helsinki-design-system/e2e && yarn update-snapshots"
+
+PACKAGE=$1
+COMPONENT=$2
+COMMAND=""
+
+# PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshot:react
+
+# if packaga and component are not provided, run all snapshots
+if [ -z "$PACKAGE" ] && [ -z "$COMPONENT" ]; then
+    COMMAND="yarn update-snapshots"
+fi
+
+# if only package is provided, run snapshots for that package
+if [ -n "$PACKAGE" ] && [ -z "$COMPONENT" ]; then
+    COMMAND="PACKAGE=${PACKAGE} yarn update-snapshots-package"
+fi
+
+# if both package and component are provided, run snapshots for that component
+if [ -n "$PACKAGE" ] && [ -n "$COMPONENT" ]; then
+    COMMAND="PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshots-component"
+fi
+
+docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.45.1-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
+
+# --update-snapshots

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,12 +4,16 @@
   "description": "e2e tests using Playwright",
   "version": "3.10.0",
   "scripts": {
+    "ci": "npx playwright test",
     "inst": "yarn playwright install",
     "install-deps": "npx playwright install-deps",
-    "ci": "npx playwright test",
+    "record": "npx playwright codegen https://hds.hel.fi",
+    "start-component": "npx playwright test tests/$PACKAGE/**/*$COMPONENT*",
+    "start-package": "npx playwright test tests/$PACKAGE/",
     "start": "npx playwright test",
-    "update-snapshots": "npx playwright test --update-snapshots",
-    "record": "npx playwright codegen https://hds.hel.fi"
+    "update-snapshots-component": "npx playwright test tests/$PACKAGE/**/*$COMPONENT* --update-snapshots",
+    "update-snapshots-package": "npx playwright test tests/$PACKAGE/ --update-snapshots",
+    "update-snapshots": "npx playwright test --update-snapshots"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.1"


### PR DESCRIPTION
## Description

Make possible to run tests package and component level to ease up testing process. Also wrote a simple README to instruct how to use them.

## Related Issue

Closes [HDS-2423](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2423)

## How Has This Been Tested?

- local machine running the scripts according to the instructions in README under e2e directory

## Demos:

Links to demos are in the comments

## Add to changelog

- Not needed, just for development & testing purposes


[HDS-2423]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ