### PR TITLE
HDS-2495 cookie hds event namings

### DIFF
--- a/packages/hds-js/standalone/example.html
+++ b/packages/hds-js/standalone/example.html
@@ -6,8 +6,8 @@
     <title>Esimerkki keksibannerista</title>
     <script>
       /* Example listener for cookie consent change events */
-      window.addEventListener('cookie-consent-changed', function (event) {
-        console.log('Got cookie-consent-changed event with accepted groups:', event.detail.acceptedGroups);
+      window.addEventListener('hds-cookie-consent-changed', function (event) {
+        console.log('Got hds-cookie-consent-changed event with accepted groups:', event.detail.acceptedGroups);
       });
 
       const test = window.addEventListener('hds-cookie-consent-unapproved-cookie-found', function (event) {
@@ -830,7 +830,7 @@
           //targetSelector: 'body', // Defaults to 'body'
           //spacerParentSelector: 'body', // Defaults to 'body'
           //pageContentSelector: 'body', // Defaults to 'body'
-          //submitEvent: 'cookie-consent-changed', // If this string is set, triggers a window level event with that string and detail.acceptedGroups before closing banner. If not set, reloads page instead
+          //submitEvent: true, // If this is set to true, triggers a window level event 'hds-cookie-consent-changed' and detail.acceptedGroups before closing banner. If not set, reloads page instead
           settingsPageSelector: '#hds-cookie-consent-full-page', // If this string is set and matching element is found on page, instead of banner, show a full page cookie settings replacing the matched element.
         };
         hds.CookieConsentCore.create(siteSettingsObj, options);

--- a/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.test.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.test.tsx
@@ -15,6 +15,7 @@ import siteSettings from '../../cookieConsentCore/example/minimal_sitesettings.j
 const mockCore = mockCookieConsentCore();
 
 jest.mock('../../cookieConsentCore/cookieConsentCore', () => ({
+  ...(jest.requireActual('../../cookieConsentCore/cookieConsentCore') as Record<string, unknown>),
   CookieConsentCore: {
     create: (...args: Parameters<typeof CookieConsentCore.create>) => mockCore.create(...args),
   },

--- a/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieBanner.test.tsx
+++ b/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieBanner.test.tsx
@@ -11,6 +11,7 @@ import { CookieConsentContextProvider } from '../../contexts/CookieConsentContex
 const mockCore = mockCookieConsentCore();
 
 jest.mock('../../../cookieConsentCore/cookieConsentCore', () => ({
+  ...(jest.requireActual('../../../cookieConsentCore/cookieConsentCore') as Record<string, unknown>),
   CookieConsentCore: {
     create: (...args: Parameters<typeof CookieConsentCore.create>) => mockCore.create(...args),
   },

--- a/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieConsent.test.tsx
+++ b/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieConsent.test.tsx
@@ -10,6 +10,7 @@ import useForceRender from '../../../../hooks/useForceRender';
 const mockCore = mockCookieConsentCore();
 
 jest.mock('../../../cookieConsentCore/cookieConsentCore', () => ({
+  ...(jest.requireActual('../../../cookieConsentCore/cookieConsentCore') as Record<string, unknown>),
   CookieConsentCore: {
     create: (...args: Parameters<typeof CookieConsentCore.create>) => mockCore.create(...args),
   },
@@ -222,7 +223,7 @@ describe('useCookieConsent', () => {
     expect(result.getAllByTestId(mockCore.getBannerTestId())).toHaveLength(1);
   });
   it('"onChange" is triggered when an event is dispatched', async () => {
-    const result = renderTests({ options: { submitEvent: 'my-event' } });
+    const result = renderTests({ options: { submitEvent: true } });
     const { getConsents, waitForReady, createPromiseForOnChangeUpdate } = result;
     await waitForReady();
     const updatedConsentData = ['group3', 'group4'];

--- a/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieSettingsPage.test.tsx
+++ b/packages/react/src/components/cookieConsent/hooks/__tests__/useCookieSettingsPage.test.tsx
@@ -12,6 +12,7 @@ import { defaultSettingsPageId } from '../useCookieConsent';
 const mockCore = mockCookieConsentCore();
 
 jest.mock('../../../cookieConsentCore/cookieConsentCore', () => ({
+  ...(jest.requireActual('../../../cookieConsentCore/cookieConsentCore') as Record<string, unknown>),
   CookieConsentCore: {
     create: (...args: Parameters<typeof CookieConsentCore.create>) => mockCore.create(...args),
   },
@@ -178,6 +179,7 @@ describe('useCookieSettingsPage', () => {
     act(() => {
       mockCore.triggerChangeEvent(updatedConsentData);
     });
+
     await waitFor(() => {
       expect(getConsents()).toEqual(updatedConsentData.map((group) => ({ group, consented: true })));
     });

--- a/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
+++ b/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { CookieConsentCore } from '../../cookieConsentCore/cookieConsentCore';
 import useForceRender from '../../../hooks/useForceRender';
-import { CookieConsentChangeEvent, defaultSubmitEvent, useCookieConsentEvents } from './useCookieConsentEvents';
+import { CookieConsentChangeEvent, useCookieConsentEvents } from './useCookieConsentEvents';
 import { Options } from '../../cookieConsentCore/types';
 import { isSsrEnvironment } from '../../../utils/isSsrEnvironment';
 
@@ -54,17 +54,16 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
     }
     return window && window.hds && window.hds.cookieConsent;
   };
-  const submitEventName = passedOptions.submitEvent || defaultSubmitEvent;
   const instanceRef = useRef<CookieCore | null>(null);
   const readyRef = useRef<boolean>(false);
   const forceRender = useForceRender();
   //
   const mergedOptions: CreateProps['options'] = {
     language,
-    submitEvent: submitEventName,
     ...passedOptions,
-    // this must always be true
+    // these must always be true
     disableAutoRender: true,
+    submitEvent: true,
   };
 
   const onChangeListener = useCallback(
@@ -91,7 +90,6 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
     onChange: onChangeListener,
     onMonitorEvent,
     onReady,
-    submitEvent: mergedOptions.submitEvent,
   });
 
   const getAllConsentStatuses = () => {

--- a/packages/react/src/components/cookieConsentCore/CookieConsentCore.test.ts
+++ b/packages/react/src/components/cookieConsentCore/CookieConsentCore.test.ts
@@ -17,8 +17,8 @@ type Options = {
   targetSelector?: string;
   spacerParentSelector?: string;
   pageContentSelector?: string;
-  submitEvent?: boolean | string;
   settingsPageSelector?: string;
+  submitEvent?: boolean;
 };
 
 jest.mock('hds-core/lib/components/cookie-consent/cookieConsent', () => ({
@@ -79,10 +79,11 @@ describe('cookieConsentCore', () => {
     // targetSelector: 'body', // Defaults to 'body'
     // spacerParentSelector: 'body', // Defaults to 'body'
     // pageContentSelector: 'body', // Defaults to 'body'
-    // submitEvent: 'cookie-consent-changed', // If this string is set, triggers a window level event with that string and detail.acceptedGroups before closing banner. If not set, reloads page instead
+    // submitEvent: false, // If this is set to true, triggers a window level event 'hds-cookie-consent-changed' containing detail.acceptedGroups before closing banner. If not set, reloads page instead
+    submitEvent: true,
     settingsPageSelector: '#hds-cookie-consent-full-page', // If this string is set and matching element is found on page, instead of banner, show a full page cookie settings replacing the matched element.
   };
-  const optionsEvent = { ...options, submitEvent: 'cookie-consent-changed' };
+  const optionsEvent = { ...options };
 
   const STORAGE_TYPE = {
     cookie: 1,

--- a/packages/react/src/components/cookieConsentCore/__mocks__/mockCookieConsentCore.ts
+++ b/packages/react/src/components/cookieConsentCore/__mocks__/mockCookieConsentCore.ts
@@ -1,8 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { RenderResult } from '@testing-library/react';
 
-import { CookieConsentCore } from '../cookieConsentCore';
-import { readyEvent, defaultSubmitEvent, monitorEvent } from '../../cookieConsent/hooks/useCookieConsentEvents';
+import { CookieConsentCore, cookieEventType } from '../cookieConsentCore';
 import { getLastMockCallArgs, getMockCalls } from '../../../utils/testHelpers';
 import { defaultSettingsPageId } from '../../cookieConsent/hooks/useCookieConsent';
 
@@ -33,28 +32,20 @@ export function mockCookieConsentCore() {
   const getRenderPageArgs = () => {
     return getLastMockCallArgs(trackers.renderPage);
   };
-  const getCreateArgsOptions = () => {
-    const lastCall = getLastMockCallArgs(trackers.create);
-    if (!lastCall || !lastCall[0]) {
-      return null;
-    }
-    return getLastMockCallArgs(trackers.create)[0][1];
-  };
 
   const triggerReadyEvent = () => {
-    window.dispatchEvent(new Event(readyEvent));
+    window.dispatchEvent(new Event(cookieEventType.READY));
   };
 
-  const triggerChangeEvent = (acceptedGroups: string[], submitEvent?: string) => {
-    const args = getCreateArgsOptions() || {};
+  const triggerChangeEvent = (acceptedGroups: string[]) => {
     innerState.consents = acceptedGroups.map((group) => {
       return { group, consented: true };
     });
-    const eventType = args.submitEvent || submitEvent || defaultSubmitEvent;
-    window.dispatchEvent(new CustomEvent(eventType, { detail: { acceptedGroups } }));
+    window.dispatchEvent(new CustomEvent(cookieEventType.CHANGE, { detail: { acceptedGroups } }));
   };
+
   const triggerMonitorEvent = (type: string, keys: string, consentedGroups: string[]) => {
-    window.dispatchEvent(new CustomEvent(monitorEvent, { detail: { type, keys, consentedGroups } }));
+    window.dispatchEvent(new CustomEvent(cookieEventType.MONITOR, { detail: { type, keys, consentedGroups } }));
   };
 
   const openBanner = async (...args: Parameters<CookieConsentCore['openBanner']>) => {
@@ -94,6 +85,9 @@ export function mockCookieConsentCore() {
         const target = innerState.renderResult.container.querySelector(targetId) as HTMLElement;
         target.appendChild(page);
         return Promise.resolve();
+      },
+      removePage: () => {
+        return false;
       },
       openBanner,
     };

--- a/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
+++ b/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
@@ -20,6 +20,12 @@ import { isSsrEnvironment } from '../../utils/isSsrEnvironment';
 // This private symbol is being used as a way to ensure that the constructor is not called without the create method.
 const privateSymbol = Symbol('private');
 
+export const cookieEventType = {
+  MONITOR: 'hds-cookie-consent-unapproved-item-found',
+  READY: 'hds-cookie-consent-ready',
+  CHANGE: 'hds-cookie-consent-changed',
+};
+
 /**
  * Represents a class for managing cookie consent.
  * @class
@@ -32,7 +38,7 @@ export class CookieConsentCore {
   #targetSelector;
   #spacerParentSelector;
   #pageContentSelector;
-  #submitEvent = '';
+  #submitEvent = false;
   #settingsPageSelector;
   #disableAutoRender;
   #monitor;
@@ -65,7 +71,7 @@ export class CookieConsentCore {
    * @param {string} [options.targetSelector='body'] - The selector for where to inject the banner.
    * @param {string} [options.spacerParentSelector='body'] - The selector for where to inject the spacer.
    * @param {string} [options.pageContentSelector='body'] - The selector for where to add scroll-margin-bottom.
-   * @param {string} [options.submitEvent=''] - If set, do not reload the page, but submit the string as an event after consent.
+   * @param {boolean} [options.submitEvent=false] - If set to true, do not reload the page, but submit the string as an event after consent.
    * @param {string} [options.settingsPageSelector=null] - If this string is set and a matching element is found on the page, show cookie settings in a page replacing the matched element.
    * @param {boolean} [options.disableAutoRender=false] - If true, neither banner or page are rendered automatically
    * @param {boolean} [calledFromCreate=false] - Indicates if the constructor was called from the create method.
@@ -80,7 +86,7 @@ export class CookieConsentCore {
       targetSelector = 'body', // Where to inject the banner
       spacerParentSelector = 'body', // Where to inject the spacer
       pageContentSelector = 'body', // Where to add scroll-margin-bottom
-      submitEvent = '', // if set, do not reload page, but submit the string as event after consent
+      submitEvent = false, // if set, do not reload page, but submit 'hds-cookie-consent-changed' as event after consent
       settingsPageSelector = null, // If this string is set and a matching element is found on the page, show cookie settings in a page replacing the matched element.
       disableAutoRender = false,
     },
@@ -152,7 +158,7 @@ export class CookieConsentCore {
    * @param {string} [options.targetSelector='body'] - The selector for where to inject the banner.
    * @param {string} [options.spacerParentSelector='body'] - The selector for where to inject the spacer.
    * @param {string} [options.pageContentSelector='body'] - The selector for where to add scroll-margin-bottom.
-   * @param {string} [options.submitEvent=''] - If set, do not reload the page, but submit the string as an event after consent.
+   * @param {boolean} [options.submitEvent=false] - If set, do not reload the page, but submit 'hds-cookie-consent-changed' event after consent.
    * @param {string} [options.settingsPageSelector=null] - If this string is set and a matching element is found on the page, show cookie settings in a page replacing the matched element.
    * @param {boolean} [options.disableAutoRender=false] - If...
    * @return {Promise<CookieConsentCore>} A promise that resolves to a new instance of the CookieConsent class.
@@ -194,7 +200,7 @@ export class CookieConsentCore {
     await instance.#init();
 
     // Dispatch event when the cookie consent is ready to be used by other scripts
-    const event = new Event('hds_cookieConsent_ready');
+    const event = new Event(cookieEventType.READY);
     if (!isSsrEnvironment()) {
       window.dispatchEvent(event);
     }
@@ -387,7 +393,7 @@ export class CookieConsentCore {
     if (!this.#submitEvent) {
       window.location.reload();
     } else {
-      window.dispatchEvent(new CustomEvent(this.#submitEvent, { detail: { acceptedGroups } }));
+      window.dispatchEvent(new CustomEvent(cookieEventType.CHANGE, { detail: { acceptedGroups } }));
       if (!this.#settingsPageElement) {
         this.#announceSettingsSaved();
         this.#removeBanner();

--- a/packages/react/src/components/cookieConsentCore/example/example_banner.html
+++ b/packages/react/src/components/cookieConsentCore/example/example_banner.html
@@ -35,7 +35,7 @@
             //targetSelector: 'body', // Defaults to 'body'
             //spacerParentSelector: 'body', // Defaults to 'body'
             //pageContentSelector: 'body', // Defaults to 'body'
-            //submitEvent: 'cookie-consent-changed', // If this string is set, triggers a window level event with that string and detail.acceptedGroups before closing banner. If not set, reloads page instead
+            //submitEvent: false, // If this string is set to true, triggers a window level event 'hds-cookie-consent-changed' and detail.acceptedGroups before closing banner. If not set, reloads page instead
             settingsPageSelector: '#hds-cookie-consent-full-page', // If this string is set and matching element is found on page, instead of banner, show a full page cookie settings replacing the matched element.
           }
         };

--- a/packages/react/src/components/cookieConsentCore/siteSettingsEditor/siteSettingsEditor.html
+++ b/packages/react/src/components/cookieConsentCore/siteSettingsEditor/siteSettingsEditor.html
@@ -964,7 +964,7 @@
       targetSelector: 'TARGET_SELECTOR',
       spacerParentSelector: 'SPACER_PARENT_SELECTOR',
       pageContentSelector: 'PAGE_CONTENT_SELECTOR',
-      submitEvent: 'SUBMIT_EVENT_NAME',
+      submitEvent: 'SUBMIT_EVENT',
       settingsPageSelector: 'SETTINGS_PAGE_SELECTOR'
     }
   )"
@@ -1005,8 +1005,8 @@
             <td>Optional selector for parent element that wraps banner and banner spacer, dynamic css variable with banner height is written into inline style of this element. Defaults to 'body'</td>
           </tr>
           <tr></tr>
-            <td><em>SUBMIT_EVENT_NAME</em></td>
-            <td>Optional string, if set, triggers a window level event using given string as the name of the event before closing banner. If not set, reloads page instead</td>
+            <td><em>SUBMIT_EVENT</em></td>
+            <td>Optional boolean, if set to true, triggers a window level event using given string as the name of the event before closing banner. If not set, reloads page instead</td>
           </tr>
           <tr></tr>
             <td><em>SETTINGS_PAGE_SELECTOR</em></td>

--- a/packages/react/src/components/cookieConsentCore/storyComponents/Banner.tsx
+++ b/packages/react/src/components/cookieConsentCore/storyComponents/Banner.tsx
@@ -7,7 +7,6 @@ export const Banner = (props: CreateProps) => {
   useEffect(() => {
     // @ts-ignore
     CookieConsentCore.create(props.siteSettings, props.options);
-    // CookieConsentCore.create(siteSettingsObj, options);
   }, []);
 
   return null;

--- a/packages/react/src/components/cookieConsentCore/types.ts
+++ b/packages/react/src/components/cookieConsentCore/types.ts
@@ -13,7 +13,7 @@ export type Options = {
   targetSelector?: string | undefined;
   spacerParentSelector?: string | undefined;
   pageContentSelector?: string | undefined;
-  submitEvent?: string | undefined;
+  submitEvent?: boolean | undefined;
   settingsPageSelector?: string | undefined;
   disableAutoRender?: boolean | undefined;
 };


### PR DESCRIPTION
## Description

Change event strings like below:

`
export const cookieEventType = {
  MONITOR: 'hds-cookie-consent-unapproved-item-found',
  READY: 'hds-cookie-consent-ready',
  CHANGE: 'hds-cookie-consent-changed',
};
`
Also changes `submitEvent` prop from string type to boolean and makes according changes across. It's also always set to true on React-side now.

Documentation changes are in another PR (cookie docs PR). 

## Related Issue

Closes [HDS-2495](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2495)

## Demos:

Links to demos are in the comments

## Add to changelog

- not needed


[HDS-2495]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ