### PR TITLE
(release-4.0.0) HDS-2365: Update design migration guide

### DIFF
--- a/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
+++ b/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
@@ -197,41 +197,62 @@ Design token black-60 is changed from #666666 to #595959 to improve contrast wit
 
 ---
 
-## Design kit
+## Figma design kit
 
 This guide will help you understand how to transition an existing project from using an older version of HDS Figma Design Kit to using the latest 4.0.0 version.
 
 ### What’s changing?
 
-This HDS Design Kit update follows the changes deployed in the code for the 4.0.0 release of HDS. The major differences include significant changes to the **CookieConsent**, **Dropdown** and **Tag** components. The new **Select** and **Multiselect** components replace the old Dropdown.
+This HDS Design Kit update follows the changes deployed in the code for the 4.0.0 release of HDS. The major differences include significant changes to the `CookieConsent`, `Dropdown` and `Tag` components. The new `Select` and `Multiselect` components replace the old Dropdown.
 
-The line heights of **headings** have been updated in the HDS Design Kit to improve readability, especially with larger titles. We have improved color **black-60** for better contrast by changing it from #666666 to #595959.
+The line heights of `headings` have been updated in the HDS Design Kit to improve readability, especially with larger titles. We have improved color `black-60` for better contrast by changing it from #666666 to #595959.
 
 The HDS Design Kit in Figma has undergone **a major restructuring**: now, each component is placed on its own page. This new organisation makes it much easier to find components without having to guess which group they belong to. Each component will also have better documentation, which may include main component, subcomponents, specifications, variant examples, and usage & prototype examples, depending on the need and documentation status. We hope these changes will better explain the features of each component and how they can be used.
 
 #### Components that need replacing
 
-- **[Dropdown]** The Dropdown component is now deprecated and will be removed in future versions. Replace it with Select or Multiselect.
+- The Dropdown component is now deprecated and will be removed in future versions. Replace it with Select or Multiselect.
     
-- **[Cookie consent]** The CookieConsent component has been replaced with a new version, and it needs to be manually updated.
-    
+- The CookieConsent component has been replaced with a new version, and it needs to be manually updated.
 
-Deprecated components needs replacing, follow [Figma guide](https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances) about swapping components.
+Deprecated components needs replacing, follow <ExternalLink href="https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances">Figma guide about swapping components</ExternalLink>.
 
 #### Components that need manual checking
 
-- **[Headings]** Line heights have been updated to improve readability. Please check that the layout does not break.
+- Line heights in headings have been updated to improve readability. Please check that the layout does not break.
     
-- **[Form components]** The asterisk indicating required fields in form components like TextInput has been renewed and is now its own property. You’ll need to manually change the required indicators in layouts.
+- The asterisk indicating required fields in form components like TextInput has been renewed and is now its own property. You’ll need to manually change the required indicators in layouts.
     
-- **[Tag]** Accessibility has been improved, and a new Link variant has been introduced. These changes do not break the old components, but it’s still better to check the updated components.
-    
+- The Tag components accessibility has been improved, and a new Link variant has been introduced. These changes do not break the old components, but it’s still better to check the updated components.
+
+### Introduction of Figma Variables in HDS
+
+We are excited to announce the introduction of variables in HDS. We will be implementing variables step by step, starting with a feature for all HDS designers!
+
+#### The first one
+
+The first variable in use is called “Deprecated”, and it’s part of the [HDS] Deprecated variable collection. This variable is used in a single component named .❌_DeprecatedIndicator, which is used to highlight deprecated components.
+
+#### What’s great about this?
+
+This feature allows designers to easily and quickly identify and highlight where deprecated HDS components are used on a page.
+
+#### How to use it
+
+1. Click an empty spot on the canvas or press Esc to deselect all layers.
+2. From the **Page** section of the right sidebar, click variable icon to **Apply variable mode**.
+3. Hover over a variable collection [HDS] Deprecated and choose a mode On.
+
+This is just the beginning of our journey to variables in the Helsinki Design System. We are eager to start implementing spacing, colour, and typography tokens. We welcome your feedback!
+
+Read more about variables in <ExternalLink href="https://help.figma.com/hc/en-us/articles/15343816063383-Modes-for-variables">Figma Learn</ExternalLink>.
+
 
 ### What should I do?
 
 #### 1. Duplicate your current design file
 
-In order to avoid disruptions to your workflow, it is recommended that you [duplicate](https://help.figma.com/hc/en-us/articles/360038511533-Duplicate-or-copy-files) your project files before accepting this update. This allows you to migrate to the latest HDS Design Kit while maintaining a reference to your original file.
+In order to avoid disruptions to your workflow, it is recommended that you duplicate your project files before accepting this update. This allows you to migrate to the latest HDS Design Kit while maintaining a reference to your original file. A guide for duplicating files can be found in <ExternalLink href="https://help.figma.com/hc/en-us/articles/360038511533-Duplicate-or-copy-files">Figma Learn</ExternalLink>.
 
 #### 2. Review and accept updates
 
@@ -249,40 +270,12 @@ This update includes breaking changes to components and may require that you upd
 
 The v3 Figma library has been copied as a new file and will no longer receive updates. However, you can continue to use it by swapping to the v3 library.
 
-Swapping libraries allows you to quickly update instances in a file to use components from another library. Follow the Figma guide to swap to the v3 library if you wish to use the previous HDS version.
-
-- [Swap style and component libraries – Figma Learn - Help Center](https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries#swap)
+Swapping libraries allows you to quickly update instances in a file to use components from another library. Follow the Figma guide to swap to the v3 library if you wish to use the previous HDS version. The guide for swapping components can be found in <ExternalLink href="https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries#swap">Figma Learn</ExternalLink>.
     
-### What about the Sketch library?
+#### What about the Sketch library?
 
 The Sketch library will no longer be updated and will be removed after the 4.0.0 release.
 
----
-
-### Introduction of Figma Variables in HDS
-
-We are excited to announce the introduction of variables in HDS. We will be implementing variables step by step, starting with a feature for all HDS designers!
-
-#### The first one
-
-The first variable in use is called “Deprecated”, and it’s part of the [HDS] Deprecated variable collection. This variable is used in a single component named .❌_DeprecatedIndicator, which is used to highlight deprecated components.
-
-#### What’s great about this?
-
-This feature allows designers to easily and quickly identify and highlight where deprecated HDS components are used on a page.
-
-#### How to use it
-
-1. Click an empty spot on the canvas or press Esc to deselect all layers.
-    
-2. From the **Page** section of the right sidebar, click variable icon to **Apply variable mode**.
-    
-3. Hover over a variable collection [HDS] Deprecated and choose a mode On.
-    
-
-This is just the beginning of our journey to variables in the Helsinki Design System. We are eager to start implementing spacing, colour, and typography tokens. We welcome your feedback!
-
-Read more about variables in [Figma Learn](https://help.figma.com/hc/en-us/articles/15343816063383-Modes-for-variables).
 
 ### Getting support
 

--- a/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
+++ b/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
@@ -195,75 +195,95 @@ There are updates to lineheights to improve readability especially on Headings. 
 #### Black-60 changed to more accesible shade
 Design token black-60 is changed from #666666 to #595959 to improve contrast with other colours. With only bus-dark and black-90 the contrast gets worse, all other colours the contrast improves. If needed, verify the used colours.
 
+---
+
 ## Design kit
 
 This guide will help you understand how to transition an existing project from using an older version of HDS Figma Design Kit to using the latest 4.0.0 version.
 
 ### What’s changing?
-This HDS Design Kit update follows the changes deployed in the code for the 4.0.0 release of HDS. The major differences include significant changes to the CookieConsent, Dropdown and Tag components. The new Select and Multiselect components replace the old Dropdown.
 
-The line heights of headings have been updated in the HDS Design Kit to improve readability, especially with larger titles. We have improved color black-60 for better contrast by changing it from #666666 to #595959.
+This HDS Design Kit update follows the changes deployed in the code for the 4.0.0 release of HDS. The major differences include significant changes to the **CookieConsent**, **Dropdown** and **Tag** components. The new **Select** and **Multiselect** components replace the old Dropdown.
 
-The HDS Design Kit in Figma has undergone a major restructuring: now, each component is placed on its own page. This new organisation makes it much easier to find components without having to guess which group they belong to. Each component will also have better documentation, which may include main component, subcomponents, specifications, variant examples, and usage & prototype examples, depending on the need and documentation status. We hope these changes will better explain the features of each component and how they can be used.
+The line heights of **headings** have been updated in the HDS Design Kit to improve readability, especially with larger titles. We have improved color **black-60** for better contrast by changing it from #666666 to #595959.
 
-### Components that need replacing
-[Dropdown] The Dropdown component is now deprecated and will be removed in future versions. Replace it with Select or Multiselect.
+The HDS Design Kit in Figma has undergone **a major restructuring**: now, each component is placed on its own page. This new organisation makes it much easier to find components without having to guess which group they belong to. Each component will also have better documentation, which may include main component, subcomponents, specifications, variant examples, and usage & prototype examples, depending on the need and documentation status. We hope these changes will better explain the features of each component and how they can be used.
 
-[Cookie consent] The CookieConsent component has been replaced with a new version, and it needs to be manually updated.
+#### Components that need replacing
 
-Deprecated components needs replacing, follow Figma guide about swapping components.
+- **[Dropdown]** The Dropdown component is now deprecated and will be removed in future versions. Replace it with Select or Multiselect.
+    
+- **[Cookie consent]** The CookieConsent component has been replaced with a new version, and it needs to be manually updated.
+    
 
-### Components that need manual checking
-[Headings] Line heights have been updated to improve readability. Please check that the layout does not break.
+Deprecated components needs replacing, follow [Figma guide](https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances) about swapping components.
 
-[Form components] The asterisk indicating required fields in form components like TextInput has been renewed and is now its own property. You’ll need to manually change the required indicators in layouts.
+#### Components that need manual checking
 
-[Tag] Accessibility has been improved, and a new Link variant has been introduced. These changes do not break the old components, but it’s still better to check the updated components.
+- **[Headings]** Line heights have been updated to improve readability. Please check that the layout does not break.
+    
+- **[Form components]** The asterisk indicating required fields in form components like TextInput has been renewed and is now its own property. You’ll need to manually change the required indicators in layouts.
+    
+- **[Tag]** Accessibility has been improved, and a new Link variant has been introduced. These changes do not break the old components, but it’s still better to check the updated components.
+    
 
 ### What should I do?
-1. Duplicate your current design file
-In order to avoid disruptions to your workflow, it is recommended that you duplicate your project files before accepting this update. This allows you to migrate to the latest HDS Design Kit while maintaining a reference to your original file.
 
-2. Review and accept updates
-In your duplicate file, review and accept the HDS Design Kit library updates. You will see updates to three libraries which include the 
+#### 1. Duplicate your current design file
 
-3. Find deprecated dropdown components
-You can now easily highlight deprecated components. Read more in section Figma major version release process | 📣 Introduction of Figma Variables in HDS.
+In order to avoid disruptions to your workflow, it is recommended that you [duplicate](https://help.figma.com/hc/en-us/articles/360038511533-Duplicate-or-copy-files) your project files before accepting this update. This allows you to migrate to the latest HDS Design Kit while maintaining a reference to your original file.
 
-5. Update components & content
+#### 2. Review and accept updates
+
+In your duplicate file, review and accept the HDS Design Kit library updates. You will see updates to three libraries which include the
+
+#### 3. Find deprecated dropdown components
+
+- You can now easily highlight deprecated components. Read more in section [Introduction of Figma Variables in HDS](#introduction-of-figma-variables-in-hds).
+    
+#### 4. Update components & content
+
 This update includes breaking changes to components and may require that you update content in components with breaking changes.
 
-### How can I continue using HDS v3?
+### **How can I continue using HDS v3?**
+
 The v3 Figma library has been copied as a new file and will no longer receive updates. However, you can continue to use it by swapping to the v3 library.
 
 Swapping libraries allows you to quickly update instances in a file to use components from another library. Follow the Figma guide to swap to the v3 library if you wish to use the previous HDS version.
 
-Swap style and component libraries – Figma Learn - Help Center
-
+- [Swap style and component libraries – Figma Learn - Help Center](https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries#swap)
+    
 ### What about the Sketch library?
+
 The Sketch library will no longer be updated and will be removed after the 4.0.0 release.
 
+---
+
 ### Introduction of Figma Variables in HDS
+
 We are excited to announce the introduction of variables in HDS. We will be implementing variables step by step, starting with a feature for all HDS designers!
 
 #### The first one
+
 The first variable in use is called “Deprecated”, and it’s part of the [HDS] Deprecated variable collection. This variable is used in a single component named .❌_DeprecatedIndicator, which is used to highlight deprecated components.
 
 #### What’s great about this?
+
 This feature allows designers to easily and quickly identify and highlight where deprecated HDS components are used on a page.
 
 #### How to use it
-Click an empty spot on the canvas or press Esc to deselect all layers.
 
-From the Page section of the right sidebar, click 
-image-20240826-111932.png
- Change variable mode.
-
-Hover over a variable collection [HDS] Deprecated and choose a mode On. 
+1. Click an empty spot on the canvas or press Esc to deselect all layers.
+    
+2. From the **Page** section of the right sidebar, click variable icon to **Apply variable mode**.
+    
+3. Hover over a variable collection [HDS] Deprecated and choose a mode On.
+    
 
 This is just the beginning of our journey to variables in the Helsinki Design System. We are eager to start implementing spacing, colour, and typography tokens. We welcome your feedback!
 
-Read more about variables in Figma Learn.
+Read more about variables in [Figma Learn](https://help.figma.com/hc/en-us/articles/15343816063383-Modes-for-variables).
 
-## Getting support
-Have a question about migration to 4.0.0? Please head over to the Support page for more guidelines and ways to contact us.
+### Getting support
+
+Have a question about migration to `4.0.0`? Please head over to the [Support page](https://hds.hel.fi/about/#support "https://hds.hel.fi/about/#support") for more guidelines and ways to contact us.

--- a/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
+++ b/site/src/docs/getting-started/tutorials/migrate-to-4.0.0.mdx
@@ -245,7 +245,7 @@ In your duplicate file, review and accept the HDS Design Kit library updates. Yo
 
 This update includes breaking changes to components and may require that you update content in components with breaking changes.
 
-### **How can I continue using HDS v3?**
+### How can I continue using HDS v3?
 
 The v3 Figma library has been copied as a new file and will no longer receive updates. However, you can continue to use it by swapping to the v3 library.
 


### PR DESCRIPTION
## Description

Design migration guide updated

## Related Issue

Closes [HDS-2365](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2365)

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [ ] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

Unreleased documentation is updated.


[HDS-2365]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ