### PR TITLE
(Release-4.0.0) HDS-2506: Add hds-js standalone to package builds

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -45,6 +45,10 @@ jobs:
         run: yarn build:hds-js
         working-directory: ./packages/react
 
+      - name: build standalone hds-js package
+        run: yarn build:hds-js-standalone
+        working-directory: ./packages/react
+
       - name: test react package
         run: yarn test
         working-directory: ./packages/react

--- a/.github/workflows/patchrelease.yml
+++ b/.github/workflows/patchrelease.yml
@@ -41,6 +41,10 @@ jobs:
         run: yarn build:hds-js
         working-directory: ./packages/react
 
+      - name: build standalone hds-js package
+        run: yarn build:hds-js-standalone
+        working-directory: ./packages/react
+
       - name: release npm packages
         run: yarn release --dist-tag patch
         env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,6 +43,10 @@ jobs:
         run: yarn build:hds-js
         working-directory: ./packages/react
 
+      - name: build standalone hds-js package
+        run: yarn build:hds-js-standalone
+        working-directory: ./packages/react
+
       - name: release npm packages
         run: yarn run release --dist-tag ${{ github.event.inputs.prerelease_stage }}
         env:

--- a/packages/react/DEVELOPMENT.md
+++ b/packages/react/DEVELOPMENT.md
@@ -25,6 +25,7 @@ yarn start:react
 | yarn                         | Install dependencies and link local packages.             |
 | yarn build                   | Builds the React package.                                 |
 | yarn build:hds-js            | Builds the hds-js package.                                |
+| yarn build:hds-js-standalone | Builds standalone files for hds-js package.               |
 | yarn start                   | Starts the development environment.                       |
 | yarn test                    | Runs the tests.                                           |
 | yarn lint                    | Runs the linting.                                         |


### PR DESCRIPTION
## Description
Added hds-js standalone to package builds
Not needed when building site etc, so did not add it to all processes



<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2506](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2506)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?



## Demos:

Nothing to see here

## Screenshots (if appropriate):

## Add to changelog

- not needed


[HDS-2506]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ