### PR TITLE
Fix login color

### DIFF
--- a/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.module.scss
+++ b/packages/react/src/components/header/components/headerActionBarItem/HeaderActionBarItem.module.scss
@@ -79,7 +79,6 @@
 
   & > h3 {
     box-sizing: border-box;
-    color: #f00;
     font-size: var(--fontsize-heading-xs);
     font-weight: bold;
     line-height: 28px;


### PR DESCRIPTION
Login menu had red color on heading line, should be black. 

<img width="303" alt="Screenshot 2024-11-15 at 8 53 12" src="https://github.com/user-attachments/assets/576cc694-697e-4834-83d3-697ea374b861">
