### PR TITLE
fix: (HDS-2640) add progress bar to "copy code" functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- Site code-examples "Copy code" notifications now have progress bar to display that they close automatically without user interaction.
 
 ### Figma
 

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -236,7 +236,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
             label="Code copied"
             position="bottom-right"
             autoClose
-            displayAutoCloseProgress={false}
+            autoCloseDuration={4000}
             onClose={() => setCopyState('')}
           >
             Example code was copied to clipboard.
@@ -247,7 +247,6 @@ const Editor = ({ onChange, initialCode, code, language }) => {
             type="error"
             label="Copy failed"
             position="bottom-right"
-            displayAutoCloseProgress={false}
             dismissible
             closeButtonLabelText="Close toast"
             onClose={() => {


### PR DESCRIPTION
Add progress bar to "copy code" functionality in documentation site examples

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2640](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2640)

## How Has This Been Tested?

- locally running the site

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

![CleanShot 2025-03-03 at 10 36 01](https://github.com/user-attachments/assets/a2cfcc34-c2c9-4b69-9556-85e3960e95a7)

## Add to changelog

- [x] Added needed line to changelog


[HDS-2640]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ