### PR TITLE
HDS-2524: fix login ssr rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [ssr] Login component works with SSR rendering
 
 ### Core
 
@@ -126,6 +126,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+
 ## [4.0.0] - November, 21, 2024
 
 ### React
@@ -277,7 +278,7 @@ Changes that are not related to specific components
 #### Added
 
 - [Select, Multiselect] New components to replace Dropdown.
-- [CookieConsent] New component replacing previous CookieConsent 
+- [CookieConsent] New component replacing previous CookieConsent
 - [Variables] The first variable named Deprecated is introduced.
 - [Design kit] New page and documentation for Shadow styles. Shadow in the Overview. New Getting started-section.
 
@@ -293,7 +294,7 @@ Changes that are not related to specific components
 - [Design kit] Components have a new configuration: Each component has its own page now. Moved documentation components to new page etc. Updated Colours-documentation page.
 - [Local styles] Headings have new line-heights (check .txt. for details)
 - [Local styles] Drop shadow-style removed, replaced by Shadow styles S-M matching HDS Shadow tokens
-- [Dialog, Notification]  Switched shadow effect to use Shadow L to match implementation
+- [Dialog, Notification] Switched shadow effect to use Shadow L to match implementation
 - [SelectionGroup] Removed 2px left and right padding and adjusted inner gaps.
 - [Tag] Updated paddings for visually better icon alignments.
 - [Tag] Changed icon property names to iconStart and iconEnd.

--- a/packages/react/src/components/login/apiTokensClient/apiTokensClient.ts
+++ b/packages/react/src/components/login/apiTokensClient/apiTokensClient.ts
@@ -24,6 +24,7 @@ import {
   apiTokensClientEvents,
 } from '.';
 import { sequentialAsyncLoop } from '../../../utils/sequentialAsyncLoop';
+import { getSessionStorage } from '../utils/getSessionStorage';
 
 async function fetchApiToken(options: FetchApiTokenOptions): Promise<TokenData | ApiTokensClientError> {
   const { url, signal, audience, accessToken, queryProps, maxRetries = 0, retryInterval = 500 } = options;
@@ -139,7 +140,8 @@ async function fetchApiTokens(
  * @param storage
  * @returns
  */
-export const getApiTokensFromStorage = (storage: Storage = window.sessionStorage): TokenData | null => {
+export const getApiTokensFromStorage = (sourceStorage?: Storage): TokenData | null => {
+  const storage = sourceStorage || getSessionStorage();
   const tokensString = storage.getItem(API_TOKEN_SESSION_STORAGE_KEY);
   try {
     return tokensString ? JSON.parse(tokensString) : null;
@@ -152,7 +154,8 @@ export const getApiTokensFromStorage = (storage: Storage = window.sessionStorage
  * Removes the api tokens from storage
  * @param storage
  */
-export const removeApiTokensFromStorage = (storage: Storage = window.sessionStorage) => {
+export const removeApiTokensFromStorage = (sourceStorage?: Storage) => {
+  const storage = sourceStorage || getSessionStorage();
   storage.removeItem(API_TOKEN_SESSION_STORAGE_KEY);
 };
 
@@ -161,7 +164,8 @@ export const removeApiTokensFromStorage = (storage: Storage = window.sessionStor
  * @param tokenObj
  * @param storage
  */
-export const setApiTokensToStorage = (tokenObj: TokenData, storage: Storage = window.sessionStorage): void => {
+export const setApiTokensToStorage = (tokenObj: TokenData, sourceStorage?: Storage): void => {
+  const storage = sourceStorage || getSessionStorage();
   storage.setItem(API_TOKEN_SESSION_STORAGE_KEY, JSON.stringify(tokenObj));
 };
 
@@ -171,10 +175,8 @@ export const setApiTokensToStorage = (tokenObj: TokenData, storage: Storage = wi
  * @param storage
  * @returns
  */
-export const getApiTokenFromStorage = (
-  tokenKey: string,
-  storage: Storage = window.sessionStorage,
-): string | undefined => {
+export const getApiTokenFromStorage = (tokenKey: string, sourceStorage?: Storage): string | undefined => {
+  const storage = sourceStorage || getSessionStorage();
   const tokens = getApiTokensFromStorage(storage);
   return tokens ? tokens[tokenKey] : undefined;
 };
@@ -183,7 +185,8 @@ export const getApiTokenFromStorage = (
  *  Removes the user reference from stored api tokens. Reference is the access token used when fetching api tokens
  * @param storage
  */
-export const removeUserReferenceFromStorage = (storage: Storage = window.sessionStorage) => {
+export const removeUserReferenceFromStorage = (sourceStorage?: Storage) => {
+  const storage = sourceStorage || getSessionStorage();
   storage.removeItem(API_TOKEN_SESSION_USER_REFERENCE_KEY);
 };
 
@@ -192,7 +195,8 @@ export const removeUserReferenceFromStorage = (storage: Storage = window.session
  * @param reference
  * @param storage
  */
-export const setUserReferenceToStorage = (reference: string, storage: Storage = window.sessionStorage): void => {
+export const setUserReferenceToStorage = (reference: string, sourceStorage?: Storage): void => {
+  const storage = sourceStorage || getSessionStorage();
   storage.setItem(API_TOKEN_SESSION_USER_REFERENCE_KEY, reference);
 };
 
@@ -201,7 +205,8 @@ export const setUserReferenceToStorage = (reference: string, storage: Storage = 
  * @param storage
  * @returns
  */
-export const getUserReferenceFromStorage = (storage: Storage = window.sessionStorage): string | null => {
+export const getUserReferenceFromStorage = (sourceStorage?: Storage): string | null => {
+  const storage = sourceStorage || getSessionStorage();
   return storage.getItem(API_TOKEN_SESSION_USER_REFERENCE_KEY);
 };
 

--- a/packages/react/src/components/login/client/oidcClient.ts
+++ b/packages/react/src/components/login/client/oidcClient.ts
@@ -19,6 +19,8 @@ import {
 import { OidcClientError, oidcClientErrors } from './oidcClientError';
 import { createRenewalTrackingPromise } from '../utils/userRenewalPromise';
 import { createNamespacedBeacon } from '../beacon/signals';
+import { getSessionStorage } from '../utils/getSessionStorage';
+import { isSsrEnvironment } from '../../../utils/isSsrEnvironment';
 
 const getDefaultProps = (baseUrl: string): Partial<OidcClientProps> => ({
   userManagerSettings: {
@@ -52,8 +54,9 @@ export const getUserStoreKey = (settings: Partial<UserManagerSettings>): string 
  */
 export const getUserFromStorage = (
   settings: Pick<UserManagerSettings, 'authority' | 'client_id'>,
-  storage: Storage = window.sessionStorage,
+  sourceStorage?: Storage,
 ): UserReturnType => {
+  const storage = sourceStorage || getSessionStorage();
   const data = storage.getItem(getUserStoreKey(settings));
   if (!data) {
     return null;
@@ -109,9 +112,9 @@ export const pickUserToken = (user: UserReturnType, tokenType: Parameters<OidcCl
 export function createOidcClient(props: OidcClientProps): OidcClient {
   const { userManagerSettings: userManagerSettingsFromProps, ...restProps } = props;
   const { userManagerSettings: defaultUserManagerSettings, ...restDefaultProps } = getDefaultProps(
-    window.location.origin,
+    isSsrEnvironment() ? '' : window.location.origin,
   );
-  const store = window.sessionStorage;
+  const store = getSessionStorage();
   const combinedProps: OidcClientProps = {
     ...restDefaultProps,
     ...restProps,

--- a/packages/react/src/components/login/utils/getSessionStorage.ts
+++ b/packages/react/src/components/login/utils/getSessionStorage.ts
@@ -1,0 +1,18 @@
+import { noop } from 'lodash';
+
+import { isSsrEnvironment } from '../../../utils/isSsrEnvironment';
+
+export function getSessionStorage(): Storage {
+  if (isSsrEnvironment()) {
+    return {
+      length: 0,
+      clear: noop,
+      removeItem: noop,
+      setItem: noop,
+      getItem: () => null,
+      key: () => null,
+    };
+  }
+
+  return window.sessionStorage;
+}

--- a/site/src/docs/components/login/index.mdx
+++ b/site/src/docs/components/login/index.mdx
@@ -54,8 +54,6 @@ To use the OIDC provider with login components, you need
 
 The HDS <UsagePageAnchorLink>Oidc client</UsagePageAnchorLink> stores data in session storage for security reasons. Session storage is not shared across browser windows or tabs, so the user must log in separately for each window.
 
-HDS Login components cannot support SSR at the moment because of the session storage requirement.
-
 Silent session renewal requires a <UsagePageAnchorLink anchor="silent-renewal">dedicated HTML file</UsagePageAnchorLink> that redirects to the OIDC provider "silently" in an iframe.
 
 ### Consents for storing data


### PR DESCRIPTION
## Description

Login uses `window.sessionStorage`, but `window` does not exist in ssr. Added a helper function to get the sessionStorage or a dummy version of it.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2524](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2524)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Used hds-cra to make zipped files, moved them to a nextjs-project and built the project. With HDS 4.0.0 there was an error "window is not defined", but worked with new version.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x ] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2524]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ