### PR TITLE
fix: (HDS-2652) fix login behaviour when browser back-button is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Login] Fix issue when cancelling logging in by browser back-button which caused the state to remain in "logging in", disabling the button.
 
 ### Core
 

--- a/packages/react/src/components/login/client/oidcClient.ts
+++ b/packages/react/src/components/login/client/oidcClient.ts
@@ -285,6 +285,15 @@ export function createOidcClient(props: OidcClientProps): OidcClient {
     isRenewing,
     login: async (loginProps) => {
       emitStateChange(oidcClientStates.LOGGING_IN);
+      // this is to check if the login was aborted or successful
+      const interval = setInterval(() => {
+        if (oidcClient.getState() === oidcClientStates.LOGGING_IN && !oidcClient.isAuthenticated()) {
+          clearInterval(interval);
+          emitStateChange(oidcClientStates.NO_SESSION);
+        } else {
+          clearInterval(interval);
+        }
+      }, 3000);
       const [err] = await to(userManager.signinRedirect(convertLoginOrLogoutParams<LoginProps>(loginProps)));
       if (err) {
         emitError(new OidcClientError('Login redirect failed', oidcClientErrors.SIGNIN_ERROR, err));

--- a/packages/react/src/components/login/whole.setup.test.ts
+++ b/packages/react/src/components/login/whole.setup.test.ts
@@ -367,17 +367,33 @@ describe('Test all modules together', () => {
       // allListener listens to all modules (oidc, apiTokens, sessionPoller and 3 listener modules)
       expect(getReceivedSignalTypes(LISTEN_TO_ALL_MARKER)).toHaveLength(6);
     });
-    it('When login starts, only login process starts', async () => {
+    it('When login starts, only login process starts (with short timeout, not checking for session)', async () => {
       const { getReceivedSignalTypes } = await initAll({});
       await waitForLoginToTimeout(mockedWindowControls);
       // open id config is called on every login
-      jest.advanceTimersByTime(1000000);
+      jest.advanceTimersByTime(1000);
       expect(getRequestCount()).toBe(1);
       expect(getRequestsInfoById(openIdResponder.id as string)).toHaveLength(1);
       expect(getReceivedSignalTypes(oidcClientNamespace)).toEqual([initSignalType, oidcClientStates.LOGGING_IN]);
       expect(getReceivedSignalTypes(apiTokensClientNamespace)).toEqual([initSignalType]);
       expect(getReceivedSignalTypes(sessionPollerNamespace)).toEqual([initSignalType]);
       expect(getReceivedSignalTypes(LISTEN_TO_ALL_MARKER)).toHaveLength(7);
+    });
+    it('When login starts, only login process starts (with long timeout, checking for session)', async () => {
+      const { getReceivedSignalTypes } = await initAll({});
+      await waitForLoginToTimeout(mockedWindowControls);
+      // open id config is called on every login
+      jest.advanceTimersByTime(1000000);
+      expect(getRequestCount()).toBe(1);
+      expect(getRequestsInfoById(openIdResponder.id as string)).toHaveLength(1);
+      expect(getReceivedSignalTypes(oidcClientNamespace)).toEqual([
+        initSignalType,
+        oidcClientStates.LOGGING_IN,
+        oidcClientStates.NO_SESSION,
+      ]);
+      expect(getReceivedSignalTypes(apiTokensClientNamespace)).toEqual([initSignalType]);
+      expect(getReceivedSignalTypes(sessionPollerNamespace)).toEqual([initSignalType]);
+      expect(getReceivedSignalTypes(LISTEN_TO_ALL_MARKER)).toHaveLength(8);
     });
     it('When login handleCallback is called and finished, apiTokens are fetched and session polling starts', async () => {
       const { getReceivedSignalTypes, oidcClient, beacon } = await initAll({});


### PR DESCRIPTION
Fix Login state stuck in `LOGGING_IN` if coming back with browser's back-button without logging in.

## Related Issue

Closes [HDS-2652](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2652)

## How Has This Been Tested?

- updating & running the tests

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog


[HDS-2652]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ