### PR TITLE
HDS-2535: login modules strict mode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
+- [Login] External modules with Strict mode throwed an error
 - [ssr] Login component works with SSR rendering
 
 ### Core

--- a/packages/react/src/components/login/Login.stories.tsx
+++ b/packages/react/src/components/login/Login.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, PropsWithChildren } from 'react';
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
 import { action } from '@storybook/addon-actions';
 
@@ -56,6 +56,13 @@ type StoryArgs = {
 const onLoginClick = action('header-login-click');
 const onLogoutClick = action('header-logout-click');
 const onLoginButtonClick = action('login-button-click');
+
+const StrictModeEmulator = (props: PropsWithChildren<unknown>) => {
+  // for some reason using React.StrictMode directly in the story causes an error
+  // Cannot convert a Symbol value to a string
+  // vendors-node_modules_juggle_resize-observer_lib_exports_resize-observer_js-node_modules_pmmmw
+  return <React.StrictMode>{props.children}</React.StrictMode>;
+};
 
 export default {
   component: LoginProvider,
@@ -670,10 +677,12 @@ export const ExampleApplication = (args: StoryArgs) => {
   };
 
   return (
-    <LoginProvider {...loginProps} modules={[signalTracker, profileGraphQL]}>
-      <IFrameWarning />
-      <WithAuthentication AuthorisedComponent={AuthenticatedContent} UnauthorisedComponent={LoginComponent} />
-    </LoginProvider>
+    <StrictModeEmulator>
+      <LoginProvider {...loginProps} modules={[signalTracker, profileGraphQL]}>
+        <IFrameWarning />
+        <WithAuthentication AuthorisedComponent={AuthenticatedContent} UnauthorisedComponent={LoginComponent} />
+      </LoginProvider>
+    </StrictModeEmulator>
   );
 };
 

--- a/packages/react/src/components/login/components/LoginProvider.tsx
+++ b/packages/react/src/components/login/components/LoginProvider.tsx
@@ -35,7 +35,7 @@ export const LoginProvider = ({
     debug,
   };
 
-  const mods = modules || [];
+  const mods = modules ? [...modules] : [];
   if (sessionPollerSettings) {
     mods.push(createSessionPoller(sessionPollerSettings));
   }


### PR DESCRIPTION
## Description

If items are added directly to the module array, the array size increases and same modules are added twice on second render.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2535](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2535)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Added strict mode emulation to Login story.

## Demos:

Login does not work on demo site.

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog



[HDS-2535]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ