### PR TITLE
remove Sketch & Abstract from CHANGELOG.template since obsolete

### DIFF
--- a/scripts/changelog/CHANGELOG.template.md
+++ b/scripts/changelog/CHANGELOG.template.md
@@ -1,4 +1,4 @@
-## [3.X.X] - Month, XX, 202X
+## [4.X.X] - Month, XX, 202X
 
 ### React
 
@@ -61,26 +61,6 @@ Changes that are not related to specific components
 - [Component] What bugs/typos are fixed?
 
 ### Figma
-
-#### Breaking
-
-- [Component] What are the breaking changes?
-
-#### Added
-
-- [Component] What is added?
-
-#### Changed
-
-Changes that are not related to specific components
-
-- [Component] What has been changed
-
-#### Fixed
-
-- [Component] What bugs/typos are fixed?
-
-### Sketch/Abstract
 
 #### Breaking
 


### PR DESCRIPTION
Self explanatory :D remove Sketch & Abstract from CHANGELOG.template since obsolete
