### PR TITLE
HDS-2451: Export graphQLModule hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Logo] Fixed data-testid attribute not being set with native props
+- [Login] Fixed GraphQLModule exports
 
 ### Core
 

--- a/packages/react/src/components/login/Login.stories.tsx
+++ b/packages/react/src/components/login/Login.stories.tsx
@@ -35,15 +35,16 @@ import {
   sessionPollerErrors,
   LoginProvider,
   LoginProviderProps,
+  useGraphQL,
+  useGraphQLModule,
+  createGraphQLModule,
 } from './index';
 import { Button } from '../button/Button';
 import { Header } from '../header/Header';
 import { Notification } from '../notification/Notification';
 import { Tabs } from '../tabs/Tabs';
 import { Logo, logoFi } from '../logo';
-import { createGraphQLModule } from './graphQLModule/graphQLModule';
 import { MyProfileQuery } from './graphQLModule/demoData/MyProfileQuery';
-import { useGraphQL, useGraphQLModule } from './graphQLModule/hooks';
 import { LoadingSpinner } from '../loadingSpinner';
 
 type StoryArgs = {

--- a/packages/react/src/components/login/index.ts
+++ b/packages/react/src/components/login/index.ts
@@ -12,6 +12,7 @@ export * from './client/hooks';
 export * from './beacon/hooks';
 export * from './apiTokensClient/hooks';
 export * from './sessionPoller/hooks';
+export * from './graphQLModule/hooks';
 
 // vanilla js code
 export * from './index.vanilla-js';


### PR DESCRIPTION
## Description
All hooks were not exported.
Changed the login stories to use imports from the index file to make sure all are exported properly.


## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2451](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2451)

## How Has This Been Tested?

With Storybook

## Demos:

Links to demos are in the comments

Note: Logging in does not work in automated demos, because login urls must be registered to backend and urls keep changing in demos.

## Screenshots (if appropriate):

## Add to changelog

- [ x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2451]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ