### PR TITLE
Hds 2352 fix missing component urls

### DIFF
--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -54,7 +54,7 @@ const fixUrlExceptions = (href, version) => {
 const hrefWithVersion = (href, version, withoutPrefix = false) => {
   const hrefWithFixedExceptions = fixUrlExceptions(href, version);
 
-  if (!version || version === '' || hrefWithFixedExceptions === ''
+  if (!version || hrefWithFixedExceptions === ''
     || hrefWithFixedExceptions.startsWith('mailto:')
     || hrefWithFixedExceptions.startsWith('#')
     || hrefWithFixedExceptions.startsWith('http'))


### PR DESCRIPTION
## Description

Found small annoyance, if documentation version is changed on component page to version where it doesn't exists, documentation leads to error. Found out that there is not many of these kind of pages. So I made small routing fix to route these links to the root page of components (better than error page)

## How Has This Been Tested?

goto to page `components/button/` or `components/dropdown/` or `components/header/` or `components/error-summary/`and change documentation version, it should not crash.
