### PR TITLE
fix: (HDS-2561) cache site files for development

### DIFF
--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -40,7 +40,7 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
         crypto: require.resolve('crypto-browserify'),
       },
     },
-    cache: false,
+    cache: isDevelopmentMode,
     optimization: {
       splitChunks: {
         chunks: 'initial',


### PR DESCRIPTION
Adds cache for development build. So, documentation site build time files are cached