### PR TITLE
hds-2553: tokenized fetch

### DIFF
--- a/packages/react/src/components/login/tokenizedFetch/hooks.test.tsx
+++ b/packages/react/src/components/login/tokenizedFetch/hooks.test.tsx
@@ -1,0 +1,398 @@
+/* eslint-disable jest/no-mocks-import */
+import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock';
+import React, { useEffect, useRef } from 'react';
+import { isObject } from 'lodash';
+import { act, fireEvent, waitFor } from '@testing-library/react';
+
+import HttpStatusCode from '../../../utils/httpStatusCode';
+import { ConnectedModule, Signal } from '../beacon/beacon';
+import { isErrorSignal } from '../beacon/signals';
+import { createConnectedBeaconModule, createTestListenerModule } from '../testUtils/beaconTestUtil';
+import { createControlledFetchMockUtil } from '../testUtils/fetchMockTestUtil';
+import { createTokenizedFetchModule } from './tokenizedFetch';
+import {
+  useTokenizedFetch,
+  useTokenizedFetchModule,
+  useTokenizedFetchResponseTracking,
+  useTokenizedFetchTracking,
+  useTokenizedFetchWithSignals,
+} from './hooks';
+import { HookTestUtil, createHookTestEnvironment } from '../testUtils/hooks.testUtil';
+import { TokenizedFetchModule, tokenizedFetchModuleNamespace } from '.';
+import { isTokenizedFetchStartedSignal } from './signals';
+import { TokenizedFetchError } from './tokenizedFetchError';
+
+const elementIds = {
+  namespaceElement: 'namespace-element',
+  lastSignalElementPrefix: 'last-signal-element-',
+  renderCountElementPrefix: 'render-count-element-',
+  loadingElementPrefix: 'is-loading-',
+  errorElementPrefix: 'error-element-',
+  loadButtonElementPrefix: 'loading-button-',
+  notUpdatingRenderCount: 'not-updating-render-count',
+  lastSignalType: 'last-signal-type',
+  lastErrorMessage: 'last-error-message',
+} as const;
+
+type ResponseType = { returnedStatus: HttpStatusCode; data?: unknown | null; error?: Error };
+type UsedSignals = 'signalA' | 'signalXyz' | 'signalNever' | 'generic';
+let testUtil: HookTestUtil;
+const url = '/path';
+
+describe(`tokenizedFetchModule`, () => {
+  const createSuccessResponse = (response = 'ok'): ResponseType => {
+    return { returnedStatus: HttpStatusCode.OK, data: { response } };
+  };
+
+  const errorResponse: ResponseType = {
+    returnedStatus: HttpStatusCode.SERVICE_UNAVAILABLE,
+    error: new Error('Failed'),
+  };
+  const { cleanUp, setResponders, addResponse } = createControlledFetchMockUtil([{ path: url }]);
+
+  let currentModule: TokenizedFetchModule;
+  let listenerModule: ReturnType<typeof createConnectedBeaconModule>;
+
+  const RenderCountIndicator = ({ id }: { id: string }) => {
+    const instanceRenderCountRef = useRef(1);
+    useEffect(() => {
+      instanceRenderCountRef.current += 1;
+    });
+    return <span id={id}>{instanceRenderCountRef.current}</span>;
+  };
+
+  const SignalOutput = ({ id, signal }: { id: string; signal: Signal | undefined | null }) => {
+    const { type, payload } =
+      signal && typeof signal === 'object' && !isErrorSignal(signal) ? signal : { payload: undefined, type: undefined };
+    return (
+      <span key="signal" id={id}>
+        {JSON.stringify({ type, payload })}
+      </span>
+    );
+  };
+  const ErrorOutput = ({ id, signal }: { id: string; signal: Signal | undefined | null }) => {
+    const error = signal && isErrorSignal(signal) ? (signal?.payload as TokenizedFetchError) : null;
+    const { identifier, originalError } = error || { type: undefined, originalError: undefined };
+    return (
+      <span key="signal" id={id}>
+        {JSON.stringify({ type: identifier, message: originalError ? originalError.message : '' })}
+      </span>
+    );
+  };
+
+  const IsLoadingOutput = ({ id, signal }: { id: string; signal: Signal | undefined | null }) => {
+    const isLoading = signal && isTokenizedFetchStartedSignal(signal);
+    return (
+      <span key="signal" id={id}>
+        {isLoading ? 1 : 0}
+      </span>
+    );
+  };
+
+  const ModuleOutput = () => {
+    const tokenizedFetchModule = useTokenizedFetchModule();
+    return (
+      <div>
+        <span key="namespace" id={elementIds.namespaceElement}>
+          {tokenizedFetchModule.namespace}
+        </span>
+        <RenderCountIndicator id={elementIds.notUpdatingRenderCount} />
+      </div>
+    );
+  };
+
+  const GenericListener = () => {
+    const event = 'generic';
+    const module = useTokenizedFetchModule();
+    const [signal] = useTokenizedFetchTracking();
+    const tokenizedFetch = useTokenizedFetch();
+    const load = async () => {
+      module.emitFetchStart(event);
+      await module
+        .emitResponse(
+          tokenizedFetch(url).then((r) => {
+            return r.json();
+          }),
+          event,
+        )
+        .catch(jest.fn());
+    };
+
+    return (
+      <div>
+        <SignalOutput id={`${elementIds.lastSignalElementPrefix}${event}`} signal={signal} />
+        <ErrorOutput id={`${elementIds.errorElementPrefix}${event}`} signal={signal} />
+        <IsLoadingOutput id={`${elementIds.loadingElementPrefix}${event}`} signal={signal} />
+        <ErrorOutput id={`${elementIds.errorElementPrefix}${event}`} signal={signal} />
+        <RenderCountIndicator id={`${elementIds.renderCountElementPrefix}${event}`} />
+        <button key="load" id={`${elementIds.loadButtonElementPrefix}${event}`} type="button" onClick={() => load()}>
+          LOAD
+        </button>
+      </div>
+    );
+  };
+
+  const Listener = ({ event }: { event: UsedSignals }) => {
+    const [signal] = useTokenizedFetchResponseTracking(event);
+    const tokenizedFetchWithSignals = useTokenizedFetchWithSignals();
+    const load = () => {
+      tokenizedFetchWithSignals(event, url);
+    };
+    return (
+      <div>
+        <SignalOutput id={`${elementIds.lastSignalElementPrefix}${event}`} signal={signal} />
+        <IsLoadingOutput id={`${elementIds.loadingElementPrefix}${event}`} signal={signal} />
+        <ErrorOutput id={`${elementIds.errorElementPrefix}${event}`} signal={signal} />
+        <RenderCountIndicator id={`${elementIds.renderCountElementPrefix}${event}`} />
+        <button key="load" id={`${elementIds.loadButtonElementPrefix}${event}`} type="button" onClick={() => load()}>
+          LOAD
+        </button>
+      </div>
+    );
+  };
+
+  const TokenizedFetchModuleCheck = () => {
+    return (
+      <div>
+        <ModuleOutput />
+        <Listener event="signalA" />
+        <Listener event="signalXyz" />
+        <Listener event="signalNever" />
+        <GenericListener />
+      </div>
+    );
+  };
+
+  const App = () => {
+    return <TokenizedFetchModuleCheck key="mod" />;
+  };
+
+  const initTests = ({ responses }: { responses: ResponseType[] }) => {
+    responses.forEach((response) => {
+      addResponse(
+        response.error || {
+          status: response.returnedStatus,
+          body: response.data ? JSON.stringify(response.data) : undefined,
+        },
+      );
+    });
+    currentModule = createTokenizedFetchModule({ tokenSetter: () => ({}) });
+
+    listenerModule = createTestListenerModule(tokenizedFetchModuleNamespace, 'tokenizedFetchModuleListener');
+
+    const modules: ConnectedModule[] = [currentModule, listenerModule];
+
+    testUtil = createHookTestEnvironment(
+      {
+        waitForRenderToggle: false,
+        children: [<App key="app" />],
+        noOidcClient: true,
+      },
+      {},
+      modules,
+    );
+    const getSignalTypeAndPayload = (signalType: UsedSignals) => {
+      return testUtil.getElementJSON(`${elementIds.lastSignalElementPrefix}${signalType}`);
+    };
+    const getSignalErrorTypeAndMessage = (signalType: UsedSignals) => {
+      return testUtil.getElementJSON(`${elementIds.errorElementPrefix}${signalType}`);
+    };
+    const getIsLoading = (signalType: UsedSignals) => {
+      return testUtil.getInnerHtml(`${elementIds.loadingElementPrefix}${signalType}`) === '1';
+    };
+    const getRenderCount = (signalType: UsedSignals) => {
+      return parseInt(testUtil.getInnerHtml(`${elementIds.renderCountElementPrefix}${signalType}`), 10);
+    };
+    const getFetchButton = (signalType: UsedSignals) => {
+      return testUtil.getElementById(`${elementIds.loadButtonElementPrefix}${signalType}`);
+    };
+
+    const waitForReturnValueChange = async (func: () => unknown, advanceTime = 0) => {
+      const current = func();
+      const compareObjects = isObject(current);
+      await waitFor(() => {
+        if (advanceTime) {
+          jest.advanceTimersByTime(advanceTime);
+        }
+        const newValue = func();
+        if (compareObjects && isObject(newValue)) {
+          expect(newValue).not.toMatchObject(current as object);
+        } else if (newValue === current) {
+          throw new Error('Same value');
+        }
+      });
+    };
+
+    const waitForIsLoadingChange = async (signalType: UsedSignals, advanceTime = 0) => {
+      await waitForReturnValueChange(() => getIsLoading(signalType), advanceTime);
+    };
+
+    const waitForRenderCountChange = async (signalType: UsedSignals, advanceTime = 0) => {
+      await waitForReturnValueChange(() => getRenderCount(signalType), advanceTime);
+    };
+
+    const waitForSignalTypeAndPayloadChange = async (signalType: UsedSignals, advanceTime = 0) => {
+      await waitForReturnValueChange(() => getSignalTypeAndPayload(signalType), advanceTime);
+    };
+
+    const waitForValue = async (func: () => unknown, advanceTime = 0, expectedValue: unknown) => {
+      await waitFor(() => {
+        if (advanceTime) {
+          jest.advanceTimersByTime(advanceTime);
+        }
+        const value = func();
+        if (value !== expectedValue) {
+          throw new Error(`Not correct value. Expected ${expectedValue}, but got ${value}`);
+        }
+      });
+    };
+
+    const waitForIsLoadingToMatch = async (signalType: UsedSignals, isLoading: boolean, advanceTime = 0) => {
+      await waitForValue(() => getIsLoading(signalType), advanceTime, isLoading);
+    };
+
+    const startFetch = async (signalType: UsedSignals, advanceTime = 0) => {
+      await waitForIsLoadingToMatch(signalType, false, advanceTime);
+      act(() => {
+        fireEvent.click(getFetchButton(signalType));
+      });
+      await waitForIsLoadingToMatch(signalType, true, advanceTime);
+    };
+
+    return {
+      ...testUtil,
+      getIsLoading,
+      waitForIsLoadingChange,
+      waitForIsLoadingToMatch,
+      waitForSignalTypeAndPayloadChange,
+      waitForRenderCountChange,
+      getSignalErrorTypeAndMessage,
+      getRenderCount,
+      getFetchButton,
+      startFetch,
+      getSignalTypeAndPayload,
+    };
+  };
+
+  const initResponder = () => {
+    setResponders([{ path: url }]);
+  };
+
+  // ApolloClient emits errors when cached data is invalid. That does not matter in these tests.
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    enableFetchMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    initResponder();
+  });
+
+  afterEach(async () => {
+    await cleanUp();
+    if (currentModule) {
+      act(() => {
+        currentModule.reset();
+      });
+    }
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('Components using hook render properly', async () => {
+    const { getInnerHtml, getRenderCount, getSignalErrorTypeAndMessage, getSignalTypeAndPayload } = initTests({
+      responses: [],
+    });
+    expect(getInnerHtml(elementIds.namespaceElement)).toBe(tokenizedFetchModuleNamespace);
+    expect(getRenderCount('generic')).toBe(1);
+    expect(getRenderCount('signalA')).toBe(1);
+    expect(getRenderCount('signalXyz')).toBe(1);
+    expect(getRenderCount('signalNever')).toBe(1);
+    expect(getSignalErrorTypeAndMessage('generic')).toMatchObject({ message: '' });
+    expect(getSignalTypeAndPayload('generic')).toMatchObject({});
+  });
+  it('Fetch re-renders only components listening to that signal', async () => {
+    const {
+      startFetch,
+      getRenderCount,
+      waitForSignalTypeAndPayloadChange,
+      getSignalTypeAndPayload,
+      waitForIsLoadingChange,
+      waitForIsLoadingToMatch,
+      getSignalErrorTypeAndMessage,
+    } = initTests({
+      responses: [
+        createSuccessResponse('ok'),
+        createSuccessResponse('ok 2'),
+        createSuccessResponse('ok 3'),
+        errorResponse,
+        errorResponse,
+      ],
+    });
+    await startFetch('generic');
+    expect(getRenderCount('generic')).toBe(2);
+    expect(getRenderCount('signalA')).toBe(1);
+    expect(getRenderCount('signalXyz')).toBe(1);
+    expect(getRenderCount('signalNever')).toBe(1);
+    await waitForSignalTypeAndPayloadChange('generic');
+    expect(getSignalTypeAndPayload('generic').payload.data).toMatchObject({ response: 'ok' });
+    expect(getRenderCount('generic')).toBe(3);
+    expect(getRenderCount('signalA')).toBe(1);
+    expect(getRenderCount('signalXyz')).toBe(1);
+    expect(getRenderCount('signalNever')).toBe(1);
+
+    await startFetch('signalA');
+    // 4=start+end+start+end, listens to all signals
+    expect(getRenderCount('generic')).toBe(4);
+    expect(getRenderCount('signalA')).toBe(2);
+    expect(getRenderCount('signalXyz')).toBe(1);
+    expect(getRenderCount('signalNever')).toBe(1);
+    await waitForSignalTypeAndPayloadChange('signalA');
+    expect(getSignalTypeAndPayload('signalA').payload.data).toMatchObject({ response: 'ok 2' });
+    // generic renders after every signal
+    expect(getSignalTypeAndPayload('generic').payload.data).toMatchObject({ response: 'ok 2' });
+    expect(getRenderCount('generic')).toBe(5);
+    expect(getRenderCount('signalA')).toBe(3);
+    expect(getRenderCount('signalXyz')).toBe(1);
+    expect(getRenderCount('signalNever')).toBe(1);
+
+    await startFetch('signalXyz');
+    // 6= 3x start+end
+    expect(getRenderCount('generic')).toBe(6);
+    expect(getRenderCount('signalA')).toBe(3);
+    expect(getRenderCount('signalXyz')).toBe(2);
+    expect(getRenderCount('signalNever')).toBe(1);
+    await waitForSignalTypeAndPayloadChange('signalXyz');
+    expect(getSignalTypeAndPayload('signalXyz').payload.data).toMatchObject({ response: 'ok 3' });
+    expect(getSignalTypeAndPayload('generic').payload.data).toMatchObject({ response: 'ok 3' });
+    expect(getSignalTypeAndPayload('signalA').payload.data).toMatchObject({ response: 'ok 2' });
+    expect(getRenderCount('generic')).toBe(7);
+    expect(getRenderCount('signalA')).toBe(3);
+    expect(getRenderCount('signalXyz')).toBe(3);
+    expect(getRenderCount('signalNever')).toBe(1);
+
+    await startFetch('signalXyz');
+    await waitForIsLoadingChange('signalXyz');
+    await startFetch('signalA');
+    await waitForIsLoadingToMatch('signalXyz', false);
+    await waitForIsLoadingToMatch('signalA', false);
+    expect(getSignalErrorTypeAndMessage('signalA')).toMatchObject({ message: 'Failed', type: 'signalA' });
+    expect(getSignalErrorTypeAndMessage('signalXyz')).toMatchObject({ message: 'Failed', type: 'signalXyz' });
+    expect(getSignalErrorTypeAndMessage('signalNever')).toMatchObject({ message: '' });
+    expect(getRenderCount('signalA')).toBe(5);
+    expect(getRenderCount('signalXyz')).toBe(5);
+    expect(getRenderCount('signalNever')).toBe(1);
+    expect(getSignalTypeAndPayload('signalXyz')).toMatchObject({});
+    expect(getSignalTypeAndPayload('generic')).toMatchObject({});
+    expect(getSignalTypeAndPayload('signalA')).toMatchObject({});
+  });
+});

--- a/packages/react/src/components/login/tokenizedFetch/hooks.tsx
+++ b/packages/react/src/components/login/tokenizedFetch/hooks.tsx
@@ -1,0 +1,52 @@
+import { Signal } from '../beacon/beacon';
+import { useConnectedModule, useSignalTrackingWithReturnValue } from '../beacon/hooks';
+import { TokenizedFetchModule, tokenizedFetchModuleNamespace } from './index';
+import { createTriggerPropsForTokenizedFetchResponseSignals, triggerForAllTokenizedFetchSignals } from './signals';
+
+/**
+ * Returns the TokenizedFetch module.
+ */
+export const useTokenizedFetchModule = (): TokenizedFetchModule => {
+  const tokenizedFetchModule = useConnectedModule<TokenizedFetchModule>(tokenizedFetchModuleNamespace);
+  if (!tokenizedFetchModule) {
+    throw new Error('Cannot find tokenizedFetchModule from LoginContext.');
+  }
+  return tokenizedFetchModule;
+};
+
+/**
+ * Returns the tokenizedFetch function.
+ */
+export const useTokenizedFetch = (): TokenizedFetchModule['tokenizedFetch'] => {
+  const tokenizedFetchModule = useTokenizedFetchModule();
+  return tokenizedFetchModule.tokenizedFetch;
+};
+
+/**
+ * Returns the tokenizedFetchWithSignals function.
+ */
+export const useTokenizedFetchWithSignals = (): TokenizedFetchModule['tokenizedFetchWithSignals'] => {
+  const tokenizedFetchModule = useTokenizedFetchModule();
+  return tokenizedFetchModule.tokenizedFetchWithSignals;
+};
+
+/**
+ * Renders the component each time the TokenizedFetchModule emits
+ */
+export const useTokenizedFetchTracking = (): [Signal | undefined, () => void, TokenizedFetchModule] => {
+  const tokenizedFetchModule = useTokenizedFetchModule();
+  return [...useSignalTrackingWithReturnValue(triggerForAllTokenizedFetchSignals), tokenizedFetchModule];
+};
+
+/**
+ * Renders the component each time the TokenizedFetchModule emits given responseIdentifier
+ */
+export const useTokenizedFetchResponseTracking = (
+  responseIdentifier: string,
+): [Signal | undefined, () => void, TokenizedFetchModule] => {
+  const tokenizedFetchModule = useTokenizedFetchModule();
+  return [
+    ...useSignalTrackingWithReturnValue(createTriggerPropsForTokenizedFetchResponseSignals(responseIdentifier)),
+    tokenizedFetchModule,
+  ];
+};

--- a/packages/react/src/components/login/tokenizedFetch/index.ts
+++ b/packages/react/src/components/login/tokenizedFetch/index.ts
@@ -1,0 +1,92 @@
+import { TokenData } from '../apiTokensClient';
+import { ApiTokenClientTracker } from '../apiTokensClient/createApiTokenClientTracker';
+import { ApolloClientModuleProps } from '../apolloClient/index';
+import { ConnectedModule } from '../beacon/beacon';
+import { appendAbortSignal, isAbortError } from '../utils/abortFetch';
+
+export type HeaderContent = Headers | Record<string, string>;
+export type FetchParameters = Parameters<typeof fetch>;
+export type FetchReturnType = ReturnType<typeof fetch>;
+
+export type TokenizedFetchModule = ConnectedModule & {
+  /**
+   * Proxy to the native fetch() function. Headers returned from the optional tokenSetter are appended to the Headers passed as args.
+   */
+  tokenizedFetch: (...args: FetchParameters) => FetchReturnType;
+  /**
+   * Calls the tokenizedFetch, but also emits start and end signals.
+   * If fetch fails, an error signal is emitted. Aborted requests are emitted as event signals.
+   * Abort and start signals can be distinguished from actual response signal with the signal.payload.data.
+   * The data includes boolean property "wasFetchAborted" or "wasFetchStarted" if the signal is either.
+   * Simplest way to check signals, is to use functions "isTokenizedFetchStartedSignal(signal)" or "isTokenizedFetchAbortedSignal(signal)".
+   * Signals can also be manually emitted with "emitResponse(promise.then(resp=>resp.json()))" and "emitFetchStart()" functions.
+   * Automatic response handling uses response.json() to parse response from data.
+   * If the data is not json, do not use automation. Use "emitResponse(promise.then(<your parse function>))".
+   */
+  tokenizedFetchWithSignals: (autoEmitSignalType: string, ...args: FetchParameters) => FetchReturnType;
+  /**
+   * Returns the apiTokenClient tracker.
+   */
+  getTracker: () => ApiTokenClientTracker;
+  /**
+   * Emits reset signal and resets the apiTokenTracker.
+   */
+  reset: () => void;
+  /**
+   * Utility to test was the returned error an AbortError.
+   */
+  isAbortError: typeof isAbortError;
+  /**
+   * The promise returned from tokenizedFetch can be passed to this function
+   * which will emit the results as event signals or error signals. When successful the emitted signal is
+   * {
+   *    type: eventSignalType,
+   *    payload: {
+   *        data: Response,
+   *        type: responseIdentifier
+   *    },
+   *    nameSpace: tokenizedFetchModuleNamespace,
+   *    context:tokenizedFetchModule
+   * }
+   * Aborted fetches are emitted also as event signals where payload.type = ${responseIdentifier}_ABORTED.
+   * Failed fetches are emitted also as error signals.
+   *
+   * Example: const results = tokenizedFetchModule.emitResponse(tokenizedFetchModule.fetch().then(resp=>resp.json()));
+   */
+  emitResponse: (promise: Promise<Response>, responseIdentifier: string) => Promise<Response>;
+  /**
+   * Emits a signal where payload.type = ${responseIdentifier}_STARTED.
+   */
+  emitFetchStart: (responseIdentifier: string) => void;
+  /**
+   * Adds abort signal to FetchInit props and returns a function that will abort the request.
+   */
+  addAbortSignal: typeof appendAbortSignal;
+};
+
+export type TokenizedFetchModuleProps = Omit<ApolloClientModuleProps, 'clientOptions' | 'tokenSetter'> & {
+  /**
+   * If true, the tokenizedFetch() will wait for possible api token renewal to end.
+   * If false, there might be times when queries are made with old api tokens. Unlikely, but possible.
+   * Default true.
+   */
+  preventQueriesWhileRenewing?: boolean;
+  /**
+   * Function to return tokens appended to the headers
+   * @param headers Current headers in the request
+   * @param tokens All tokens from the apiTokenClient
+   */
+  tokenSetter?: (headers: HeaderContent, tokens: TokenData) => HeaderContent;
+};
+
+export const tokenizedFetchModuleEvents = {
+  TOKENIZED_FETCH_MODULE_RESET: 'TOKENIZED_FETCH_MODULE_RESET',
+} as const;
+
+export type TokenizedFetchModuleEvent = keyof typeof tokenizedFetchModuleEvents;
+
+export const tokenizedFetchModuleNamespace = 'tokenizedFetch';
+
+export const defaultOptions: Partial<TokenizedFetchModuleProps> = {
+  preventQueriesWhileRenewing: true,
+};

--- a/packages/react/src/components/login/tokenizedFetch/signals.test.ts
+++ b/packages/react/src/components/login/tokenizedFetch/signals.test.ts
@@ -1,0 +1,175 @@
+import { tokenizedFetchModuleNamespace } from '.';
+import { createTriggerPropsForAllSignals, errorSignalType, EventPayload, eventSignalType } from '../beacon/signals';
+import {
+  createAbortSignalData,
+  createStartSignalData,
+  createTriggerPropsForAllTokenizedFetchSignals,
+  createTriggerPropsForTokenizedFetchResponseSignals,
+  triggerForAllTokenizedFetchEvents,
+  triggerForAllTokenizedFetchSignals,
+  triggerForAllTokenizedFetchErrors,
+  isTokenizedFetchAbortedSignal,
+  isTokenizedFetchModuleSignal,
+  isTokenizedFetchStartedSignal,
+  getTokenizedFetchModuleErrorPayload,
+  getTokenizedFetchModuleEventPayload,
+  getTokenizedFetchPayloadData,
+} from './signals';
+import { TokenizedFetchError } from './tokenizedFetchError';
+import { oidcClientNamespace } from '../client';
+import { createTokenizedFetchModule } from './tokenizedFetch';
+import { Signal } from '../beacon/beacon';
+
+describe(`signals`, () => {
+  const eventData = { response: 'ok' };
+  const module = createTokenizedFetchModule({});
+  const createTokenizedFetchModuleEventSignal = ({ type, data }: EventPayload): Signal => {
+    return {
+      type: eventSignalType,
+      namespace: tokenizedFetchModuleNamespace,
+      payload: {
+        type,
+        data,
+      },
+      context: module,
+    };
+  };
+
+  const createTokenizedFetchModuleErrorSignal = (error: TokenizedFetchError) => {
+    const signal = createTokenizedFetchModuleEventSignal({ type: '' });
+    signal.type = errorSignalType;
+    signal.payload = error;
+    return signal;
+  };
+
+  describe(`isTokenizedFetchModuleSignal`, () => {
+    it(`returns true when signal.namespace equals tokenizedFetchModuleNamespace`, () => {
+      expect(
+        isTokenizedFetchModuleSignal({ type: eventSignalType, namespace: tokenizedFetchModuleNamespace }),
+      ).toBeTruthy();
+      expect(isTokenizedFetchModuleSignal({ type: 'any', namespace: tokenizedFetchModuleNamespace })).toBeTruthy();
+      expect(isTokenizedFetchModuleSignal({ type: '', namespace: tokenizedFetchModuleNamespace })).toBeTruthy();
+      expect(isTokenizedFetchModuleSignal({ namespace: tokenizedFetchModuleNamespace })).toBeTruthy();
+    });
+    it(`returns false when signal.namespace does not equal tokenizedFetchModuleNamespace`, () => {
+      expect(isTokenizedFetchModuleSignal({ type: eventSignalType, namespace: oidcClientNamespace })).toBeFalsy();
+      expect(isTokenizedFetchModuleSignal({ type: errorSignalType, namespace: 'any' })).toBeFalsy();
+      expect(isTokenizedFetchModuleSignal({ namespace: '' })).toBeFalsy();
+      expect(isTokenizedFetchModuleSignal(createTriggerPropsForAllSignals())).toBeFalsy();
+    });
+  });
+
+  describe(`event signal functions`, () => {
+    describe(`getTokenizedFetchModuleEventPayload`, () => {
+      it(`Returns signal's payload, if signal is an event signal`, () => {
+        const payload = { type: 'type', data: eventData };
+        const signal = createTokenizedFetchModuleEventSignal(payload);
+        expect(getTokenizedFetchModuleEventPayload(signal)).toEqual(payload);
+        expect(getTokenizedFetchModuleEventPayload({ ...signal, type: errorSignalType })).toBeNull();
+        expect(getTokenizedFetchModuleEventPayload({})).toBeNull();
+      });
+    });
+    describe(`getTokenizedFetchPayloadData`, () => {
+      it(`Returns signal's payload, if signal is an event signal`, () => {
+        const payload = { type: 'type', data: eventData };
+        const signal = createTokenizedFetchModuleEventSignal(payload);
+        expect(getTokenizedFetchPayloadData(signal)).toEqual(payload.data);
+        expect(getTokenizedFetchPayloadData({ ...signal, type: errorSignalType })).toEqual(payload.data);
+        expect(getTokenizedFetchPayloadData({ ...signal, namespace: oidcClientNamespace })).toBeNull();
+        expect(getTokenizedFetchPayloadData({})).toBeNull();
+      });
+    });
+    describe(`getTokenizedFetchModuleErrorPayload`, () => {
+      it(`Returns signal's payload, if signal is an error signal`, () => {
+        const error = new TokenizedFetchError('ups');
+        const signal = createTokenizedFetchModuleErrorSignal(error);
+        expect(getTokenizedFetchModuleErrorPayload(signal)).toEqual(error);
+        expect(getTokenizedFetchModuleErrorPayload({ ...signal, type: eventSignalType })).toBeNull();
+        expect(getTokenizedFetchModuleErrorPayload({})).toBeNull();
+        expect(getTokenizedFetchModuleErrorPayload(createTokenizedFetchModuleEventSignal({ type: 'ups' }))).toBeNull();
+      });
+    });
+  });
+  describe(`Abort signals`, () => {
+    it(`isTokenizedFetchAbortedSignal identifies signal with createAbortSignalData()`, () => {
+      const payload = { type: 'type', data: createAbortSignalData() };
+      const signal = createTokenizedFetchModuleEventSignal(payload);
+      expect(isTokenizedFetchAbortedSignal(signal)).toBeTruthy();
+      expect(isTokenizedFetchAbortedSignal({ ...signal, payload: { data: {} } })).toBeFalsy();
+      expect(isTokenizedFetchAbortedSignal({})).toBeFalsy();
+      expect(
+        isTokenizedFetchAbortedSignal(
+          createTokenizedFetchModuleEventSignal({ type: 'type', data: createStartSignalData() }),
+        ),
+      ).toBeFalsy();
+    });
+    it(`isTokenizedFetchStartedSignal identifies signal with createStartSignalData()`, () => {
+      const payload = { type: 'type', data: createStartSignalData() };
+      const signal = createTokenizedFetchModuleEventSignal(payload);
+      expect(isTokenizedFetchStartedSignal(signal)).toBeTruthy();
+      expect(isTokenizedFetchStartedSignal({ ...signal, payload: { data: {} } })).toBeFalsy();
+      expect(isTokenizedFetchStartedSignal({})).toBeFalsy();
+      expect(
+        isTokenizedFetchStartedSignal(
+          createTokenizedFetchModuleEventSignal({ type: 'type', data: createAbortSignalData() }),
+        ),
+      ).toBeFalsy();
+    });
+  });
+  describe(`Start signals`, () => {
+    it(`isTokenizedFetchStartedSignal identifies signal with createStartSignalData()`, () => {
+      const payload = { type: 'type', data: createStartSignalData() };
+      const signal = createTokenizedFetchModuleEventSignal(payload);
+      expect(isTokenizedFetchStartedSignal(signal)).toBeTruthy();
+      expect(isTokenizedFetchStartedSignal({ ...signal, payload: { data: {} } })).toBeFalsy();
+      expect(isTokenizedFetchStartedSignal({})).toBeFalsy();
+      expect(
+        isTokenizedFetchStartedSignal(
+          createTokenizedFetchModuleEventSignal({ type: 'type', data: createAbortSignalData() }),
+        ),
+      ).toBeFalsy();
+    });
+  });
+  describe(`Triggers match events`, () => {
+    it(`triggerForAllTokenizedFetchErrors returns true if signal.type and payload.type matches`, () => {
+      const signal = createTokenizedFetchModuleErrorSignal(new TokenizedFetchError('ups'));
+      expect(triggerForAllTokenizedFetchErrors(signal)).toBeTruthy();
+      expect(createTriggerPropsForAllTokenizedFetchSignals()).toBeTruthy();
+      expect(triggerForAllTokenizedFetchErrors({ ...signal, payload: undefined })).toBeTruthy();
+      expect(triggerForAllTokenizedFetchErrors({ ...signal, type: eventSignalType })).toBeFalsy();
+      expect(triggerForAllTokenizedFetchErrors({ ...signal, namespace: oidcClientNamespace })).toBeFalsy();
+      expect(triggerForAllTokenizedFetchErrors({})).toBeFalsy();
+    });
+    it(`triggerForAllTokenizedFetchEvents returns true if signal.type and payload.type matches`, () => {
+      const signal = createTokenizedFetchModuleEventSignal({ type: undefined });
+      expect(triggerForAllTokenizedFetchEvents(signal)).toBeTruthy();
+      expect(createTriggerPropsForAllTokenizedFetchSignals()).toBeTruthy();
+      expect(triggerForAllTokenizedFetchEvents({ ...signal, payload: undefined })).toBeTruthy();
+      expect(triggerForAllTokenizedFetchEvents({ ...signal, type: errorSignalType })).toBeFalsy();
+      expect(triggerForAllTokenizedFetchErrors({ ...signal, namespace: oidcClientNamespace })).toBeFalsy();
+      expect(triggerForAllTokenizedFetchEvents({})).toBeFalsy();
+    });
+    it(`triggerForAllTokenizedFetchSignals returns true if signal namespace matches`, () => {
+      const signal = createTokenizedFetchModuleEventSignal({ type: undefined });
+      expect(triggerForAllTokenizedFetchSignals(signal)).toBeTruthy();
+      expect(createTriggerPropsForAllTokenizedFetchSignals()).toBeTruthy();
+      expect(triggerForAllTokenizedFetchSignals({ ...signal, payload: undefined })).toBeTruthy();
+      expect(triggerForAllTokenizedFetchSignals({ ...signal, type: errorSignalType })).toBeTruthy();
+      expect(triggerForAllTokenizedFetchSignals({ ...signal, namespace: oidcClientNamespace })).toBeFalsy();
+      expect(triggerForAllTokenizedFetchSignals({})).toBeFalsy();
+    });
+    it(`createTriggerPropsForTokenizedFetchResponseSignals matches only if signal and its payload.typs matches`, () => {
+      const responseType = 'fetchX';
+      const trigger = createTriggerPropsForTokenizedFetchResponseSignals(responseType);
+      const signal = createTokenizedFetchModuleEventSignal({ type: responseType });
+      const mismatchingSignal = createTokenizedFetchModuleEventSignal({ type: 'wrong' });
+      expect(trigger(signal)).toBeTruthy();
+      expect(trigger(mismatchingSignal)).toBeFalsy();
+      expect(trigger({ ...signal, payload: undefined })).toBeFalsy();
+      expect(trigger(createTokenizedFetchModuleErrorSignal(new TokenizedFetchError('ups')))).toBeFalsy();
+      expect(trigger({ ...signal, type: errorSignalType })).toBeFalsy();
+      expect(trigger({ ...signal, namespace: oidcClientNamespace })).toBeFalsy();
+      expect(trigger({})).toBeFalsy();
+    });
+  });
+});

--- a/packages/react/src/components/login/tokenizedFetch/signals.ts
+++ b/packages/react/src/components/login/tokenizedFetch/signals.ts
@@ -1,0 +1,99 @@
+import { tokenizedFetchModuleNamespace } from '.';
+import { Signal, SignalTrigger, SignalTriggerProps, createSignalTrigger } from '../beacon/beacon';
+import {
+  isNamespacedSignal,
+  createTriggerPropsForAllSignals,
+  EventPayload,
+  getEventSignalPayload,
+  createErrorTriggerProps,
+  createEventTriggerProps,
+  getErrorSignalPayload,
+  EventSignal,
+  isErrorSignal,
+} from '../beacon/signals';
+import { TokenizedFetchError } from './tokenizedFetchError';
+
+export function isTokenizedFetchModuleSignal(signal: Signal) {
+  return isNamespacedSignal(signal, tokenizedFetchModuleNamespace);
+}
+
+export function getTokenizedFetchModuleEventPayload(signal: Signal): EventPayload | null {
+  return isTokenizedFetchModuleSignal(signal) ? (getEventSignalPayload(signal) as EventPayload) : null;
+}
+
+export function getTokenizedFetchModuleErrorPayload(signal: Signal): Error | null {
+  return isTokenizedFetchModuleSignal(signal) ? (getErrorSignalPayload(signal) as Error) : null;
+}
+
+export function getTokenizedFetchPayloadData<T = unknown>(signal: Signal): T | null {
+  if (!isTokenizedFetchModuleSignal(signal)) {
+    return null;
+  }
+  const { payload } = signal as EventSignal;
+  const data = payload && payload.data;
+  return (data as T) || null;
+}
+
+/**
+ *  Start / abort signal handling
+ */
+
+export function createStartSignalData(): { wasFetchStarted: boolean } {
+  return { wasFetchStarted: true };
+}
+
+export function createAbortSignalData(): { wasFetchAborted: boolean } {
+  return { wasFetchAborted: true };
+}
+
+export function isTokenizedFetchStartedSignal(signal: Signal): boolean {
+  const data = getTokenizedFetchPayloadData<ReturnType<typeof createStartSignalData>>(signal);
+  return !!(data && data.wasFetchStarted);
+}
+
+export function isTokenizedFetchAbortedSignal(signal: Signal): boolean {
+  const data = getTokenizedFetchPayloadData<ReturnType<typeof createAbortSignalData>>(signal);
+  return !!(data && data.wasFetchAborted);
+}
+
+/**
+ *  trigger creators
+ */
+
+export function createTriggerPropsForAllTokenizedFetchSignals(): SignalTriggerProps {
+  return createTriggerPropsForAllSignals(tokenizedFetchModuleNamespace);
+}
+
+export function createTriggerPropsForTokenizedFetchResponseSignals(responseIdentifier: string): SignalTrigger {
+  return (signal) => {
+    if (!isTokenizedFetchModuleSignal(signal)) {
+      return false;
+    }
+    if (isErrorSignal(signal)) {
+      const payload = getErrorSignalPayload(signal) as TokenizedFetchError;
+      return !!(
+        payload &&
+        payload.hasResponseIdentifierMatch &&
+        payload.hasResponseIdentifierMatch(responseIdentifier)
+      );
+    }
+    const payload = getEventSignalPayload(signal);
+    return !!(payload && payload.type === responseIdentifier);
+  };
+}
+
+/**
+ * Triggers
+ */
+
+export const triggerForAllTokenizedFetchSignals: SignalTrigger = createSignalTrigger(
+  createTriggerPropsForAllTokenizedFetchSignals(),
+);
+
+export const triggerForAllTokenizedFetchEvents: SignalTrigger = createSignalTrigger(
+  createEventTriggerProps(tokenizedFetchModuleNamespace),
+);
+
+export const triggerForAllTokenizedFetchErrors: SignalTrigger = createSignalTrigger(
+  createErrorTriggerProps(tokenizedFetchModuleNamespace),
+);

--- a/packages/react/src/components/login/tokenizedFetch/tokenizedFetch.test.ts
+++ b/packages/react/src/components/login/tokenizedFetch/tokenizedFetch.test.ts
@@ -1,0 +1,565 @@
+import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock';
+
+import { Beacon, createBeacon } from '../beacon/beacon';
+import { emitInitializationSignals, EventPayload, eventSignalType } from '../beacon/signals';
+import { createControlledFetchMockUtil, getLastFetchMockCallArguments } from '../testUtils/fetchMockTestUtil';
+import { apiTokensClientEvents, apiTokensClientNamespace, TokenData } from '../apiTokensClient';
+import { advanceUntilPromiseResolved } from '../testUtils/timerTestUtil';
+import { getLastMockCallArgs } from '../../../utils/testHelpers';
+import { mergeHeaders, createTokenizedFetchModule } from './tokenizedFetch';
+import { TokenizedFetchModule, tokenizedFetchModuleNamespace, TokenizedFetchModuleProps } from '.';
+import { createApiTokenClient } from '../apiTokensClient/apiTokensClient';
+import {
+  createConnectedBeaconModule,
+  createTestListenerModule,
+  getReceivedErrorSignalPayloads,
+  getReceivedEventSignalPayloads,
+} from '../testUtils/beaconTestUtil';
+import HttpStatusCode from '../../../utils/httpStatusCode';
+import {
+  createAbortSignalData,
+  createStartSignalData,
+  createTriggerPropsForAllTokenizedFetchSignals,
+  createTriggerPropsForTokenizedFetchResponseSignals,
+  isTokenizedFetchAbortedSignal,
+  isTokenizedFetchStartedSignal,
+  triggerForAllTokenizedFetchErrors,
+} from './signals';
+
+type ResponseType = { status: HttpStatusCode; data?: unknown | null; error?: Error };
+
+describe(`tokenizedFetchModule`, () => {
+  const defaultApiTokens: TokenData = { token1: 'token1Value', token2: 'token2Value' };
+  const uri = '/query';
+  const {
+    cleanUp,
+    setResponders,
+    addResponse,
+    getResponseListenerCallCount,
+    getRequestCount,
+    waitUntilRequestStarted,
+  } = createControlledFetchMockUtil([{ path: uri }]);
+
+  let currentModule: TokenizedFetchModule;
+  let currentBeacon: Beacon;
+  let apiTokenStorage: TokenData | null = null;
+  let listenerModule: ReturnType<typeof createConnectedBeaconModule>;
+
+  const getLastQueryHeaders = () => {
+    return getLastFetchMockCallArguments()[1].headers;
+  };
+
+  const createTokenSetter = (extraParams?: TokenData): TokenizedFetchModuleProps['tokenSetter'] => {
+    return jest.fn().mockImplementation((headers, tokens) => {
+      return {
+        ...tokens,
+        ...extraParams,
+      };
+    });
+  };
+
+  // @ts-ignore is for complaints about Object.fromEntries
+  const headersToObject = (headers: Headers) => Object.fromEntries(headers);
+
+  const initTests = ({
+    apiTokens,
+    moduleOptions = {},
+    responses,
+  }: {
+    apiTokens?: TokenData;
+    moduleOptions?: Partial<TokenizedFetchModuleProps>;
+    responses?: ResponseType[];
+  }) => {
+    if (!responses) {
+      addResponse({ status: HttpStatusCode.OK, body: JSON.stringify({ response: 'good' }) });
+    } else {
+      responses.forEach((response) => {
+        addResponse(
+          response.error || {
+            status: response.status,
+            body: response.data ? JSON.stringify(response.data) : undefined,
+          },
+        );
+      });
+    }
+
+    currentModule = createTokenizedFetchModule(moduleOptions);
+    apiTokenStorage = apiTokens || defaultApiTokens;
+    const apiTokensClient = createApiTokenClient({ url: '/does-not-matter' });
+    jest.spyOn(apiTokensClient, 'getTokens').mockImplementation(() => {
+      return apiTokenStorage;
+    });
+    listenerModule = createTestListenerModule('*', 'listenerModule');
+    currentBeacon = createBeacon();
+    currentBeacon.addSignalContext(apiTokensClient);
+    currentBeacon.addSignalContext(currentModule);
+    currentBeacon.addSignalContext(listenerModule);
+
+    // initialize all modules
+    emitInitializationSignals(currentBeacon);
+  };
+
+  // helpers for emitting api token signals
+  const emitApiTokensClientStateChange = (payload: EventPayload) => {
+    currentBeacon.emit({ type: eventSignalType, namespace: apiTokensClientNamespace, payload });
+  };
+
+  const emitApiTokensUpdatedStateChange = (tokens: TokenData) => {
+    apiTokenStorage = tokens;
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_UPDATED, data: tokens };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  const emitApiTokensRemovedStateChange = () => {
+    apiTokenStorage = null;
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_REMOVED };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  const emitApiTokensRenewalStart = () => {
+    apiTokenStorage = null;
+    const payload: EventPayload = { type: apiTokensClientEvents.API_TOKENS_RENEWAL_STARTED };
+    emitApiTokensClientStateChange(payload);
+  };
+
+  beforeAll(() => {
+    enableFetchMocks();
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setResponders([{ path: uri }]);
+  });
+
+  afterEach(async () => {
+    jest.advanceTimersByTime(100000);
+    if (currentModule) {
+      const promise = currentModule.getTracker().waitForApiTokens();
+      await advanceUntilPromiseResolved(promise);
+      currentModule.reset();
+    }
+    await cleanUp();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    if (currentBeacon) {
+      currentBeacon.clear();
+    }
+    apiTokenStorage = null;
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+  });
+  describe(`mergeHeaders`, () => {
+    it('Returns a Header instance if first param is a Header instance', async () => {
+      const originalHeaders = { key1: 'value2', smallCaps: '1' };
+      const headerObj = { key2: 'value2', anotherKey: '1', 'x-auth': 'auth' };
+      const headers = new Headers(originalHeaders);
+      expect(headersToObject(mergeHeaders(headers, headerObj) as Headers)).toEqual({
+        key1: 'value2',
+        smallcaps: '1',
+        key2: 'value2',
+        anotherkey: '1',
+        'x-auth': 'auth',
+      });
+      expect(mergeHeaders(headers, headerObj) instanceof Headers).toBeTruthy();
+    });
+    it('Returns an object if first param is an object', async () => {
+      const originalHeaders = { key1: 'value2', notSmallCaps: '1' };
+      const headerObj = { key2: 'value2', anotherKey: '1', 'x-auth': 'auth' };
+      expect(mergeHeaders(originalHeaders, headerObj)).toEqual({
+        key1: 'value2',
+        notSmallCaps: '1',
+        key2: 'value2',
+        anotherKey: '1',
+        'x-auth': 'auth',
+      });
+      expect(mergeHeaders(originalHeaders, headerObj) instanceof Headers).toBeFalsy();
+
+      const headers = new Headers(headerObj);
+      expect(mergeHeaders(originalHeaders, headers)).toEqual({
+        key1: 'value2',
+        notSmallCaps: '1',
+        key2: 'value2',
+        anotherKey: '1',
+        'x-auth': 'auth',
+      });
+      expect(mergeHeaders(originalHeaders, headers) instanceof Headers).toBeFalsy();
+    });
+  });
+  describe(`When created`, () => {
+    it('The module is created and current tokens exist in the tracker.', async () => {
+      initTests({});
+      expect(currentModule.getTracker().getTokens()).toMatchObject(defaultApiTokens);
+    });
+  });
+  describe(`tokenSetter`, () => {
+    it('The token setter is called and headers are appended.', async () => {
+      const tokenSetter = createTokenSetter({ extraHeader: 'extraHeader' });
+
+      initTests({
+        moduleOptions: { tokenSetter },
+      });
+      const promise = currentModule.tokenizedFetch(uri);
+
+      await advanceUntilPromiseResolved(promise);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      const headers = getLastQueryHeaders();
+      expect(headers).toMatchObject({
+        extraHeader: 'extraHeader',
+        ...defaultApiTokens,
+      });
+    });
+  });
+  describe(`on-going api token renewal`, () => {
+    it('Delays the query until tokens are renewed and new tokens are used.', async () => {
+      const tokenSetter = createTokenSetter();
+      initTests({
+        moduleOptions: { tokenSetter },
+      });
+      emitApiTokensRenewalStart();
+      const tracker = currentModule.getTracker();
+      const renewalPromiseTracker = jest.fn();
+      // the renewalPromise returns false, if timed out
+      tracker.waitForApiTokens().then(renewalPromiseTracker);
+      const promise = currentModule.tokenizedFetch(uri);
+      jest.advanceTimersByTime(10000);
+      const updatedTokens = { tokenx: 'tokenx', tokeny: 'tokeny' };
+      emitApiTokensUpdatedStateChange(updatedTokens);
+      await advanceUntilPromiseResolved(promise);
+      expect(renewalPromiseTracker).toHaveBeenCalledWith(true);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      const headers = getLastQueryHeaders();
+      expect(headers).toMatchObject({
+        ...updatedTokens,
+      });
+    });
+    it('If renewal is timed out, the query is executed anyway.', async () => {
+      const tokenSetter = createTokenSetter();
+      initTests({
+        moduleOptions: { tokenSetter, keepTokensWhileRenewing: false },
+      });
+      emitApiTokensRenewalStart();
+      const tracker = currentModule.getTracker();
+      const renewalPromiseTracker = jest.fn();
+      // the renewalPromise returns false, if timed out
+      tracker.waitForApiTokens().then(renewalPromiseTracker);
+      const promise = currentModule.tokenizedFetch(uri);
+
+      await advanceUntilPromiseResolved(promise);
+      expect(renewalPromiseTracker).toHaveBeenCalledWith(false);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      const headers = getLastQueryHeaders();
+      expect(headers.token1).toBeUndefined();
+      expect(headers.token2).toBeUndefined();
+      expect(getRequestCount()).toBe(1);
+      expect(getResponseListenerCallCount()).toBe(1);
+    });
+  });
+  describe(`fetch can be aborted`, () => {
+    it('Type of failure can be checked with currentModule.isAbortError', async () => {
+      const tokenSetter = createTokenSetter();
+      const rejectCatcher = jest.fn();
+
+      initTests({
+        moduleOptions: { tokenSetter },
+      });
+      expect(getRequestCount()).toBe(0);
+      expect(getResponseListenerCallCount()).toBe(0);
+      const props = {};
+      const abort = currentModule.addAbortSignal(props);
+      const promise = currentModule.tokenizedFetch(uri, props).catch(rejectCatcher);
+      await waitUntilRequestStarted();
+      jest.advanceTimersByTime(500);
+
+      abort();
+      await advanceUntilPromiseResolved(promise);
+      expect(tokenSetter).toHaveBeenCalledTimes(1);
+      expect(currentModule.isAbortError(getLastMockCallArgs(rejectCatcher)[0])).toBeTruthy();
+    });
+  });
+  describe(`Fetched results can be emitted with emitResponse()`, () => {
+    it('Resolved results are emitted data as event signals', async () => {
+      const tokenSetter = createTokenSetter();
+      const successSignal = 'successSignal';
+      initTests({
+        moduleOptions: { tokenSetter },
+      });
+      const promise = currentModule.emitResponse(
+        currentModule.tokenizedFetch(uri).then((r) => r.json()),
+        successSignal,
+      );
+      await advanceUntilPromiseResolved(promise);
+      const payloads = getReceivedEventSignalPayloads(listenerModule);
+      const successPayload = payloads.filter((p) => p.type === successSignal)[0];
+      expect(successPayload).toMatchObject({ data: { response: 'good' } });
+    });
+    it('Aborted results are emitted data as event signals', async () => {
+      const tokenSetter = createTokenSetter();
+      const successSignal = 'successSignal';
+      initTests({
+        moduleOptions: { tokenSetter },
+      });
+      const props = {};
+      const abort = currentModule.addAbortSignal(props);
+      const promise = currentModule.emitResponse(
+        currentModule.tokenizedFetch(uri, props).then((r) => r.json()),
+        successSignal,
+      );
+      abort();
+      await advanceUntilPromiseResolved(promise);
+      const payloads = getReceivedEventSignalPayloads(listenerModule);
+      const abortPayload = payloads.filter((payload) =>
+        isTokenizedFetchAbortedSignal({ namespace: tokenizedFetchModuleNamespace, payload }),
+      )[0];
+      expect(abortPayload).toMatchObject({ data: createAbortSignalData() });
+    });
+    it('Failed requests are emitted data as error signals', async () => {
+      const tokenSetter = createTokenSetter();
+      const successSignal = 'successSignal';
+      initTests({
+        moduleOptions: { tokenSetter },
+        responses: [
+          {
+            status: HttpStatusCode.SERVICE_UNAVAILABLE,
+            error: new Error('Failed'),
+          },
+        ],
+      });
+      const promise = currentModule.emitResponse(
+        currentModule.tokenizedFetch(uri).then((r) => r.json()),
+        successSignal,
+      );
+      await advanceUntilPromiseResolved(promise);
+      expect(getReceivedErrorSignalPayloads(listenerModule)).toHaveLength(1);
+    });
+    it('tokenizedFetchWithSignals() triggers signals as request progresses', async () => {
+      const tokenSetter = createTokenSetter();
+      const autoEmitSignalType = 'autoEmitSignalType';
+      initTests({
+        moduleOptions: { tokenSetter, preventQueriesWhileRenewing: false },
+        responses: [
+          {
+            status: HttpStatusCode.SERVICE_UNAVAILABLE,
+            error: new Error('Failed'),
+          },
+          { status: HttpStatusCode.OK, data: { response: 'good response' } },
+          { status: HttpStatusCode.OK, data: { response: 'good response' } },
+        ],
+      });
+      const errorPromise = currentModule.tokenizedFetchWithSignals(autoEmitSignalType, uri).catch(jest.fn());
+      await advanceUntilPromiseResolved(errorPromise);
+      const startPayload = getReceivedEventSignalPayloads(listenerModule).filter((payload) =>
+        isTokenizedFetchStartedSignal({ namespace: tokenizedFetchModuleNamespace, payload }),
+      )[0];
+      expect(startPayload).toMatchObject({ data: createStartSignalData() });
+
+      expect(getReceivedErrorSignalPayloads(listenerModule)).toHaveLength(1);
+
+      const successPromise = currentModule.tokenizedFetchWithSignals(autoEmitSignalType, uri);
+      await advanceUntilPromiseResolved(successPromise);
+      const payloads = getReceivedEventSignalPayloads(listenerModule);
+      // 3 = start + start + result:
+      expect(payloads).toHaveLength(3);
+      const successPayload = payloads.filter((payload) =>
+        isTokenizedFetchStartedSignal({ namespace: tokenizedFetchModuleNamespace, payload }),
+      )[1];
+      expect(successPayload).toMatchObject({ data: createStartSignalData() });
+      expect(payloads[2]).toMatchObject({ data: { response: 'good response' } });
+
+      const props = {};
+      const abort = currentModule.addAbortSignal(props);
+      const abortedPromise = currentModule.tokenizedFetchWithSignals(autoEmitSignalType, uri, props);
+      abort();
+      await advanceUntilPromiseResolved(abortedPromise);
+      expect(getReceivedErrorSignalPayloads(listenerModule)).toHaveLength(1);
+      const latestPayloads = getReceivedEventSignalPayloads(listenerModule);
+      // 5 = start + start + result + start + abort:
+      expect(latestPayloads).toHaveLength(5);
+      const abortPayload = latestPayloads.filter((payload) =>
+        isTokenizedFetchAbortedSignal({ namespace: tokenizedFetchModuleNamespace, payload }),
+      )[0];
+      expect(abortPayload).toMatchObject({ data: createAbortSignalData() });
+    });
+    it('Emitted signals trigger only events with certain payload.types and errors.', async () => {
+      const tokenSetter = createTokenSetter();
+      initTests({
+        moduleOptions: { tokenSetter, preventQueriesWhileRenewing: false },
+        responses: [
+          { status: HttpStatusCode.OK, data: { response: 'good response1' } },
+          { status: HttpStatusCode.OK, data: { response: 'good response2' } },
+          { status: HttpStatusCode.OK, data: { response: 'good response3' } },
+          { status: HttpStatusCode.OK, data: { response: 'good response4' } },
+          {
+            status: HttpStatusCode.SERVICE_UNAVAILABLE,
+            error: new Error('Failed'),
+          },
+          {
+            status: HttpStatusCode.SERVICE_UNAVAILABLE,
+            error: new Error('Failed'),
+          },
+        ],
+      });
+
+      const signalA = 'signalA';
+      const listenerForSignalA = jest.fn();
+      currentBeacon.addListener(createTriggerPropsForTokenizedFetchResponseSignals(signalA), listenerForSignalA);
+
+      const errorListener = jest.fn();
+      currentBeacon.addListener(triggerForAllTokenizedFetchErrors, errorListener);
+
+      const signalXX = 'signalXX';
+      const listenerForSignalXX = jest.fn();
+      currentBeacon.addListener(createTriggerPropsForTokenizedFetchResponseSignals(signalXX), listenerForSignalXX);
+
+      const listenerForAllSignals = jest.fn();
+      currentBeacon.addListener(createTriggerPropsForAllTokenizedFetchSignals(), listenerForAllSignals);
+
+      const notUsedSignal = 'notUsedSignal';
+      const listenerForNeverTriggered = jest.fn();
+      currentBeacon.addListener(
+        createTriggerPropsForTokenizedFetchResponseSignals(notUsedSignal),
+        listenerForNeverTriggered,
+      );
+
+      await advanceUntilPromiseResolved(currentModule.tokenizedFetchWithSignals(signalA, uri));
+
+      // 2 = start + end
+      expect(listenerForSignalA).toHaveBeenCalledTimes(2);
+      expect(listenerForSignalXX).toHaveBeenCalledTimes(0);
+
+      await advanceUntilPromiseResolved(currentModule.tokenizedFetchWithSignals(signalXX, uri));
+      await advanceUntilPromiseResolved(currentModule.tokenizedFetchWithSignals(signalXX, uri));
+      expect(listenerForSignalA).toHaveBeenCalledTimes(2);
+      expect(listenerForSignalXX).toHaveBeenCalledTimes(4);
+
+      await advanceUntilPromiseResolved(currentModule.tokenizedFetchWithSignals(signalA, uri));
+      expect(listenerForSignalA).toHaveBeenCalledTimes(4);
+      expect(listenerForSignalXX).toHaveBeenCalledTimes(4);
+
+      await advanceUntilPromiseResolved(currentModule.tokenizedFetchWithSignals(signalA, uri));
+      expect(listenerForSignalA).toHaveBeenCalledTimes(6);
+      expect(listenerForSignalXX).toHaveBeenCalledTimes(4);
+      expect(errorListener).toHaveBeenCalledTimes(1);
+
+      await advanceUntilPromiseResolved(currentModule.tokenizedFetchWithSignals(signalXX, uri));
+      expect(listenerForSignalA).toHaveBeenCalledTimes(6);
+      expect(listenerForSignalXX).toHaveBeenCalledTimes(6);
+      expect(errorListener).toHaveBeenCalledTimes(2);
+
+      expect(listenerForAllSignals).toHaveBeenCalledTimes(12);
+      expect(listenerForNeverTriggered).toHaveBeenCalledTimes(0);
+    });
+  });
+  describe(`Multiple fetches work.`, () => {
+    it('Resolved results are emitted data as event signals', async () => {
+      const tokenSetter = createTokenSetter();
+      const successSignal = 'successSignal';
+      const responseCatcher = jest.fn();
+      const responses = [
+        { status: HttpStatusCode.OK, data: { response: 'good response' } },
+        { status: HttpStatusCode.OK, data: { response: 'good response 2' } },
+        {
+          status: HttpStatusCode.SERVICE_UNAVAILABLE,
+          error: new Error('Failed'),
+        },
+        {
+          status: HttpStatusCode.SERVICE_UNAVAILABLE,
+          error: new Error('Failed2'),
+        },
+        { status: HttpStatusCode.OK, data: { response: 'good response 3' } },
+        { status: HttpStatusCode.OK, data: { response: 'renew first response' } },
+        {
+          status: HttpStatusCode.SERVICE_UNAVAILABLE,
+          error: new Error('Failed3'),
+        },
+        { status: HttpStatusCode.OK, data: { response: 'good response 4' } },
+      ];
+      initTests({
+        moduleOptions: { tokenSetter, keepTokensWhileRenewing: false },
+        responses,
+      });
+
+      const executeFetch = async ({ abort, renewTokens }: { abort?: boolean; renewTokens?: TokenData } = {}) => {
+        const props = {};
+        const abortFn = abort ? currentModule.addAbortSignal(props) : undefined;
+
+        if (renewTokens) {
+          emitApiTokensRenewalStart();
+        }
+
+        const promise = currentModule
+          .tokenizedFetch(uri, props)
+          .then(async (r) => {
+            const json = await r.json();
+            responseCatcher(json);
+            return r;
+          })
+          .catch((e) => {
+            responseCatcher(e);
+            return e;
+          });
+        currentModule.emitResponse(
+          promise.then((r) => {
+            return r.json();
+          }),
+          successSignal,
+        );
+        if (abortFn) {
+          abortFn();
+        }
+        if (renewTokens) {
+          jest.advanceTimersByTime(10000);
+          emitApiTokensUpdatedStateChange(renewTokens);
+        }
+        await advanceUntilPromiseResolved(promise);
+        return promise;
+      };
+
+      await executeFetch();
+      expect(responseCatcher).toHaveBeenLastCalledWith(responses[0].data);
+
+      await executeFetch();
+      expect(responseCatcher).toHaveBeenLastCalledWith(responses[1].data);
+
+      await executeFetch({ abort: true });
+      expect(currentModule.isAbortError(getLastMockCallArgs(responseCatcher)[0])).toBeTruthy();
+
+      await executeFetch();
+      expect(getLastMockCallArgs(responseCatcher)[0].message).toBe(responses[2]?.error?.message);
+
+      await executeFetch();
+      expect(getLastMockCallArgs(responseCatcher)[0].message).toBe(responses[3]?.error?.message);
+
+      await executeFetch();
+      expect(responseCatcher).toHaveBeenLastCalledWith(responses[4].data);
+      const renewTokens = { token: '3000' };
+
+      await executeFetch({ renewTokens });
+      expect(responseCatcher).toHaveBeenLastCalledWith(responses[5].data);
+      const headers = getLastQueryHeaders();
+      expect(headers).toMatchObject({
+        ...renewTokens,
+      });
+
+      const renewTokens2 = { token: '5000' };
+      await executeFetch({ abort: true, renewTokens: renewTokens2 });
+      expect(currentModule.isAbortError(getLastMockCallArgs(responseCatcher)[0])).toBeTruthy();
+      const headers2 = getLastQueryHeaders();
+      expect(headers2).toMatchObject({
+        ...renewTokens2,
+      });
+
+      emitApiTokensRemovedStateChange();
+      await executeFetch();
+      // previous test did not actually use responses so next is response[6]
+      expect(getLastMockCallArgs(responseCatcher)[0].message).toBe(responses[6]?.error?.message);
+      const headers3 = getLastQueryHeaders();
+      expect(Object.keys(headers3)).toHaveLength(0);
+
+      await executeFetch();
+      expect(responseCatcher).toHaveBeenLastCalledWith(responses[7].data);
+    });
+  });
+});

--- a/packages/react/src/components/login/tokenizedFetch/tokenizedFetch.ts
+++ b/packages/react/src/components/login/tokenizedFetch/tokenizedFetch.ts
@@ -1,0 +1,120 @@
+import {
+  TokenizedFetchModule,
+  tokenizedFetchModuleEvents,
+  tokenizedFetchModuleNamespace,
+  TokenizedFetchModuleProps,
+  defaultOptions,
+  HeaderContent,
+} from '.';
+import { createNamespacedBeacon } from '../beacon/signals';
+import { createApiTokenClientTracker } from '../apiTokensClient/createApiTokenClientTracker';
+import { appendAbortSignal, isAbortError } from '../utils/abortFetch';
+import { createAbortSignalData, createStartSignalData } from './signals';
+import { TokenizedFetchError } from './tokenizedFetchError';
+
+export const mergeHeaders = (
+  target: HeaderContent | undefined | null,
+  source: HeaderContent | undefined | null,
+): HeaderContent => {
+  if (!target || !source) {
+    return target || source || {};
+  }
+  const isHeadersObject = target instanceof Headers;
+  if (typeof source === 'object') {
+    Object.entries(source).forEach(([key, value]) => {
+      if (isHeadersObject) {
+        target.append(key, value);
+      } else {
+        // eslint-disable-next-line no-param-reassign
+        target[key] = value;
+      }
+    });
+  }
+
+  return target;
+};
+
+export function createTokenizedFetchModule(props: TokenizedFetchModuleProps): TokenizedFetchModule {
+  // custom beacon for sending signals in tokenizedFetchModuleNamespace
+  const dedicatedBeacon = createNamespacedBeacon(tokenizedFetchModuleNamespace);
+
+  const mergedProps: TokenizedFetchModuleProps = {
+    ...defaultOptions,
+    ...props,
+  };
+
+  const { keepTokensWhileRenewing, tokenSetter, apiTokensWaitTime, preventQueriesWhileRenewing } = mergedProps;
+
+  const apiTokenTracker = createApiTokenClientTracker({ keepTokensWhileRenewing, timeout: apiTokensWaitTime });
+
+  const emitResponse: TokenizedFetchModule['emitResponse'] = (
+    promise: Promise<Response>,
+    responseIdentifier: string,
+  ) => {
+    promise
+      .then(async (response) => {
+        dedicatedBeacon.emitEvent(responseIdentifier, response);
+      })
+      .catch((e) => {
+        if (isAbortError(e)) {
+          dedicatedBeacon.emitEvent(responseIdentifier, createAbortSignalData());
+        } else {
+          dedicatedBeacon.emitError(new TokenizedFetchError(responseIdentifier, e));
+        }
+      });
+    return promise;
+  };
+
+  const emitFetchStart: TokenizedFetchModule['emitFetchStart'] = (responseIdentifier: string) => {
+    dedicatedBeacon.emitEvent(responseIdentifier, createStartSignalData());
+  };
+
+  const tokenizedFetch: TokenizedFetchModule['tokenizedFetch'] = async (...args) => {
+    const [input, init = {}] = args;
+
+    if (preventQueriesWhileRenewing) {
+      await apiTokenTracker.waitForApiTokens();
+    }
+    if (tokenSetter) {
+      let headers = (init.headers || {}) as HeaderContent;
+      const newHeaders = tokenSetter(headers as Headers, apiTokenTracker.getTokens());
+      headers = mergeHeaders(headers, newHeaders);
+      init.headers = headers;
+    }
+
+    const promise = fetch(input, init);
+
+    return promise;
+  };
+
+  return {
+    namespace: tokenizedFetchModuleNamespace,
+    connect: (beacon) => {
+      dedicatedBeacon.storeBeacon(beacon);
+      apiTokenTracker.connect(beacon);
+    },
+    addAbortSignal: (initProps: Parameters<typeof fetch>[1]): (() => void) => {
+      return appendAbortSignal(initProps);
+    },
+    tokenizedFetch,
+    tokenizedFetchWithSignals: (autoEmitResponseIdentifier, ...rest) => {
+      emitFetchStart(autoEmitResponseIdentifier);
+      const promise = tokenizedFetch(...rest);
+      emitResponse(
+        promise.then((r) => r.json()),
+        autoEmitResponseIdentifier,
+      );
+      return promise;
+    },
+    emitResponse,
+    emitFetchStart,
+    getTracker: () => {
+      return apiTokenTracker;
+    },
+    reset: async () => {
+      dedicatedBeacon.emitEvent(tokenizedFetchModuleEvents.TOKENIZED_FETCH_MODULE_RESET);
+      apiTokenTracker.dispose();
+    },
+    isAbortError,
+  };
+}

--- a/packages/react/src/components/login/tokenizedFetch/tokenizedFetchError.ts
+++ b/packages/react/src/components/login/tokenizedFetch/tokenizedFetchError.ts
@@ -1,0 +1,14 @@
+export class TokenizedFetchError extends Error {
+  constructor(
+    public identifier: string,
+    public originalError?: Error | null,
+  ) {
+    super('TokenizedFetch failed');
+    this.identifier = identifier;
+    this.originalError = originalError;
+  }
+
+  hasResponseIdentifierMatch(responseIdentifier: string) {
+    return this.identifier === responseIdentifier;
+  }
+}

--- a/site/src/docs/components/login/api.mdx
+++ b/site/src/docs/components/login/api.mdx
@@ -70,14 +70,16 @@ export const CustomisationPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>Oidc Client</AnchorLink>
   - <AnchorLink>Api tokens client</AnchorLink>
   - <AnchorLink>Session poller</AnchorLink>
-  - <AnchorLink>ApolloClient module</AnchorLink>
   - <AnchorLink>GraphQL module</AnchorLink>
+  - <AnchorLink>ApolloClient module</AnchorLink>
+  - <AnchorLink>TokenizedFetch module</AnchorLink>
 
 - <AnchorLink>Oidc client hooks</AnchorLink>
 - <AnchorLink>Api tokens client hooks</AnchorLink>
 - <AnchorLink>Session poller hooks</AnchorLink>
-- <AnchorLink>ApolloClient module hooks</AnchorLink>
 - <AnchorLink>GraphQL module hooks</AnchorLink>
+- <AnchorLink>ApolloClient module hooks</AnchorLink>
+- <AnchorLink>TokenizedFetch module hooks</AnchorLink>
 - <AnchorLink>Generic signal hooks</AnchorLink>
 
 - <AnchorLink>Beacon</AnchorLink>
@@ -163,7 +165,8 @@ There are four modules to handle the user's needs:
 - <AnchorLink>Api tokens client</AnchorLink> for acquiring backend tokens.
 - <UsagePageAnchorLink>ApolloClient module</UsagePageAnchorLink> to provide the client and auto-append api tokens to queries.
 - <AnchorLink>GraphQL module</AnchorLink> for fetching data from a graphQL server. Fetching can be automatically linked to
-  the Api Tokens client.
+- <AnchorLink>TokenizedFetch module</AnchorLink> for fetching data from a server. Requests are automatically linked to the
+  Api Tokens client.
 
 All modules can be used without React and without each other. But a <OidcClientTsLink>>user</OidcClientTsLink> object is required to get API tokens and poll the session.
 
@@ -792,11 +795,9 @@ If the given signal is not from the `GraphQL module` or is not given type, the f
 
 Appending api tokens to every query and manually waiting for api token renewal is a complicated task. The ApolloClient module links itself to the Api token client and automatically appends tokens and also awaits for token renewals.
 
-The module can also be used without api tokens.
+The module can also be used without api tokens. This module does not emit signals.
 
-This module does not emit signals.
-
-Unlike the `Api token client` and `Session Poller`, the `ApolloClient Module` must be manually added to the `<LoginProvider>`. Preferably use the <UsagePageAnchorLink>LoginProviderWithApolloContext</UsagePageAnchorLink> which also creates the `ApolloContext`.
+The `ApolloClient Module` must be manually added to the `<LoginProvider>`. Preferably use the <UsagePageAnchorLink>LoginProviderWithApolloContext</UsagePageAnchorLink> which also creates the `ApolloContext`.
 
 <PlaygroundPreview>
 
@@ -813,9 +814,9 @@ const options = {
     };
   },
 };
-const tokenizedFetchModule = createApolloClientModule(options);
+const apolloClientModule = createApolloClientModule(options);
 
-<LoginProviderWithApolloContext {...loginProps} modules={[ApolloClientModule]}></LoginProviderWithApolloContextx  >;
+<LoginProviderWithApolloContext {...loginProps} modules={[apolloClientModule]}></LoginProviderWithApolloContextx  >;
 ```
 
 </PlaygroundPreview>
@@ -848,6 +849,105 @@ The `createApolloClientModule` function is a Generic Typescript function: `creat
 
 The ApolloClient does not emit any signals. Therefore there are no hooks or triggers related to signals.
 
+#### TokenizedFetch Module
+
+Loading data from a server may require user authentication and api tokens. The TokenizedFetch module listens to the Api token client and appends api tokens to the request headers.
+
+The `TokenizedFetch Module` must be manually added to the `<LoginProvider>`.
+
+<PlaygroundPreview>
+
+```jsx
+import { createTokenizedFetchModule } from 'hds-react';
+
+const options = {
+  tokenSetter: (headers, apiTokens) => {
+    return {
+      Authentication: apiTokens['tokenToAppend'],
+    };
+  },
+};
+const tokenizedFetchModule = createTokenizedFetchModule(options);
+
+<LoginProvider {...loginProps} modules={[tokenizedFetchModule]}></LoginProvider>;
+```
+
+</PlaygroundPreview>
+
+##### Settings
+
+| Property                                   | Type                                                           | Description                                                                                                                                                                     | Default value |
+| ------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `preventQueriesWhileRenewing`              | `string`                                                       | If true, a ApolloLink is added to wait for possible api token renewal to end. If false, there might be times when queries are made with old api tokens. Unlikely, but possible. | `true`        |
+| `tokenSetter`                              | `(headers:unknown, tokens:TokenData) => Record<string,string>` | The returned object is appended to the headers. First argument type depends on the request. Can be an object or Headers.                                                        | -             |
+| [Table 51: TokenizedFetch module settings] |
+
+##### Methods
+
+| Property                                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Argument(s)             | Return value            |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------- |
+| `tokenizedFetch`                          | Proxy to the native `fetch` function. Headers returned from the optional `tokenSetter` are appended to the Headers passed as args.                                                                                                                                                                                                                                                                                                                                                                                                     | Same as native `fetch`. | Same as native `fetch`. |
+| `tokenizedFetchWithSignals`               | Calls the tokenizedFetch, but also emits start and end signals. If fetch fails, an error signal is emitted. Aborted requests are emitted as event signals. Abort and start signals can be distinguished from actual responses with `isTokenizedFetchStartedSignal(signal)` and `isTokenizedFetchAbortedSignal(signal)`. Automatic response handling uses the `response.json()` to parse response from data. If the data is not json, do not use automation and this function. Use `emitResponse(promise.then(<your parse function>))`. | -                       | -                       |
+| `getTracker`                              | Returns the apiTokenClient tracker.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                       | -                       |
+| `reset`                                   | Emits reset signal and resets the apiTokenTracker.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | -                       | -                       |
+| `isAbortError`                            | Utility to test was the returned error an AbortError.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | -                       | -                       |
+| `emitResponse`                            | The promise returned from tokenizedFetch can be passed to this function which will emit the results as event signals or error signals.                                                                                                                                                                                                                                                                                                                                                                                                 | -                       | -                       |
+| `emitFetchStart`                          | Emits a signal where `payload.type = ${responseSignalType}\_STARTED`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | -                       | -                       |
+| `addAbortSignal`                          | Adds abort signal to FetchInit props and returns a function that will abort the request.                                                                                                                                                                                                                                                                                                                                                                                                                                               | -                       | -                       |
+| [Table 52: TokenizedFetch module methods] |
+
+##### Other exported utility functions
+
+The following functions can be imported and used without the `TokenizedFetch module` module:
+
+| Function                                          | Description                                                     | Argument(s)                 | Return value           |
+| ------------------------------------------------- | --------------------------------------------------------------- | --------------------------- | ---------------------- |
+| `createTokenizedFetchModule(options)`             | Creates the module.                                             | `TokenizedFetchModuleProps` | `TokenizedFetchModule` |
+| `isTokenizedFetchStartedSignal(signal)`           | Returns true if the signal was emitted to indicate fetch start. | `Signal`                    | `boolean`              |
+| `isTokenizedFetchAbortedSignal(signal)`           | Returns true if the signal was emitted to indicate fetch abort. | `Signal`                    | `boolean`              |
+| [Table 53: Other TokenizedFetch module functions] |
+
+##### State change signals
+
+The `TokenizedFetch module` has no state changes.
+
+##### Error signal
+
+The module emits only one kind of error. They are instances of the `TokenizedFetchModuleError`. It is an extended Error object with type property and a `hasResponseIdentifierMatch` helper function to identify fetch calls. The error object also contains the thrown error in `error.originalError` property.
+
+The `hasResponseIdentifierMatch(type:string)=>boolean` returns true if the error originated from a fetch with given id. Ids are used only when using `tokenizedFetchWithSignals` or `emitResponse`.
+
+##### Event signals
+
+The `TokenizedFetch module` also emits events only when the `tokenizedFetchWithSignals` is used. Events can also be manually emitted with `emitFetchStart` or `emitResponse`
+
+The simplest way to track signals is <UsagePageAnchorLink anchor="useTokenizedFetchTracking">with hooks</UsagePageAnchorLink>.
+
+##### Dedicated signal triggers
+
+Triggers for `TokenizedFetch module` signals. These trigger signals only originated from the `TokenizedFetch module`.
+
+| Generic triggers                           | Required signal props to trigger the listener       |
+| ------------------------------------------ | --------------------------------------------------- |
+| `triggerForAllTokenizedFetchErrors`        | `TokenizedFetch module` namespace and type `error`. |
+| `triggerForAllTokenizedFetchEvents`        | `TokenizedFetch module` namespace and type `event`. |
+| `triggerForAllTokenizedFetchSignals`       | `TokenizedFetch module` namespace.                  |
+| [Table 54: TokenizedFetch module triggers] |
+
+The `createTriggerPropsForTokenizedFetchResponseSignals(identifier: string): SignalTrigger` creates a `SignalTrigger` that returns true if the signal is an event signal from the `TokenizedFetch Module` and its payload has given identifier.
+
+##### Getting signal payloads
+
+Sometimes the most significant part of a signal is the payload. There are predefined payload getters for the `TokenizedFetch module`.
+If the given signal is not from the `TokenizedFetch module` or is not given type, the function returns null. So there is no need to pre-check the signal namespace or type.
+
+| Payload getter                                           | Returns                                                                                                    |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `getTokenizedFetchModuleEventPayload`                    | `null` or `EventPayload`. The payload may be a `Response` or information about `start` or `abort` signals. |
+| `getTokenizedFetchModuleErrorPayload`                    | `null` or `Error`.                                                                                         |
+| `getTokenizedFetchPayloadData`                           | `null` or the actual server `Response`.                                                                    |
+| [Table 55: TokenizedFetch module signal payload getters] |
+
 #### Oidc client hooks
 
 | Hook                          | Description                                                                                                                                                       | Return value                                        |
@@ -856,7 +956,7 @@ The ApolloClient does not emit any signals. Therefore there are no hooks or trig
 | `useCachedAmr`                | Returns the user's `amr` value. It is cached because in some cases it must be decrypted from `id_token`.                                                          | `string[]`                                          |
 | `useOidcClient`               | Returns the `Oidc client`.                                                                                                                                        | `OidcClient`                                        |
 | `useOidcClientTracking`       | Returns an array of `[Signal, resetFunction, oidcClient instance]`. The hook forces the component using it to re-render each time the listener is triggered.      | `[Signal or undefined, ()=>void, OidcClient]`       |
-| [Table 51: Oidc client hooks] |
+| [Table 56: Oidc client hooks] |
 
 The usage of the `Oidc client` hooks is described in the <UsagePageAnchorLink anchor="useoidcclient">usage</UsagePageAnchorLink> section.
 
@@ -867,7 +967,7 @@ The usage of the `Oidc client` hooks is described in the <UsagePageAnchorLink an
 | `useApiTokens`                      | Returns functions for checking tokens and the status of renewal.                                                                                                  | `{getStoredApiTokens(), isRenewing()}`             |
 | `useApiTokensClient`                | Returns the `Api tokens client`.                                                                                                                                  | `ApiTokensClient`                                  |
 | `useApiTokensClientTracking`        | Returns an array of `[Signal, resetFunction, apiTokensClient instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[Signal or undefined, ()=>void, ApiTokensClient]` |
-| [Table 52: Api tokens client hooks] |
+| [Table 57: Api tokens client hooks] |
 
 The usage of the `Api tokens client` hooks is described in the <UsagePageAnchorLink anchor="useapitokensclient">usage</UsagePageAnchorLink> section.
 
@@ -877,7 +977,7 @@ The usage of the `Api tokens client` hooks is described in the <UsagePageAnchorL
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `useSessionPoller`               | Returns the `Session poller`.                                                                                                                                   | `SessionPoller`                                  |
 | `useSessionPollerTracking`       | Returns an array of `[Signal, resetFunction, sessionPoller instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[Signal or undefined, ()=>void, SessionPoller]` |
-| [Table 53: Session poller hooks] |
+| [Table 58: Session poller hooks] |
 
 The usage of the `Session poller` hooks is described in the <UsagePageAnchorLink anchor="usesessionpoller">usage</UsagePageAnchorLink> section.
 
@@ -888,7 +988,7 @@ The usage of the `Session poller` hooks is described in the <UsagePageAnchorLink
 | `useGraphQLModule`               | Returns the `GraphQL module`.                                                                                                                                                                                                                                                     | `GraphQLModule`                                     |
 | `useGraphQLModuleTracking`       | Returns `[Signal, resetFunction, GraphQL module instance]`. The hook forces the component using it to re-render each time the listener is triggered.                                                                                                                              | `[signal, reset function, GraphQL module instance]` |
 | `useGraphQL`                     | Mimics the <ExternalLink href="https://www.apollographql.com/docs/react/data/queries#manual-execution-with-uselazyquery">useLazyQuery</ExternalLink> hook of the Apollo GraphQL library. The hook forces the component using it to re-render each time the module emits a signal. | `[query, {data, error, loading, refetch}]`          |
-| [Table 54: GraphQL module hooks] |
+| [Table 59: GraphQL module hooks] |
 
 The usage of the `GraphQL module` hooks is described in the <UsagePageAnchorLink anchor="usegraphql">usage</UsagePageAnchorLink> section.
 
@@ -898,9 +998,20 @@ The usage of the `GraphQL module` hooks is described in the <UsagePageAnchorLink
 | ------------------------------------- | ----------------------------------- | -------------------- |
 | `useApolloClientModule`               | Returns the `ApolloClient module`.  | `ApolloClientModule` |
 | `useApolloClient`                     | Returns the created `ApolloClient`. | `ApolloClient`       |
-| [Table 55: ApolloClient module hooks] |
+| [Table 60: ApolloClient module hooks] |
 
 The usage of the `ApolloClient module` hooks is described in the <UsagePageAnchorLink anchor="useapolloclient">usage</UsagePageAnchorLink> section.
+
+#### TokenizedFetch module hooks
+
+| Hook                                    | Description                                                                                                                                                 | Return value                                               |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `useTokenizedFetchModule`               | Returns the `TokenizedFetch module`.                                                                                                                        | `TokenizedFetch`                                           |
+| `useTokenizedFetch`                     | Returns a function identical to the native `fetch` function..                                                                                               | The native `fetch` function                                |
+| `useTokenizedFetchModuleTracking`       | Returns `[Signal, resetFunction, TokenizedFetch module instance]`. The hook forces the component using it to re-render each time the listener is triggered. | `[signal, reset function, TokenizedFetch module instance]` |
+| `useTokenizedFetchWithSignals`          | This hook works just like the `useTokenizedFetch` except it emits signals so individual fetches can be tracked.                                             | `Promise<Response>`                                        |
+| `useTokenizedFetchResponseTracking`     | This hook works just like the `useTokenizedFetchModuleTracking` except it tracks only signals emitted by the module **and** with given identifier.          | `Signal`                                                   |
+| [Table 61: TokenizedFetch module hooks] |
 
 #### Generic signal hooks
 
@@ -909,7 +1020,7 @@ The usage of the `ApolloClient module` hooks is described in the <UsagePageAncho
 | `useSignalListener(listener)`                           | The listener function. There are no trigger props. The listener is always called when any signal is emitted in any namespace. The listener should return `true` if the component should re-render. | An array of `[Signal or undefined, ()=>void]`. Latter is a reset function that clears the signal and re-renders the component. |
 | `useSignalTrackingWithCallback(triggerProps, callback)` | Signal props need to match the incoming signal to trigger the callback function. The hook never causes a re-render. The callback must do it.                                                       | none                                                                                                                           |
 | `useSignalTrackingWithReturnValue(triggerProps)`        | Signal props need to match the incoming signal to trigger re-rendering. The hook creates a trigger from the props and re-renders if the trigger returns `true`.                                    | Same as above.                                                                                                                 |
-| [Table 56: Generic signal listener hooks]               |
+| [Table 62: Generic signal listener hooks]               |
 
 **Important!** The listener passed to `useSignalListener` must be memoized or the hook will attach a new listener on each render because the props changed. The old one is disposed of but to avoid unnecessary listeners, use memoization with `useMemo` or `useCallback`. Note that all `triggerFor...` functions are constants and do not need memoization.
 
@@ -932,7 +1043,7 @@ Modules are added and connected by calling `beacon.addContext(module)`. The beac
 | `emit(signal)`                      | A signal to emit.                                                                              | none                                         |
 | `getAllSignalContextsAsObject()`    | Returns all stored contexts as on object of `{[context.namespace]:context}`.                   | `Object`                                     |
 | `getSignalContext(module)`          | Returns context for the given namespace.                                                       | Context module or `undefined`.               |
-| [Table 57: Beacon methods]          |
+| [Table 63: Beacon methods]          |
 
 ##### Important
 
@@ -952,7 +1063,7 @@ A signal is an object with the following properties:
 | `namespace`                          | **Required**. The namespace is the name of the module that emitted the signal.                                                                                                              | `string`   |
 | `payload`                            | Optional. The payload contains metadata. For example type of the event. A payload can also be an Error object.                                                                              | unknown    |
 | `type`                               | **Required**. Type of the signal. Can be any string, but HDS emits `init`, `error`, `event` and `stateChange` signals.                                                                      | `string`   |
-| [Table 58: Signal object properties] |
+| [Table 64: Signal object properties] |
 
 ##### Signal types and payloads
 
@@ -962,7 +1073,7 @@ A signal is an object with the following properties:
 | `event`                               | `eventSignalType`       | Usually `{type:event type}` indicating what kind of event is emitted. May also have `data` property containing for example User or Tokens. |
 | `init`                                | `initSignalType`        | Emitted when all modules are connected and everything is ready. Emitted only once. Note that modules may emit other signals before this.   |
 | `stateChange`                         | `stateChangeSignalType` | `{state, previousState}` New state and the previous state, if any.                                                                         |
-| [Table 59: Signal types and payloads] |
+| [Table 65: Signal types and payloads] |
 
 Custom modules may emit any other kind of signal with different payloads.
 
@@ -995,6 +1106,7 @@ Instead of writing signal types as strings, it is better to use predefined trigg
 - <AnchorLink anchor="dedicated-signal-triggers-1">Api tokens client triggers</AnchorLink>.
 - <AnchorLink anchor="dedicated-signal-triggers-2">Session poller triggers</AnchorLink>.
 - <AnchorLink anchor="dedicated-signal-triggers-3">GraphQL module triggers</AnchorLink>.
+- <AnchorLink anchor="dedicated-signal-triggers-4">TokenizedFetch module triggers</AnchorLink>.
 - <AnchorLink anchor="dedicated-signal-triggers">Generic triggers</AnchorLink>.
 
 ##### Generic triggers
@@ -1009,7 +1121,7 @@ Generic `create...` functions create trigger functions from given props. Creator
 | `createStateChangeTriggerProps(namespace, state, previousState)` | Namespace to listen to. Given state and previousState must also match. Both are optional. | all namespaces |
 | `createTriggerForAllNamespaces()`                                | Listens to all signals in any namespace.                                                  | none           |
 | `createTriggerPropsForAllSignals(namespace)`                     | Namespace to listen to. If omitted listens to all signals.                                | all namespaces |
-| [Table 60: Generic trigger creators]                             |
+| [Table 66: Generic trigger creators]                             |
 
 See also <AnchorLink anchor="hooks">hooks</AnchorLink>.
 
@@ -1024,7 +1136,7 @@ Signals are easier to create with functions than by manually setting all propert
 | `createErrorSignal(namespace, payload)`                    | Creates an error signal with the given namespace and error payload.                |
 | `createEventSignal(namespace, payload)`                    | Creates an event signal with the given namespace and event payload.                |
 | `createStateChangeSignal(namespace, state, previousState)` | Creates a `stateChange` signal with the given namespace and `stateChange` payload. |
-| [Table 61: Generic signal creators]                        |
+| [Table 67: Generic signal creators]                        |
 
 ###### Check
 
@@ -1037,7 +1149,7 @@ Check the signal type or namespace with these utilities.
 | `isEventSignal(signal)`                 | Returns true if the given signal is an event signal.        |
 | `isNamespacedSignal(signal, namespace)` | Returns true if the given signal has given namespace.       |
 | `isStateChangeSignal(signal)`           | Returns true if the given signal is a `stateChange` signal. |
-| [Table 62: Generic signal checks]       |
+| [Table 68: Generic signal checks]       |
 
 ###### Get payloads
 
@@ -1048,7 +1160,7 @@ Returns signal payload if the signal type is a match.
 | `getErrorSignalPayload(signal)`       | Returns the payload if the given signal is an error signal. |
 | `getEventSignalPayload(signal)`       | Returns true if the given signal is an event signal.        |
 | `getStateChangeSignalPayload(signal)` | Returns true if the given signal is a `stateChange` signal. |
-| [Table 63: Generic payloads getters]  |
+| [Table 69: Generic payloads getters]  |
 
 ###### Convert and filter
 
@@ -1056,7 +1168,7 @@ Returns signal payload if the signal type is a match.
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `convertSignalToTrigger(signal)`               | Removes the `context` from the signal if the property exists. The given signal is not mutated. |
 | `filterSignals(arrayOfSignals, matchingProps)` | Filters signals from the array. Returns signals which match given props.                       |
-| [Table 64: Convert and filter signals]         |
+| [Table 70: Convert and filter signals]         |
 
 ##### waitForSignals
 
@@ -1078,7 +1190,7 @@ When the promise is resolved, it returns an array of received signals. If it is 
 | `options.allowSkipping`            | `boolean`  | If true, and triggers are in order A, B, C, D and signal "C" is received. "A", "B", "C" are all removed from the array and are not checked again. | `true`  |
 | `options.strictOrder`              | `boolean`  | If true, signals are not tracked in strict order. If true and signals are received in the wrong order, the promise is rejected.                   | `false` |
 | `options.rejectOn`                 | `Object[]` | Array of signals/signal props, which cause promise rejection, if a match is found.                                                                | none    |
-| [Table 65: waitForSignals utility] |
+| [Table 71: waitForSignals utility] |
 
 There is no timeout. The promise can be rejected by setting a custom signal type to `options.rejectOn` and emit a matching signal.
 

--- a/site/src/docs/components/login/index.mdx
+++ b/site/src/docs/components/login/index.mdx
@@ -37,7 +37,8 @@ Current modules can handle
 - User authorisation with any OIDC server.
 - Exchange of user tokens to API tokens.
 - Creation of ApolloClient with auto-appended api tokens in query headers.
-- GraphQL queries with auto-appended api tokens in query headers.
+- GraphQL queries with auto-appended api tokens in the query headers.
+- Fetch requests with auto-appended api tokens in the request headers.
 - Active session polling if user session is ended in other browsers or server side.
 - Addition of custom modules.
 
@@ -139,6 +140,7 @@ There are five modules to handle different scenarios:
   provider.
 - <UsagePageAnchorLink>ApolloClient module</UsagePageAnchorLink> to provide the client and auto-append api tokens to queries.
 - <UsagePageAnchorLink>GraphQL module</UsagePageAnchorLink> for fetching data from a graphQL server. Fetching can be automatically
+- <UsagePageAnchorLink>TokenizedFetch module</UsagePageAnchorLink> for making fetch calls to a server. Fetching is automatically
   linked to the Api Tokens client.
 
 If a module is not needed, it can be dropped with settings. <InternalLink href="/components/login/customisation">Custom modules</InternalLink> can also be added. All modules can be used without React and without each other. But a valid user object is required to get API tokens and poll the session.
@@ -163,10 +165,17 @@ This module polls the user's session from the Oidc provider and signals an error
 
 This module creates a client with middleware and provides the client to all modules and also to all components in the Login Context including ApolloClient's hooks. The module can wait for api tokens and automatically append them to headers.
 When ApolloClient's own hooks are used, the ApolloContext is not automatically created unless the <UsagePageAnchorLink anchor="modules">LoginProviderWithApolloContext</UsagePageAnchorLink> component is used. The context can also be created manually by picking the ApolloClient with <ApiPageAnchorLink href="apolloclient-module-hooks">hooks</ApiPageAnchorLink>.
+The ApolloClient is not automatically added, but <ApiPageAnchorLink anchor="apolloclient-module">it's setup is simple</ApiPageAnchorLink>.
 
 #### GraphQL module
 
 This module was added to make it easier to use the login system with authenticated graphQL queries. The GraphQL module waits for api tokens and automatically picks a token and uses it in queries.
+The GraphQL module is not automatically added, but <ApiPageAnchorLink anchor="graphql-module">it's setup is simple</ApiPageAnchorLink>.
+
+#### TokenizedFetch module
+
+This module was added to make it easier to use the login system with authenticated `fetch` calls. The TokenizedFetch module waits for api tokens and assigns headers to the request headers.
+The TokenizedFetch module is not automatically added, but <ApiPageAnchorLink anchor="tokenizedfetch-module">it's setup is simple</ApiPageAnchorLink>.
 
 #### Custom modules
 
@@ -223,6 +232,3 @@ const loginProviderProps: LoginProviderProps = {
   sessionPollerSettings: { pollIntervalInMs: 10000 },
 };
 ```
-
-GraphQL module is not automatically added, but <ApiPageAnchorLink anchor="graphql-module">it's setup is simple</ApiPageAnchorLink>.
-ApolloClient is not automatically added either, but <ApiPageAnchorLink anchor="apolloclient-module">it's setup is simple</ApiPageAnchorLink>.

--- a/site/src/docs/components/login/usage.mdx
+++ b/site/src/docs/components/login/usage.mdx
@@ -64,6 +64,14 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>useApolloClientModule</AnchorLink>
   - <AnchorLink>useApolloClient</AnchorLink>
 
+- <AnchorLink>TokenizedFetch module hooks</AnchorLink>{' '}
+
+  - <AnchorLink>useTokenizedFetchModule</AnchorLink>
+  - <AnchorLink>useTokenizedFetch</AnchorLink>
+  - <AnchorLink>useTokenizedFetchWithSignals</AnchorLink>
+  - <AnchorLink>useTokenizedFetchTracking</AnchorLink>
+  - <AnchorLink>useTokenizedFetchResponseTracking</AnchorLink>
+
 - <AnchorLink>Generic signal hooks</AnchorLink>
 
   - <AnchorLink>useSignalListener</AnchorLink>
@@ -77,6 +85,7 @@ export const ApiPageAnchorLink = ({ anchor, children }) => {
   - <AnchorLink>Session poller</AnchorLink>
   - <AnchorLink>ApolloClient module</AnchorLink>
   - <AnchorLink>GraphQL module</AnchorLink>
+  - <AnchorLink>TokenizedFetch module</AnchorLink>
 
 - <AnchorLink>Silent renewal</AnchorLink>
 
@@ -467,6 +476,104 @@ const GraphQLModuleHooks = () => {
 
 </PlaygroundPreview>
 
+### TokenizedFetch module hooks
+
+More detailed information about <AnchorLink>TokenizedFetch module</AnchorLink> hooks are listed on the <ApiPageAnchorLink anchor="tokenizedfetch-module">API page</ApiPageAnchorLink>.
+
+#### useTokenizedFetchModule
+
+Returns the <AnchorLink>TokenizedFetch module</AnchorLink>.
+
+#### useTokenizedFetchModuleTracking
+
+Returns an array of `[signal, reset function, TokenizedFetch module instance]`. The hook re-renders the component each time the module emits a signal.
+
+#### useTokenizedFetch
+
+Returns a function identical to the native `fetch` function. The function will append headers with the `tokenSetter` function passed to the module on creation. The function will wait for on-going api tokens renewals.
+
+Note that state handling must be manually added. The hook does not return states like "loading", "error", "data".
+
+The <AnchorLink>useTokenizedFetchResponseTracking</AnchorLink> with <AnchorLink>useTokenizedFetchWithSignals</AnchorLink> helps with state changes.
+
+#### useTokenizedFetchWithSignals
+
+This hook works just like the <AnchorLink>useTokenizedFetch</AnchorLink> except it emits signals so individual fetches can be tracked.
+The hook returns the <ApiPageAnchorLink anchor="tokenizedfetch-module">tokenizedFetchWithSignals</ApiPageAnchorLink> function. The function accepts ids for `fetch` calls and native `fetch` arguments.
+
+The <AnchorLink>useTokenizedFetchResponseTracking</AnchorLink> will track signals with given id and re-renders the component only when signals match.
+
+<PlaygroundPreview>
+
+```jsx
+import {
+  useTokenizedFetchWithSignals,
+  useTokenizedFetchResponseTracking,
+  Button,
+  LoadingSpinner,
+  isErrorSignal,
+} from 'hds-react';
+const [signal] = useTokenizedFetchResponseTracking(event);
+const tokenizedFetchWithSignals = useTokenizedFetchWithSignals();
+
+const MyTokenizedFetch = () => {
+  const fetchId = "my-important-fetch";
+  // the signal is only triggered if there is a state change with a fetch() call started with same id.
+   const [signal] = useTokenizedFetchResponseTracking(fetchId);
+  const tokenizedFetch = useTokenizedFetch();
+  const executeFetch = useCallback(())=>{
+    tokenizedFetch(fetchId);
+  },[tokenizedFetch,fetchId]);
+
+  const getLoadState = (signal?:Signal)=>{
+    if(signal){
+      if(isErrorSignal(signal)){
+        return 'error';
+      }
+      if(isTokenizedFetchStartedSignal(signal)){
+        return 'loading';
+      }
+      if(isTokenizedFetchAbortedSignal(signal)){
+        return 'aborted';
+      }
+      if(getTokenizedFetchPayloadData(signal)){
+        return 'loaded';
+      }
+    }
+    return undefined;
+  }
+
+  const state = getLoadState(signal);
+
+
+
+  if (state === 'loading') {
+    return <LoadingSpinner loadingText="loading" />;
+  }
+  if (state === 'loaded' && signal) {
+    const data = getTokenizedFetchPayloadData(signal);
+    // render data
+  }
+  return (
+     <Button
+    onClick={() => {
+      executeFetch();
+    }}
+  >
+    Load data
+  </Button>;
+  )
+};
+```
+
+</PlaygroundPreview>
+
+#### useTokenizedFetchResponseTracking
+
+This hook works like the <AnchorLink>useTokenizedFetchTracking</AnchorLink> except it tracks only signals emitted by the module **and** with given identifier.
+
+See a working example in <AnchorLink>useTokenizedFetchWithSignals</AnchorLink>.
+
 ### Generic signal hooks
 
 Hooks are the easiest way to listen to signals. Most hooks return the last triggered signal and re-render the component. Re-rendering is done only if the listener returns true. So listeners added by hooks must return a boolean.
@@ -706,6 +813,32 @@ All `ApolloClient module` settings, properties, methods and signals are detailed
 - <AnchorLink>useApolloClient</AnchorLink>
 
 Detailed information about these hooks is listed on the <ApiPageAnchorLink anchor="apolloclient-module-hooks">API page</ApiPageAnchorLink>.
+
+#### TokenizedFetch module
+
+Loading data from a server may require user authentication and api tokens. The TokenizedFetch module listens to the Api token client and appends api tokens to the request headers.
+
+##### API
+
+All `TokenizedFetch module` settings, properties, methods and signals are detailed on the API page:
+
+- <ApiPageAnchorLink anchor="settings-4">Module settings</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="methods-4">Methods</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="other-exported-utility-functions-4">Utility functions</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="event-signals-4">Event signals</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="error-signal-types-4">Error signal types</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="dedicated-signal-triggers-4">Dedicated signal triggers</ApiPageAnchorLink>.
+- <ApiPageAnchorLink anchor="getting-signal-payloads-4">Getting signal payloads</ApiPageAnchorLink>.
+
+##### Hooks
+
+- <AnchorLink>useTokenizedFetchModule</AnchorLink>
+- <AnchorLink>useTokenizedFetch</AnchorLink>
+- <AnchorLink>useTokenizedFetchTracking</AnchorLink>
+- <AnchorLink>useTokenizedFetchWithSignals</AnchorLink>
+- <AnchorLink>useTokenizedFetchResponseTracking</AnchorLink>
+
+Detailed information about these hooks is listed on the <ApiPageAnchorLink anchor="tokenizedfetch-module-hooks">API page</ApiPageAnchorLink>.
 
 #### Silent renewal
 


### PR DESCRIPTION
## Description

Login module to automatically append api tokens to `fetch()` calls.

Works like the recently added ApolloClient module, but with `fetch`.

The module returns a `tokenizedFetch` function which is a proxy to the native `fetch`. It appends headers automatically.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2553](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2553)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x ] Added needed line to changelog



[HDS-2553]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ