### PR TITLE
fix: (HDS-1929) keyboard navigation on mobile menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes that are not related to specific components
 - [Component] What bugs/typos are fixed?
 - [Login] Fix issue when cancelling logging in by browser back-button which caused the state to remain in "logging in", disabling the button.
 - [SelectionGroup] Fix warnings about groups with no selections since the new guideline is not to have a preselected value.
+- [Header] Keyboard navigation in mobile menu allows navigation to browser controls, but not to page contents under mobile menu
 
 ### Core
 

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBarNavigationMenu.test.tsx.snap
@@ -9,10 +9,6 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
       class="headerBackgroundWrapper"
     >
       <div
-        aria-hidden="true"
-        tabindex="0"
-      />
-      <div
         class="headerActionBarContainer mobileMenuContainer"
       >
         <div
@@ -697,10 +693,6 @@ exports[`<HeaderActionBarNavigationMenu /> spec renders the component and menu c
           </div>
         </div>
       </div>
-      <div
-        aria-hidden="true"
-        tabindex="0"
-      />
     </div>
   </header>
 </DocumentFragment>


### PR DESCRIPTION
## Description

It wasn't possible to navigate with the keyboard from page to browser controls if the mobile menu was open. Now it is, and it still avoids navigation page content under the visible mobile menu.

When the mobile menu is opened, all other focusable elements (outside the mobile menu and the action bar) are set to tab index -1 (unfocusable). When the mobile menu is closed, the original tab index is returned to altered elements.

## Related Issue

Closes [HDS-1929](https://helsinkisolutionoffice.atlassian.net/browse/HDS-1929)

## Motivation and Context

To make the keyboard navigation as good as possible.

## How Has This Been Tested?

Manually navigating with the keyboard in the Header's Storybook.

## Demos:

Links to demos are in the comments.

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-1929]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ