### PR TITLE
(release-4.0.0) HDS-2520 fix async render and multiple create class()

### DIFF
--- a/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.tsx
+++ b/packages/react/src/components/cookieConsent/contexts/CookieConsentContext.tsx
@@ -13,6 +13,7 @@ export const ConsentContext = createContext<ConsentContextType>({
   instance: null,
   consents: [],
   openBanner: () => Promise.reject(new Error("'openBanner' not initialized")),
+  removeBanner: () => false,
   openBannerIfNeeded: () => Promise.reject(new Error("'openBannerIfNeeded' not initialized")),
   renderPage: () => Promise.reject(new Error("'renderPage' not initialized")),
   removePage: () => false,

--- a/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
+++ b/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
@@ -32,6 +32,7 @@ export type CookieConsentReactType = {
   consents: Array<GroupConsentData>;
   instance: CookieConsentCore | null;
   openBanner: () => Promise<boolean>;
+  removeBanner: () => void;
   openBannerIfNeeded: () => Promise<boolean>;
   renderPage: (selector?: string) => Promise<boolean>;
   removePage: () => void;
@@ -155,11 +156,19 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
     instanceRef.current.removePage();
   };
 
+  const removeBanner = () => {
+    if (!instanceRef.current) {
+      return;
+    }
+    instanceRef.current.removeBanner();
+  };
+
   return {
     isReady: readyRef.current && !!instanceRef.current,
     instance: instanceRef.current,
     consents: getAllConsentStatuses(),
     openBanner,
+    removeBanner,
     openBannerIfNeeded,
     renderPage,
     removePage,

--- a/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
+++ b/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
@@ -135,14 +135,14 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
     if (!instanceRef.current) {
       return Promise.resolve(false);
     }
-    return instanceRef.current.openBanner(highlightedGroups).then(() => true);
+    return instanceRef.current.openBanner(highlightedGroups);
   }, []);
 
   const openBannerIfNeeded = useCallback(async () => {
     if (!instanceRef.current) {
       return Promise.resolve(false);
     }
-    return instanceRef.current.openBannerIfNeeded().then(() => true);
+    return instanceRef.current.openBannerIfNeeded();
   }, []);
 
   const renderPage = useCallback(
@@ -155,7 +155,7 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
       if (currentElement && currentElement.childElementCount > 0) {
         currentElement.innerHTML = '';
       }
-      return instanceRef.current.renderPage(selector).then(() => true);
+      return instanceRef.current.renderPage(selector);
     },
     [elementId],
   );

--- a/packages/react/src/components/cookieConsentCore/__mocks__/mockCookieConsentCore.ts
+++ b/packages/react/src/components/cookieConsentCore/__mocks__/mockCookieConsentCore.ts
@@ -89,6 +89,9 @@ export function mockCookieConsentCore() {
       removePage: () => {
         return false;
       },
+      removeBanner: () => {
+        return undefined;
+      },
       openBanner,
     };
   };

--- a/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
+++ b/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
@@ -199,9 +199,9 @@ export class CookieConsentCore {
     // Initialise the class instance
     await instance.#init();
 
-    // Dispatch event when the cookie consent is ready to be used by other scripts
-    const event = new Event(cookieEventType.READY);
     if (!isSsrEnvironment()) {
+      // Dispatch event when the cookie consent is ready to be used by other scripts
+      const event = new Event(cookieEventType.READY);
       window.dispatchEvent(event);
     }
 
@@ -252,7 +252,7 @@ export class CookieConsentCore {
       console.error(`Cookie consent: The user is already on settings page`);
       return;
     }
-    this.#removeBanner();
+    this.removeBanner();
     await this.#render(this.#language, this.#siteSettings, true, null, highlightedGroups);
   }
   /**
@@ -313,14 +313,11 @@ export class CookieConsentCore {
     this.#cookieHandler.setLanguage(language);
   }
 
-  // MARK: Private methods
-
   /**
    * Removes the banner and related elements.
-   * @private
-   * @function #removeBanner
+   * @returns {void}
    */
-  #removeBanner() {
+  removeBanner() {
     // Remove banner size observer
     if (this.#resizeReference.resizeObserver && this.#resizeReference.bannerHeightElement) {
       this.#resizeReference.resizeObserver.unobserve(this.#resizeReference.bannerHeightElement);
@@ -341,6 +338,8 @@ export class CookieConsentCore {
     // Remove scroll-margin-bottom variable from all elements inside the contentSelector
     document.documentElement.style.removeProperty('--hds-cookie-consent-height');
   }
+
+  // MARK: Private methods
 
   /**
    * Gets accepted checkbox groups from form
@@ -396,7 +395,7 @@ export class CookieConsentCore {
       window.dispatchEvent(new CustomEvent(cookieEventType.CHANGE, { detail: { acceptedGroups } }));
       if (!this.#settingsPageElement) {
         this.#announceSettingsSaved();
-        this.#removeBanner();
+        this.removeBanner();
         return;
       }
       this.#announceSettingsSaved();
@@ -748,7 +747,7 @@ export class CookieConsentCore {
       }
     });
 
-    this.#removeBanner();
+    this.removeBanner();
 
     let settingsPageElement = null;
     // If settings page selector is enabled, check if the element exists

--- a/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
+++ b/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
@@ -246,21 +246,21 @@ export class CookieConsentCore {
   /**
    * Opens banner when not on cookie settings page.
    */
-  async openBanner(highlightedGroups = []) {
+  openBanner(highlightedGroups = []) {
     if (this.#settingsPageSelector && document.querySelector(this.#settingsPageSelector)) {
       // eslint-disable-next-line no-console
       console.error(`Cookie consent: The user is already on settings page`);
       return;
     }
     this.removeBanner();
-    await this.#render(this.#language, this.#siteSettings, true, null, highlightedGroups);
+    this.#render(this.#language, this.#siteSettings, true, null, highlightedGroups);
   }
   /**
    * Opens banner only if necessary
    */
-  async openBannerIfNeeded(highlightedGroups = []) {
+  openBannerIfNeeded(highlightedGroups = []) {
     if (this.#shouldDisplayBanner()) {
-      await this.openBanner(highlightedGroups);
+      this.openBanner(highlightedGroups);
       return Promise.resolve(true);
     }
     return Promise.resolve(false);
@@ -270,7 +270,7 @@ export class CookieConsentCore {
    * Renders cookie settings page.
    * @param {string|undefined} settingsPageSelector - target element selector. If not set options.settingsPageSelector is used.
    */
-  async renderPage(settingsPageSelector = undefined) {
+  renderPage(settingsPageSelector = undefined) {
     const selector = settingsPageSelector || this.#settingsPageSelector;
     // If settings page selector is enabled, check if the element exists
     const settingsPageElement = selector ? document.querySelector(selector) : null;
@@ -278,7 +278,7 @@ export class CookieConsentCore {
     this.#settingsPageElement = settingsPageElement;
     if (settingsPageElement) {
       // If settings page element is found, render site settings in page instead of banner
-      await this.#render(this.#language, this.#siteSettings, false, settingsPageElement);
+      this.#render(this.#language, this.#siteSettings, false, settingsPageElement);
     }
   }
   /**
@@ -572,10 +572,10 @@ export class CookieConsentCore {
    * Inject CSS styles into the shadow root.
    * @private
    * @param {ShadowRoot} shadowRoot - The shadow root element to inject the styles into.
-   * @return {Promise<void>} - A promise that resolves when the styles are injected successfully.
+   * @return {void}
    * @throws {Error} - If there is an error fetching or injecting the styles.
    */
-  async #injectCssStyles(shadowRoot) {
+  #injectCssStyles(shadowRoot) {
     // Create and inject the style
     const style = document.createElement('style');
     style.textContent = styles;
@@ -594,7 +594,7 @@ export class CookieConsentCore {
    * @throws {Error} If the spacerParentSelector element is not found.
    * @throws {Error} If the contentSelector element is not found.
    */
-  async #render(lang, siteSettings, isBanner, renderTarget = null, highlightedGroups = []) {
+  #render(lang, siteSettings, isBanner, renderTarget = null, highlightedGroups = []) {
     let spacerParent;
     let renderTargetToPrepend = renderTarget;
     if (isBanner) {
@@ -630,8 +630,7 @@ export class CookieConsentCore {
 
     const shadowRoot = container.attachShadow({ mode: 'open' });
 
-    // Inject CSS styles
-    await this.#injectCssStyles(shadowRoot);
+    this.#injectCssStyles(shadowRoot);
 
     const browserCookie = this.#cookieHandler.getCookie();
     const listOfAcceptedGroups = browserCookie ? browserCookie.groups : [];
@@ -763,12 +762,12 @@ export class CookieConsentCore {
       if (settingsPageElement) {
         this.#settingsPageElement = settingsPageElement;
         // If settings page element is found, render site settings in page instead of banner
-        await this.#render(this.#language, siteSettings, false, settingsPageElement);
+        this.#render(this.#language, siteSettings, false, settingsPageElement);
       } else {
         // Check if banner is needed or not
         const shouldDisplayBanner = this.#shouldDisplayBanner();
         if (shouldDisplayBanner) {
-          await this.#render(this.#language, siteSettings, true);
+          this.#render(this.#language, siteSettings, true);
         }
       }
     }

--- a/packages/react/src/components/cookieConsentCore/storyComponents/Banner.tsx
+++ b/packages/react/src/components/cookieConsentCore/storyComponents/Banner.tsx
@@ -5,8 +5,7 @@ import { CreateProps } from '../types';
 
 export const Banner = (props: CreateProps) => {
   useEffect(() => {
-    // @ts-ignore
-    CookieConsentCore.create(props.siteSettings, props.options);
+    CookieConsentCore.create(props.siteSettings, props.options || {});
   }, []);
 
   return null;


### PR DESCRIPTION
## Description

Cookie core render() was unnecessarily async, which caused problems when rendering multiple times in a row.

Also create() could be called multiple times if json is loaded slowly or React CRA renders everything twice, which is the default in dev mode.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2520](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2520)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- no need.


[HDS-2520]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ