### PR TITLE
HDS-2577 fix running docker tests in non-default hds-root folder

### DIFF
--- a/e2e/docker/run.sh
+++ b/e2e/docker/run.sh
@@ -1,12 +1,11 @@
 
 #!/bin/sh
 HDS_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )"
+HDS_DIR_BASENAME="$(basename "$HDS_ROOT_DIR")"
 
 PACKAGE=$1
 COMPONENT=$2
 COMMAND=""
-
-# PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshot:react
 
 # if packaga and component are not provided, run all snapshots
 if [ -z "$PACKAGE" ] && [ -z "$COMPONENT" ]; then
@@ -23,6 +22,4 @@ if [ -n "$PACKAGE" ] && [ -n "$COMPONENT" ]; then
     COMMAND="PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn start-component"
 fi
 
-docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.48.2-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
-
-# --update-snapshots
+docker run -v ${HDS_ROOT_DIR}:/${HDS_DIR_BASENAME} -it --rm --ipc=host mcr.microsoft.com/playwright:v1.48.2-jammy /bin/bash -c "cd /${HDS_DIR_BASENAME}/e2e && ${COMMAND}"

--- a/e2e/docker/update-snapshots.sh
+++ b/e2e/docker/update-snapshots.sh
@@ -1,12 +1,11 @@
 
 #!/bin/sh
 HDS_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )"
+HDS_DIR_BASENAME="$(basename "$HDS_ROOT_DIR")"
 
 PACKAGE=$1
 COMPONENT=$2
 COMMAND=""
-
-# PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshot:react
 
 # if packaga and component are not provided, run all snapshots
 if [ -z "$PACKAGE" ] && [ -z "$COMPONENT" ]; then
@@ -23,6 +22,4 @@ if [ -n "$PACKAGE" ] && [ -n "$COMPONENT" ]; then
     COMMAND="PACKAGE=${PACKAGE} COMPONENT=${COMPONENT} yarn update-snapshots-component"
 fi
 
-docker run -v ${HDS_ROOT_DIR}:/helsinki-design-system -it --rm --ipc=host mcr.microsoft.com/playwright:v1.48.2-jammy /bin/bash -c "cd /helsinki-design-system/e2e && ${COMMAND}"
-
-# --update-snapshots
+docker run -v ${HDS_ROOT_DIR}:/${HDS_DIR_BASENAME} -it --rm --ipc=host mcr.microsoft.com/playwright:v1.48.2-jammy /bin/bash -c "cd /${HDS_DIR_BASENAME}/e2e && ${COMMAND}"


### PR DESCRIPTION
## Description

Fixes issue when hds was cloned to non-default folder

## Related Issue

Closes [HDS-2577](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2577)

## How Has This Been Tested?

- running scripts locally

## Add to changelog

- not needed


[HDS-2577]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ