### PR TITLE
Release-3.10.2 - HDS-2473 fix text input cross origin prop

### DIFF
--- a/packages/react/src/components/link/Link.tsx
+++ b/packages/react/src/components/link/Link.tsx
@@ -5,62 +5,63 @@ import styles from './Link.module.scss';
 import { IconLinkExternal } from '../../icons';
 import classNames from '../../utils/classNames';
 import { getTextFromReactChildren } from '../../utils/getTextFromReactChildren';
+import { AllElementPropsWithoutRef, MergeAndOverrideProps } from '../../utils/elementTypings';
 
-export type LinkProps = {
-  /**
-   * aria-label for providing detailed information for screen readers about a link text.
-   * @deprecated Will be replaced in the next major release with "aria-label"
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  ariaLabel?: string;
-  /**
-   * Link content
-   */
-  children: React.ReactNode;
-  /**
-   * Boolean indicating whether visited styles of the link are applied
-   */
-  disableVisitedStyles?: boolean;
-  /**
-   * Boolean indicating whether the link will lead user to external domain.
-   */
-  external?: boolean;
-  /**
-   * Hypertext Reference of the link.
-   */
-  href: string;
-  /**
-   * Element placed on the left side of the link text
-   * @deprecated Will be replaced with iconStart in the next major release.
-   */
-  iconLeft?: React.ReactNode;
-  /**
-   * Boolean indicating whether the link will open in new tab or not.
-   */
-  openInNewTab?: boolean;
-  /**
-   * The aria-label for opening link in a new tab
-   */
-  openInNewTabAriaLabel?: string;
-  /**
-   * The aria-label for opening link in an external domain
-   */
-  openInExternalDomainAriaLabel?: string;
-  /**
-   * Size of the link
-   */
-  size?: 'S' | 'M' | 'L';
-  /**
-   * Additional styles
-   */
-  style?: React.CSSProperties;
-  /**
-   * Style the link as a button
-   */
-  useButtonStyles?: boolean;
-} & Omit<
-  React.ComponentPropsWithoutRef<'a'>,
-  'target' | 'href' | 'onPointerEnterCapture' | 'onPointerLeaveCapture' | 'aria-label'
+export type LinkProps = MergeAndOverrideProps<
+  AllElementPropsWithoutRef<'a'>,
+  {
+    /**
+     * aria-label for providing detailed information for screen readers about a link text.
+     * @deprecated Will be replaced in the next major release with "aria-label"
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    ariaLabel?: string;
+    /**
+     * Link content
+     */
+    children: React.ReactNode;
+    /**
+     * Boolean indicating whether visited styles of the link are applied
+     */
+    disableVisitedStyles?: boolean;
+    /**
+     * Boolean indicating whether the link will lead user to external domain.
+     */
+    external?: boolean;
+    /**
+     * Hypertext Reference of the link.
+     */
+    href: string;
+    /**
+     * Element placed on the left side of the link text
+     * @deprecated Will be replaced with iconStart in the next major release.
+     */
+    iconLeft?: React.ReactNode;
+    /**
+     * Boolean indicating whether the link will open in new tab or not.
+     */
+    openInNewTab?: boolean;
+    /**
+     * The aria-label for opening link in a new tab
+     */
+    openInNewTabAriaLabel?: string;
+    /**
+     * The aria-label for opening link in an external domain
+     */
+    openInExternalDomainAriaLabel?: string;
+    /**
+     * Size of the link
+     */
+    size?: 'S' | 'M' | 'L';
+    /**
+     * Additional styles
+     */
+    style?: React.CSSProperties;
+    /**
+     * Style the link as a button
+     */
+    useButtonStyles?: boolean;
+  }
 >;
 
 type LinkToIconSizeMappingType = {

--- a/packages/react/src/components/tag/Tag.test.tsx
+++ b/packages/react/src/components/tag/Tag.test.tsx
@@ -33,7 +33,7 @@ describe('<Tag /> spec', () => {
     expect(results).toHaveNoViolations();
   });
   it('native html props are passed to the element', async () => {
-    const divProps = getCommonElementTestProps<'div', Pick<TagProps, 'onClick' | 'role'>>('div');
+    const divProps = getCommonElementTestProps<'div', Pick<TagProps, 'role'>>('div');
     const { getByTestId } = render(<Tag {...divProps}>Foo</Tag>);
     const element = getByTestId(divProps['data-testid']);
     expect(getElementAttributesMisMatches(element, divProps)).toHaveLength(0);

--- a/packages/react/src/utils/commonHTMLAttributes.ts
+++ b/packages/react/src/utils/commonHTMLAttributes.ts
@@ -1,3 +1,17 @@
+import { PointerEventHandler } from 'react';
+
+type TypesReactFixes = {
+  /**
+   * These are added to all since @types/react has problems across versions
+   * TODO: This is here just to fix issues with react/types in the TextInput and various component.
+   * It should be removed once the issue is fixed.
+   * https://github.com/creativetimofficial/material-tailwind/issues/427
+   */
+  crossOrigin?: string;
+  onPointerEnterCapture?: PointerEventHandler<HTMLElement>;
+  onPointerLeaveCapture?: PointerEventHandler<HTMLElement>;
+};
+
 export type CommonHTMLAttributes = {
   [key: `data-${string}`]: string;
-};
+} & TypesReactFixes;


### PR DESCRIPTION
## Description

Fixes issue with built projects wanting `crossOrigin` prop as mandatory for TextInput. Also fixes other same kind of issues with more props too. Depending on different version of `types/react`-package.

## Related Issue

Closes [HDS-2473](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2473)

## How Has This Been Tested?

- locally tested with hds-cra app

## Demos:

Links to demos are in the comments

## Add to changelog

- not needed


[HDS-2473]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ