### PR TITLE
(HDS-2589) delete patchrelease branch after release in workflow

### DIFF
--- a/.github/workflows/patchrelease.yml
+++ b/.github/workflows/patchrelease.yml
@@ -49,3 +49,12 @@ jobs:
         run: yarn release --dist-tag patch
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: delete the patchrelease branch
+        run: |
+          git config --global user.email "hds@hel.fi"
+          git config --global user.name "Github Actions"
+          git push origin --delete patchrelease
+
+      - name: End
+        run: echo "Done!"


### PR DESCRIPTION
## Description

Delete the `patchrelease` branch after npm release has been done not to leave it hanging for nothing.

## Related Issue

Closes [HDS-2589](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2589)

## How Has This Been Tested?

- difficult to test without running a "real" patchrelease, next time?

## Add to changelog

- no need


[HDS-2589]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ