### PR TITLE
HDS-2535: external modules listeners fix in Strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes that are not related to specific components
 
 - [Login] External modules with Strict mode throwed an error
 - [ssr] Login component works with SSR rendering
+- [Login] Event listeners with Strict mode were lost in double render
 
 ### Core
 

--- a/packages/react/src/components/login/Login.stories.tsx
+++ b/packages/react/src/components/login/Login.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, PropsWithChildren } from 'react';
+import React, { useState, useCallback, PropsWithChildren, useMemo } from 'react';
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
 import { action } from '@storybook/addon-actions';
 
@@ -676,9 +676,12 @@ export const ExampleApplication = (args: StoryArgs) => {
     );
   };
 
+  const modules = useMemo(() => {
+    return [signalTracker, profileGraphQL];
+  }, [signalTracker, profileGraphQL]);
   return (
     <StrictModeEmulator>
-      <LoginProvider {...loginProps} modules={[signalTracker, profileGraphQL]}>
+      <LoginProvider {...loginProps} modules={modules}>
         <IFrameWarning />
         <WithAuthentication AuthorisedComponent={AuthenticatedContent} UnauthorisedComponent={LoginComponent} />
       </LoginProvider>

--- a/packages/react/src/components/login/components/LoginContext.tsx
+++ b/packages/react/src/components/login/components/LoginContext.tsx
@@ -27,17 +27,12 @@ export const LoginContext = createContext<LoginContextData>({
 
 export const LoginContextProvider = (props: ContextProps): React.ReactElement => {
   const { children, loginProps, modules } = props;
-  const beacon = useMemo(() => {
-    return createBeacon();
-  }, []);
-  const oidcClient = useMemo(() => {
-    const client = createOidcClient({
+  const memoizedBeacon = useMemo(() => {
+    const beacon = createBeacon();
+    const oidcClient = createOidcClient({
       ...loginProps,
     });
-    return client;
-  }, []);
 
-  useMemo(() => {
     if (modules) {
       modules.forEach((module) => {
         beacon.addSignalContext(module);
@@ -45,14 +40,15 @@ export const LoginContextProvider = (props: ContextProps): React.ReactElement =>
     }
     beacon.addSignalContext(oidcClient);
     emitInitializationSignals(beacon);
+    return beacon;
   }, []);
 
   const contextData: LoginContextData = {
     addListener: (signalOrJustSignalType, listener) => {
-      return beacon.addListener(signalOrJustSignalType, listener);
+      return memoizedBeacon.addListener(signalOrJustSignalType, listener);
     },
     getModule: <T extends ConnectedModule>(namespace: SignalNamespace) => {
-      return beacon.getSignalContext(namespace) as T;
+      return memoizedBeacon.getSignalContext(namespace) as T;
     },
   };
 

--- a/packages/react/src/components/login/components/LoginProvider.tsx
+++ b/packages/react/src/components/login/components/LoginProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { LoginContextProvider } from './LoginContext';
 import { OidcClientProps } from '../client/index';
@@ -35,13 +35,20 @@ export const LoginProvider = ({
     debug,
   };
 
-  const mods = modules ? [...modules] : [];
-  if (sessionPollerSettings) {
-    mods.push(createSessionPoller(sessionPollerSettings));
-  }
-  if (apiTokensClientSettings) {
-    mods.push(createApiTokenClient(apiTokensClientSettings));
-  }
+  // Settings are not intentionally not used in memoization,
+  // because they should not change in runtime and using them would require memoizing
+  // them up in the component tree or memoization is useless.
+  const mods = useMemo(() => {
+    const currentMods = modules ? [...modules] : [];
+    if (sessionPollerSettings) {
+      currentMods.push(createSessionPoller(sessionPollerSettings));
+    }
+    if (apiTokensClientSettings) {
+      currentMods.push(createApiTokenClient(apiTokensClientSettings));
+    }
+    return currentMods;
+  }, [modules]);
+
   return (
     <LoginContextProvider loginProps={loginProps} modules={mods}>
       {children}


### PR DESCRIPTION
## Description

Fix event listeners in external modules if beacon is re-created

In a scenario where external modules are used and the component is created multiple times, the listeners are set only once in the modules.

This happens in StrictMode.

On the second storeBeacon call the listeners in dedicated beacon are not added back and old ones are not removed.

The list of listeners must be kept and disposers must be called.

Now listeners are added again.

Listeners added after a beacon is created are not stored, because those are logically added when second beacon is created - as in first run.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2535](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2535)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Added tests.

## Demos:

Login does not work in demo site.

## Screenshots (if appropriate):

## Add to changelog

- [x ] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2535]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ