### PR TITLE
(Release-4.0.0) Hds-2529: dispatch cookie change events

### DIFF
--- a/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
+++ b/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
@@ -15,6 +15,7 @@ import { StoryComponent } from './components/StoryComponent';
 // importing the json because load won't work in e2e
 import siteSettings from '../cookieConsentCore/example/helfi_sitesettings.json';
 import { ToggleButton } from '../toggleButton/ToggleButton';
+import { cookieEventType } from '../cookieConsentCore/cookieConsentCore';
 
 export default {
   component: StoryComponent,
@@ -57,6 +58,7 @@ const Actions = () => {
     document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
     // eslint-disable-next-line no-console
     console.log('Cookie removed:', cookieName);
+    window.dispatchEvent(new CustomEvent(cookieEventType.CHANGE, { detail: { acceptedGroups: [] } }));
   };
   const openBanner = async () => {
     // eslint-disable-next-line no-console

--- a/packages/react/src/components/cookieConsentCore/CookieConsentCore.stories.tsx
+++ b/packages/react/src/components/cookieConsentCore/CookieConsentCore.stories.tsx
@@ -26,7 +26,10 @@ const Actions = () => {
   };
   const addUnallowedCookie = async () => {
     // eslint-disable-next-line no-console
-    console.log('Adding chat cookie:', await window.hds.cookieConsent.setGroupsStatusToAccepted(['unallowed']));
+    console.log(
+      'Trying to add an unallowed cookie:',
+      await window.hds.cookieConsent.setGroupsStatusToAccepted(['unallowed']),
+    );
   };
   const removeConsentCookie = async () => {
     const cookieName = `helfi-cookie-consents`;

--- a/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
+++ b/packages/react/src/components/cookieConsentCore/cookieConsentCore.js
@@ -246,7 +246,14 @@ export class CookieConsentCore {
    * @return {Promise<boolean>} - A promise that resolves to true if the groups' status is successfully set to accepted, otherwise false.
    */
   async setGroupsStatusToAccepted(acceptedGroupsArray) {
-    return this.#cookieHandler.setGroupsStatusToAccepted(acceptedGroupsArray);
+    const success = await this.#cookieHandler.setGroupsStatusToAccepted(acceptedGroupsArray);
+    if (success) {
+      const acceptedGroups = this.getAllConsentStatuses()
+        .filter((item) => item.consented)
+        .map((item) => item.group);
+      window.dispatchEvent(new CustomEvent(cookieEventType.CHANGE, { detail: { acceptedGroups } }));
+    }
+    return Promise.resolve(success);
   }
 
   /**


### PR DESCRIPTION


## Description

The cookieCore.setGroupsStatusToAccepted did not dispatch change events.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2529](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2529)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Not at all. There are no event tests in any scenario. Added later.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- no need


[HDS-2529]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ