### PR TITLE
fix: buttons with icons renders incorrectly

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,6 +44,8 @@ jobs:
       - name: build documentation site
         run: yarn build
         working-directory: ./site
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
 
       - name: Copy CNAME file
         run: cp CNAME ./site/public/

--- a/.github/workflows/hds-demo-preview.yml
+++ b/.github/workflows/hds-demo-preview.yml
@@ -81,6 +81,8 @@ jobs:
       - name: build site package
         run: yarn build --prefix-paths
         working-directory: ./site
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
 
       # Build core storybook
       - name: build core storybook

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -41,7 +41,6 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
     },
     cache: false,
     optimization: {
-      chunkIds: 'deterministic',
       splitChunks: {
         chunks: 'initial',
         minChunks: 2,

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -39,7 +39,9 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
         crypto: require.resolve('crypto-browserify'),
       },
     },
+    cache: false,
     optimization: {
+      chunkIds: 'deterministic',
       splitChunks: {
         chunks: 'initial',
         minChunks: 2,

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -39,20 +39,16 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
         crypto: require.resolve('crypto-browserify'),
       },
     },
-    /*
     optimization: {
       splitChunks: {
         chunks: 'initial',
         minChunks: 2,
-        minSize: 10000000,
-        maxSize: 0,
         cacheGroups: {
           default: false,
           vendors: false,
         },
       },
     },
-    */
   });
 };
 

--- a/site/package.json
+++ b/site/package.json
@@ -78,7 +78,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "yarn lint && gatsby build",
+    "build": "yarn lint && NODE_OPTIONS='--max_old_space_size=8192' gatsby build",
     "develop": "gatsby develop -o",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "gatsby develop -o",


### PR DESCRIPTION
## Description

Buttons with icons don't render correctly on core examples on the documentation page. These buttons render correctly in Storybook. 

I found out that the `::before` pseudo selector (which attaches icons to these buttons) doesn't work correctly because CSS rules are loaded in the wrong order. But only on the documentation page. 

The problem was in Webpack chunking configuration. Currently chunking optimization was turned off, because I haven't found any configuration that would work correctly (I have tried quite many). Now I found minimal configuration that do some chunk split optimization and still works. 

## Related Issue

Closes [HDS-2540](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2540)

## Demos:

Links to demos are in the comments.

## Screenshots (if appropriate):

## Add to changelog

<!-- Or comment here why it is not relevant in the change log -->
Just change the documentation site build process, not the actual change to the code.

[HDS-2540]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ