### PR TITLE
(release-4.0.0) hds-2510: Change cookie consent exports.

### DIFF
--- a/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
+++ b/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
@@ -4,7 +4,7 @@ import { Header, LanguageOption } from '../header';
 import { Logo, logoFi } from '../logo';
 import { Tabs } from '../tabs/Tabs';
 import { Button } from '../button';
-import { Provider, useCookieConsents } from './contexts/CookieConsentContext';
+import { CookieConsentContextProvider, useCookieConsents } from './contexts/CookieConsentContext';
 import { CookieConsentReactProps } from './hooks/useCookieConsent';
 import { StoryComponent } from './components/StoryComponent';
 import { CookieBanner } from './components/CookieBanner';
@@ -98,7 +98,7 @@ export const Example = ({ currentTabIndex }: { currentTabIndex?: number } = {}) 
   };
 
   return (
-    <Provider
+    <CookieConsentContextProvider
       onChange={onChange}
       options={{ language }}
       siteSettings={{ ...siteSettings, remove: false, monitorInterval: 0 }}
@@ -158,6 +158,6 @@ export const Example = ({ currentTabIndex }: { currentTabIndex?: number } = {}) 
         </Tabs.TabPanel>
       </Tabs>
       <span data-testid="current-language" lang={language} />
-    </Provider>
+    </CookieConsentContextProvider>
   );
 };

--- a/packages/react/src/components/cookieConsent/components/StoryComponent.tsx
+++ b/packages/react/src/components/cookieConsent/components/StoryComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Provider } from '../contexts/CookieConsentContext';
+import { CookieConsentContextProvider } from '../contexts/CookieConsentContext';
 import { CookieConsentReactProps } from '../hooks/useCookieConsent';
 import { CookieBanner } from './CookieBanner';
 import { CookieSettingsPage } from './CookieSettingsPage';
@@ -13,9 +13,9 @@ import { CookieSettingsPage } from './CookieSettingsPage';
 
 export const StoryComponent = (props: CookieConsentReactProps) => {
   return (
-    <Provider {...props}>
+    <CookieConsentContextProvider {...props}>
       <CookieSettingsPage />
       <CookieBanner />
-    </Provider>
+    </CookieConsentContextProvider>
   );
 };

--- a/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.test.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { act, fireEvent, render, RenderResult, waitFor } from '@testing-library/react';
 
-import { Provider, useCookieConsentContext, useCookieConsentsInstance } from './CookieConsentContext';
+import {
+  CookieConsentContextProvider,
+  useCookieConsentContext,
+  useCookieConsentsInstance,
+} from './CookieConsentContext';
 // eslint-disable-next-line jest/no-mocks-import
 import { mockCookieConsentCore } from '../../cookieConsentCore/__mocks__/mockCookieConsentCore';
 import { CookieConsentCore } from '../../cookieConsentCore/cookieConsentCore';
@@ -58,11 +62,11 @@ describe('ConsentContext', () => {
     const forceRender = useForceRender();
     return (
       <div>
-        <Provider onChange={onChange} siteSettings={siteSettings} options={{ language }}>
+        <CookieConsentContextProvider onChange={onChange} siteSettings={siteSettings} options={{ language }}>
           <p data-testid={testIds.ready}>Context is ready</p>
           <ContextHookComponent />
           <InstanceHookComponent />
-        </Provider>
+        </CookieConsentContextProvider>
         <button
           type="button"
           data-testid={testIds.renderAgain}

--- a/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.tsx
@@ -20,7 +20,7 @@ export const ConsentContext = createContext<ConsentContextType>({
   language: '',
 });
 
-export const Provider = ({ children, ...rest }: CookieConsentContextProps): React.ReactElement => {
+export const CookieConsentContextProvider = ({ children, ...rest }: CookieConsentContextProps): React.ReactElement => {
   const contextData = useCookieConsent({ ...rest });
 
   return <ConsentContext.Provider value={contextData}>{contextData.isReady ? children : null}</ConsentContext.Provider>;

--- a/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieBanner.test.tsx
+++ b/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieBanner.test.tsx
@@ -6,7 +6,7 @@ import { useCookieBanner } from '../useCookieBanner';
 import { mockCookieConsentCore } from '../../../cookieConsentCore/__mocks__/mockCookieConsentCore';
 import { CookieConsentCore } from '../../../cookieConsentCore/cookieConsentCore';
 import useForceRender from '../../../../hooks/useForceRender';
-import { Provider } from '../../contexts/CookieConsentContext';
+import { CookieConsentContextProvider } from '../../contexts/CookieConsentContext';
 
 const mockCore = mockCookieConsentCore();
 
@@ -42,7 +42,7 @@ describe('useCookieBanner', () => {
     renderCount += 1;
     const forceRender = useForceRender();
     return (
-      <Provider onChange={jest.fn()}>
+      <CookieConsentContextProvider onChange={jest.fn()}>
         <div>
           {isMounted && <ModalComponent />}
           <div data-testid={testIds.isMounted}>{isMounted ? 1 : 0}</div>
@@ -66,7 +66,7 @@ describe('useCookieBanner', () => {
           </button>
           );
         </div>
-      </Provider>
+      </CookieConsentContextProvider>
     );
   };
   afterEach(() => {

--- a/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieSettingsPage.test.tsx
+++ b/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieSettingsPage.test.tsx
@@ -6,7 +6,7 @@ import { useCookieSettingsPage } from '../useCookieSettingsPage';
 import { mockCookieConsentCore } from '../../../cookieConsentCore/__mocks__/mockCookieConsentCore';
 import { CookieConsentCore } from '../../../cookieConsentCore/cookieConsentCore';
 import useForceRender from '../../../../hooks/useForceRender';
-import { Provider } from '../../contexts/CookieConsentContext';
+import { CookieConsentContextProvider } from '../../contexts/CookieConsentContext';
 import { defaultSettingsPageId } from '../useCookieConsent';
 
 const mockCore = mockCookieConsentCore();
@@ -47,7 +47,7 @@ describe('useCookieSettingsPage', () => {
     renderCount += 1;
     const forceRender = useForceRender();
     return (
-      <Provider onChange={jest.fn()} settingsPageId={settingsPageId}>
+      <CookieConsentContextProvider onChange={jest.fn()} settingsPageId={settingsPageId}>
         <div>
           {isMounted && <ModalComponent />}
           <div data-testid={testIds.isMounted}>{isMounted ? 1 : 0}</div>
@@ -71,7 +71,7 @@ describe('useCookieSettingsPage', () => {
           </button>
           );
         </div>
-      </Provider>
+      </CookieConsentContextProvider>
     );
   };
   afterEach(() => {

--- a/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
+++ b/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { CookieConsentCore } from '../../cookieConsentCore/cookieConsentCore';
 import useForceRender from '../../../hooks/useForceRender';
-import { ChangeEvent, defaultSubmitEvent, useCookieConsentEvents } from './useCookieConsentEvents';
+import { CookieConsentChangeEvent, defaultSubmitEvent, useCookieConsentEvents } from './useCookieConsentEvents';
 import { Options } from '../../cookieConsentCore/types';
 import { isSsrEnvironment } from '../../../utils/isSsrEnvironment';
 
@@ -21,9 +21,8 @@ declare global {
   }
 }
 
-export type ChangeProps = { type: string; acceptedGroups: string[]; storageType?: string; storageKeys?: string[] };
 export type CookieConsentReactProps = Omit<CreateProps, 'settingsPageSelector'> & {
-  onChange: (changeProps: ChangeProps) => void;
+  onChange: (changeProps: CookieConsentChangeEvent) => void;
   settingsPageId?: string;
 };
 type GroupConsentData = { group: string; consented: boolean };
@@ -69,7 +68,7 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
   };
 
   const onChangeListener = useCallback(
-    (e: ChangeEvent) => {
+    (e: CookieConsentChangeEvent) => {
       onChange(e);
       forceRender();
     },
@@ -77,7 +76,7 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
   );
 
   const onMonitorEvent = useCallback(
-    (e: ChangeEvent) => {
+    (e: CookieConsentChangeEvent) => {
       onChange(e);
     },
     [useCallback],

--- a/packages/react/src/components/cookieConsent/hooks/useCookieConsentEvents.ts
+++ b/packages/react/src/components/cookieConsent/hooks/useCookieConsentEvents.ts
@@ -2,11 +2,16 @@ import { MutableRefObject, useEffect, useMemo, useRef } from 'react';
 
 import { isSsrEnvironment } from '../../../utils/isSsrEnvironment';
 
-export type ChangeEvent = { type: string; acceptedGroups: string[]; storageType?: string; storageKeys?: string[] };
+export type CookieConsentChangeEvent = {
+  type: string;
+  acceptedGroups: string[];
+  storageType?: string;
+  storageKeys?: string[];
+};
 export type CookieConsentEventsProps = {
-  onChange: (changeProps: ChangeEvent) => void;
+  onChange: (changeProps: CookieConsentChangeEvent) => void;
   onReady: () => void;
-  onMonitorEvent: (changeProps: ChangeEvent) => void;
+  onMonitorEvent: (changeProps: CookieConsentChangeEvent) => void;
   submitEvent?: string;
 };
 export type CookieConsentEventsReturnType = () => void;
@@ -34,9 +39,9 @@ export function useCookieConsentEvents(props: CookieConsentEventsProps): CookieC
       return () => undefined;
     }
 
-    const getChangeProps = (e: Event): ChangeEvent => {
+    const getChangeProps = (e: Event): CookieConsentChangeEvent => {
       const { detail, type } = e as CustomEvent;
-      const changeProps: ChangeEvent = {
+      const changeProps: CookieConsentChangeEvent = {
         type,
         acceptedGroups: detail.consentedGroups || detail.acceptedGroups || [],
       };

--- a/packages/react/src/components/cookieConsent/index.ts
+++ b/packages/react/src/components/cookieConsent/index.ts
@@ -2,6 +2,12 @@ export * from './contexts/CookieConsentContext';
 export * from './components/CookieBanner';
 export * from './components/CookieSettingsPage';
 export * from './hooks/useCookieConsent';
-export * from './hooks/useCookieConsentEvents';
+// not exporting event names to the bundle. Not needed on React side.
+export {
+  useCookieConsentEvents,
+  CookieConsentChangeEvent,
+  CookieConsentEventsProps,
+  CookieConsentEventsReturnType,
+} from './hooks/useCookieConsentEvents';
 export * from './hooks/useCookieBanner';
 export * from './hooks/useCookieSettingsPage';


### PR DESCRIPTION

## Description

Renamed some exported cookie consent code that was too generic and uninformative.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2510](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2510)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

All tests pass.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

No need.


[HDS-2510]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ