### PR TITLE
(HDS-2598) Fix Button typings with ButtonVariant.Supplementary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Button] Fixed typing errors in conditionally changing variant to ButtonVariant.Supplementary
 
 ### Core
 

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { ArgsTable, Stories, Title } from '@storybook/addon-docs/blocks';
 
 import { IconShare, IconAngleRight, IconFaceSmile, IconTrash } from '../../icons';
-import { Button, ButtonTheme, ButtonSize, ButtonPresetTheme, ButtonVariant, CommonButtonProps } from './Button';
+import { Button, ButtonTheme, ButtonSize, ButtonPresetTheme, ButtonVariant, ButtonProps } from './Button';
 import { LoadingSpinner } from '../loadingSpinner';
 
 const onClick = action('button-click');
@@ -184,7 +184,7 @@ export const Loading = () => (
   </Button>
 );
 
-export const LoadingOnClick = (args: CommonButtonProps) => {
+export const LoadingOnClick = (args: ButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const onButtonClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     setIsLoading(true);

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -27,7 +27,7 @@ export interface ButtonTheme {
   '--color-active'?: string;
   '--color-disabled'?: string;
   '--outline-color-focus'?: string;
-  [key: string]: string;
+  [key: string]: string | undefined;
 }
 
 export enum ButtonPresetTheme {
@@ -45,7 +45,7 @@ export enum ButtonVariant {
   Clear = 'clear',
 }
 
-export type CommonButtonProps = AllElementPropsWithoutRef<'button'> & {
+type NonSupplementaryButtonProps = AllElementPropsWithoutRef<'button'> & {
   /**
    * The content (label) of the button
    */
@@ -83,19 +83,18 @@ export type CommonButtonProps = AllElementPropsWithoutRef<'button'> & {
   size?: ButtonSize;
 };
 
-// Supplementary variant requires iconStart or iconEnd
-export type SupplementaryButtonProps = Omit<CommonButtonProps, 'variant'> & {
-  variant: ButtonVariant.Supplementary;
-} & (
-    | {
-        iconStart: React.ReactNode;
-      }
-    | {
-        iconEnd: React.ReactNode;
-      }
-  );
+type NonVariantButtonProps = Omit<NonSupplementaryButtonProps, 'variant'>;
 
-export type ButtonProps = CommonButtonProps | SupplementaryButtonProps;
+export type ButtonProps =
+  | (NonVariantButtonProps & { variant?: Exclude<ButtonVariant, ButtonVariant.Supplementary> })
+  | (NonVariantButtonProps & {
+      variant: ButtonVariant.Supplementary | ButtonVariant;
+      iconStart: React.ReactNode;
+    })
+  | (NonVariantButtonProps & {
+      variant: ButtonVariant.Supplementary | ButtonVariant;
+      iconEnd: React.ReactNode;
+    });
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (


### PR DESCRIPTION
## Description

Typings would fail in case of conditionally setting ButtonVariant.x <-> ButtonVariant.Supplementary and icons (because in Supplementary and icon is mandatory). Thanks go to Joonatan Kuosa for pointing this out.

## Related Issue

Closes [HDS-2598](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2598)

## How Has This Been Tested?

- locally in IDE

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog


[HDS-2598]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ