### PR TITLE
(HDS-2508) update playwright version from ^1.45.1 -> ^1.48.2, install…

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,14 +57,9 @@ jobs:
           yarn
         working-directory: ./e2e
 
-      - name: install playwright dependencies
+      - name: install playwright browser and OS dependencies
         run: |
-          yarn install-deps
-        working-directory: ./e2e
-
-      - name: install test tools
-        run: |
-          yarn inst
+          yarn playwright-install
         working-directory: ./e2e
 
       - name: run tests

--- a/e2e/docker/run.sh
+++ b/e2e/docker/run.sh
@@ -23,6 +23,6 @@ if [ -n "$PACKAGE" ] && [ -n "$COMPONENT" ]; then
     COMMAND="PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn start-component"
 fi
 
-docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.45.1-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
+docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.48.2-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
 
 # --update-snapshots

--- a/e2e/docker/update-snapshots.sh
+++ b/e2e/docker/update-snapshots.sh
@@ -23,6 +23,6 @@ if [ -n "$PACKAGE" ] && [ -n "$COMPONENT" ]; then
     COMMAND="PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshots-component"
 fi
 
-docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.45.1-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
+docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.48.2-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
 
 # --update-snapshots

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,9 +5,7 @@
   "version": "3.11.0",
   "scripts": {
     "ci": "npx playwright test",
-    "inst": "yarn playwright install",
-    "install-deps": "npx playwright install-deps",
-    "record": "npx playwright codegen https://hds.hel.fi",
+    "playwright-install": "yarn playwright install --with-deps chromium",
     "serve-core": "http-server ../packages/core/storybook-static -d -p 6007",
     "serve-react": "http-server ../packages/react/storybook-static -d -p 6006",
     "start-component": "npx playwright test tests/$PACKAGE/**/*$COMPONENT*",
@@ -18,7 +16,7 @@
     "update-snapshots": "npx playwright test --update-snapshots"
   },
   "devDependencies": {
-    "@playwright/test": "^1.45.1",
+    "@playwright/test": "^1.48.2",
     "http-server": "^14.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,12 +3774,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.0.tgz#7d8dacb7fdef0e4387caf7396cbd77f179867d06"
   integrity sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==
 
-"@playwright/test@^1.45.1":
-  version "1.45.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.45.1.tgz#819b90fa43d17000fce5ebd127043fd661938b7a"
-  integrity sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==
+"@playwright/test@^1.48.2":
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.48.2.tgz#87dd40633f980872283404c8142a65744d3f13d6"
+  integrity sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==
   dependencies:
-    playwright "1.45.1"
+    playwright "1.48.2"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1", "@pmmmwh/react-refresh-webpack-plugin@^0.5.10", "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.10"
@@ -21661,17 +21661,17 @@ platform@^1.3.6:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-playwright-core@1.45.1:
-  version "1.45.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.1.tgz#549a2701556b58245cc75263f9fc2795c1158dc1"
-  integrity sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==
+playwright-core@1.48.2:
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.2.tgz#cd76ed8af61690edef5c05c64721c26a8db2f3d7"
+  integrity sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==
 
-playwright@1.45.1:
-  version "1.45.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.45.1.tgz#aaa6b0d6db14796b599d80c6679e63444e942534"
-  integrity sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==
+playwright@1.48.2:
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.48.2.tgz#fca45ae8abdc34835c715718072aaff7e305167e"
+  integrity sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==
   dependencies:
-    playwright-core "1.45.1"
+    playwright-core "1.48.2"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Description

Update playwright version from ^1.45.1 -> ^1.48.2 and installs only one browser to playwright which is used in tests (cutting download times & uselessness)

## Related Issue

Closes [HDS-2508](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2508)

## How Has This Been Tested?

- tests

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

![Pasted Graphic](https://github.com/user-attachments/assets/d563ab99-6c42-4207-a894-b7de0d0e2e1b)

## Add to changelog

- no need


[HDS-2508]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ