### PR TITLE
Release-4.0.0 (HDS-2479) Fix tag theme, add documentation to tag and button themes' color orders

### DIFF
--- a/packages/core/src/components/tag/tag.css
+++ b/packages/core/src/components/tag/tag.css
@@ -2,26 +2,36 @@
 @import url("../../icons/cross.css");
 
 .hds-tag {
-  --background-color-hover: var(--color-black-20);
-  --background-color: var(--color-black-10);
-  --border-color-action: var(--color-black-90);
-  --color: var(--color-black-90);
+  /* logics, always falls back to previous (upper) if not given ->
+  (no) active color -> (no) hover color -> (no) focus color -> default color
+  */
+  --computed-background-color: var(--background-color, var(--color-black-10));
+  --computed-background-color-focus: var(--background-color-focus, var(--computed-background-color, transparent));
+  --computed-background-color-hover: var(--background-color-hover, var(--computed-background-color-focus, transparent));
+  --computed-background-color-active: var(--background-color-active, var(--computed-background-color-hover, transparent));
+  --computed-border-color: var(--border-color, var(--computed-background-color));
+  --computed-border-color-focus: var(--border-color-focus, var(--computed-border-color, transparent));
+  --computed-border-color-hover: var(--border-color-hover, var(--computed-border-color-focus, transparent));
+  --computed-border-color-active: var(--border-color-active, var(--computed-border-color-hover, transparent));
+  --computed-color: var(--color, --color-black-90);
+  --computed-color-focus: var(--color-focus, var(--computed-color, inherit));
+  --computed-color-hover: var(--color-hover, var(--computed-color-focus, inherit));
+  --computed-color-active: var(--color-active, var(--computed-color-hover, inherit));
+  --computed-outline-color: var(--outline-color, transparent);
   --font-size: var(--fontsize-body-s);
   --gap: var(--spacing-3-xs);
   --height: 32px;
   --icon-reposition: -4px;
   --icon-size: 24px;
-  --outline-color-focus: var(--color-focus-outline);
   --outline-width: 2px;
   --padding-horizontal: 12px;
   --padding-vertical: 3px;
 
-
   align-items: center;
-  background-color: var(--background-color);
+  background-color: var(--computed-background-color);
   border-radius: calc(var(--height) / 2);
   box-sizing: border-box;
-  color: var(--color);
+  color: var(--computed-color, inherit);
   display: inline-flex;
   flex-direction: row;
   font-size: var(--font-size);
@@ -32,6 +42,7 @@
   max-width: 100%;
   min-height: var(--height);
   outline: none;
+  outline-offset: 2px;
   overflow: hidden;
   padding: var(--padding-vertical) var(--padding-horizontal);
 
@@ -64,7 +75,9 @@
 }
 
 .hds-tag--action {
-  border: 1px solid var(--border-color-action);
+  --border-color: var(--color-black-90);
+
+  border: 1px solid var(--computed-border-color);
   padding: calc(var(--padding-vertical) - 1px) calc(var(--padding-horizontal) - 1px);
 }
 
@@ -80,15 +93,35 @@
 }
 
 .hds-tag--action, .hds-tag--link {
+  --background-color-hover: var(--color-black-20);
+  --outline-color: var(--color-focus-outline);
+
+  cursor: pointer;
+
+  /* focus */
+  &:focus-visible {
+    background-color: var(--computed-background-color-focus);
+    border-color: var(--computed-border-color-focus);
+    color: var(--computed-color-focus);
+  }
+
+  /* hover */
   &:hover {
-    background-color: var(--background-color-hover);
-    cursor: pointer;
+    background-color: var(--computed-background-color-hover);
+    border-color: var(--computed-border-color-hover);
+    color: var(--computed-color-hover);
+  }
+
+  /* active */
+  &:active {
+    background-color: var(--computed-background-color-active);
+    border-color: var(--computed-border-color-active);
+    color: var(--computed-color-active);
   }
 
   &:focus-visible, &:active:hover {
     box-shadow: none;
-    outline: var(--outline-width) solid var(--outline-color-focus);
-    outline-offset: 2px;
+    outline: var(--outline-width) solid var(--computed-outline-color);
   }
 }
 

--- a/packages/core/src/components/tag/tag.stories.js
+++ b/packages/core/src/components/tag/tag.stories.js
@@ -29,23 +29,23 @@ export const ActionTags = () => `
 const customA = `
     --background-color: var(--color-brick);
     --color: var(--color-white);
-    --outline-color-focus: var(--color-black-90);`;
+    --outline-color: var(--color-black-90);`;
 
 const customB = `
     --background-color: var(--color-engel);
     --color: var(--color-black-90);
-    --outline-color-focus: var(--color-black-90);`;
+    --outline-color: var(--color-black-90);`;
 
 const customC = `
     --background-color: var(--color-copper-dark);
     --background-color-hover: var(--color-tram-dark);
     --color: var(--color-white);
-    --outline-color-focus: var(--color-metro);`;
+    --outline-color: var(--color-metro);`;
 
 const customD = `
     --background-color: var(--color-fog);
     --color: var(--color-black-90);
-    --outline-color-focus: var(--color-black-90);
+    --outline-color: var(--color-black-90);
     --background-color-hover: orange;`;
 
 export const CustomThemeTags = () => `

--- a/packages/react/src/components/tag/Tag.stories.tsx
+++ b/packages/react/src/components/tag/Tag.stories.tsx
@@ -133,26 +133,26 @@ export const CustomThemeTags = (args: TagProps) => {
   const customA: TagTheme = {
     '--background-color': 'var(--color-brick)',
     '--color': 'var(--color-white)',
-    '--outline-color-focus': 'var(--color-black-90)',
+    '--outline-color': 'var(--color-black-90)',
   };
 
   const customB: TagTheme = {
     '--background-color': 'var(--color-engel)',
     '--color': 'var(--color-black-90)',
-    '--outline-color-focus': 'var(--color-black-90)',
+    '--outline-color': 'var(--color-black-90)',
   };
 
   const customC: TagTheme = {
     '--background-color': 'var(--color-copper-dark)',
     '--background-color-hover': 'var(--color-tram-dark)',
     '--color': 'var(--color-white)',
-    '--outline-color-focus': 'var(--color-metro)',
+    '--outline-color': 'var(--color-metro)',
   };
 
   const customD: TagTheme = {
     '--background-color': 'var(--color-fog)',
     '--color': 'var(--color-black-90)',
-    '--outline-color-focus': 'var(--color-black-90)',
+    '--outline-color': 'var(--color-black-90)',
     '--background-color-hover': 'orange',
   };
 

--- a/packages/react/src/components/tag/Tag.tsx
+++ b/packages/react/src/components/tag/Tag.tsx
@@ -12,7 +12,7 @@ export interface TagTheme {
   '--background-color'?: string;
   '--border-color-action'?: string;
   '--color'?: string;
-  '--outline-color-focus'?: string;
+  '--outline-color'?: string;
 }
 
 export enum TagVariant {

--- a/site/src/docs/components/button/customisation.mdx
+++ b/site/src/docs/components/button/customisation.mdx
@@ -15,7 +15,8 @@ In Core version, you can use button theme classes `hds-button--theme-black` and 
 
 In React version, you can use the `theme` property to customise the component by giving it a `ButtonPresetTheme` string or a `ButtonTheme` object.
 
-See all available theme variables in the tables below.
+See all available theme variables in the tables below. All colours don't have to be given,
+they will fallback to previous colour which exists (active -> hover -> focus -> default).
 
 
 | Preset Theme       | Description                              |

--- a/site/src/docs/components/tag/customisation.mdx
+++ b/site/src/docs/components/tag/customisation.mdx
@@ -15,15 +15,24 @@ In Core version, you can either use the `style` or `class` attributes in the HT
 
 In React version, you can use the `theme` (type of `TagTheme` in Typescript) property to customise the component. 
 
-See all available theme variables in the table below.
+See all available theme variables in the table below. All colours of interactive (Tags with click or link) don't have to be given,
+they will fallback to previous colour which exists (active -> hover -> focus -> default).
 
-| Theme variable                        | Description                                 |
-| ------------------------------------- | ------------------------------------------- |
-| '--background-color-hover'            | Colour of the tag background when hovered upon. |
-| '--background-color'                  | Colour of the tag background.               |
-| '--border-color-action'               | Colour of the border of Tags with onClick or onDelete actions |
-| '--color'                             | Colour of elements inside the tag.          |
-| '--outline-color-focus'               | Colour of the tag focus border.             |
+| Theme variable                         | Description                                 |
+| -------------------------------------- | ------------------------------------------- |
+| <code>--background-color</code>        | Colour of the tag background.               |
+| <code>--background-color-focus</code>  | Colour of background of Tags with onClick or onDelete actions when focused. |
+| <code>--background-color-hover</code>  | Colour of background of Tags with onClick or onDelete actions when hovered upon. |
+| <code>--background-color-active</code> | Colour of background of Tags with onClick or onDelete actions when active.  |
+| <code>--border-color</code>            | Colour of the border of Tags with onClick or onDelete actions |
+| <code>--border-color-focus</code>      | Colour of the border of Tags with onClick or onDelete actions when focused |
+| <code>--border-color-hover</code>      | Colour of the border of Tags with onClick or onDelete actions when hovered upon |
+| <code>--border-color-active</code>     | Colour of the border of Tags with onClick or onDelete actions when active |
+| <code>--color</code>                   | Colour of elements inside the tag.          |
+| <code>--color-focus</code>             | Colour of elements inside of Tags with onClick or onDelete actions when focused.      |
+| <code>--color-hover</code>             | Colour of elements inside of Tags with onClick or onDelete actions when hovered upon. |
+| <code>--color-active</code>            | Colour of elements inside of Tags with onClick or onDelete actions when active.       |
+| <code>--outline-color</code>           | Colour of the tag focus border of Tags with onClick or onDelete actions.              |
 
 ### Customisation example
 <Playground scope={{ Tag }}>
@@ -40,7 +49,7 @@ import { Tag } from 'hds-react';
       '--background-color-hover': 'var(--color-tram-dark)',
       '--background-color': 'var(--color-copper-dark)',
       '--color': 'var(--color-white)',
-      '--outline-color-focus': 'var(--color-metro)',
+      '--outline-color': 'var(--color-metro)',
     }}
   >
     Action
@@ -56,7 +65,7 @@ import { Tag } from 'hds-react';
     --background-color-hover: var(--color-tram-dark);
     --background-color: var(--color-copper-dark);
     --color: var(--color-white);
-    --outline-color-focus: var(--color-metro);
+    --outline-color: var(--color-metro);
   "
   tabindex="0"
   onclick={}


### PR DESCRIPTION
## Description

Adds Tag theme to allow more customization, also add more documentation to Tag and Button themes.

## Related Issue

Closes [HDS-2479](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2479)

## How Has This Been Tested?

- running all tests locally

## Demos:

Links to demos are in the comments

## Add to changelog

- done already earlier (rewritten components)


[HDS-2479]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ