### PR TITLE
hds-2539: Apollo Client module to Login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- [Component] What is added?
+- [LoginProviderWithApolloContext] Login Provider with automatic ApolloClient context.
+- [ApolloClientModule] New Login module for auto-appending api tokens to query headers.
+- [ApiTokenClientTracker] Util to track api token changes and renewals.
 
 #### Changed
 
 Changes that are not related to specific components
 
-- [Component] What has been changed
+- [GraphQLModule] Use the ApolloClient Module when available
 
 #### Fixed
 
@@ -117,13 +119,12 @@ Changes that are not related to specific components
 
 #### Added
 
-- [Component] What is added?
+- [ApolloClientModule] New Login module for auto-appending api tokens to query headers.
+- [ApiTokenClientTracker] Util to track api token changes and renewals.
 
 #### Changed
 
-Changes that are not related to specific components
-
-- [Component] What has been changed
+- [GraphQLModule] Use the ApolloClient Module when available
 
 #### Fixed
 

--- a/packages/hds-js/package.json
+++ b/packages/hds-js/package.json
@@ -9,9 +9,11 @@
   "esnext": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
+    "@apollo/client": "^3.10.1",
     "@babel/runtime": "7.17.9",
     "await-to-js": "^3.0.0",
     "cookie": "^0.4.1",
+    "graphql": "^16.8.1",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "oidc-client-ts": "^2.4.1"

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -77,6 +77,20 @@ const checkModule = (forHdsJs) => {
   const forbiddenImportIds = ['react', 'react-dom'];
   const forbiddenFileExtensions = ['.tsx', '.jsx', '.css', '.scss'];
   const allowedExternals = ['tslib'];
+  // the following externals needed to be allowed because
+  // import { setContext } from '@apollo/client/link/context';
+  // is not properly detected to be part of the @apollo/client package.
+  // The same happens if
+  // import { <any import> } from '@apollo/client/core';
+  // is used. The only proper way seems to be
+  // import { <any import> } from '@apollo/client';
+  // Otherwise whole Apollo client in bundled in to hds-js.
+  allowedExternals.push('@apollo');
+  allowedExternals.push('zen-observable-ts');
+  allowedExternals.push('symbol-observable');
+  allowedExternals.push('optimism');
+  allowedExternals.push('ts-invariant');
+  allowedExternals.push('@wry');
   if (!forHdsJs) {
     // https://github.com/Hacker0x01/react-datepicker/issues/1606
     allowedExternals.push('date-fns');

--- a/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.test.ts
+++ b/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.test.ts
@@ -1,0 +1,515 @@
+import { disableFetchMocks } from 'jest-fetch-mock';
+import { waitFor } from '@testing-library/dom';
+
+import { createApiTokenClient } from './apiTokensClient';
+import { Beacon, createBeacon, Signal, SignalTriggerProps } from '../beacon/beacon';
+import { createApiTokenClientTracker } from './createApiTokenClientTracker';
+import { apiTokensClientEvents, TokenData } from './index';
+import { createInitTriggerProps, errorSignalType } from '../beacon/signals';
+import { apiTokensClientError, ApiTokensClientError, ApiTokensClientErrorType } from './apiTokensClientError';
+import { advanceUntilPromiseResolved } from '../testUtils/timerTestUtil';
+import { createApiTokensClientEventSignal, createApiTokensClientEventTriggerProps } from './signals';
+import { getLastMockCallArgs } from '../../../utils/testHelpers';
+
+type InitProps = {
+  trackerProps?: Parameters<typeof createApiTokenClientTracker>[0];
+  tokens?: TokenData;
+  isRenewing?: boolean;
+  autoConnect?: boolean;
+  init?: boolean;
+};
+
+describe(`createApiTokenClientTracker`, () => {
+  let currentBeacon: Beacon;
+  let currentTracker: ReturnType<typeof createApiTokenClientTracker>;
+  const tokenData: TokenData = { first: '1', second: '2' };
+  const newTokenData: TokenData = { first: '1.1', second: '2.1', third: '3.1' };
+  const newestTokenData: TokenData = { first: '1.2', second: '2.2', third: '3.2', fourth: '4.2' };
+  const onChangeTracker = jest.fn();
+  const getLastChangedTokens = () => {
+    return getLastMockCallArgs(onChangeTracker)[0];
+  };
+  const initTests = ({ trackerProps = {}, tokens, autoConnect, isRenewing, init }: InitProps) => {
+    const tokenStorage: [TokenData | null] = [tokens || null];
+    const renewalStorage: [boolean] = [!!isRenewing];
+
+    const apiTokensClient = createApiTokenClient({ url: '/does-not-matter' });
+    const getTokensSpy = jest.spyOn(apiTokensClient, 'getTokens').mockImplementation(() => {
+      return tokenStorage[0];
+    });
+    const isRenewingSpy = jest.spyOn(apiTokensClient, 'isRenewing').mockImplementation(() => {
+      return renewalStorage[0];
+    });
+    currentBeacon = createBeacon();
+    currentBeacon.addSignalContext(apiTokensClient);
+    currentTracker = createApiTokenClientTracker({ ...trackerProps, onChange: onChangeTracker });
+
+    const emitApiTokenSignal = (signal: Partial<Signal>) => {
+      currentBeacon.emit({ ...signal, namespace: apiTokensClient.namespace });
+    };
+
+    const emitInitSignal = () => {
+      emitApiTokenSignal(createInitTriggerProps());
+    };
+
+    const emitUpdateSignal = (signalTokens: TokenData) => {
+      const eventSignalProps = createApiTokensClientEventSignal({
+        type: apiTokensClientEvents.API_TOKENS_UPDATED,
+        data: signalTokens,
+      });
+      emitApiTokenSignal(eventSignalProps);
+    };
+
+    const emitRenewalSignal = () => {
+      emitApiTokenSignal(
+        createApiTokensClientEventTriggerProps({
+          type: apiTokensClientEvents.API_TOKENS_RENEWAL_STARTED,
+        }),
+      );
+    };
+
+    const emitRemovedSignal = () => {
+      emitApiTokenSignal(
+        createApiTokensClientEventTriggerProps({
+          type: apiTokensClientEvents.API_TOKENS_REMOVED,
+        }),
+      );
+    };
+
+    const emitErrorSignal = (type: ApiTokensClientErrorType) => {
+      const payload = new ApiTokensClientError('Error', type);
+      emitApiTokenSignal({ type: errorSignalType, payload });
+    };
+
+    if (autoConnect) {
+      currentTracker.connect(currentBeacon);
+    }
+    if (init) {
+      emitInitSignal();
+    }
+
+    return {
+      beacon: currentBeacon,
+      tracker: currentTracker,
+      getTokensSpy,
+      emitInitSignal,
+      emitUpdateSignal,
+      emitRenewalSignal,
+      emitRemovedSignal,
+      emitErrorSignal,
+      apiTokensClient,
+      isRenewingSpy,
+      setRenewalState: (state: boolean) => {
+        renewalStorage[0] = state;
+      },
+      setTokens: (newTokens: TokenData) => {
+        tokenStorage[0] = newTokens;
+      },
+    };
+  };
+
+  const initTestsWithConnectedAndInitalizedTokens = (
+    trackerProps?: Parameters<typeof createApiTokenClientTracker>[0],
+  ) => {
+    return initTests({
+      trackerProps,
+      autoConnect: true,
+      init: true,
+      tokens: tokenData,
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    currentTracker.dispose();
+    onChangeTracker.mockClear();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+  });
+
+  describe(`when tracker.connect() is called`, () => {
+    it('listeners are added', async () => {
+      const { beacon, tracker } = initTests({});
+      const listenerSpy = jest.spyOn(beacon, 'addListener');
+      tracker.connect(beacon);
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+      expect(onChangeTracker).toHaveBeenCalledTimes(0);
+    });
+    it('listeners are added removed if connect is called twice.', async () => {
+      const { beacon, tracker } = initTests({});
+      const disposerTracker = jest.fn();
+      const listenerSpy = jest.spyOn(beacon, 'addListener').mockReturnValue(disposerTracker);
+      const secondBeacon = createBeacon();
+      const listenerSpy2 = jest.spyOn(secondBeacon, 'addListener').mockReturnValue(disposerTracker);
+      tracker.connect(beacon);
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+      expect(disposerTracker).toHaveBeenCalledTimes(0);
+      tracker.connect(secondBeacon);
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+      expect(listenerSpy2).toHaveBeenCalledTimes(1);
+      expect(disposerTracker).toHaveBeenCalledTimes(1);
+      expect(onChangeTracker).toHaveBeenCalledTimes(0);
+    });
+  });
+  describe(`dispose()`, () => {
+    it('removes all data and rejects on-going promise', async () => {
+      const { beacon, tracker, emitRenewalSignal, emitUpdateSignal } = initTests({});
+      let renewalSuccessful: boolean | null = null;
+      tracker.connect(beacon);
+      emitUpdateSignal(newTokenData);
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      emitRenewalSignal();
+      // tokens are kept, so no change triggered.
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      tracker.waitForApiTokens().then((value) => {
+        renewalSuccessful = value;
+      });
+      tracker.dispose();
+      await waitFor(() => {
+        expect(renewalSuccessful === false).toBe(true);
+      });
+
+      // start new renewal, which does nothing as listener are removed
+      emitRenewalSignal();
+      emitUpdateSignal(newestTokenData);
+      expect(tracker.getTokens()).toMatchObject({});
+      // should resolve immediately because there is no on-going renewal
+      const ok = await tracker.waitForApiTokens();
+      expect(ok).toBe(true);
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      // calling twice does not throw
+      tracker.dispose();
+      tracker.dispose();
+      // dispose does not trigger change
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe(`when apiTokenClient init event is received`, () => {
+    it('api tokens are stored', async () => {
+      const initialTokens = { token1: 'token1' };
+      const { tracker, emitInitSignal } = initTests({
+        tokens: initialTokens,
+        autoConnect: true,
+      });
+      emitInitSignal();
+      expect(tracker.getTokens()).toMatchObject(initialTokens);
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      expect(getLastChangedTokens()).toMatchObject(initialTokens);
+    });
+    it('if renewal was in progress, a promise is created which adds new listeners to the beacon. Promise is resoved with new tokens.', async () => {
+      const updatedTokens = { token1: 'updated1' };
+      const { emitInitSignal, beacon, tracker, emitUpdateSignal } = initTests({
+        autoConnect: false,
+        isRenewing: true,
+      });
+      const listenerSpy = jest.spyOn(beacon, 'addListener');
+
+      tracker.connect(beacon);
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+      emitInitSignal();
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      expect(listenerSpy).toHaveBeenCalledTimes(2);
+      const renewalPromise = tracker.waitForApiTokens();
+      emitUpdateSignal(updatedTokens);
+      await renewalPromise;
+      expect(tracker.getTokens()).toMatchObject(updatedTokens);
+      expect(onChangeTracker).toHaveBeenCalledTimes(2);
+      expect(getLastChangedTokens()).toMatchObject(updatedTokens);
+    });
+  });
+  describe(`when apiTokenClient starts renewing`, () => {
+    it('A listener is added that can cancel the promise. tracker.stopWaitingForTokens() emits the cancel event.', async () => {
+      const { beacon, tracker, emitRenewalSignal } = initTests({
+        autoConnect: true,
+        init: true,
+      });
+      const listenerSpy = jest.spyOn(beacon, 'addListener');
+
+      emitRenewalSignal();
+      const renewalPromise = tracker.waitForApiTokens();
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+      tracker.stopWaitingForTokens();
+      await renewalPromise;
+      // test needs at least one "expect"
+      expect(tracker.getTokens()).toBeDefined();
+    });
+    it('The listener timeouts in given time', async () => {
+      const timeout = 4000;
+      const { tracker, emitRenewalSignal } = initTests({
+        trackerProps: { timeout },
+        autoConnect: true,
+        init: true,
+      });
+
+      emitRenewalSignal();
+      const renewalPromise = tracker.waitForApiTokens();
+      jest.advanceTimersByTime(timeout);
+      await renewalPromise;
+      expect(tracker.getTokens()).toBeDefined();
+    });
+    it('Given external signal triggers can cancel the promise', async () => {
+      const rejectionSignalType = 'rejectIt';
+      const rejectionSignalTrigger: SignalTriggerProps = { type: rejectionSignalType, namespace: 'anyspace' };
+      const { beacon, tracker, emitRenewalSignal } = initTests({
+        trackerProps: { rejectionSignalTrigger },
+        autoConnect: true,
+        init: true,
+      });
+
+      emitRenewalSignal();
+      const renewalPromise = tracker.waitForApiTokens();
+      beacon.emit(rejectionSignalTrigger as unknown as Signal);
+      await renewalPromise;
+      expect(tracker.getTokens()).toBeDefined();
+    });
+  });
+  describe(`when apiTokenClient renewal is completed successfully`, () => {
+    it('New tokens are stored. Promise is resolved. Old tokens are kept while renewing (default)', async () => {
+      const tokens = tokenData;
+      const { tracker, emitRenewalSignal, emitUpdateSignal } = initTestsWithConnectedAndInitalizedTokens();
+
+      emitRenewalSignal();
+      expect(tracker.getTokens()).toMatchObject(tokens);
+      const renewalPromise = tracker.waitForApiTokens();
+      emitUpdateSignal(newTokenData);
+      await renewalPromise;
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+    });
+    it('All update signals sets new tokens.', async () => {
+      const { tracker, emitUpdateSignal } = initTestsWithConnectedAndInitalizedTokens();
+
+      emitUpdateSignal(newTokenData);
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      // first call was in init
+      expect(onChangeTracker).toHaveBeenCalledTimes(2);
+      expect(getLastChangedTokens()).toMatchObject(newTokenData);
+      emitUpdateSignal(newestTokenData);
+      expect(tracker.getTokens()).toMatchObject(newestTokenData);
+      expect(onChangeTracker).toHaveBeenCalledTimes(3);
+      expect(getLastChangedTokens()).toMatchObject(newestTokenData);
+    });
+    it('New tokens are stored also after a cancel event.', async () => {
+      const { tracker, emitRenewalSignal, emitUpdateSignal } = initTestsWithConnectedAndInitalizedTokens();
+
+      emitRenewalSignal();
+      const renewalPromise = tracker.waitForApiTokens();
+      tracker.stopWaitingForTokens();
+      await renewalPromise;
+      emitUpdateSignal(newTokenData);
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+    });
+    it('if props.keepTokensWhileRenewing is false, tokens are cleared when renewal starts.', async () => {
+      const { tracker, emitRenewalSignal, emitUpdateSignal } = initTestsWithConnectedAndInitalizedTokens({
+        keepTokensWhileRenewing: false,
+      });
+
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      emitRenewalSignal();
+      expect(onChangeTracker).toHaveBeenCalledTimes(2);
+      expect(Object.keys(getLastChangedTokens())).toHaveLength(0);
+      expect(Object.keys(tracker.getTokens())).toHaveLength(0);
+      const renewalPromise = tracker.waitForApiTokens();
+      emitUpdateSignal(newTokenData);
+      await renewalPromise;
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      expect(onChangeTracker).toHaveBeenCalledTimes(3);
+      expect(getLastChangedTokens()).toMatchObject(newTokenData);
+    });
+  });
+  describe(`when apiTokenClient renewal fails`, () => {
+    it('Promise is resolved. Tokens are cleared if keepTokensAfterRenewalError is not true (default false).', async () => {
+      const { tracker, emitRenewalSignal, emitErrorSignal, emitUpdateSignal } =
+        initTestsWithConnectedAndInitalizedTokens();
+
+      emitRenewalSignal();
+      const renewalPromise = tracker.waitForApiTokens();
+      emitErrorSignal(apiTokensClientError.INVALID_API_TOKENS);
+      await renewalPromise;
+      expect(Object.keys(tracker.getTokens())).toHaveLength(0);
+      expect(onChangeTracker).toHaveBeenCalledTimes(2);
+      expect(Object.keys(getLastChangedTokens())).toHaveLength(0);
+      emitUpdateSignal(newTokenData);
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      emitRenewalSignal();
+      const renewalPromise2 = tracker.waitForApiTokens();
+      emitErrorSignal(apiTokensClientError.API_TOKEN_FETCH_FAILED);
+      await renewalPromise2;
+      expect(Object.keys(tracker.getTokens())).toHaveLength(0);
+    });
+    it('Tokens are not cleared if keepTokensAfterRenewalError is true.', async () => {
+      const { tracker, emitRenewalSignal, emitErrorSignal } = initTestsWithConnectedAndInitalizedTokens({
+        keepTokensAfterRenewalError: true,
+      });
+
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      emitRenewalSignal();
+      const renewalPromise = tracker.waitForApiTokens();
+      emitErrorSignal(apiTokensClientError.INVALID_API_TOKENS);
+      await renewalPromise;
+      expect(Object.keys(tracker.getTokens())).toHaveLength(2);
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      expect(getLastChangedTokens()).toMatchObject(tokenData);
+    });
+  });
+  describe(`when apiTokenClient removes tokens`, () => {
+    it('Tokens are also removed from the util if props.keepTokensWhileRenewing is false. Default is true', async () => {
+      const { tracker, emitRemovedSignal } = initTestsWithConnectedAndInitalizedTokens({
+        keepTokensWhileRenewing: false,
+      });
+
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      expect(Object.keys(tracker.getTokens())).toHaveLength(2);
+      emitRemovedSignal();
+      expect(Object.keys(tracker.getTokens())).toHaveLength(0);
+      expect(onChangeTracker).toHaveBeenCalledTimes(2);
+      expect(Object.keys(getLastChangedTokens())).toHaveLength(0);
+    });
+    it('Tokens are not removed from the util if props.keepTokensWhileRenewing is true', async () => {
+      const { tracker, emitRemovedSignal } = initTestsWithConnectedAndInitalizedTokens();
+      expect(Object.keys(tracker.getTokens())).toHaveLength(2);
+      emitRemovedSignal();
+      expect(Object.keys(tracker.getTokens())).toHaveLength(2);
+      expect(onChangeTracker).toHaveBeenCalledTimes(1);
+      expect(Object.keys(getLastChangedTokens())).toHaveLength(2);
+    });
+  });
+  describe(`Multiple utils do not interfere with each others`, () => {
+    const initWithMultipleTrackers = () => {
+      const result = initTests({ tokens: tokenData });
+      result.tracker.connect(result.beacon);
+      result.emitInitSignal();
+      const tracker2 = createApiTokenClientTracker({
+        rejectionSignalTrigger: { type: 'tracker1', namespace: 'anyspace1' },
+        keepTokensAfterRenewalError: true,
+        timeout: 5000,
+      });
+      const tracker3 = createApiTokenClientTracker({
+        rejectionSignalTrigger: { type: 'tracker1', namespace: 'anyspace1' },
+        keepTokensWhileRenewing: false,
+        timeout: 30000,
+      });
+      tracker2.connect(result.beacon);
+      tracker3.connect(result.beacon);
+      return {
+        ...result,
+        tracker2,
+        tracker3,
+      };
+    };
+    it('All receive signals', async () => {
+      const { tracker, tracker2, tracker3, emitUpdateSignal, emitRenewalSignal } = initWithMultipleTrackers();
+
+      expect(tracker.getTokens()).toMatchObject(tokenData);
+      // tracker2 and tracker3 were added after init signal.
+      expect(tracker2.getTokens()).toMatchObject({});
+      expect(tracker3.getTokens()).toMatchObject({});
+      emitRenewalSignal();
+      const promise = Promise.all([
+        tracker.waitForApiTokens(),
+        tracker2.waitForApiTokens(),
+        tracker3.waitForApiTokens(),
+      ]);
+      emitUpdateSignal(newTokenData);
+      await promise;
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      expect(tracker2.getTokens()).toMatchObject(newTokenData);
+      expect(tracker3.getTokens()).toMatchObject(newTokenData);
+
+      emitUpdateSignal(newestTokenData);
+      await promise;
+      expect(tracker.getTokens()).toMatchObject(newestTokenData);
+      expect(tracker2.getTokens()).toMatchObject(newestTokenData);
+      expect(tracker3.getTokens()).toMatchObject(newestTokenData);
+    });
+    it('All states change independently according to own settings.', async () => {
+      const { tracker, tracker2, tracker3, emitUpdateSignal, emitRenewalSignal, emitRemovedSignal, emitErrorSignal } =
+        initWithMultipleTrackers();
+
+      emitUpdateSignal(newTokenData);
+      emitRemovedSignal();
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      expect(tracker2.getTokens()).toMatchObject(newTokenData);
+      // tracker3 has keepTokensWhileRenewing: false
+      expect(tracker3.getTokens()).toMatchObject({});
+
+      // renewal with error
+      emitRenewalSignal();
+      const promise2 = Promise.all([
+        tracker.waitForApiTokens(),
+        tracker2.waitForApiTokens(),
+        tracker3.waitForApiTokens(),
+      ]);
+      emitErrorSignal(apiTokensClientError.API_TOKEN_FETCH_FAILED);
+      await promise2;
+      expect(tracker.getTokens()).toMatchObject({});
+      // tracker3 has keepTokensAfterRenewalError: true
+      expect(tracker2.getTokens()).toMatchObject(newTokenData);
+      // tracker3 has keepTokensWhileRenewing: false
+      expect(tracker3.getTokens()).toMatchObject({});
+    });
+    it('Stopping a tracker do not stop others.', async () => {
+      const { tracker, tracker2, tracker3, emitUpdateSignal, emitRenewalSignal } = initWithMultipleTrackers();
+
+      emitUpdateSignal(newTokenData);
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      expect(tracker2.getTokens()).toMatchObject(newTokenData);
+      expect(tracker3.getTokens()).toMatchObject(newTokenData);
+      emitRenewalSignal();
+      const trackerPromise = tracker.waitForApiTokens();
+      const tracker2Promise = tracker2.waitForApiTokens();
+      const tracker3Promise = tracker3.waitForApiTokens();
+
+      tracker.stopWaitingForTokens();
+      await trackerPromise;
+
+      tracker2.stopWaitingForTokens();
+      await tracker2Promise;
+
+      emitUpdateSignal(newestTokenData);
+      await tracker3Promise;
+      expect(tracker.getTokens()).toMatchObject({});
+      expect(tracker2.getTokens()).toMatchObject({});
+      expect(tracker3.getTokens()).toMatchObject(newestTokenData);
+    });
+    it('Timeouts work independently', async () => {
+      const { tracker, tracker2, tracker3, emitUpdateSignal, emitRenewalSignal } = initWithMultipleTrackers();
+      const resolveTracking = [false, false, false];
+
+      emitUpdateSignal(newTokenData);
+      expect(tracker.getTokens()).toMatchObject(newTokenData);
+      expect(tracker2.getTokens()).toMatchObject(newTokenData);
+      expect(tracker3.getTokens()).toMatchObject(newTokenData);
+      emitRenewalSignal();
+      // default timeout 15000ms
+      const trackerPromise = tracker.waitForApiTokens().then(() => {
+        resolveTracking[0] = true;
+      });
+      // timeout 5000ms
+      const tracker2Promise = tracker2.waitForApiTokens().then(() => {
+        resolveTracking[1] = true;
+      });
+      // timeout 30000ms
+      const tracker3Promise = tracker3.waitForApiTokens().then(() => {
+        resolveTracking[2] = true;
+      });
+
+      await advanceUntilPromiseResolved(tracker2Promise);
+      expect(resolveTracking).toMatchObject([false, true, false]);
+
+      await advanceUntilPromiseResolved(trackerPromise);
+      expect(resolveTracking).toMatchObject([true, true, false]);
+
+      await advanceUntilPromiseResolved(tracker3Promise);
+      expect(resolveTracking).toMatchObject([true, true, true]);
+    });
+  });
+});

--- a/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.ts
+++ b/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.ts
@@ -1,0 +1,259 @@
+import { noop, uniqueId } from 'lodash';
+
+import { ApiTokenClient, apiTokensClientEvents, apiTokensClientNamespace, TokenData } from '.';
+import { Beacon, Disposer, Signal, SignalListener, SignalTriggerProps } from '../beacon/beacon';
+import { errorSignalType, eventSignalType, isInitSignal, waitForSignals } from '../beacon/signals';
+import { apiTokensClientError } from './apiTokensClientError';
+import {
+  isApiTokensUpdatedSignal,
+  getApiTokensClientEventPayload,
+  isApiTokensRemovedSignal,
+  createTriggerPropsForAllApiTokensClientSignals,
+  isApiTokensRenewalStartedSignal,
+  isApiTokensFetchFailedErrorSignal,
+  isInvalidApiTokensErrorSignal,
+} from './signals';
+
+type ApiTokenClientTrackerProps = {
+  /**
+   * How long to wait for apitoken renewal to fulfill. Default 15000ms.
+   */
+  timeout?: number;
+  /**
+   * If true, the stored api tokens are not cleared when renewal starts. Default true.
+   */
+  keepTokensWhileRenewing?: boolean;
+  /**
+   * If true, the stored api tokens are not cleared when renewal starts. Default false.
+   */
+  keepTokensAfterRenewalError?: boolean;
+  /**
+   * Type of the signal that should end the pending api token renewal promise.
+   * Usually it is a clear/dispose signal from the module using this util, so the promise is fulfilled when the module is not used anymore.
+   */
+  rejectionSignalTrigger?: SignalTriggerProps;
+  /**
+   * Called when api tokens change. Not called when dispose() is called.
+   */
+  onChange?: (tokens: TokenData, changeTrigger: Signal) => void;
+};
+
+export type ApiTokenClientTracker = {
+  /**
+   * Connect the utility to a beacon
+   */
+  connect: (connectedBeacon: Beacon) => void;
+  /**
+   * Get current tokens
+   */
+  getTokens: () => TokenData;
+  /**
+   * Dispose listeners, references and data
+   */
+  dispose: Disposer;
+  /**
+   * Discards pending promise for api token renewal.
+   * Emits signal to abort it. Same signal is used in all instance of this utility, so the signal stops them all.
+   */
+  stopWaitingForTokens: Disposer;
+  /**
+   * Returns the pending renewal promise or immediately resolved promise.
+   * Never rejects, the returned boolean indicates was the promise successful.
+   */
+  waitForApiTokens: () => Promise<boolean>;
+  /**
+   * Returns true, if renewal process is on-going
+   */
+  isRenewing: () => boolean;
+};
+
+type InnerState = {
+  tokens: TokenData;
+  disposer: Disposer;
+  renewalPromise: Promise<boolean> | null;
+  beacon: Beacon | null;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+};
+
+/**
+ * Utility for tracking changes in the apiTokenClient module
+ * Use it in the connect() function of any ConnectedModule.
+ * @param {ApiTokenClientTrackerProps}
+ * @returns {ApiTokenClientTracker}
+ */
+
+export function createApiTokenClientTracker({
+  timeout = 15000,
+  keepTokensWhileRenewing = true,
+  keepTokensAfterRenewalError = false,
+  rejectionSignalTrigger,
+  onChange,
+}: ApiTokenClientTrackerProps): ApiTokenClientTracker {
+  const innerState: InnerState = {
+    tokens: {},
+    disposer: noop,
+    renewalPromise: null,
+    beacon: null,
+    timeoutId: null,
+  };
+
+  const isRenewing = () => !!innerState.renewalPromise;
+
+  // self triggered and self listened signal to stop listening renewals
+  // must be unique so other listeners in other instances of this utils are not cancelled.
+  const signalTypeToRejectApiTokenAwait = `REJECT_API_TOKEN_AWAIT_${uniqueId()}`;
+  const clearPromiseTimeOut = () => {
+    if (innerState.timeoutId) {
+      clearTimeout(innerState.timeoutId);
+      innerState.timeoutId = null;
+    }
+  };
+  const markRenewalCompleted = () => {
+    clearPromiseTimeOut();
+    innerState.renewalPromise = null;
+  };
+
+  const updateTokens = (tokens: TokenData | null = null, changeTrigger: Signal) => {
+    innerState.tokens = tokens || {};
+    if (onChange) {
+      onChange(innerState.tokens, changeTrigger);
+    }
+  };
+
+  const updateInnerRenewalState = (changeTrigger: Signal, tokens: TokenData | null = null) => {
+    const renewalStarted = isApiTokensRenewalStartedSignal(changeTrigger);
+    if (renewalStarted) {
+      if (!keepTokensWhileRenewing) {
+        updateTokens({}, changeTrigger);
+      }
+    } else {
+      markRenewalCompleted();
+    }
+    if (tokens) {
+      updateTokens(tokens, changeTrigger);
+    }
+  };
+  const createRenewalPromise = async (timeoutDelay: number): Promise<boolean> => {
+    if (!innerState.beacon) {
+      return Promise.reject(new Error('No Beacon found for api token renewal.'));
+    }
+
+    const promiseRejectionSignals: Array<Signal> = [
+      { type: eventSignalType, payload: { type: signalTypeToRejectApiTokenAwait } },
+      { type: errorSignalType, payload: { type: apiTokensClientError.API_TOKEN_FETCH_FAILED } },
+      { type: errorSignalType, payload: { type: apiTokensClientError.INVALID_API_TOKENS } },
+    ];
+    if (rejectionSignalTrigger) {
+      promiseRejectionSignals.push(rejectionSignalTrigger as unknown as Signal);
+    }
+    const signalPromise = waitForSignals(
+      innerState.beacon,
+      [{ payload: { type: apiTokensClientEvents.API_TOKENS_UPDATED } }],
+      {
+        rejectOn: promiseRejectionSignals,
+      },
+    );
+
+    const timeoutPromise = timeoutDelay
+      ? new Promise((resolve, reject) => {
+          innerState.timeoutId = setTimeout(() => {
+            reject(new Error('Timeout for waitForApiTokens() reached'));
+            innerState.timeoutId = null;
+          }, timeoutDelay);
+        })
+      : null;
+
+    // The promise never rejects to make handling more simpler
+    return (timeoutPromise ? Promise.race([signalPromise, timeoutPromise]) : signalPromise)
+      .then(() => {
+        return Promise.resolve(true);
+      })
+      .catch(() => {
+        return Promise.resolve(false);
+      });
+  };
+
+  const startWaitingForRenewal = (trigger: Signal) => {
+    updateInnerRenewalState(trigger);
+    innerState.renewalPromise = createRenewalPromise(timeout);
+    innerState.renewalPromise.then(() => {
+      markRenewalCompleted();
+    });
+  };
+
+  const listener: SignalListener = (signal) => {
+    if (isInitSignal(signal)) {
+      const apiTokensClient = signal.context as ApiTokenClient;
+      // fail safe if signals are mixed.
+      if (!apiTokensClient) {
+        return;
+      }
+      if (apiTokensClient.isRenewing()) {
+        startWaitingForRenewal(signal);
+      }
+      updateTokens(apiTokensClient.getTokens() || {}, signal);
+      return;
+    }
+    if (isApiTokensRenewalStartedSignal(signal)) {
+      startWaitingForRenewal(signal);
+      return;
+    }
+    if (isApiTokensFetchFailedErrorSignal(signal) || isInvalidApiTokensErrorSignal(signal)) {
+      updateInnerRenewalState(signal, keepTokensAfterRenewalError ? null : {});
+      return;
+    }
+    if (isApiTokensUpdatedSignal(signal)) {
+      const payload = getApiTokensClientEventPayload(signal);
+      const newTokens = (payload && (payload.data as TokenData)) || {};
+      updateInnerRenewalState(signal, newTokens);
+      return;
+    }
+    if (!keepTokensWhileRenewing && isApiTokensRemovedSignal(signal)) {
+      updateTokens({}, signal);
+    }
+  };
+
+  const emitApiTokenAwaitRejectionSignal = () => {
+    if (!innerState.renewalPromise || !innerState.beacon) {
+      return;
+    }
+    innerState.beacon.emit({
+      type: eventSignalType,
+      namespace: apiTokensClientNamespace,
+      payload: { type: signalTypeToRejectApiTokenAwait },
+    });
+  };
+
+  const dispose = () => {
+    emitApiTokenAwaitRejectionSignal();
+    clearPromiseTimeOut();
+    innerState.disposer();
+    innerState.disposer = noop;
+    innerState.beacon = null;
+    innerState.renewalPromise = null;
+    innerState.tokens = {};
+  };
+
+  return {
+    connect: (connectedBeacon: Beacon) => {
+      dispose();
+      innerState.beacon = connectedBeacon;
+      innerState.disposer = connectedBeacon.addListener(createTriggerPropsForAllApiTokensClientSignals(), listener);
+    },
+    getTokens: () => {
+      return innerState.tokens;
+    },
+    stopWaitingForTokens: () => {
+      clearPromiseTimeOut();
+      emitApiTokenAwaitRejectionSignal();
+    },
+    isRenewing,
+    waitForApiTokens: () => {
+      if (isRenewing()) {
+        return innerState.renewalPromise as Promise<boolean>;
+      }
+      return Promise.resolve(true);
+    },
+    dispose,
+  };
+}

--- a/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.ts
+++ b/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.ts
@@ -24,7 +24,7 @@ type ApiTokenClientTrackerProps = {
    */
   keepTokensWhileRenewing?: boolean;
   /**
-   * If true, the stored api tokens are not cleared when renewal starts. Default false.
+   * If renewal fails, should old tokens be kept of not.
    */
   keepTokensAfterRenewalError?: boolean;
   /**

--- a/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.ts
+++ b/packages/react/src/components/login/apiTokensClient/createApiTokenClientTracker.ts
@@ -78,8 +78,6 @@ type InnerState = {
 /**
  * Utility for tracking changes in the apiTokenClient module
  * Use it in the connect() function of any ConnectedModule.
- * @param {ApiTokenClientTrackerProps}
- * @returns {ApiTokenClientTracker}
  */
 
 export function createApiTokenClientTracker({

--- a/packages/react/src/components/login/apolloClient/apolloClientModule.test.ts
+++ b/packages/react/src/components/login/apolloClient/apolloClientModule.test.ts
@@ -1,0 +1,229 @@
+/* eslint-disable jest/expect-expect */
+/* eslint-disable jest/no-mocks-import */
+import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock';
+import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from '@apollo/client';
+
+import { Beacon, createBeacon } from '../beacon/beacon';
+import { emitInitializationSignals, EventPayload, eventSignalType } from '../beacon/signals';
+import { createControlledFetchMockUtil, getLastFetchMockCallArguments } from '../testUtils/fetchMockTestUtil';
+import { createApolloClientModule } from './apolloClientModule';
+import { apiTokensClientEvents, apiTokensClientNamespace, TokenData } from '../apiTokensClient';
+import { advanceUntilPromiseResolved } from '../testUtils/timerTestUtil';
+import { getLastMockCallArgs } from '../../../utils/testHelpers';
+import { ApolloClientModule, ApolloClientModuleProps } from './index';
+import { createApiTokenClient } from '../apiTokensClient/apiTokensClient';
+import { USER_QUERY } from '../graphQLModule/__mocks__/mockData';
+import { createQueryResponse } from '../graphQLModule/__mocks__/mockResponses';
+
+describe(`apolloClientModule`, () => {
+  const defaultApiTokens: TokenData = { token1: 'token1Value', token2: 'token2Value' };
+  const uri = '/query';
+  const { cleanUp, setResponders, addResponse } = createControlledFetchMockUtil([{ path: uri }]);
+
+  let currentModule: ApolloClientModule;
+  let currentBeacon: Beacon;
+  let currentApolloClient: ApolloClient<InMemoryCache>;
+  let apiTokenStorage: TokenData | null = null;
+  let apolloClientQuerySpy: jest.SpyInstance | undefined;
+
+  const getQueryParams = () => {
+    if (!apolloClientQuerySpy) {
+      return undefined;
+    }
+    return getLastMockCallArgs(apolloClientQuerySpy)[0];
+  };
+  const getLastQueryHeaders = () => {
+    return getLastFetchMockCallArguments()[1].headers;
+  };
+
+  const initTests = ({
+    apiTokens,
+    moduleOptions = {},
+  }: {
+    apiTokens?: TokenData;
+    moduleOptions?: Partial<ApolloClientModuleProps>;
+  }) => {
+    const links: ApolloLink[] = [new HttpLink({ uri })];
+    const { clientOptions, ...rest } = moduleOptions;
+    const { link } = clientOptions || {};
+    if (link) {
+      links.unshift(link);
+    }
+    const options = {
+      ...clientOptions,
+    };
+
+    options.link = ApolloLink.from(links);
+
+    addResponse({ status: 200, body: JSON.stringify(createQueryResponse({ id: 100 })) });
+
+    currentModule = createApolloClientModule({ ...rest, clientOptions: options });
+    currentApolloClient = currentModule.getClient();
+    apolloClientQuerySpy = jest.spyOn(currentApolloClient, 'query');
+    apiTokenStorage = apiTokens || defaultApiTokens;
+    const apiTokensClient = createApiTokenClient({ url: '/does-not-matter' });
+    jest.spyOn(apiTokensClient, 'getTokens').mockImplementation(() => {
+      return apiTokenStorage;
+    });
+    currentBeacon = createBeacon();
+    currentBeacon.addSignalContext(apiTokensClient);
+    currentBeacon.addSignalContext(currentModule);
+
+    // initialize all modules
+    emitInitializationSignals(currentBeacon);
+  };
+
+  // helpers for emitting api token signals
+  const emitApiTokensClientStateChange = (payload: EventPayload) => {
+    currentBeacon.emit({ type: eventSignalType, namespace: apiTokensClientNamespace, payload });
+  };
+
+  const emitApiTokensRenewalStart = () => {
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_RENEWAL_STARTED };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  const emitApiTokensUpdatedStateChange = (tokens: TokenData) => {
+    apiTokenStorage = tokens;
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_UPDATED, data: tokens };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  // ApolloClient emits errors when cached data is invalid. That does not matter in these tests.
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    enableFetchMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setResponders([{ path: uri }]);
+  });
+
+  afterEach(async () => {
+    jest.advanceTimersByTime(100000);
+    const promise = currentModule.getTracker().waitForApiTokens();
+    await advanceUntilPromiseResolved(promise);
+    currentModule.reset();
+
+    await cleanUp();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    currentBeacon.clear();
+    apiTokenStorage = null;
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+    consoleErrorSpy.mockRestore();
+  });
+  describe(`create`, () => {
+    it('The module is created and current tokens exist in the tracker.', async () => {
+      initTests({});
+      expect(currentModule.getTracker().getTokens()).toMatchObject(defaultApiTokens);
+    });
+  });
+  describe(`tokenSetter`, () => {
+    it('The token setter is called and headers set. Query variables are passed as usual.', async () => {
+      const tokenSetter: ApolloClientModuleProps['tokenSetter'] = jest.fn().mockImplementation((headers, tokens) => {
+        return {
+          ...tokens,
+          extraHeader: 'extraHeader',
+        };
+      });
+      // add extra link to make sure all links are processed.
+      const languageHeaderSetter = new ApolloLink((operation, forward) => {
+        operation.setContext(({ headers }) => ({
+          headers: {
+            language: 'za',
+            ...headers,
+          },
+        }));
+        return forward(operation);
+      });
+      const xHeaderSetter = new ApolloLink((operation, forward) => {
+        operation.setContext(({ headers }) => ({
+          headers: {
+            'x-header': 'x-value',
+            token1: 'this-should-be-overridden-in-module',
+            ...headers,
+          },
+        }));
+        return forward(operation);
+      });
+      initTests({
+        moduleOptions: { tokenSetter, clientOptions: { link: languageHeaderSetter.concat(xHeaderSetter) } },
+      });
+      const variables = { variable1: 'var1' };
+      const promise = currentModule.getClient().query({ query: USER_QUERY, variables });
+
+      await advanceUntilPromiseResolved(promise);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      const headers = getLastQueryHeaders();
+      // note that extraHeader is lower-case because of ApolloLink default settings.
+      expect(headers).toMatchObject({
+        language: 'za',
+        extraheader: 'extraHeader',
+        'x-header': 'x-value',
+        ...defaultApiTokens,
+      });
+      expect(getQueryParams()).toMatchObject({ variables });
+    });
+  });
+  describe(`on-going api token renewal`, () => {
+    it('Delays the query until tokens are renewed and new tokens are used.', async () => {
+      const tokenSetter: ApolloClientModuleProps['tokenSetter'] = jest.fn().mockImplementation((headers, tokens) => {
+        return {
+          ...tokens,
+        };
+      });
+      initTests({
+        // keepTokensWhileRenewing is set to false, so if token timeout, header have no apiTokens
+        moduleOptions: { tokenSetter, keepTokensWhileRenewing: false },
+      });
+      emitApiTokensRenewalStart();
+      const tracker = currentModule.getTracker();
+      const renewalPromiseTracker = jest.fn();
+      // the renewalPromise returns false, if timed out
+      tracker.waitForApiTokens().then(renewalPromiseTracker);
+      const promise = currentModule.getClient().query({ query: USER_QUERY });
+      jest.advanceTimersByTime(10000);
+      const updatedTokens = { tokenx: 'tokenx', tokeny: 'tokeny' };
+      emitApiTokensUpdatedStateChange(updatedTokens);
+      await advanceUntilPromiseResolved(promise);
+      expect(renewalPromiseTracker).toHaveBeenCalledWith(true);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      const headers = getLastQueryHeaders();
+      expect(headers).toMatchObject({
+        ...updatedTokens,
+      });
+    });
+    it('If renewal is timed out, the query is executed anyway.', async () => {
+      const tokenSetter: ApolloClientModuleProps['tokenSetter'] = jest.fn().mockImplementation((headers, tokens) => {
+        return {
+          ...tokens,
+        };
+      });
+      initTests({
+        // keepTokensWhileRenewing is set to false, so if token timeout, header have no apiTokens
+        moduleOptions: { tokenSetter, keepTokensWhileRenewing: false },
+      });
+      emitApiTokensRenewalStart();
+      const tracker = currentModule.getTracker();
+      const renewalPromiseTracker = jest.fn();
+      // the renewalPromise returns false, if timed out
+      tracker.waitForApiTokens().then(renewalPromiseTracker);
+      const promise = currentModule.getClient().query({ query: USER_QUERY });
+
+      await advanceUntilPromiseResolved(promise);
+      expect(renewalPromiseTracker).toHaveBeenCalledWith(false);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      const headers = getLastQueryHeaders();
+      expect(headers.token1).toBeUndefined();
+      expect(headers.token2).toBeUndefined();
+    });
+  });
+});

--- a/packages/react/src/components/login/apolloClient/apolloClientModule.ts
+++ b/packages/react/src/components/login/apolloClient/apolloClientModule.ts
@@ -1,0 +1,81 @@
+import { ApolloCache, ApolloClient, from, HttpLink, InMemoryCache } from '@apollo/client/core';
+import { setContext } from '@apollo/client/link/context';
+
+import {
+  ApolloClientModule,
+  apolloClientModuleEvents,
+  apolloClientModuleNamespace,
+  ApolloClientModuleProps,
+  defaultOptions,
+} from '.';
+import { createNamespacedBeacon } from '../beacon/signals';
+import { createApiTokenClientTracker } from '../apiTokensClient/createApiTokenClientTracker';
+import { createAuthLink } from './authLink';
+
+/**
+ * IMPORTANT NOTICE:
+ *
+ * Apollo HttpLink converts all header keys to lower-case by default.
+ * To bypass this, the user has to provide a HttpLink and not to use options.uri, because HttpLink created here
+ * does not change the default behaviour.
+ *
+ * Example: new HttpLink({ uri, preserveHeaderCase: true }
+ *
+ */
+export function createApolloClientModule<T = InMemoryCache>(props: ApolloClientModuleProps<T>): ApolloClientModule<T> {
+  // custom beacon for sending signals in apolloClientModuleNamespace
+  const dedicatedBeacon = createNamespacedBeacon(apolloClientModuleNamespace);
+
+  const mergedProps: ApolloClientModuleProps<T> = {
+    ...defaultOptions,
+    ...props,
+  };
+
+  const { clientOptions, keepTokensWhileRenewing, tokenSetter, apiTokensWaitTime, preventQueriesWhileRenewing } =
+    mergedProps;
+
+  // tool for waiting for apiTokens and stopping awaits
+  const apiTokenTracker = createApiTokenClientTracker({ keepTokensWhileRenewing, timeout: apiTokensWaitTime });
+
+  const { link, cache, uri, ...rest } = clientOptions;
+  const links = [link || new HttpLink({ uri })];
+  if (tokenSetter) {
+    links.unshift(createAuthLink(tokenSetter, () => apiTokenTracker.getTokens()));
+  }
+  if (preventQueriesWhileRenewing) {
+    links.unshift(
+      setContext(async (_, previousContext) => {
+        // waitForApiTokens() never rejects so not catching it.
+        await apiTokenTracker.waitForApiTokens();
+        return previousContext;
+      }),
+    );
+  }
+
+  const clientProps = {
+    ...rest,
+    cache: (cache || new InMemoryCache()) as ApolloCache<T>,
+    link: from(links),
+  };
+  const client = new ApolloClient<T>(clientProps);
+
+  return {
+    namespace: apolloClientModuleNamespace,
+    connect: (beacon) => {
+      dedicatedBeacon.storeBeacon(beacon);
+      apiTokenTracker.connect(beacon);
+    },
+    getClient: () => {
+      return client;
+    },
+    getTracker: () => {
+      return apiTokenTracker;
+    },
+    reset: async () => {
+      dedicatedBeacon.emitEvent(apolloClientModuleEvents.APOLLO_CLIENT_MODULE_RESET);
+      apiTokenTracker.dispose();
+      client.stop();
+      await client.resetStore();
+    },
+  };
+}

--- a/packages/react/src/components/login/apolloClient/apolloClientModule.ts
+++ b/packages/react/src/components/login/apolloClient/apolloClientModule.ts
@@ -1,4 +1,4 @@
-import { ApolloCache, ApolloClient, from, HttpLink, InMemoryCache } from '@apollo/client/core';
+import { ApolloCache, ApolloClient, from, HttpLink, InMemoryCache } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 
 import {

--- a/packages/react/src/components/login/apolloClient/authLink.ts
+++ b/packages/react/src/components/login/apolloClient/authLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/core';
+import { ApolloLink } from '@apollo/client';
 
 import { TokenSetter } from '.';
 import { TokenData } from '../apiTokensClient';

--- a/packages/react/src/components/login/apolloClient/authLink.ts
+++ b/packages/react/src/components/login/apolloClient/authLink.ts
@@ -1,0 +1,19 @@
+import { ApolloLink } from '@apollo/client/core';
+
+import { TokenSetter } from '.';
+import { TokenData } from '../apiTokensClient';
+
+export function createAuthLink(tokenSetter: TokenSetter, tokenGetter: () => TokenData): ApolloLink {
+  return new ApolloLink((operation, forward) => {
+    operation.setContext(({ headers }) => {
+      const authHeaders = tokenSetter(headers, tokenGetter());
+      return {
+        headers: {
+          ...headers,
+          ...authHeaders,
+        },
+      };
+    });
+    return forward(operation);
+  });
+}

--- a/packages/react/src/components/login/apolloClient/hooks.test.tsx
+++ b/packages/react/src/components/login/apolloClient/hooks.test.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable jest/no-mocks-import */
+import React from 'react';
+
+import { ConnectedModule } from '../beacon/beacon';
+import { useApolloClient, useApolloClientModule } from './hooks';
+import { HookTestUtil, createHookTestEnvironment } from '../testUtils/hooks.testUtil';
+import { createApolloClientModule } from './apolloClientModule';
+import { ApolloClientModule, apolloClientModuleNamespace } from '.';
+
+const elementIds = {
+  namespaceElement: 'apolloclientmodule-namespace-element',
+  clientExistsElement: 'apolloclient-exists-element',
+} as const;
+
+let testUtil: HookTestUtil;
+
+describe(`ApolloClientModule`, () => {
+  let currentModule: ApolloClientModule;
+
+  const App = () => {
+    const apolloClientModule = useApolloClientModule();
+    const apolloClient = useApolloClient();
+    return (
+      <div>
+        <span key="namespace" id={elementIds.namespaceElement}>
+          {apolloClientModule.namespace}
+        </span>
+        <span key="client" id={elementIds.clientExistsElement}>
+          {typeof apolloClient.query === 'function' ? 1 : 0}
+        </span>
+      </div>
+    );
+  };
+
+  const initTests = () => {
+    currentModule = createApolloClientModule({ clientOptions: { uri: 'does-not-matter' } });
+
+    const modules: ConnectedModule[] = [currentModule];
+
+    testUtil = createHookTestEnvironment(
+      {
+        waitForRenderToggle: false,
+        children: [<App key="app" />],
+        noOidcClient: true,
+      },
+      {},
+      modules,
+    );
+
+    return {
+      ...testUtil,
+    };
+  };
+
+  it('Hooks return module and client', async () => {
+    const { getElementById } = initTests();
+
+    expect(getElementById(elementIds.namespaceElement).innerHTML).toEqual(apolloClientModuleNamespace);
+    expect(getElementById(elementIds.clientExistsElement).innerHTML).toEqual('1');
+  });
+});

--- a/packages/react/src/components/login/apolloClient/hooks.tsx
+++ b/packages/react/src/components/login/apolloClient/hooks.tsx
@@ -1,0 +1,25 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+import { useConnectedModule } from '../beacon/hooks';
+import { ApolloClientModule, apolloClientModuleNamespace } from './index';
+
+/**
+ * Returns the ApolloClient module.
+ * @returns ApolloClient
+ */
+export const useApolloClientModule = <T = InMemoryCache,>(): ApolloClientModule<T> => {
+  const apolloClientModule = useConnectedModule<ApolloClientModule<T>>(apolloClientModuleNamespace);
+  if (!apolloClientModule) {
+    throw new Error('Cannot find apolloClientModule from LoginContext.');
+  }
+  return apolloClientModule;
+};
+
+/**
+ * Returns the ApolloClient.
+ * @returns ApolloClient
+ */
+export const useApolloClient = <T = InMemoryCache,>(): ApolloClient<T> => {
+  const apolloClientModule = useApolloClientModule<T>();
+  return apolloClientModule.getClient();
+};

--- a/packages/react/src/components/login/apolloClient/index.ts
+++ b/packages/react/src/components/login/apolloClient/index.ts
@@ -1,0 +1,63 @@
+import { ApolloClient, InMemoryCache, ApolloClientOptions } from '@apollo/client/core';
+
+import { TokenData } from '../apiTokensClient';
+import { ApiTokenClientTracker } from '../apiTokensClient/createApiTokenClientTracker';
+import { ConnectedModule } from '../beacon/beacon';
+
+export type TokenSetter = (headers: Record<string, string>, tokens: TokenData) => Record<string, string>;
+
+export type ApolloClientModule<T = InMemoryCache> = ConnectedModule & {
+  /**
+   * Returns the client.
+   */
+  getClient: () => ApolloClient<T>;
+  /**
+   * Returns the apiTokenClient tracker.
+   */
+  getTracker: () => ApiTokenClientTracker;
+  /**
+   * Resets the client and apiTokenTracker.
+   */
+  reset: () => Promise<void>;
+};
+
+export type ApolloClientModuleProps<T = InMemoryCache> = {
+  /**
+   * How long in milliseconds should api tokens be awaited before rejecting a query.
+   * Default 15 000, set in createApiTokenClientTracker.
+   */
+  apiTokensWaitTime?: number;
+  /**
+   * Function to return tokens appended to the headers
+   * @param {headers} Current headers in the request
+   * @param {tokens} All tokens from the apiTokenClient
+   */
+  tokenSetter?: TokenSetter;
+  /**
+   * Options for the ApolloClient. If "uri" option is given, a HttpLink is automatically created from it.
+   * The module adds its own AplloLink(s) before other links.
+   * Default cache is InMemoryCache.
+   */
+  clientOptions: Partial<ApolloClientOptions<T>>;
+  /**
+   * If true, the stored api tokens are not cleared when renewal starts.
+   * Default true, set in createApiTokenClientTracker.
+   */
+  keepTokensWhileRenewing?: boolean;
+  /**
+   * If true, a ApolloLink is added to wait for possible api token renewal to end.
+   * If false, there might be times when queries are made with old api tokens. Unlikely, but possible.
+   * Default true.
+   */
+  preventQueriesWhileRenewing?: boolean;
+};
+
+export const apolloClientModuleEvents = {
+  APOLLO_CLIENT_MODULE_RESET: 'APOLLO_CLIENT_MODULE_RESET',
+} as const;
+
+export const apolloClientModuleNamespace = 'apolloClient';
+
+export const defaultOptions: Partial<ApolloClientModuleProps> = {
+  preventQueriesWhileRenewing: true,
+};

--- a/packages/react/src/components/login/apolloClient/index.ts
+++ b/packages/react/src/components/login/apolloClient/index.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache, ApolloClientOptions } from '@apollo/client/core';
+import { ApolloClient, InMemoryCache, ApolloClientOptions } from '@apollo/client';
 
 import { TokenData } from '../apiTokensClient';
 import { ApiTokenClientTracker } from '../apiTokensClient/createApiTokenClientTracker';

--- a/packages/react/src/components/login/apolloClient/index.ts
+++ b/packages/react/src/components/login/apolloClient/index.ts
@@ -56,6 +56,8 @@ export const apolloClientModuleEvents = {
   APOLLO_CLIENT_MODULE_RESET: 'APOLLO_CLIENT_MODULE_RESET',
 } as const;
 
+export type ApolloClientModuleEvent = keyof typeof apolloClientModuleEvents;
+
 export const apolloClientModuleNamespace = 'apolloClient';
 
 export const defaultOptions: Partial<ApolloClientModuleProps> = {

--- a/packages/react/src/components/login/apolloClient/index.ts
+++ b/packages/react/src/components/login/apolloClient/index.ts
@@ -29,8 +29,8 @@ export type ApolloClientModuleProps<T = InMemoryCache> = {
   apiTokensWaitTime?: number;
   /**
    * Function to return tokens appended to the headers
-   * @param {headers} Current headers in the request
-   * @param {tokens} All tokens from the apiTokenClient
+   * @param headers Current headers in the request
+   * @param tokens All tokens from the apiTokenClient
    */
   tokenSetter?: TokenSetter;
   /**

--- a/packages/react/src/components/login/beacon/signals.ts
+++ b/packages/react/src/components/login/beacon/signals.ts
@@ -12,6 +12,7 @@ import {
   compareSignalTriggers,
   convertToComparableSignals,
   splitTypeAndNamespace,
+  ConnectedModule,
 } from './beacon';
 
 export type NamespacedBeacon = {
@@ -280,6 +281,10 @@ export function getStateChangeSignalPayload(signal: Signal): StateChangeSignalPa
 
 export function getErrorSignalPayload(signal: Signal): ErrorPayload | null {
   return (isErrorSignal(signal) && (signal.payload as ErrorPayload)) || null;
+}
+
+export function getSignalContext(signal: Signal): ConnectedModule | null {
+  return signal.context || null;
 }
 
 export function checkEventSignalPayload(signal: Signal, checker: (payload: EventPayload) => boolean): boolean {

--- a/packages/react/src/components/login/components/LoginProviderWithApolloContext.test.tsx
+++ b/packages/react/src/components/login/components/LoginProviderWithApolloContext.test.tsx
@@ -1,0 +1,182 @@
+/* eslint-disable jest/no-mocks-import */
+import React, { useMemo } from 'react';
+import { HttpLink, useLazyQuery } from '@apollo/client';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { enableFetchMocks, disableFetchMocks } from 'jest-fetch-mock';
+
+import { useApolloClient, useApolloClientModule } from '../apolloClient/hooks';
+import { HookTestUtil, createHookTestEnvironment } from '../testUtils/hooks.testUtil';
+import { LoginProviderWithApolloContext, LoginProviderWithApolloContextProps } from './LoginProviderWithApolloContext';
+import { apolloClientModuleNamespace } from '../apolloClient/index';
+import { USER_QUERY } from '../graphQLModule/__mocks__/mockData';
+import { createControlledFetchMockUtil } from '../testUtils/fetchMockTestUtil';
+import { mockedGraphQLUri } from '../graphQLModule/__mocks__/apolloClient.mock';
+import { createQueryResponse } from '../graphQLModule/__mocks__/mockResponses';
+import { ConnectedModule, Beacon, createTriggerPropsForAllSignals } from '../index.vanilla-js';
+
+const elementIds = {
+  namespaceElement: 'namespace-element',
+  clientExistsElement: 'client-exists-element',
+  loading: 'loading-element',
+  data: 'data-element',
+  error: 'error-element',
+  queryButton: 'query-button',
+} as const;
+
+let testUtil: HookTestUtil;
+
+describe(`LoginProviderWithApolloContext`, () => {
+  const { cleanUp, setResponders, addResponse } = createControlledFetchMockUtil([{ path: mockedGraphQLUri }]);
+  const tokenSetter = jest.fn();
+  const eventLog: string[] = [];
+  // ApolloClient emits errors when cached data is invalid. That does not matter in these tests.
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    enableFetchMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setResponders([{ path: mockedGraphQLUri }]);
+  });
+
+  afterEach(async () => {
+    await cleanUp();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    tokenSetter.mockClear();
+    eventLog.length = 0;
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+    consoleErrorSpy.mockRestore();
+  });
+  const ApolloClientUser = () => {
+    const apolloClientModule = useApolloClientModule();
+    const apolloClient = useApolloClient();
+
+    const [query, { data, loading, error }] = useLazyQuery(USER_QUERY);
+    return (
+      <div>
+        <span key="namespace" id={elementIds.namespaceElement}>
+          {apolloClientModule.namespace}
+        </span>
+        <span key="client" id={elementIds.clientExistsElement}>
+          {typeof apolloClient.query === 'function' ? 1 : 0}
+        </span>
+        <button
+          type="button"
+          id={elementIds.queryButton}
+          onClick={() => {
+            query();
+          }}
+        >
+          Query
+        </button>
+        {loading && (
+          <span key="loading" id={elementIds.loading}>
+            loading
+          </span>
+        )}
+        {data && (
+          <span key="data" id={elementIds.data}>
+            {JSON.stringify(data)}
+          </span>
+        )}
+        {error && (
+          <span key="error" id={elementIds.error}>
+            {error.message}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  const App = () => {
+    const props = useMemo((): LoginProviderWithApolloContextProps => {
+      const createListenerModule = (): ConnectedModule => {
+        let beacon: Beacon | undefined;
+        return {
+          namespace: 'listenerModule',
+          connect: (connectedBeacon) => {
+            beacon = connectedBeacon;
+            beacon.addListener(createTriggerPropsForAllSignals(), ({ type, namespace }) => {
+              eventLog.push(`${namespace}:${type}`);
+            });
+          },
+        };
+      };
+      const listener = createListenerModule();
+      return {
+        apolloClientSettings: {
+          clientOptions: {
+            link: new HttpLink({
+              uri: mockedGraphQLUri,
+            }),
+          },
+          tokenSetter,
+          preventQueriesWhileRenewing: true,
+        },
+        modules: [listener],
+        userManagerSettings: {},
+        apiTokensClientSettings: { url: mockedGraphQLUri },
+      };
+    }, []);
+    return (
+      <LoginProviderWithApolloContext {...props}>
+        <ApolloClientUser />
+      </LoginProviderWithApolloContext>
+    );
+  };
+
+  const initTests = () => {
+    testUtil = createHookTestEnvironment(
+      {
+        waitForRenderToggle: false,
+        children: [<App key="app" />],
+        noOidcClient: true,
+      },
+      {},
+    );
+
+    const executeQuery = async () => {
+      addResponse({ status: 200, body: JSON.stringify(createQueryResponse({ id: 100 })) });
+      const button = testUtil.getElementById(elementIds.queryButton);
+      const getData = () => {
+        const dataEl = testUtil.getElementById(elementIds.data);
+        if (!dataEl) {
+          return null;
+        }
+        return dataEl.innerHTML;
+      };
+      fireEvent.click(button);
+      await waitFor(() => {
+        if (!getData()) {
+          jest.advanceTimersByTime(1000);
+          throw new Error('No data');
+        }
+      });
+      return getData();
+    };
+
+    return {
+      ...testUtil,
+      executeQuery,
+    };
+  };
+
+  it('ApolloClient is created and queries can be executed with api token', async () => {
+    const { getElementById, executeQuery } = initTests();
+
+    expect(getElementById(elementIds.namespaceElement).innerHTML).toEqual(apolloClientModuleNamespace);
+    expect(getElementById(elementIds.clientExistsElement).innerHTML).toEqual('1');
+    const data = await executeQuery();
+    expect(data).toBeDefined();
+    expect(tokenSetter).toHaveBeenCalledTimes(1);
+    expect(eventLog).toEqual(['listenerModule:init', 'apolloClient:init', 'apiTokensClient:init', 'oidcClient:init']);
+  });
+});

--- a/packages/react/src/components/login/components/LoginProviderWithApolloContext.tsx
+++ b/packages/react/src/components/login/components/LoginProviderWithApolloContext.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
-import { InMemoryCache } from '@apollo/client/cache';
-import { ApolloProvider } from '@apollo/client';
+import { ApolloProvider, InMemoryCache } from '@apollo/client';
 
 import { ApolloClientModuleProps } from '../apolloClient/index';
 import { createApolloClientModule } from '../apolloClient/apolloClientModule';

--- a/packages/react/src/components/login/components/LoginProviderWithApolloContext.tsx
+++ b/packages/react/src/components/login/components/LoginProviderWithApolloContext.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react';
+import { InMemoryCache } from '@apollo/client/cache';
+import { ApolloProvider } from '@apollo/client';
+
+import { ApolloClientModuleProps } from '../apolloClient/index';
+import { createApolloClientModule } from '../apolloClient/apolloClientModule';
+import { LoginProvider, LoginProviderProps } from './LoginProvider';
+
+export type LoginProviderWithApolloContextProps<T = InMemoryCache> = LoginProviderProps & {
+  apolloClientSettings: ApolloClientModuleProps<T>;
+};
+
+/**
+ * Renders LoginProvider with ApolloProvider. Creates an ApolloClientModule and appends it to modules.
+ * @param props LoginProviderWithApolloContextProps
+ */
+export const LoginProviderWithApolloContext = ({
+  apolloClientSettings,
+  modules,
+  children,
+  ...rest
+}: React.PropsWithChildren<LoginProviderWithApolloContextProps>) => {
+  const mods = modules ? [...modules] : [];
+  const apolloClient = useMemo(() => {
+    return createApolloClientModule(apolloClientSettings);
+  }, [apolloClientSettings]);
+  mods.push(apolloClient);
+  const client = apolloClient.getClient();
+  return (
+    <LoginProvider {...rest} modules={mods}>
+      <ApolloProvider client={client}>{children}</ApolloProvider>
+    </LoginProvider>
+  );
+};

--- a/packages/react/src/components/login/graphQLModule/graphQLModule.ts
+++ b/packages/react/src/components/login/graphQLModule/graphQLModule.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, ApolloError, ApolloQueryResult, QueryOptions } from '@apollo/client/core';
+import { ApolloClient, ApolloError, ApolloQueryResult, QueryOptions } from '@apollo/client';
 
 import {
   GraphQLModuleModuleProps,

--- a/packages/react/src/components/login/graphQLModule/hooks.test.tsx
+++ b/packages/react/src/components/login/graphQLModule/hooks.test.tsx
@@ -222,6 +222,9 @@ describe(`graphQLModule`, () => {
         getTokens: () => {
           return apiTokenStorage;
         },
+        isRenewing: () => {
+          return false;
+        },
         connect: () => {},
         namespace: apiTokensClientNamespace,
       };
@@ -306,7 +309,7 @@ describe(`graphQLModule`, () => {
 
     const emitApiTokensUpdatedStateChange = (tokens: TokenData) => {
       apiTokenStorage = tokens;
-      const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_UPDATED };
+      const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_UPDATED, data: tokens };
       testUtil.emit({ type: eventSignalType, namespace: apiTokensClientNamespace, payload });
     };
 

--- a/packages/react/src/components/login/graphQLModule/index.ts
+++ b/packages/react/src/components/login/graphQLModule/index.ts
@@ -7,7 +7,7 @@ import {
   ApolloQueryResult,
   ApolloError,
   DocumentNode,
-} from '@apollo/client/core';
+} from '@apollo/client';
 
 import { ApiTokenClient } from '../apiTokensClient';
 import { Beacon, ConnectedModule } from '../beacon/beacon';

--- a/packages/react/src/components/login/graphQLModule/index.ts
+++ b/packages/react/src/components/login/graphQLModule/index.ts
@@ -80,7 +80,10 @@ export type GraphQLModuleModuleProps<T = NormalizedCacheObject, Q = GraphQLQuery
    * Optional property, but must be set before the query is executed.
    */
   graphQLClient?: ApolloClient<T>;
-  getClientModule?: boolean;
+  /**
+   * Get the client from modules.
+   */
+  useApolloClientModule?: boolean;
   /**
    * GraphQL module options.
    */

--- a/packages/react/src/components/login/graphQLModule/index.ts
+++ b/packages/react/src/components/login/graphQLModule/index.ts
@@ -72,7 +72,7 @@ export type GraphQLModule<T = NormalizedCacheObject, Q = GraphQLQueryResult> = C
   /**
    * Returns a promise that is resolved when api tokens are found.
    */
-  waitForApiTokens: (timeout?: number) => Promise<unknown>;
+  waitForApiTokens: () => Promise<boolean>;
 };
 
 export type GraphQLModuleModuleProps<T = NormalizedCacheObject, Q = GraphQLQueryResult> = {
@@ -80,6 +80,7 @@ export type GraphQLModuleModuleProps<T = NormalizedCacheObject, Q = GraphQLQuery
    * Optional property, but must be set before the query is executed.
    */
   graphQLClient?: ApolloClient<T>;
+  getClientModule?: boolean;
   /**
    * GraphQL module options.
    */

--- a/packages/react/src/components/login/graphQLModule/utils.ts
+++ b/packages/react/src/components/login/graphQLModule/utils.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from '@apollo/client/core';
+import { QueryOptions } from '@apollo/client';
 import { merge } from 'lodash';
 
 import { GraphQLModuleModuleProps } from '.';

--- a/packages/react/src/components/login/index.ts
+++ b/packages/react/src/components/login/index.ts
@@ -13,6 +13,7 @@ export * from './beacon/hooks';
 export * from './apiTokensClient/hooks';
 export * from './sessionPoller/hooks';
 export * from './graphQLModule/hooks';
+export * from './apolloClient/hooks';
 
 // vanilla js code
 export * from './index.vanilla-js';

--- a/packages/react/src/components/login/index.ts
+++ b/packages/react/src/components/login/index.ts
@@ -6,6 +6,7 @@ export * from './components/WithAuthenticatedUser';
 export * from './components/WithAuthentication';
 export * from './components/WithoutAuthenticatedUser';
 export * from './components/SessionEndedHandler';
+export * from './components/LoginProviderWithApolloContext';
 
 // hooks
 export * from './client/hooks';

--- a/packages/react/src/components/login/index.vanilla-js.ts
+++ b/packages/react/src/components/login/index.vanilla-js.ts
@@ -7,6 +7,7 @@ export * from './types';
 export { ApiTokenClientProps, TokenData, ApiTokenClient, ApiTokensClientEvent } from './apiTokensClient/index';
 export { SessionPoller, SessionPollerEvent, SessionPollerOptions } from './sessionPoller/sessionPoller';
 export { GraphQLModule, GraphQLModuleModuleProps, GraphQLModuleEvent } from './graphQLModule/index';
+export { ApolloClientModule, ApolloClientModuleProps, ApolloClientModuleEvent } from './apolloClient/index';
 export {
   OidcClient,
   OidcClientEvent,
@@ -48,6 +49,7 @@ export * from './client/oidcClient';
 export * from './apiTokensClient/apiTokensClient';
 export { createSessionPoller } from './sessionPoller/sessionPoller';
 export { createGraphQLModule } from './graphQLModule/graphQLModule';
+export { createApolloClientModule } from './apolloClient/apolloClientModule';
 
 // beacon
 export { createBeacon, createSignalTrigger } from './beacon/beacon';
@@ -68,12 +70,14 @@ export {
   mergeHeadersToQueryOptions,
   mergeQueryOptionContexts,
 } from './graphQLModule/utils';
+export { createApiTokenClientTracker } from './apiTokensClient/createApiTokenClientTracker';
 
 // events
 export { apiTokensClientEvents } from './apiTokensClient/index';
 export { oidcClientEvents } from './client/index';
 export { sessionPollerEvents } from './sessionPoller/sessionPoller';
 export { graphQLModuleEvents } from './graphQLModule/index';
+export { apolloClientModuleEvents } from './apolloClient/index';
 
 // stateChanges
 export { oidcClientStates } from './client/index';
@@ -86,6 +90,7 @@ export { apiTokensClientNamespace } from './apiTokensClient/index';
 export { oidcClientNamespace } from './client/index';
 export { sessionPollerNamespace } from './sessionPoller/sessionPoller';
 export { graphQLModuleNamespace } from './graphQLModule/index';
+export { apolloClientModuleNamespace } from './apolloClient/index';
 
 // signals
 export * from './apiTokensClient/signals';

--- a/packages/react/src/components/login/utils/abortFetch.ts
+++ b/packages/react/src/components/login/utils/abortFetch.ts
@@ -2,6 +2,15 @@ export function isAbortError(error: Error): boolean {
   return !!error && error.name === 'AbortError';
 }
 
+export function appendAbortSignal(target: Parameters<typeof fetch>[1]): AbortController['abort'] {
+  const abortController = new AbortController();
+  // eslint-disable-next-line no-param-reassign
+  target.signal = abortController.signal;
+  return (reason?: unknown) => {
+    abortController.abort(reason);
+  };
+}
+
 export function createFetchAborter() {
   let isAborted = false;
   let abortController: AbortController | undefined;

--- a/site/package.json
+++ b/site/package.json
@@ -79,9 +79,8 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn lint && NODE_OPTIONS='--max_old_space_size=8192' gatsby build",
-    "develop": "gatsby develop -o",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "start": "gatsby develop -o",
+    "start": "NODE_OPTIONS=--max_old_space_size=8192 gatsby develop -o",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",

--- a/site/src/docs/components/login/api.mdx
+++ b/site/src/docs/components/login/api.mdx
@@ -70,15 +70,15 @@ export const CustomisationPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>Oidc Client</AnchorLink>
   - <AnchorLink>Api tokens client</AnchorLink>
   - <AnchorLink>Session poller</AnchorLink>
-  - <AnchorLink>GraphQL module</AnchorLink>
+  - <AnchorLink>ApolloClient module</AnchorLink>
   - <AnchorLink>GraphQL module</AnchorLink>
 
 - <AnchorLink>Oidc client hooks</AnchorLink>
-- <AnchorLink>Api tokens client hooks</AnchorLink>{' '}
-- <AnchorLink>Session poller hooks</AnchorLink>{' '}
-- <AnchorLink>GraphQL module hooks</AnchorLink>{' '}
-- <AnchorLink>GraphQL module hooks</AnchorLink>{' '}
-- <AnchorLink>Generic signal hooks</AnchorLink>{' '}
+- <AnchorLink>Api tokens client hooks</AnchorLink>
+- <AnchorLink>Session poller hooks</AnchorLink>
+- <AnchorLink>ApolloClient module hooks</AnchorLink>
+- <AnchorLink>GraphQL module hooks</AnchorLink>
+- <AnchorLink>Generic signal hooks</AnchorLink>
 
 - <AnchorLink>Beacon</AnchorLink>
 - <AnchorLink>Signals</AnchorLink>
@@ -95,7 +95,7 @@ export const CustomisationPageAnchorLink = ({ anchor, children }) => {
 | `redirectionProps` | Properties appended to the url when redirecting. Read more in the <InternalLink href="/components/login/api/#methods">documentation of the oidcClient login method</InternalLink>. | none                                                        |
 | `onClick`          | Called when the component is clicked and before the oidcClient.login() is called.                                                                                                  | none                                                        |
 
-| [Table 2: Properties of the LoginButton component] |
+| [Table 1: Properties of the LoginButton component] |
 
 Button text is passed and rendered as a child.
 
@@ -106,7 +106,7 @@ Button text is passed and rendered as a child.
 | `children`                                                  | Optional. Usually, child elements inform the user that a response is being processed.                                                                         |
 | `onError`                                                   | **Required**. The function is called when a login fails. The function is called with an <AnchorLink anchor="error-signal-types">OidcClientError</AnchorLink>. |
 | `onSuccess`                                                 | **Required**. The function is called when a response is handled successfully. The function is called with a <OidcClientTsLink>User</OidcClientTsLink> object. |
-| [Table 3: Properties of the LoginCallbackHandler component] |
+| [Table 2: Properties of the LoginCallbackHandler component] |
 
 In some scenarios, when the component is rendered multiple times, usually in development mode with strict mode enabled, the `onError` callback is called with an error that can usually be ignored. The error indicates a login callback is already being handled. The error can be checked with the exported function `isHandlingLoginCallbackError(error)`.
 
@@ -119,7 +119,7 @@ In some scenarios, when the component is rendered multiple times, usually in dev
 | `modules`                                            | Optional. An array of <CustomisationPageAnchorLink>custom modules</CustomisationPageAnchorLink>.                                                                                                                                                                                                                                                                        |
 | `sessionPollerSettings`                              | Optional. <AnchorLink anchor="settings-2">Settings for the Session poller</AnchorLink>. If omitted, the `Session poller` is not created. If default values are acceptable, an empty object is required to create the poller.                                                                                                                                            |
 | `userManagerSettings`                                | **Required**. The <AnchorLink anchor="oidc-client">HDS Oidc client</AnchorLink> uses <ExternalLink href="https://github.com/authts/oidc-client-ts">oidc-client-ts</ExternalLink> to handle redirect URLs, token parsing and expiration. Both use the same `userManagerSettings`, but <AnchorLink anchor="default-usermanager-settings">different defaults</AnchorLink>. |
-| [Table 4: Properties of the LoginProvider component] |
+| [Table 3: Properties of the LoginProvider component] |
 
 #### SessionEndedHandler
 
@@ -128,7 +128,7 @@ In some scenarios, when the component is rendered multiple times, usually in dev
 | `content`                                                  | **Required**. Textual content with properties `title`, `text`, `buttonText` and `closeButtonLabelText`.              |
 | `dialogProps`                                              | Optional. Additional <GitHubSourceLink path="dialog/Dialog.tsx">DialogProps</GitHubSourceLink> passed to the Dialog. |
 | `ids`                                                      | Optional. Ids for the dialog elements with properties `dialog`, `title`, and `text`. If omitted, ids are created.    |
-| [Table 5: Properties of the SessionEndedHandler component] |
+| [Table 4: Properties of the SessionEndedHandler component] |
 
 #### WithAuthentication
 
@@ -136,21 +136,21 @@ In some scenarios, when the component is rendered multiple times, usually in dev
 | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AuthorisedComponent`                                     | Optional. Component to render if the user is authenticated. The <OidcClientTsLink>user</OidcClientTsLink> object is passed to the component. |
 | `UnauthorisedComponent`                                   | Optional. Component to render if the user is not authenticated.                                                                              |
-| [Table 6: Properties of the WithAuthentication component] |
+| [Table 5: Properties of the WithAuthentication component] |
 
 #### WithAuthenticatedUser
 
 | Property                                                     | Description                                                                                 |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
 | `children`                                                   | React children. A <OidcClientTsLink>user</OidcClientTsLink> object is passed to each child. |
-| [Table 7: Properties of the WithAuthenticatedUser component] |
+| [Table 6: Properties of the WithAuthenticatedUser component] |
 
 #### WithoutAuthenticatedUser
 
 | Property                                                     | Description     |
 | ------------------------------------------------------------ | --------------- |
 | `children`                                                   | React children. |
-| [Table 8: Properties of the WithAuthenticatedUser component] |
+| [Table 7: Properties of the WithAuthenticatedUser component] |
 
 ### Modules
 
@@ -161,7 +161,7 @@ There are four modules to handle the user's needs:
 
 - <AnchorLink>Oidc client</AnchorLink> for user data.
 - <AnchorLink>Api tokens client</AnchorLink> for acquiring backend tokens.
-- <AnchorLink>Session poller</AnchorLink> for checking if the user's session is still valid at the Oidc provider.
+- <UsagePageAnchorLink>ApolloClient module</UsagePageAnchorLink> to provide the client and auto-append api tokens to queries.
 - <AnchorLink>GraphQL module</AnchorLink> for fetching data from a graphQL server. Fetching can be automatically linked to
   the Api Tokens client.
 
@@ -177,22 +177,22 @@ The `Oidc client` uses the <ExternalLink href="https://github.com/authts/oidc-cl
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `debug`                                | Optional. If true, debugging is enabled in the oidc-client-ts instance with `Log.setLevel(Log.Debug)` and `Log.setLogger(console)`. |
 | `userManagerSettings`                  | **Required**, but not all options. At least `authority`, `client_id` and `scope` must be set.                                       |
-| [Table 9: Settings of the Oidc client] |
+| [Table 8: Settings of the Oidc client] |
 
 ##### Default userManager settings
 
-| Property                                                     | Default value                      |
-| ------------------------------------------------------------ | ---------------------------------- |
-| `automaticSilentRenew`                                       | true                               |
-| `includeIdTokenInSilentRenew`                                | true                               |
-| `loadUserInfo`                                               | true                               |
-| `monitorSession`                                             | false                              |
-| `post_logout_redirect_uri`                                   | window.origin + /                  |
-| `redirect_uri`                                               | window.origin + /callback          |
-| `response_type`                                              | code                               |
-| `silent_redirect_uri`                                        | window.origin + /silent_renew.html |
-| `validateSubOnSilentRenew`                                   | false                              |
-| [Table 10: Default userManager settings of the Oidc client ] |
+| Property                                                    | Default value                      |
+| ----------------------------------------------------------- | ---------------------------------- |
+| `automaticSilentRenew`                                      | true                               |
+| `includeIdTokenInSilentRenew`                               | true                               |
+| `loadUserInfo`                                              | true                               |
+| `monitorSession`                                            | false                              |
+| `post_logout_redirect_uri`                                  | window.origin + /                  |
+| `redirect_uri`                                              | window.origin + /callback          |
+| `response_type`                                             | code                               |
+| `silent_redirect_uri`                                       | window.origin + /silent_renew.html |
+| `validateSubOnSilentRenew`                                  | false                              |
+| [Table 9: Default userManager settings of the Oidc client ] |
 
 These override the default settings of the <ExternalLink href="https://github.com/authts/oidc-client-ts/blob/main/src/UserManagerSettings.ts">oidc-client-ts</ExternalLink>.
 
@@ -211,7 +211,7 @@ These override the default settings of the <ExternalLink href="https://github.co
 | `login`                                | Calls the `authorization_endpoint` with given parameters. The browser window is redirected and the returned promise is fulfilled only, if an error occurs when redirecting. Parameters are documented in the <OidcClientTsLink>UserManager.signinRedirect</OidcClientTsLink> of the oidc-client-ts. Used language can be set with a custom `language` prop.              | `Promise<never>`                                             |
 | `logout`                               | Calls the `end_session_endpoint` with given parameters. The browser window is redirected so the returned promise is never fulfilled. Parameters are documented in the <OidcClientTsLink>UserManager.signoutRedirect</OidcClientTsLink> of the oidc-client-ts. Used language can be set with a custom `language` prop.                                                    | `Promise<never>`                                             |
 | `renewUser`                            | For manual user renewal. The Promise will never be rejected.                                                                                                                                                                                                                                                                                                             | `Promise<User>`                                              |
-| [Table 11: Methods of the Oidc client] |
+| [Table 10: Methods of the Oidc client] |
 
 ##### Other exported utility functions
 
@@ -225,7 +225,7 @@ The following functions can be imported and used without the `Oidc client` modul
 | `isUserExpired(user)`                                    | Returns true if the user is expired.                             | <OidcClientTsLink>User</OidcClientTsLink> object.                                                                                      | `boolean`                                           |
 | `isValidUser(user)`                                      | Returns true if the user is not expired and has an access token. | <OidcClientTsLink>User</OidcClientTsLink> object.                                                                                      | `boolean`                                           |
 | `pickUserToken(user, tokenType)`                         | Returns one of the user's tokens: `access`, `id` or `refresh`.   | <OidcClientTsLink>User</OidcClientTsLink> object, token type ( `access`, `id` or `refresh`).                                           | `string` or `undefined`                             |
-| [Table 12: Other Oidc client and user-related functions] |
+| [Table 11: Other Oidc client and user-related functions] |
 
 <PlaygroundPreview>
 
@@ -253,7 +253,7 @@ There are utility functions for each state change. Use these to check if the emi
 | `LOGGING_OUT`                  | State changes to this when `logout()` is called.                         | `isLoggingOutSignal(signal)`            |
 | `NO_SESSION`                   | No valid user exists.                                                    | `isNoSessionSignal(signal)`             |
 | `VALID_SESSION`                | User is found and is valid.                                              | `isValidSessionSignal(signal)`          |
-| [Table 13: Oidc client states] |
+| [Table 12: Oidc client states] |
 
 ##### Error signal types
 
@@ -265,7 +265,7 @@ The error object also contains the thrown error in `error.originalError` propert
 | `INVALID_OR_EXPIRED_USER`      | The returned <OidcClientTsLink>user</OidcClientTsLink> object is expired or invalid. | `error.isInvalidUserError`     | `isInvalidUserErrorSignal(signal) `  |
 | `RENEWAL_FAILED`               | User renewal failed.                                                                 | `error.isRenewalError`         | `isRenewalErrorSignal(signal)`       |
 | `SIGNIN_ERROR`                 | Emitted when `handleCallback()` or `login()` failed.                                 | `error.isSignInError`          | `isSigninErroSignal(signal) `        |
-| [Table 14: Oidc client errors] |
+| [Table 13: Oidc client errors] |
 
 ##### Event signals
 
@@ -276,7 +276,7 @@ The `Oidc client` also emits event signals when an action is complete or startin
 | `USER_UPDATED`                 | User data has changed. Includes also changes to `null`, if login or renewal fail.                        | `isUserUpdatedSignal(signal) `        |
 | `USER_REMOVED`                 | User data was removed. Happens when the user logs out or tokens expire.                                  | `isUserRemovedSignal(signal) `        |
 | `USER_RENEWAL_STARTED`         | User is being renewed. Current access_token and API tokens may be invalid until the renewal is complete. | `isUserRenewalStartedSignal(signal) ` |
-| [Table 15: Oidc client events] |
+| [Table 14: Oidc client events] |
 
 ##### Dedicated signal triggers
 
@@ -288,7 +288,7 @@ Generic triggers for `Oidc client` signals. These trigger only if the signal ori
 | `triggerForAllOidcClientEvents`       | `Oidc client` namespace and type `event`.       |
 | `triggerForAllOidcClientSignals`      | `Oidc client` namespace.                        |
 | `triggerForAllOidcClientStateChanges` | `Oidc client` namespace and type `stateChange`. |
-| [Table 16: Oidc client triggers]      |
+| [Table 15: Oidc client triggers]      |
 
 State change triggers require the signal to have the `Oidc client` namespace and type `stateChange`.
 `Signal.payload.type` must contain one of the <AnchorLink anchor="state-change-signals">states</AnchorLink>.
@@ -299,7 +299,7 @@ State change triggers require the signal to have the `Oidc client` namespace and
 | `loggingOutTrigger`                           | `payload.type` has a matching state.          |
 | `noSessionTrigger`                            | `payload.type` has a matching state.          |
 | `validSessionTrigger`                         | `payload.type` has a matching state.          |
-| [Table 17: Oidc client state change triggers] |
+| [Table 16: Oidc client state change triggers] |
 
 Event triggers require the signal to have the `Oidc client` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals">events</AnchorLink>.
@@ -309,7 +309,7 @@ Event triggers require the signal to have the `Oidc client` namespace and type `
 | `userRemovedTrigger`                   | `payload.type` has a matching event.          |
 | `userRenewalStartedTrigger`            | `payload.type` has a matching event.          |
 | `userUpdatedTrigger`                   | `payload.type` has a matching event.          |
-| [Table 18: Oidc client event triggers] |
+| [Table 17: Oidc client event triggers] |
 
 Error triggers require the signal to have the `Oidc client` namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types">errors</AnchorLink>.
@@ -319,7 +319,7 @@ Error triggers require the signal to have the `Oidc client` namespace and type `
 | `invalidUserErrorTrigger`              | `payload.type` has a matching error.          |
 | `renewalErrorTrigger`                  | `payload.type` has a matching error.          |
 | `signInErrorTrigger`                   | `payload.type` has a matching error.          |
-| [Table 19: Oidc client error triggers] |
+| [Table 18: Oidc client error triggers] |
 
 ##### Getting signal payloads
 
@@ -331,7 +331,7 @@ If the given signal is not from `Oidc client` or is not of the given type, the f
 | `getOidcClientEventPayload`                    | `null` or `{type, data}`. The data is usually a <OidcClientTsLink>user</OidcClientTsLink> object. |
 | `getOidcClientErrorPayload`                    | `null` or <AnchorLink anchor="error-signal-types">OidcClientError</AnchorLink> object.            |
 | `getOidcClientStateChangePayload`              | `null` or `{state, previousState}`.                                                               |
-| [Table 20: Oidc client signal payload getters] |
+| [Table 19: Oidc client signal payload getters] |
 
 ##### Hooks
 
@@ -357,7 +357,7 @@ URL where to get the tokens from. A user's access token is also required, so the
 | `queryProps`                           | Optional. An object. Used with Helsinki Profile api token requests. Contains properties `grantType` and `permission`. | none          |
 | `retryInterval`                        | Optional. Waiting time in milliseconds between failed requests.                                                       | 500           |
 | `url`                                  | **Required**. URL to the API tokens endpoint.                                                                         | none          |
-| [Table 21: Api tokens client settings] |
+| [Table 20: Api tokens client settings] |
 
 ##### Methods
 
@@ -367,7 +367,32 @@ URL where to get the tokens from. A user's access token is also required, so the
 | `fetch`                               | Fetches the tokens from the given URI.        | `Promise<Tokens>` |
 | `getTokens`                           | Gets locally stored tokens.                   | `Tokens`          |
 | `isRenewing`                          | Returns true if tokens are currently fetched. | `boolean`         |
-| [Table 22: Api tokens client methods] |
+| [Table 21: Api tokens client methods] |
+
+##### Api Token Client Tracker utility
+
+Multiple modules need to track api tokens and their renewal process. This util listens to changes and also times out when the renewal is taking too long.
+
+| Name                                                 | Description                                                                                                                                                                                                      | Default value |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `keepTokensAfterRenewalError`                        | If renewal fails, should old tokens be kept of not.                                                                                                                                                              | `false`       |
+| `keepTokensWhileRenewing`                            | If true, the stored api tokens are not cleared when renewal starts.                                                                                                                                              | `true`        |
+| `onChange(tokens: TokenData, changeTrigger: Signal)` | Called when api tokens change. Not called when dispose() is called. Second argument is the signal that caused the change.                                                                                        | -             |
+| `rejectionSignalTrigger`                             | Type of the signal that should end the pending api token renewal promise. Usually it is a clear/dispose signal from the module using this util, so the promise is fulfilled when the module is not used anymore. | -             |
+| `timeout`                                            | How long to wait for apitoken renewal to fulfill.                                                                                                                                                                | `15000`       |
+| [Table 22: createApiTokenClientTracker settings]     |
+
+The function returns an object with following properties
+
+| Property                                     | Arguments                                                                                                                                                    | Return values                                     |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| `connect(connectedBeacon: Beacon)`           | Connect the utility to a beacon.                                                                                                                             | `void`                                            |
+| `dispose()`                                  | Dispose listeners, references and data.                                                                                                                      | `void`                                            |
+| `getTokens()`                                | Get current tokens.                                                                                                                                          | `TokenData` (empty object, if no existing tokens) |
+| `isRenewing()`                               | Returns true, if renewal process is on-going.                                                                                                                | `boolean`                                         |
+| `stopWaitingForTokens()`                     | Discards pending promise for api token renewal. Emits signal to abort it. Same signal is used in all instance of this utility, so the signal stops them all. | `void`                                            |
+| `waitForApiTokens()`                         | Returns the pending renewal promise or immediately resolved promise. Never rejects, the returned boolean indicates was the promise successful.               | `Promise<boolean>`                                |
+| [Table 23: ApiTokenClientTracker properties] |
 
 ##### Other exported utility functions
 
@@ -382,7 +407,7 @@ The following functions can be imported and used without the `Api tokens client`
 | `removeUserReferenceFromStorage(storage)`             | Removes the user's access token used as reference. | Storage to remove the reference from. (optional, default is session storage).                      | none                                                                                           |
 | `setApiTokensToStorage(tokens, storage)`              | Sets the API tokens to storage.                    | Tokens, storage to set the tokens to. (optional, default is session storage).                      | none                                                                                           |
 | `setUserReferenceToStorage(reference,storage)`        | Sets the user's access token used as reference.    | Reference as string, tokens, storage to set the tokens to. (optional, default is session storage). | none                                                                                           |
-| [Table 23: Other Api tokens client-related functions] |
+| [Table 24: Other Api tokens client-related functions] |
 
 <PlaygroundPreview>
 
@@ -410,7 +435,7 @@ Returned errors are instances of the `ApiTokensClientError`. It is an extended E
 | `API_TOKEN_FETCH_FAILED`             | Fetch failed.                           | `error.isFetchError`                | `isApiTokensFetchFailedErrorSignal(signal)` |
 | `INVALID_API_TOKENS`                 | The returned object is an invalid json. | `error.isInvalidTokensError`        | `isInvalidApiTokensErrorSignal(signal)`     |
 | `INVALID_USER_FOR_API_TOKENS`        | User is not valid.                      | `error.isInvalidApiTokensUserError` | `isInvalidApiTokensUserErrorSignal(signal)` |
-| [Table 24: Api tokens client errors] |
+| [Table 25: Api tokens client errors] |
 
 ##### Event signals
 
@@ -421,7 +446,7 @@ The `Api tokens client` also emits events when an action is complete or starting
 | `API_TOKENS_UPDATED`                 | Tokens have changed. Includes also changes to `null`.                                          | `isApiTokensUpdatedSignal(signal)`        |
 | `API_TOKENS_REMOVED`                 | Tokens have been removed. Happens usually when the user object has been removed or is renewed. | `isApiTokensRemovedSignal(signal)`        |
 | `API_TOKENS_RENEWAL_STARTED`         | Api tokens are renewed. Happens usually right after user renewal.                              | `isApiTokensRenewalStartedSignal(signal)` |
-| [Table 25: Api tokens client events] |
+| [Table 26: Api tokens client events] |
 
 ##### Dedicated signal triggers
 
@@ -432,7 +457,7 @@ Triggers for `Api tokens client` signals. These trigger signals only originated 
 | `triggerForAllApiTokensClientErrors`   | `Api tokens client` namespace and type `error`. |
 | `triggerForAllApiTokensClientEvents`   | `Api tokens client` namespace and type `event`. |
 | `triggerForAllApiTokensClientSignals`  | `Api tokens client` namespace.                  |
-| [Table 26: Api tokens client triggers] |
+| [Table 27: Api tokens client triggers] |
 
 Event triggers require the signal to have `Api tokens client` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals-1">events</AnchorLink>.
@@ -442,7 +467,7 @@ Event triggers require the signal to have `Api tokens client` namespace and type
 | `apiTokensRemovedTrigger`                    | `payload.type` has a matching event.          |
 | `apiTokensRenewalStartedTrigger`             | `payload.type` has a matching event.          |
 | `apiTokensUpdatedTrigger`                    | `payload.type` has a matching event.          |
-| [Table 27: Api tokens client event triggers] |
+| [Table 28: Api tokens client event triggers] |
 
 Error triggers require the signal to have `Api tokens client` namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types-1">errors</AnchorLink>.
@@ -452,7 +477,7 @@ Error triggers require the signal to have `Api tokens client` namespace and type
 | `apiTokensFetchFailedErrorTrigger`           | `payload.type` has a matching error.          |
 | `invalidApiTokensErrorTrigger`               | `payload.type` has a matching error.          |
 | `invalidApiTokensUserErrorTrigger`           | `payload.type` has a matching error.          |
-| [Table 28: Api tokens client error triggers] |
+| [Table 29: Api tokens client error triggers] |
 
 ##### Getting signal payloads
 
@@ -463,7 +488,7 @@ If the given signal is not from `Api tokens client` or is not given type, the fu
 | ---------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `getApiTokensClientErrorPayload`                     | `null` or <AnchorLink anchor="error-signal-types-1">ApiTokensClientError</AnchorLink> object. |
 | `getApiTokensClientEventPayload`                     | `null` or `{type, data}`. The data is usually tokens.                                         |
-| [Table 29: Api tokens client signal payload getters] |
+| [Table 30: Api tokens client signal payload getters] |
 
 ##### Hooks
 
@@ -483,7 +508,7 @@ Polling requires a user and the `userManager` from the `Oidc client`. The pollin
 | Property                            | Description                                                                      | Default value |
 | ----------------------------------- | -------------------------------------------------------------------------------- | ------------- |
 | `pollIntervalInMs`                  | Optional. Waiting time between polls in milliseconds. The default is one minute. | 60000         |
-| [Table 30: Session poller settings] |
+| [Table 31: Session poller settings] |
 
 ##### Methods
 
@@ -491,7 +516,7 @@ Polling requires a user and the `userManager` from the `Oidc client`. The pollin
 | ---------------------------------- | ----------------------------------------------------------------------------------------------- | ------------ |
 | `start`                            | Starts the polling. The first check is done after pollIntervalInMs is expired. Not immediately. |              |
 | `stop`                             | Stops the polling and aborts current requests, if any.                                          | `Tokens`     |
-| [Table 31: Session poller methods] |
+| [Table 32: Session poller methods] |
 
 ##### Other exported utility functions
 
@@ -500,7 +525,7 @@ The following function can be imported and used without the `Session poller` mod
 | Property                                   | Description         | Argument(s)           | Return value    |
 | ------------------------------------------ | ------------------- | --------------------- | --------------- |
 | `createSessionPoller(options)`             | Creates the poller. | SessionPollerOptions. | `SessionPoller` |
-| [Table 32: Other Session poller functions] |
+| [Table 33: Other Session poller functions] |
 
 <PlaygroundPreview>
 
@@ -524,7 +549,7 @@ Returned errors are instances of the `SessionPollerError`. It is an extended Err
 | -------------------------------------------- | ------------------------------------------------------------ | ------------------------------- | --------------------------------------- |
 | `SESSION_ENDED`                              | The server returned a forbidden or unauthorized status code. | `error.isSessionEnded`          | `isSessionEndedSignal(signal) `         |
 | `SESSION_POLLING_FAILED`                     | Polling has failed and max retries have been reached.        | `error.isSessionPollingFailure` | `isSessionPollingFailureSignal(signal)` |
-| [Table 33: Other Session poller error types] |
+| [Table 34: Other Session poller error types] |
 
 ##### Event signals
 
@@ -534,7 +559,7 @@ The `Session poller` also emits events when an action is complete or starting.
 | -------------------------------------------- | -------------------- | -------------------------------------- |
 | `SESSION_POLLING_STARTED`                    | Polling has started. | `isSessionPollerStartedSignal(signal)` |
 | `SESSION_POLLING_STOPPED`                    | Polling has stopped. | `isSessionPollerStoppedSignal(signal)` |
-| [Table 34: Other Session poller event types] |
+| [Table 35: Other Session poller event types] |
 
 ##### Dedicated signal triggers
 
@@ -545,7 +570,7 @@ Triggers for `Session poller`signals. These trigger signals only originated from
 | `triggerForAllSessionPollerErrors`  | `Session poller` namespace and type `error`.  |
 | `triggerForAllSessionPollerEvents`  | `Session poller` namespace and type `event`.  |
 | `triggerForAllSessionPollerSignals` | `Session poller` namespace.                   |
-| [Table 35: Session poller triggers] |
+| [Table 36: Session poller triggers] |
 
 Event triggers require the signal to have a `Session poller` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals-2">events</AnchorLink>.
@@ -554,7 +579,7 @@ Event triggers require the signal to have a `Session poller` namespace and type 
 | ----------------------------------------- | --------------------------------------------- |
 | `sessionPollingStartedTrigger`            | `payload.type` has a matching event.          |
 | `sessionPollingStoppedTrigger`            | `payload.type` has a matching event.          |
-| [Table 36: Session poller event triggers] |
+| [Table 37: Session poller event triggers] |
 
 Error triggers require the signal to have a `Session poller`namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types-2">errors</AnchorLink>.
@@ -563,7 +588,7 @@ Error triggers require the signal to have a `Session poller`namespace and type `
 | ----------------------------------------- | --------------------------------------------- |
 | `sessionEndedTrigger`                     | `payload.type` has a matching error.          |
 | `sessionPollingFailedTrigger`             | `payload.type` has a matching error.          |
-| [Table 37: Session poller error triggers] |
+| [Table 38: Session poller error triggers] |
 
 ##### Getting signal payloads
 
@@ -574,7 +599,7 @@ If the given signal is not from the `Session poller` or is not given type, the f
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `getSessionPollerErrorPayload`                    | `null` or <AnchorLink anchor="error-signal-types-2">SessionPollerError</AnchorLink> object. |
 | `getSessionPollerEventPayload`                    | `null` or `{type, data}`. The data is usually tokens.                                       |
-| [Table 38: Session poller signal payload getters] |
+| [Table 39: Session poller signal payload getters] |
 
 #### GraphQL Module
 
@@ -587,7 +612,7 @@ Unlike the `Api token client` and `Session Poller`, the `GraphQL Module` must be
 <PlaygroundPreview>
 
 ```jsx
-import { ApolloClient } from '@apollo/client/core';
+import { ApolloClient } from '@apollo/client';
 import { createGraphQLModule } from 'hds-react';
 import { queryDocument } from './<path to queries>';
 
@@ -637,20 +662,21 @@ The `createGraphQLModule` function is a Generic Typescript function with two typ
 
 <div className="container-for-table-10-30-50-10">
 
-| Property                            | Type                                                                                                   | Description                                                                                                                                                       | Default value |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `graphQLClient`                     | <ExternalLink href="https://www.apollographql.com/docs/react/get-started">Apollo Client</ExternalLink> | Optional property, but must be set before the query is executed. Can be set with `setApolloClient` or when calling a `query(options)`.                            | -             |
-| `query`                             | `TypedDocumentNode or DocumentNode`                                                                    | A graphQL query document.                                                                                                                                         | -             |
-| `queryHelper`                       | `(currentOptions:QueryOptions, apiTokenClient?: ApiTokenClient, beacon?:Beacon) => QueryOptions`       | This function is called before a query is executed. The options object returned by the function is used as query options.                                         | -             |
-| `options`                           | `object`                                                                                               | GraphQL module options.                                                                                                                                           | {}            |
-| `options.autoFetch`                 | `boolean`                                                                                              | Should query be executed automatically on initialization.                                                                                                         | `true`        |
-| `options.requireApiTokens`          | `boolean`                                                                                              | Are api tokens required for queries.                                                                                                                              | `true`        |
-| `options.abortIfLoading`            | `boolean`                                                                                              | Should an on-going query be aborted when `query()` is called again. If false, the `query()` will return a pending promise, and a new query is not started.        | `true`        |
-| `options.keepOldResultOnError`      | `boolean`                                                                                              | Should old result be kept, if a newer query fails.                                                                                                                | `false`       |
-| `options.apiTokensWaitTime`         | `number`                                                                                               | How long in milliseconds should api tokens be awaited before rejecting a query.                                                                                   | 15 000        |
-| `options.apiTokenKey`               | `string`                                                                                               | An object key for the api token to use in a query. The token is picked with `apiTokens[key]`.                                                                     | -             |
-| `queryOptions`                      | `QueryOptions` excluding the `query` property                                                          | Other <ExternalLink href="https://www.apollographql.com/docs/react/api/core/ApolloClient#query">ApolloClient queryOptions</ExternalLink> except `query` document. | -             |
-| [Table 39: GraphQL module settings] |
+| Property                            | Type                                                                                                  | Description                                                                                                                                                                                                                            | Default value |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `graphQLClient`                     | <ExternalLink href="https://www.apollographql.com/docs/react/get-started">ApolloClient</ExternalLink> | Optional property, but must be set before the query is executed. Can be set with `setApolloClient` or when calling a `query(options)`. The <AnchorLink anchor="apolloclient-module">ApolloClient Module</AnchorLink> can also be used. | -             |
+| `query`                             | `TypedDocumentNode or DocumentNode`                                                                   | A graphQL query document.                                                                                                                                                                                                              | -             |
+| `queryHelper`                       | `(currentOptions:QueryOptions, apiTokenClient?: ApiTokenClient, beacon?:Beacon) => QueryOptions`      | This function is called before a query is executed. The options object returned by the function is used as query options.                                                                                                              | -             |
+| `options`                           | `object`                                                                                              | GraphQL module options.                                                                                                                                                                                                                | {}            |
+| `options.autoFetch`                 | `boolean`                                                                                             | Should query be executed automatically on initialization.                                                                                                                                                                              | `true`        |
+| `options.requireApiTokens`          | `boolean`                                                                                             | Are api tokens required for queries.                                                                                                                                                                                                   | `true`        |
+| `options.abortIfLoading`            | `boolean`                                                                                             | Should an on-going query be aborted when `query()` is called again. If false, the `query()` will return a pending promise, and a new query is not started.                                                                             | `true`        |
+| `options.keepOldResultOnError`      | `boolean`                                                                                             | Should old result be kept, if a newer query fails.                                                                                                                                                                                     | `false`       |
+| `options.apiTokensWaitTime`         | `number`                                                                                              | How long in milliseconds should api tokens be awaited before rejecting a query.                                                                                                                                                        | 15 000        |
+| `options.apiTokenKey`               | `string`                                                                                              | An object key for the api token to use in a query. The token is picked with `apiTokens[key]`.                                                                                                                                          | -             |
+| `queryOptions`                      | `QueryOptions` excluding the `query` property                                                         | Other <ExternalLink href="https://www.apollographql.com/docs/react/api/core/ApolloClient#query">ApolloClient queryOptions</ExternalLink> except `query` document.                                                                      | -             |
+| `useApolloClientModule`             | `boolean`                                                                                             | If true, ApolloClient is picked from modules. The <AnchorLink anchor="apolloclient-module">ApolloClient Module</AnchorLink> must be created manually.                                                                                  | `false`       |
+| [Table 40: GraphQL module settings] |
 
 </div>
 
@@ -670,9 +696,9 @@ The `createGraphQLModule` function is a Generic Typescript function with two typ
 | `query`                            | Executes a query.                                                                          | `Partial<GraphQLModuleModuleProps>`                                                                              | `Promise<QueryResult>`                           |
 | `queryCache`                       | Calls `query(options)` with `fetchPolicy: 'cache-only'` in options.                        | `Partial<GraphQLModuleModuleProps>`                                                                              | `Promise<QueryResult>`                           |
 | `queryServer`                      | Calls `query(options)` with `fetchPolicy: 'network-only'` in options.                      | `Partial<GraphQLModuleModuleProps>`                                                                              | `Promise<QueryResult>`                           |
-| `setClient`                        | Sets the graphQLClient.                                                                    | <ExternalLink href="https://www.apollographql.com/docs/react/get-started">Apollo Client</ExternalLink>           | -                                                |
+| `setClient`                        | Sets the graphQLClient.                                                                    | <ExternalLink href="https://www.apollographql.com/docs/react/get-started">ApolloClient</ExternalLink>            | -                                                |
 | `waitForApiTokens`                 | Returns a promise that is resolved when api tokens are found.                              | `timeout?: number`. Time in milliseconds when the Promise is rejected. If omitted, the promise will not timeout. | `Promise<void>`                                  |
-| [Table 40: GraphQL module methods] |
+| [Table 41: GraphQL module methods] |
 
 ##### Other exported utility functions
 
@@ -689,7 +715,7 @@ The following functions can be imported and used without the `GraphQL module` mo
 | `mergeQueryOptions`                          | Deep merges given queryOptions to another queryOptions object                                                     | `QueryOptions, QueryOptions`            | QueryOptions    |
 | `setBearerToQueryOptions`                    | Shortcut for calling `mergeAuthorizationHeaderToQueryOptions(options, 'Bearer: <token>')`.                        | `QueryOptions, string`                  | QueryOptions    |
 | `appendFetchOptions`                         | Appends fetchOptions to `queryOptions.context`.                                                                   | `QueryOptions, Partial<RequestInit>`    | QueryOptions    |
-| [Table 41: Other GraphQL module functions]   |
+| [Table 42: Other GraphQL module functions]   |
 
 </div>
 ##### State change signals
@@ -705,7 +731,7 @@ Returned errors are instances of the `GraphQLModuleError`. It is an extended Err
 | `GRAPHQL_LOAD_FAILED`                         | Query failed.                                                      | `error.isLoadError`            | `isGraphQLModuleLoadFailedSignal(signal) `       |
 | `GRAPHQL_NO_CLIENT`                           | Query failed, because client is not provided.                      | `error.isNoClientError`        | `isGraphQLModuleNoClientErrorSignal(signal) `    |
 | `GRAPHQL_NO_API_TOKENS`                       | Api tokens are required, but not found or fetching them timed out. | `error.isNoApiTokensError`     | `isGraphQLModuleNoApiTokensErrorSignal(signal) ` |
-| [Table 42: GraphQL module error signal types] |
+| [Table 43: GraphQL module error signal types] |
 
 ##### Event signals
 
@@ -717,7 +743,7 @@ The `GraphQL module` also emits events when an action is complete or starting.
 | `GRAPHQL_MODULE_LOAD_SUCCESS`                | Query was successful.   | `isGraphQLModuleLoadSuccessSignal(signal)` |
 | `GRAPHQL_MODULE_LOAD_ABORTED`                | Query was aborted.      | `isGraphQLModuleLoadAbortedSignal(signal)` |
 | `GRAPHQL_MODULE_CLEARED`                     | The module was cleared. | `isGraphQLModuleClearedSignal(signal)`     |
-| [Table 43: Other GraphQL module event types] |
+| [Table 44: Other GraphQL module event types] |
 
 ##### Dedicated signal triggers
 
@@ -728,7 +754,7 @@ Triggers for `GraphQL module`signals. These trigger signals only originated from
 | `triggerForAllGraphQLModuleErrors`  | `GraphQL module` namespace and type `error`.  |
 | `triggerForAllGraphQLModuleEvents`  | `GraphQL module` namespace and type `event`.  |
 | `triggerForAllGraphQLModuleSignals` | `GraphQL module` namespace.                   |
-| [Table 44: GraphQL module triggers] |
+| [Table 45: GraphQL module triggers] |
 
 Event triggers require the signal to have a `GraphQL module` namespace and type `event`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="event-signals-3">events</AnchorLink>.
@@ -739,7 +765,7 @@ Event triggers require the signal to have a `GraphQL module` namespace and type 
 | `graphQLModuleLoadAbortedTrigger`         | `payload.type` has a matching event.          |
 | `graphQLModuleLoadingTrigger`             | `payload.type` has a matching event.          |
 | `graphQLModuleLoadSuccessTrigger`         | `payload.type` has a matching event.          |
-| [Table 45: GraphQL module event triggers] |
+| [Table 46: GraphQL module event triggers] |
 
 Error triggers require the signal to have a `GraphQL module`namespace and type `error`.
 `Signal.payload.type` contains one of the <AnchorLink anchor="error-signal-types-3">errors</AnchorLink>.
@@ -749,7 +775,7 @@ Error triggers require the signal to have a `GraphQL module`namespace and type `
 | `loadFailedErrorTrigger`                  | `payload.type` has a matching error.          |
 | `noApiTokensErrorTrigger`                 | `payload.type` has a matching error.          |
 | `noClientErrorTrigger`                    | `payload.type` has a matching error.          |
-| [Table 46: GraphQL module error triggers] |
+| [Table 47: GraphQL module error triggers] |
 
 ##### Getting signal payloads
 
@@ -760,7 +786,67 @@ If the given signal is not from the `GraphQL module` or is not given type, the f
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `getGraphQLModuleErrorPayload`                    | `null` or <AnchorLink anchor="error-signal-types-3">GraphQLModuleError</AnchorLink> object. |
 | `getGraphQLModuleEventPayload`                    | `null` or `{type, data}`.                                                                   |
-| [Table 47: GraphQL module signal payload getters] |
+| [Table 48: GraphQL module signal payload getters] |
+
+#### ApolloClient Module
+
+Appending api tokens to every query and manually waiting for api token renewal is a complicated task. The ApolloClient module links itself to the Api token client and automatically appends tokens and also awaits for token renewals.
+
+The module can also be used without api tokens.
+
+This module does not emit signals.
+
+Unlike the `Api token client` and `Session Poller`, the `ApolloClient Module` must be manually added to the `<LoginProvider>`. Preferably use the <UsagePageAnchorLink>LoginProviderWithApolloContext</UsagePageAnchorLink> which also creates the `ApolloContext`.
+
+<PlaygroundPreview>
+
+```jsx
+import { createApolloClientModule } from 'hds-react';
+
+const options = {
+  clientOptions:{
+    // apollo client option.
+  },
+  tokenSetter: (headers, apiTokens) => {
+    return {
+      Authentication: apiTokens['tokenToAppend'],
+    };
+  },
+};
+const tokenizedFetchModule = createApolloClientModule(options);
+
+<LoginProviderWithApolloContext {...loginProps} modules={[ApolloClientModule]}></LoginProviderWithApolloContextx  >;
+```
+
+</PlaygroundPreview>
+
+The `createApolloClientModule` function is a Generic Typescript function: `createApolloClientModule<T = InMemoryCache>`. The generic describes the cache type of the ApolloClient and is not usually changed.
+
+##### Settings
+
+<div className="container-for-table-10-30-50-10">
+
+| Property                                 | Type                                                         | Description                                                                                                                                                                     | Default value |
+| ---------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `apiTokensWaitTime`                      | `number`                                                     | How long in milliseconds should api tokens be awaited before stopping the wait time. This will never reject any queries even if timeout is reached.                             | `15000`       |
+| `clientOptions`                          | `Partial<ApolloClientOptions>`                               | Options for the ApolloClient. If "uri" option is given, a HttpLink is automatically created from it. The module adds its own AplloLink(s) before other links.                   | -             |
+| `keepTokensWhileRenewing`                | `boolean`                                                    | If true, the stored api tokens are not cleared when renewal starts.                                                                                                             | `true`        |
+| `preventQueriesWhileRenewing`            | `boolean`                                                    | If true, a ApolloLink is added to wait for possible api token renewal to end. If false, there might be times when queries are made with old api tokens. Unlikely, but possible. | `true`        |
+| `tokenSetter`                            | `(headers:unknown,tokens:TokenData)=> Record<string,string>` | The returned object is appended to the headers. First argument type depends on the request. Can be an object or Headers.                                                        | -             |
+| [Table 49: ApolloClient module settings] |
+
+</div>
+
+##### Methods
+
+| Property                                | Description                           | Argument(s) | Return value      |
+| --------------------------------------- | ------------------------------------- | ----------- | ----------------- |
+| `getClient`                             | Returns the ApolloClient.             | -           | `ApolloClient`    |
+| `getTracker`                            | Returns the apiTokenClient tracker.   | -           | `ApiTokenTracker` |
+| `reset`                                 | Resets the client and apiTokenTracker | -           | `Promise<void>`   |
+| [Table 50: ApolloClient module methods] |
+
+The ApolloClient does not emit any signals. Therefore there are no hooks or triggers related to signals.
 
 #### Oidc client hooks
 
@@ -770,7 +856,7 @@ If the given signal is not from the `GraphQL module` or is not given type, the f
 | `useCachedAmr`                | Returns the user's `amr` value. It is cached because in some cases it must be decrypted from `id_token`.                                                          | `string[]`                                          |
 | `useOidcClient`               | Returns the `Oidc client`.                                                                                                                                        | `OidcClient`                                        |
 | `useOidcClientTracking`       | Returns an array of `[Signal, resetFunction, oidcClient instance]`. The hook forces the component using it to re-render each time the listener is triggered.      | `[Signal or undefined, ()=>void, OidcClient]`       |
-| [Table 48: Oidc client hooks] |
+| [Table 51: Oidc client hooks] |
 
 The usage of the `Oidc client` hooks is described in the <UsagePageAnchorLink anchor="useoidcclient">usage</UsagePageAnchorLink> section.
 
@@ -781,7 +867,7 @@ The usage of the `Oidc client` hooks is described in the <UsagePageAnchorLink an
 | `useApiTokens`                      | Returns functions for checking tokens and the status of renewal.                                                                                                  | `{getStoredApiTokens(), isRenewing()}`             |
 | `useApiTokensClient`                | Returns the `Api tokens client`.                                                                                                                                  | `ApiTokensClient`                                  |
 | `useApiTokensClientTracking`        | Returns an array of `[Signal, resetFunction, apiTokensClient instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[Signal or undefined, ()=>void, ApiTokensClient]` |
-| [Table 49: Api tokens client hooks] |
+| [Table 52: Api tokens client hooks] |
 
 The usage of the `Api tokens client` hooks is described in the <UsagePageAnchorLink anchor="useapitokensclient">usage</UsagePageAnchorLink> section.
 
@@ -791,7 +877,7 @@ The usage of the `Api tokens client` hooks is described in the <UsagePageAnchorL
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `useSessionPoller`               | Returns the `Session poller`.                                                                                                                                   | `SessionPoller`                                  |
 | `useSessionPollerTracking`       | Returns an array of `[Signal, resetFunction, sessionPoller instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[Signal or undefined, ()=>void, SessionPoller]` |
-| [Table 50: Session poller hooks] |
+| [Table 53: Session poller hooks] |
 
 The usage of the `Session poller` hooks is described in the <UsagePageAnchorLink anchor="usesessionpoller">usage</UsagePageAnchorLink> section.
 
@@ -802,9 +888,19 @@ The usage of the `Session poller` hooks is described in the <UsagePageAnchorLink
 | `useGraphQLModule`               | Returns the `GraphQL module`.                                                                                                                                                                                                                                                     | `GraphQLModule`                                     |
 | `useGraphQLModuleTracking`       | Returns `[Signal, resetFunction, GraphQL module instance]`. The hook forces the component using it to re-render each time the listener is triggered.                                                                                                                              | `[signal, reset function, GraphQL module instance]` |
 | `useGraphQL`                     | Mimics the <ExternalLink href="https://www.apollographql.com/docs/react/data/queries#manual-execution-with-uselazyquery">useLazyQuery</ExternalLink> hook of the Apollo GraphQL library. The hook forces the component using it to re-render each time the module emits a signal. | `[query, {data, error, loading, refetch}]`          |
-| [Table 51: GraphQL module hooks] |
+| [Table 54: GraphQL module hooks] |
 
 The usage of the `GraphQL module` hooks is described in the <UsagePageAnchorLink anchor="usegraphql">usage</UsagePageAnchorLink> section.
+
+#### ApolloClient module hooks
+
+| Hook                                  | Description                         | Return value         |
+| ------------------------------------- | ----------------------------------- | -------------------- |
+| `useApolloClientModule`               | Returns the `ApolloClient module`.  | `ApolloClientModule` |
+| `useApolloClient`                     | Returns the created `ApolloClient`. | `ApolloClient`       |
+| [Table 55: ApolloClient module hooks] |
+
+The usage of the `ApolloClient module` hooks is described in the <UsagePageAnchorLink anchor="useapolloclient">usage</UsagePageAnchorLink> section.
 
 #### Generic signal hooks
 
@@ -813,7 +909,7 @@ The usage of the `GraphQL module` hooks is described in the <UsagePageAnchorLink
 | `useSignalListener(listener)`                           | The listener function. There are no trigger props. The listener is always called when any signal is emitted in any namespace. The listener should return `true` if the component should re-render. | An array of `[Signal or undefined, ()=>void]`. Latter is a reset function that clears the signal and re-renders the component. |
 | `useSignalTrackingWithCallback(triggerProps, callback)` | Signal props need to match the incoming signal to trigger the callback function. The hook never causes a re-render. The callback must do it.                                                       | none                                                                                                                           |
 | `useSignalTrackingWithReturnValue(triggerProps)`        | Signal props need to match the incoming signal to trigger re-rendering. The hook creates a trigger from the props and re-renders if the trigger returns `true`.                                    | Same as above.                                                                                                                 |
-| [Table 52: Generic signal listener hooks]               |
+| [Table 56: Generic signal listener hooks]               |
 
 **Important!** The listener passed to `useSignalListener` must be memoized or the hook will attach a new listener on each render because the props changed. The old one is disposed of but to avoid unnecessary listeners, use memoization with `useMemo` or `useCallback`. Note that all `triggerFor...` functions are constants and do not need memoization.
 
@@ -836,7 +932,7 @@ Modules are added and connected by calling `beacon.addContext(module)`. The beac
 | `emit(signal)`                      | A signal to emit.                                                                              | none                                         |
 | `getAllSignalContextsAsObject()`    | Returns all stored contexts as on object of `{[context.namespace]:context}`.                   | `Object`                                     |
 | `getSignalContext(module)`          | Returns context for the given namespace.                                                       | Context module or `undefined`.               |
-| [Table 53: Beacon methods]          |
+| [Table 57: Beacon methods]          |
 
 ##### Important
 
@@ -856,7 +952,7 @@ A signal is an object with the following properties:
 | `namespace`                          | **Required**. The namespace is the name of the module that emitted the signal.                                                                                                              | `string`   |
 | `payload`                            | Optional. The payload contains metadata. For example type of the event. A payload can also be an Error object.                                                                              | unknown    |
 | `type`                               | **Required**. Type of the signal. Can be any string, but HDS emits `init`, `error`, `event` and `stateChange` signals.                                                                      | `string`   |
-| [Table 54: Signal object properties] |
+| [Table 58: Signal object properties] |
 
 ##### Signal types and payloads
 
@@ -866,7 +962,7 @@ A signal is an object with the following properties:
 | `event`                               | `eventSignalType`       | Usually `{type:event type}` indicating what kind of event is emitted. May also have `data` property containing for example User or Tokens. |
 | `init`                                | `initSignalType`        | Emitted when all modules are connected and everything is ready. Emitted only once. Note that modules may emit other signals before this.   |
 | `stateChange`                         | `stateChangeSignalType` | `{state, previousState}` New state and the previous state, if any.                                                                         |
-| [Table 55: Signal types and payloads] |
+| [Table 59: Signal types and payloads] |
 
 Custom modules may emit any other kind of signal with different payloads.
 
@@ -913,7 +1009,7 @@ Generic `create...` functions create trigger functions from given props. Creator
 | `createStateChangeTriggerProps(namespace, state, previousState)` | Namespace to listen to. Given state and previousState must also match. Both are optional. | all namespaces |
 | `createTriggerForAllNamespaces()`                                | Listens to all signals in any namespace.                                                  | none           |
 | `createTriggerPropsForAllSignals(namespace)`                     | Namespace to listen to. If omitted listens to all signals.                                | all namespaces |
-| [Table 56: Generic trigger creators]                             |
+| [Table 60: Generic trigger creators]                             |
 
 See also <AnchorLink anchor="hooks">hooks</AnchorLink>.
 
@@ -928,7 +1024,7 @@ Signals are easier to create with functions than by manually setting all propert
 | `createErrorSignal(namespace, payload)`                    | Creates an error signal with the given namespace and error payload.                |
 | `createEventSignal(namespace, payload)`                    | Creates an event signal with the given namespace and event payload.                |
 | `createStateChangeSignal(namespace, state, previousState)` | Creates a `stateChange` signal with the given namespace and `stateChange` payload. |
-| [Table 57: Generic signal creators]                        |
+| [Table 61: Generic signal creators]                        |
 
 ###### Check
 
@@ -941,7 +1037,7 @@ Check the signal type or namespace with these utilities.
 | `isEventSignal(signal)`                 | Returns true if the given signal is an event signal.        |
 | `isNamespacedSignal(signal, namespace)` | Returns true if the given signal has given namespace.       |
 | `isStateChangeSignal(signal)`           | Returns true if the given signal is a `stateChange` signal. |
-| [Table 58: Generic signal checks]       |
+| [Table 62: Generic signal checks]       |
 
 ###### Get payloads
 
@@ -952,7 +1048,7 @@ Returns signal payload if the signal type is a match.
 | `getErrorSignalPayload(signal)`       | Returns the payload if the given signal is an error signal. |
 | `getEventSignalPayload(signal)`       | Returns true if the given signal is an event signal.        |
 | `getStateChangeSignalPayload(signal)` | Returns true if the given signal is a `stateChange` signal. |
-| [Table 59: Generic payloads getters]  |
+| [Table 63: Generic payloads getters]  |
 
 ###### Convert and filter
 
@@ -960,7 +1056,7 @@ Returns signal payload if the signal type is a match.
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `convertSignalToTrigger(signal)`               | Removes the `context` from the signal if the property exists. The given signal is not mutated. |
 | `filterSignals(arrayOfSignals, matchingProps)` | Filters signals from the array. Returns signals which match given props.                       |
-| [Table 60: Convert and filter signals]         |
+| [Table 64: Convert and filter signals]         |
 
 ##### waitForSignals
 
@@ -982,7 +1078,7 @@ When the promise is resolved, it returns an array of received signals. If it is 
 | `options.allowSkipping`            | `boolean`  | If true, and triggers are in order A, B, C, D and signal "C" is received. "A", "B", "C" are all removed from the array and are not checked again. | `true`  |
 | `options.strictOrder`              | `boolean`  | If true, signals are not tracked in strict order. If true and signals are received in the wrong order, the promise is rejected.                   | `false` |
 | `options.rejectOn`                 | `Object[]` | Array of signals/signal props, which cause promise rejection, if a match is found.                                                                | none    |
-| [Table 61: waitForSignals utility] |
+| [Table 65: waitForSignals utility] |
 
 There is no timeout. The promise can be rejected by setting a custom signal type to `options.rejectOn` and emit a matching signal.
 

--- a/site/src/docs/components/login/index.mdx
+++ b/site/src/docs/components/login/index.mdx
@@ -30,7 +30,18 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
 
 ## Introduction
 
-HDS Login components include React context, components and hooks for handling user authorisation, API tokens, session polling and graphQL queries. React is not a requirement, but currently, no plain JavaScript UI components exist.
+HDS Login system is built on modular vanilla JavaScript and can handle every aspect of user authorization. It can be used with or without React. React version also includes a context, components and hooks.
+
+Current modules can handle
+
+- User authorisation with any OIDC server.
+- Exchange of user tokens to API tokens.
+- Creation of ApolloClient with auto-appended api tokens in query headers.
+- GraphQL queries with auto-appended api tokens in query headers.
+- Active session polling if user session is ended in other browsers or server side.
+- Addition of custom modules.
+
+Modules interact with emitted signals that can be listened like native events. React is not a requirement, but currently, no vanilla JavaScript UI components exist, but modules can be controlled with any interactive elements.
 
 Implementation requires an OIDC provider, which is a server for user authorization. The City of Helsinki uses Helsinki Profile, but HDS login components can be used with any compatible OIDC provider. Read more about <ExternalLink href="https://auth0.com/intro-to-iam/what-is-openid-connect-oidc">OpenID Connect (OIDC)</ExternalLink>.
 
@@ -113,18 +124,20 @@ HDS Login hooks enable to
 - Add listeners.
 - Login and logout.
 - Get API tokens.
+- Use API tokens in requests.
 - Get modules.
 
 Detailed documentation is in the <UsagePageAnchorLink anchor="oidc-client-hooks">hooks section</UsagePageAnchorLink> of the <UsagePageAnchorLink anchor="usage">Usage page</UsagePageAnchorLink>.
 
 ### Modules
 
-There are four modules to handle the user's needs:
+There are five modules to handle different scenarios:
 
 - <UsagePageAnchorLink>Oidc client</UsagePageAnchorLink> for user data.
 - <UsagePageAnchorLink>Api tokens client</UsagePageAnchorLink> for acquiring backend tokens.
 - <UsagePageAnchorLink>Session poller</UsagePageAnchorLink> for checking if the user's session is still valid at the Oidc
   provider.
+- <UsagePageAnchorLink>ApolloClient module</UsagePageAnchorLink> to provide the client and auto-append api tokens to queries.
 - <UsagePageAnchorLink>GraphQL module</UsagePageAnchorLink> for fetching data from a graphQL server. Fetching can be automatically
   linked to the Api Tokens client.
 
@@ -146,6 +159,11 @@ This module exchanges the user's tokens for API tokens. API tokens are used for 
 
 This module polls the user's session from the Oidc provider and signals an error if polling returns an unauthorized response. If you have logged in with the same user in multiple browser windows, this module detects when the user is logged out in any browser window.
 
+#### ApolloClient module
+
+This module creates a client with middleware and provides the client to all modules and also to all components in the Login Context including ApolloClient's hooks. The module can wait for api tokens and automatically append them to headers.
+When ApolloClient's own hooks are used, the ApolloContext is not automatically created unless the <UsagePageAnchorLink anchor="modules">LoginProviderWithApolloContext</UsagePageAnchorLink> component is used. The context can also be created manually by picking the ApolloClient with <ApiPageAnchorLink href="apolloclient-module-hooks">hooks</ApiPageAnchorLink>.
+
 #### GraphQL module
 
 This module was added to make it easier to use the login system with authenticated graphQL queries. The GraphQL module waits for api tokens and automatically picks a token and uses it in queries.
@@ -166,8 +184,6 @@ Detailed information is in the <UsagePageAnchorLink anchor="signals">signals sec
 
 Every service must have its own `client_id` and `scope`, but these settings can be used for testing.
 They only work in `http://localhost:3000`. Make sure you have `redirect_uri`, `silent_redirect_uri` and `post_logout_redirect_uri` registered at the OIDC server.
-
-GraphQL module is not automatically added, but <ApiPageAnchorLink anchor="graphql-module">it's setup is simple</ApiPageAnchorLink>.
 
 ```js
 const loginProviderProps: LoginProviderProps = {
@@ -207,3 +223,6 @@ const loginProviderProps: LoginProviderProps = {
   sessionPollerSettings: { pollIntervalInMs: 10000 },
 };
 ```
+
+GraphQL module is not automatically added, but <ApiPageAnchorLink anchor="graphql-module">it's setup is simple</ApiPageAnchorLink>.
+ApolloClient is not automatically added either, but <ApiPageAnchorLink anchor="apolloclient-module">it's setup is simple</ApiPageAnchorLink>.

--- a/site/src/docs/components/login/tabs.mdx
+++ b/site/src/docs/components/login/tabs.mdx
@@ -20,8 +20,8 @@ import StatusLabel from '../../../components/StatusLabel';
 </div>
 
 <LeadParagraph>
-  Login components include React components, context and hooks for handling user authorisation, api tokens, session
-  polling and GraphQL queries.
+  Login components include React components, context and hooks for handling user authorisation, api tokens and
+  authorized requests.
 </LeadParagraph>
 
 <PageTabs pageContext={props.pageContext}>

--- a/site/src/docs/components/login/usage.mdx
+++ b/site/src/docs/components/login/usage.mdx
@@ -29,6 +29,7 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>LoginButton</AnchorLink>
   - <AnchorLink>LoginCallbackHandler</AnchorLink>
   - <AnchorLink>LoginProvider</AnchorLink>
+  - <AnchorLink>LoginProviderWithApolloContext</AnchorLink>
   - <AnchorLink>SessionEndedHandler</AnchorLink>
   - <AnchorLink>WithAuthentication</AnchorLink>
   - <AnchorLink>WithAuthenticatedUser</AnchorLink>
@@ -41,24 +42,29 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>useOidcClient</AnchorLink>
   - <AnchorLink>useOidcClientTracking</AnchorLink>
 
-- <AnchorLink>Api tokens client hooks</AnchorLink>{' '}
+- <AnchorLink>Api tokens client hooks</AnchorLink>
 
   - <AnchorLink>useApiTokens</AnchorLink>
   - <AnchorLink>useApiTokensClient</AnchorLink>
   - <AnchorLink>useApiTokensClientTracking</AnchorLink>
 
-- <AnchorLink>Session poller hooks</AnchorLink>{' '}
+- <AnchorLink>Session poller hooks</AnchorLink>
 
   - <AnchorLink>useSessionPoller</AnchorLink>
   - <AnchorLink>useSessionPollerTracking</AnchorLink>
 
-- <AnchorLink>GraphQL module hooks</AnchorLink>{' '}
+- <AnchorLink>GraphQL module hooks</AnchorLink>
 
   - <AnchorLink>useGraphQLModule</AnchorLink>
   - <AnchorLink>useGraphQLModuleTracking</AnchorLink>
   - <AnchorLink>useGraphQL</AnchorLink>
 
-- <AnchorLink>Generic signal hooks</AnchorLink>{' '}
+- <AnchorLink>ApolloClient module hooks</AnchorLink>
+
+  - <AnchorLink>useApolloClientModule</AnchorLink>
+  - <AnchorLink>useApolloClient</AnchorLink>
+
+- <AnchorLink>Generic signal hooks</AnchorLink>
 
   - <AnchorLink>useSignalListener</AnchorLink>
   - <AnchorLink>useSignalTrackingWithCallback</AnchorLink>
@@ -69,6 +75,7 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>Oidc Client</AnchorLink>
   - <AnchorLink>Api tokens client</AnchorLink>
   - <AnchorLink>Session poller</AnchorLink>
+  - <AnchorLink>ApolloClient module</AnchorLink>
   - <AnchorLink>GraphQL module</AnchorLink>
 
 - <AnchorLink>Silent renewal</AnchorLink>
@@ -190,6 +197,10 @@ const MyApp = () => {
 </PlaygroundPreview>
 
 All component properties are listed on the <ApiPageAnchorLink anchor="loginprovider">API page</ApiPageAnchorLink>.
+
+#### LoginProviderWithApolloContext
+
+This works like the <AnchorLink>LoginProvider</AnchorLink> and it also creates the `<ApolloContext>` so all ApolloClient's hooks work. The component requires the ApolloClient module is passed in the `modules` property.
 
 #### SessionEndedHandler
 
@@ -384,6 +395,20 @@ const SessionPollerHooks = () => {
 ```
 
 </PlaygroundPreview>
+
+### ApolloClient module hooks
+
+More detailed information about <AnchorLink>ApolloClient module</AnchorLink> hooks are listed on the <ApiPageAnchorLink anchor="apolloclient-module">API page</ApiPageAnchorLink>.
+
+#### useApolloClientModule
+
+Returns the <AnchorLink>ApolloClient module</AnchorLink>.
+
+#### useApolloClient
+
+Returns the ApolloClient.
+
+The ApolloClient does not emit any signals. Therefore there are no hooks related to signals.
 
 ### GraphQL module hooks
 
@@ -656,6 +681,31 @@ All `GraphQL module` settings, properties, methods and signals are detailed on t
 - <AnchorLink>useGraphQL</AnchorLink>
 
 Detailed information about these hooks is listed on the <ApiPageAnchorLink anchor="graphql-module-hooks">API page</ApiPageAnchorLink>.
+
+#### ApolloClient module
+
+Appending api tokens to every query and manually waiting for api token renewal are a complicated tasks. The ApolloClient module links itself to the Api token client and automatically appends tokens and also awaits for token renewals.
+
+The module can also be used without api tokens.
+
+##### Requirements
+
+The module requires at least the same properties as the ApolloClient it creates.
+
+##### API
+
+All `ApolloClient module` settings, properties, methods and signals are detailed on the API page:
+
+- <ApiPageAnchorLink anchor="settings-3">Module settings</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="methods-3">Methods</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="other-exported-utility-functions-3">Utility functions</ApiPageAnchorLink>.
+
+##### Hooks
+
+- <AnchorLink>useApolloClientModule</AnchorLink>
+- <AnchorLink>useApolloClient</AnchorLink>
+
+Detailed information about these hooks is listed on the <ApiPageAnchorLink anchor="apolloclient-module-hooks">API page</ApiPageAnchorLink>.
 
 #### Silent renewal
 


### PR DESCRIPTION
## Description

Projects using the HDS Login had to manually pick and append api tokens to graphql queries. That is not easy when the ApolloClient is not part of the Login.

Added the ApolloClient as module. The client uses given "tokenSetter" function that adds tokens to ApolloQueries.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2539](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2539)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [ x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2539]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ