### PR TITLE
feat: add technology tags to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Changes that are not related to specific components
 
 #### Added
 
-- [Component] What is added?
+- Technology tags to all components
 
 #### Changed
 

--- a/site/scripts/scaffold.js
+++ b/site/scripts/scaffold.js
@@ -47,7 +47,7 @@ const createComponentFiles = (templatePath, destination, name, pathName) => {
 
 }
 
-const appendToComponentsData = (name, description, pathName) => {
+const appendToComponentsData = (name, description, pathName, isCoreComponent) => {
   try {
     const newDataObject = {
       name,
@@ -60,7 +60,8 @@ const appendToComponentsData = (name, description, pathName) => {
         alt: `An illustration of the ${name} component.`,
         height: 180,
         width: 280
-      }
+      },
+      tags: ["react", ...(isCoreComponent ? ["core"] : [])]
     };
 
     const componentsDataPath = path.resolve(__dirname, '../src/data/components.json');
@@ -91,6 +92,12 @@ const scaffold = async () => {
     validate: (input) => (input.split(' ').length > 2 ? true : `Description not long enough: ${input}`)
   });
 
+  const { isCoreComponent } = await inquirer.prompt({
+    type: 'confirm',
+    name: 'isCoreComponent',
+    message: 'Is there also a core component?',
+  });
+
   const pathName = name.split(/(?=[A-Z])/).join('-').toLowerCase();
   const path = createFolder(`src/docs/components/${pathName}`);
 
@@ -100,7 +107,7 @@ const scaffold = async () => {
 
   logStep(`${chalk.bold(`Created files:`)}\n\t${chalk.italic(files.join('\n\t'))}`);
 
-  appendToComponentsData(name, description, pathName);
+  appendToComponentsData(name, description, pathName, isCoreComponent);
 
   logStep(`${chalk.bold(`${name} component included in components.json.`)}`);
 

--- a/site/src/components/LinkboxList.js
+++ b/site/src/components/LinkboxList.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { navigate, withPrefix } from 'gatsby';
 import { Linkbox } from 'hds-react';
 import PropTypes from 'prop-types';
+import TechTags from './TechTags';
 
 import './LinkboxList.scss';
 
@@ -28,7 +29,9 @@ const LinkboxList = ({ data, className }) => (
                 navigate(item.href);
               }
             }}
-          />
+          >
+            <TechTags componentName={item.name} withoutHeading />
+          </Linkbox>
         </div>
       );
     })}

--- a/site/src/components/TechTags.js
+++ b/site/src/components/TechTags.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Tag } from 'hds-react';
+import PropTypes from 'prop-types';
+import componentData from '../data/components.json';
+
+const tagStyles = {
+  core: { label: 'Core', theme: { '--background-color': 'var(--color-copper-medium-light)' } },
+  react: { label: 'React', theme: { '--background-color': 'var(--color-fog-medium-light)' } },
+  js: { label: 'Vanilla JS', theme: { '--background-color': 'var(--color-engel)' } },
+};
+
+export const TechTags = ({ componentName, withoutHeading }) => {
+  const componentTags = componentData.find((item) => item.name === componentName)?.tags;
+
+  return (
+    <>
+      {!withoutHeading && <h4 className="heading-s">Available technologies</h4>}
+      {componentTags && (
+        <div style={{ display: 'flex', gap: 'var(--spacing-2-xs)' }}>
+          {componentTags.map(
+            (tag) =>
+              tagStyles?.[tag] && (
+                <Tag key={tag} theme={tagStyles[tag]?.theme}>
+                  {tagStyles[tag]?.label}
+                </Tag>
+              ),
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+TechTags.propTypes = {
+  componentName: PropTypes.string.isRequired,
+  withoutHeading: PropTypes.bool,
+};
+
+export default TechTags;

--- a/site/src/data/components.json
+++ b/site/src/data/components.json
@@ -10,7 +10,8 @@
       "alt": "An illustration of the Accordion component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Breadcrumb",
@@ -23,7 +24,8 @@
       "alt": "An illustration of the Breadcrumb component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Button",
@@ -36,7 +38,8 @@
       "alt": "An illustration of the Button component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Card",
@@ -49,7 +52,8 @@
       "alt": "An illustration of the Card component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Checkbox",
@@ -62,7 +66,8 @@
       "alt": "An illustration of the Checkbox component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "CookieConsent",
@@ -75,7 +80,8 @@
       "alt": "An illustration of the CookieConsent component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react", "js"]
   },
   {
     "name": "DateInput",
@@ -88,7 +94,8 @@
       "alt": "An illustration of the DateInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Dialog",
@@ -101,7 +108,8 @@
       "alt": "An illustration of the Dialog component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Dropdown",
@@ -114,7 +122,8 @@
       "alt": "An illustration of the Dropdown component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "ErrorSummary",
@@ -127,7 +136,8 @@
       "alt": "An illustration of the Error Summary component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Fieldset",
@@ -140,7 +150,8 @@
       "alt": "An illustration of the Fieldset component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "FileInput",
@@ -153,7 +164,8 @@
       "alt": "An illustration of the FileInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Footer",
@@ -166,7 +178,8 @@
       "alt": "An illustration of the Footer component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Header",
@@ -179,7 +192,8 @@
       "alt": "An illustration of the Header component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Hero",
@@ -192,7 +206,8 @@
       "alt": "An illustration of the Hero component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Highlight",
@@ -205,7 +220,8 @@
       "alt": "An illustration of the Highlight component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Icon",
@@ -218,7 +234,8 @@
       "alt": "An illustration of the Icon component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Koros",
@@ -231,7 +248,8 @@
       "alt": "An illustration of the Koros component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Link",
@@ -244,7 +262,8 @@
       "alt": "An illustration of the Link component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Linkbox",
@@ -257,7 +276,8 @@
       "alt": "An illustration of the Linkbox component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "LoadingSpinner",
@@ -270,7 +290,8 @@
       "alt": "An illustration of the LoadingSpinner component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Login",
@@ -283,7 +304,8 @@
       "alt": "An illustration of the Login component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react", "js"]
   },
   {
     "name": "Logo",
@@ -296,7 +318,8 @@
       "alt": "An illustration of the Logo component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Notification",
@@ -309,7 +332,8 @@
       "alt": "An illustration of the Notification component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "NumberInput",
@@ -322,7 +346,8 @@
       "alt": "An illustration of the NumberInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Pagination",
@@ -335,7 +360,8 @@
       "alt": "An illustration of the Pagination component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "PasswordInput",
@@ -348,7 +374,8 @@
       "alt": "An illustration of the PasswordInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "PhoneInput",
@@ -361,7 +388,8 @@
       "alt": "An illustration of the PhoneInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "RadioButton",
@@ -374,7 +402,8 @@
       "alt": "An illustration of the RadioButton component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "SearchInput",
@@ -387,7 +416,8 @@
       "alt": "An illustration of the SearchInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Select",
@@ -400,7 +430,8 @@
       "alt": "An illustration of the Select component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "SelectionGroup",
@@ -413,7 +444,8 @@
       "alt": "An illustration of the SelectionGroup component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "SideNavigation",
@@ -426,7 +458,8 @@
       "alt": "An illustration of the SideNavigation component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "StatusLabel",
@@ -439,7 +472,8 @@
       "alt": "An illustration of the StatusLabel component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "StepByStep",
@@ -452,7 +486,8 @@
       "alt": "An illustration of the StepByStep component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Stepper",
@@ -465,7 +500,8 @@
       "alt": "An illustration of the Stepper component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Table",
@@ -478,7 +514,8 @@
       "alt": "An illustration of the Table component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "Tabs",
@@ -491,7 +528,8 @@
       "alt": "An illustration of the Tabs component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Tag",
@@ -504,7 +542,8 @@
       "alt": "An illustration of the Tag component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "TextArea",
@@ -517,7 +556,8 @@
       "alt": "An illustration of the TextArea component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "TextInput",
@@ -530,7 +570,8 @@
       "alt": "An illustration of the TextInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["core", "react"]
   },
   {
     "name": "TimeInput",
@@ -543,7 +584,8 @@
       "alt": "An illustration of the TimeInput component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "ToggleButton",
@@ -556,7 +598,8 @@
       "alt": "An illustration of the ToggleButton component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   },
   {
     "name": "Tooltip",
@@ -569,6 +612,7 @@
       "alt": "An illustration of the Tooltip component.",
       "height": 180,
       "width": 280
-    }
+    },
+    "tags": ["react"]
   }
 ]

--- a/site/src/docs/components/accordion/tabs.mdx
+++ b/site/src/docs/components/accordion/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Accordion
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Accordions can be used to hide and reveal information. When used correctly, they are a good way to make a higher amount of information easier to digest for the user.</LeadParagraph>
+
+<TechTags componentName="Accordion" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/breadcrumb/tabs.mdx
+++ b/site/src/docs/components/breadcrumb/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Breadcrumb
 
@@ -19,6 +20,8 @@ import StatusLabel from '../../../components/StatusLabel';
 
 <LeadParagraph>Breadcrumb is a navigational element that provides links back to each previous page the user navigated through and
   shows the user's current location on a website.</LeadParagraph>
+
+<TechTags componentName="Breadcrumb" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/button/tabs.mdx
+++ b/site/src/docs/components/button/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Button
 
@@ -19,6 +20,8 @@ import StatusLabel from '../../../components/StatusLabel';
 
 <LeadParagraph>Buttons are meant to make actions easily visible and understandable to the user. HDS offers different kinds of button
   variations which each suit for different needs.</LeadParagraph>
+
+<TechTags componentName="Button" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/card/tabs.mdx
+++ b/site/src/docs/components/card/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Card
 
@@ -21,6 +22,8 @@ import StatusLabel from '../../../components/StatusLabel';
   Cards can be used to divide and organise interface content for better understandability and readability. When used
   correctly, Cards can help your users to scan through vast amounts of information quicker.
 </LeadParagraph>
+
+<TechTags componentName="Card" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/checkbox/tabs.mdx
+++ b/site/src/docs/components/checkbox/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Checkbox
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Checkboxes are used to pick an option when one or more options can be chosen.</LeadParagraph>
+
+<TechTags componentName="Checkbox" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/components.scss
+++ b/site/src/docs/components/components.scss
@@ -16,7 +16,7 @@
     background-color: var(--color-fog-medium-light);
   }
 
-  & .js-storybook div {
+  & .js-documentation div {
     background-color: var(--color-engel);
   }
 }

--- a/site/src/docs/components/components.scss
+++ b/site/src/docs/components/components.scss
@@ -1,18 +1,22 @@
 @import "~hds-design-tokens/lib/all.scss";
 
-.linkbox-list {
+.components-storybook-links {
   column-gap: var(--spacing-layout-xs);
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(216px, 1fr));
   margin-top: var(--spacing-layout-xs) !important;
   row-gap: var(--spacing-layout-xs);
   width: 100%;
-}
 
-.linkbox-list-item {
-  width: 100%;
-}
+  & .core-storybook div {
+    background-color: var(--color-copper-medium-light);
+  }
 
-.linkbox-list-link {
-  height: 100%;
+  & .react-storybook div {
+    background-color: var(--color-fog-medium-light);
+  }
+
+  & .js-storybook div {
+    background-color: var(--color-engel);
+  }
 }

--- a/site/src/docs/components/cookie-consent/tabs.mdx
+++ b/site/src/docs/components/cookie-consent/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # CookieConsent
 
@@ -23,6 +24,8 @@ import StatusLabel from '../../../components/StatusLabel';
   The cookie consent component informs users about cookie usage. This banner is shown when they visit a website or an
   application for the first time.
 </LeadParagraph>
+
+<TechTags componentName="CookieConsent" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/date-input/tabs.mdx
+++ b/site/src/docs/components/date-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # DateInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Date input allows the user to easily input a specific date or a date range. By default, HDS date input is supplied with a date picker functionality.</LeadParagraph>
+
+<TechTags componentName="DateInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/dialog/tabs.mdx
+++ b/site/src/docs/components/dialog/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Dialog
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Dialogs initiate a conversation between the service and the user. They are used when an input or a confirmation is needed from the user or when important information needs to be conveyed.</LeadParagraph>
+
+<TechTags componentName="Dialog" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/error-summary/tabs.mdx
+++ b/site/src/docs/components/error-summary/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # ErrorSummary
 
@@ -20,6 +21,8 @@ import StatusLabel from '../../../components/StatusLabel';
 <LeadParagraph>
   The error summary is notification-like element which lists all errors (and their descriptions) found in a form or other inputs and provides anchor links to each erroneous input for easy access.
 </LeadParagraph>
+
+<TechTags componentName="ErrorSummary" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/fieldset/tabs.mdx
+++ b/site/src/docs/components/fieldset/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Fieldset
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Fieldset groups multiple related form input fields together by giving them a common legend heading.</LeadParagraph>
+
+<TechTags componentName="Fieldset" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/file-input/tabs.mdx
+++ b/site/src/docs/components/file-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # FileInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>A file input helps the user to browse and select one or multiple files to be uploaded to the service.</LeadParagraph>
+
+<TechTags componentName="FileInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/footer/tabs.mdx
+++ b/site/src/docs/components/footer/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Footer
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>The Footer component is located at the bottom of the page below the main body content. It provides a place for secondary navigation, site-wide actions, and additional information.</LeadParagraph>
+
+<TechTags componentName="Footer" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/header/tabs.mdx
+++ b/site/src/docs/components/header/tabs.mdx
@@ -9,6 +9,7 @@ import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
 import Notification from '../../../components/Notification';
+import TechTags from '../../../components/TechTags';
 
 # Header
 
@@ -24,6 +25,8 @@ import Notification from '../../../components/Notification';
   The Header components are a collection of new navigation components the HDS team is currently fine tuning. This means
   that these components are subject to change. We are open to feedback regarding how they work.
 </Notification>
+
+<TechTags componentName="Header" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/hero/tabs.mdx
+++ b/site/src/docs/components/hero/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Hero
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Hero elements are used below the main navigation as the first content element. They can be used for different purposes, but most often, they shortly describe the page's role and offer the page's essential function as a call-to-action button.</LeadParagraph>
+
+<TechTags componentName="Hero" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/highlight/tabs.mdx
+++ b/site/src/docs/components/highlight/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Highlight
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Highlight component allows lifting an excerpt from a longer text for emphasis. Highlight supports two types: highlight (default) and quotation. The Quote element has a reference to the quote source. The Highlight element is an excerpt from the text without the source information.</LeadParagraph>
+
+<TechTags componentName="Highlight" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/icon/tabs.mdx
+++ b/site/src/docs/components/icon/tabs.mdx
@@ -8,6 +8,7 @@ import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import LeadParagraph from '../../../components/LeadParagraph';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Icon
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Icons are used for providing visual cues and highlighting actions, denoting types and classes of information, and giving additional meaning to content.</LeadParagraph>
+
+<TechTags componentName="Icon" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/index.mdx
+++ b/site/src/docs/components/index.mdx
@@ -15,7 +15,7 @@ This section lists all components currently available in HDS. Components can be 
 <div className="components-storybook-links">
   <Linkbox className="core-storybook" size={LinkboxSize.Small} linkboxAriaLabel="Core Storybook" linkAriaLabel="Core Storybook" href="/storybook/core" external heading="Core Storybook" />
   <Linkbox className="react-storybook" size={LinkboxSize.Small} linkboxAriaLabel="React Storybook" linkAriaLabel="React Storybook" href="/storybook/react" external heading="React Storybook" />
-  <Linkbox className="js-storybook" size={LinkboxSize.Small} linkboxAriaLabel="Vanilla JS" linkAriaLabel="Vanilla JS" href="/storybook/js" external heading="Vanilla JS" />
+  <Linkbox className="js-documentation" size={LinkboxSize.Small} linkboxAriaLabel="Vanilla JS" linkAriaLabel="Vanilla JS" href="/getting-started/developer/#hds-js" external heading="Vanilla JS" />
 </div>
 
 Tags will tell you which technologies the component is available in.

--- a/site/src/docs/components/index.mdx
+++ b/site/src/docs/components/index.mdx
@@ -5,13 +5,19 @@ title: "Components overview"
 
 import ComponentsList from '../../components/ComponentsList';
 import InternalLink from '../../components/InternalLink';
+import { Linkbox, LinkboxSize } from 'hds-react';
+import './components.scss';
 
 # Components overview
 
-This section lists all components currently available in HDS.
+This section lists all components currently available in HDS. Components can be viewed also in the Storybook examples.
 
-Components can be viewed also in the Storybook examples.
-- <InternalLink href="/storybook/react">React Storybook</InternalLink>
-- <InternalLink href="/storybook/core">Core Storybook</InternalLink>
+<div className="components-storybook-links">
+  <Linkbox className="core-storybook" size={LinkboxSize.Small} linkboxAriaLabel="Core Storybook" linkAriaLabel="Core Storybook" href="/storybook/core" external heading="Core Storybook" />
+  <Linkbox className="react-storybook" size={LinkboxSize.Small} linkboxAriaLabel="React Storybook" linkAriaLabel="React Storybook" href="/storybook/react" external heading="React Storybook" />
+  <Linkbox className="js-storybook" size={LinkboxSize.Small} linkboxAriaLabel="Vanilla JS" linkAriaLabel="Vanilla JS" href="/storybook/js" external heading="Vanilla JS" />
+</div>
+
+Tags will tell you which technologies the component is available in.
 
 <ComponentsList />

--- a/site/src/docs/components/index.mdx
+++ b/site/src/docs/components/index.mdx
@@ -15,7 +15,7 @@ This section lists all components currently available in HDS. Components can be 
 <div className="components-storybook-links">
   <Linkbox className="core-storybook" size={LinkboxSize.Small} linkboxAriaLabel="Core Storybook" linkAriaLabel="Core Storybook" href="/storybook/core" external heading="Core Storybook" />
   <Linkbox className="react-storybook" size={LinkboxSize.Small} linkboxAriaLabel="React Storybook" linkAriaLabel="React Storybook" href="/storybook/react" external heading="React Storybook" />
-  <Linkbox className="js-documentation" size={LinkboxSize.Small} linkboxAriaLabel="Vanilla JS" linkAriaLabel="Vanilla JS" href="/getting-started/developer/#hds-js" external heading="Vanilla JS" />
+  <Linkbox className="js-documentation" size={LinkboxSize.Small} linkboxAriaLabel="Vanilla JS" linkAriaLabel="Vanilla JS" href="/getting-started/developer/#hds-js" heading="Vanilla JS" />
 </div>
 
 Tags will tell you which technologies the component is available in.

--- a/site/src/docs/components/koros/tabs.mdx
+++ b/site/src/docs/components/koros/tabs.mdx
@@ -7,6 +7,7 @@ import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Koros
 
@@ -17,6 +18,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Koros, also known as Wave motifs, are part of the visual identity of City of Helsinki. The Koros can be used as visual elements, for example as part of the hero image or the footer and as a divider of content in the user interface.</LeadParagraph>
+
+<TechTags componentName="Koros" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/link/tabs.mdx
+++ b/site/src/docs/components/link/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Link
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Links are used as navigational elements and can be used on their own or in inline with text. They provide a lightweight option for navigation.</LeadParagraph>
+
+<TechTags componentName="Link" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/linkbox/tabs.mdx
+++ b/site/src/docs/components/linkbox/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Linkbox
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Linkboxes are used to combine multiple elements into a single interactable element. While they are visually similar to HDS Cards, Linkboxes are always a single clickable link and they cannot contain other interactable elements.</LeadParagraph>
+
+<TechTags componentName="Linkbox" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/loading-spinner/tabs.mdx
+++ b/site/src/docs/components/loading-spinner/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # LoadingSpinner
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Loading spinner is used for notifying users that their action is being processed or data retrieved from server.</LeadParagraph>
+
+<TechTags componentName="LoadingSpinner" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/login/tabs.mdx
+++ b/site/src/docs/components/login/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
 import Notification from '../../../components/Notification';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Login
 
@@ -23,6 +24,8 @@ import StatusLabel from '../../../components/StatusLabel';
   Login components include React components, context and hooks for handling user authorisation, api tokens, session
   polling and GraphQL queries.
 </LeadParagraph>
+
+<TechTags componentName="Login" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/logo/tabs.mdx
+++ b/site/src/docs/components/logo/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Logo
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>The logo is used to identify the site or application as an official City of Helsinki service.</LeadParagraph>
+
+<TechTags componentName="Logo" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/notification/tabs.mdx
+++ b/site/src/docs/components/notification/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Notification
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Notifications are used to present timely information to the user. HDS offers two types of notifications for different use cases.</LeadParagraph>
+
+<TechTags componentName="Notification" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/number-input/tabs.mdx
+++ b/site/src/docs/components/number-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # NumberInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>  A number input allows the user to enter numeric values. It also features optional steppers for increasing or decreasing the value by a set amount.</LeadParagraph>
+
+<TechTags componentName="NumberInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/pagination/tabs.mdx
+++ b/site/src/docs/components/pagination/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Pagination
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>The pagination component allows the user to navigate between pages when content is split into several pages.</LeadParagraph>
+
+<TechTags componentName="Pagination" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/password-input/tabs.mdx
+++ b/site/src/docs/components/password-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # PasswordInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>A password field is a foundational input field component that the user can interact with and specifically input password data.</LeadParagraph>
+
+<TechTags componentName="PasswordInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/phone-input/tabs.mdx
+++ b/site/src/docs/components/phone-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # PhoneInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>A phone input allows the user to enter phone number values. </LeadParagraph>
+
+<TechTags componentName="PhoneInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/radio-button/tabs.mdx
+++ b/site/src/docs/components/radio-button/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # RadioButton
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Radio buttons are used to pick an option when only one option can be chosen. </LeadParagraph>
+
+<TechTags componentName="RadioButton" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/search-input/tabs.mdx
+++ b/site/src/docs/components/search-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # SearchInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>A search input allows the user to find relevant content. The user can filter content using different words or phrases as keywords.</LeadParagraph>
+
+<TechTags componentName="SearchInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/select/tabs.mdx
+++ b/site/src/docs/components/select/tabs.mdx
@@ -9,6 +9,7 @@ import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
 import Notification from '../../../components/Notification';
+import TechTags from '../../../components/TechTags';
 
 # Select
 
@@ -24,6 +25,8 @@ import Notification from '../../../components/Notification';
   The select is a dialog that allows users to quickly navigate and select one or multiple items from a list. It includes
   a text input for filtering and supports item grouping. Dropdowns are often used as part of forms and filters.
 </LeadParagraph>
+
+<TechTags componentName="Select" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/selection-group/tabs.mdx
+++ b/site/src/docs/components/selection-group/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # SelectionGroup
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Selection group allows grouping related form selection elements (such as Checkboxes) to each other.</LeadParagraph>
+
+<TechTags componentName="SelectionGroup" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/side-navigation/tabs.mdx
+++ b/site/src/docs/components/side-navigation/tabs.mdx
@@ -9,6 +9,7 @@ import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
 import Notification from '../../../components/Notification';
+import TechTags from '../../../components/TechTags';
 
 # SideNavigation
 
@@ -23,6 +24,8 @@ import Notification from '../../../components/Notification';
 <Notification label="A visual rework is coming soon!" className="siteNotification">
   The HDS team will be unifying the SideNavigation component with the Hel.fi project side navigation in the near future.
 </Notification>
+
+<TechTags componentName="SideNavigation" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/status-label/tabs.mdx
+++ b/site/src/docs/components/status-label/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # StatusLabel
 
@@ -24,6 +25,8 @@ import StatusLabel from '../../../components/StatusLabel';
   Status labels can be used to highlight different statuses or items to the user. Status labels cannot be interacted with
   and they are only meant to convey relevant information.
 </LeadParagraph>
+
+<TechTags componentName="StatusLabel" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/step-by-step/tabs.mdx
+++ b/site/src/docs/components/step-by-step/tabs.mdx
@@ -7,6 +7,7 @@ import StatusLabelTooltip from '../../../components/StatusLabelTooltip';
 import LeadParagraph from '../../../components/LeadParagraph';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # StepByStep
 
@@ -17,6 +18,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>StepByStep component is useful for visualising a process in steps. The component supports numbered list for cases where the steps must be completed in a specific order, and unnumbered list for cases where the steps are more of a guideline.</LeadParagraph>
+
+<TechTags componentName="StepByStep" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/stepper/tabs.mdx
+++ b/site/src/docs/components/stepper/tabs.mdx
@@ -9,6 +9,7 @@ import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
 import Notification from '../../../components/Notification';
+import TechTags from '../../../components/TechTags';
 
 # Stepper
 
@@ -23,6 +24,8 @@ import Notification from '../../../components/Notification';
 <Notification label="Note about multi-page forms!" className="siteNotification">
   This documentation page is about HDS multi-page stepper component. If you are looking for documentation about building multi-page forms, please refer to <InternalLink href="/patterns/forms/form-multi-page">HDS multi-page form pattern documentation page</InternalLink>.
 </Notification>
+
+<TechTags componentName="Stepper" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/table/tabs.mdx
+++ b/site/src/docs/components/table/tabs.mdx
@@ -9,6 +9,7 @@ import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
 import Notification from '../../../components/Notification';
+import TechTags from '../../../components/TechTags';
 
 # Table
 
@@ -23,6 +24,8 @@ import Notification from '../../../components/Notification';
 <Notification label="More table features are coming!" className="siteNotification">
   HDS Tables are work in progress. The current feature set will serve most projects but later we are also looking into adding more features such as single row actions (edit, delete), expandable rows and supporting more HDS components inside tables.
 </Notification>
+
+<TechTags componentName="Table" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/tabs/tabs.mdx
+++ b/site/src/docs/components/tabs/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Tabs
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Tabs are used to help the user browse and navigate between information contents that have a relation.</LeadParagraph>
+
+<TechTags componentName="Tabs" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/tag/tabs.mdx
+++ b/site/src/docs/components/tag/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Tag
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Tags are used to show attributes of an object or element such as categories. HDS also uses Tags to present filters selected for searches.</LeadParagraph>
+
+<TechTags componentName="Tag" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/text-area/tabs.mdx
+++ b/site/src/docs/components/text-area/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # TextArea
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>A text area is a specialised version of the text input component. Text areas can be used for multiline answers.</LeadParagraph>
+
+<TechTags componentName="TextArea" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/text-input/tabs.mdx
+++ b/site/src/docs/components/text-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # TextInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>A text field is an input field that the user can interact with and input content and data. The user can also be provided with helper text if needed. Text inputs are used for shorter information while Text areas can be used for multiline answers.</LeadParagraph>
+
+<TechTags componentName="TextInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/time-input/tabs.mdx
+++ b/site/src/docs/components/time-input/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # TimeInput
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>  A time input helps the user select a specific time.</LeadParagraph>
+
+<TechTags componentName="TimeInput" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/toggle-button/tabs.mdx
+++ b/site/src/docs/components/toggle-button/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # ToggleButton
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Toggle button allows the user to switch between two distinct states such as "On" and "Off".</LeadParagraph>
+
+<TechTags componentName="ToggleButton" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/components/tooltip/tabs.mdx
+++ b/site/src/docs/components/tooltip/tabs.mdx
@@ -8,6 +8,7 @@ import LeadParagraph from '../../../components/LeadParagraph';
 import Layout from '../../../components/layout';
 import PageTabs from '../../../components/PageTabs';
 import StatusLabel from '../../../components/StatusLabel';
+import TechTags from '../../../components/TechTags';
 
 # Tooltip
 
@@ -18,6 +19,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>Tooltips are used to present context or background information to the user.</LeadParagraph>
+
+<TechTags componentName="Tooltip" />
 
 <PageTabs pageContext={props.pageContext}>
   <PageTabs.TabList>

--- a/site/src/docs/getting-started/developer.mdx
+++ b/site/src/docs/getting-started/developer.mdx
@@ -82,3 +82,7 @@ JavaScript is required to be enabled in the web browser to guarantee full functi
 While HDS does not currently offer WordPress or Drupal implementations, HDS cooperates with multiple WordPress and Drupal projects in the City of Helsinki. Many of these projects have already implemented HDS components which can be reused in other projects.
 
 If your project is using either WordPress or Drupal, please contact [ketu@hel.fi](mailto:ketu@hel.fi) to learn about available implementations that follow HDS.
+
+## HDS-JS
+
+<ExternalLink openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="https://www.npmjs.com/package/hds-js">www.npmjs.com/package/hds-js</ExternalLink> contains vanilla js exported from the hds-react package of the Helsinki Design System. It has no own source; the files are hand-picked from the React version. React or CSS are not included. This package does not include any UI components either.


### PR DESCRIPTION
## Description

- Technology tags to all components in the documentation (on Components overview page)
- Add tags to the scaffolding script

# To think
- where Vanilla JS link (on Components overview page) should go?

## Related Issue

Closes [HDS-1366](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1366)

## Motivation and Context

It would be user friendly if there would be component tags (as Stable, Accessible, etc) that include the packages that it’s in.

## How Has This Been Tested?

- See it in the component overview page in the documentation.
- Try scaffolding script to chose the core tag (React tag is added automatically)

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-1366]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ