### PR TITLE
fix: (HDS-2655) Links to Figma colour examples and community file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Changes that are not related to specific components
 
 - [Component] What is added?
 - [Select] Add documentation and an example for added `onClose` property.
+- [Getting started] Added links to Figma Community file
 
 #### Changed
 
@@ -72,6 +73,7 @@ Changes that are not related to specific components
 - [Component] What bugs/typos are fixed?
 - Site code-examples "Copy code" notifications now have progress bar to display that they close automatically without user interaction.
 - [SelectionGroup] Do not recommend a preselected value anymore according to our new guideline.
+- [Colours] Link to Figma colour examples
 
 ### Figma
 

--- a/site/src/docs/foundation/design-tokens/colour/index.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/index.mdx
@@ -18,7 +18,7 @@ Colour can be used for branding, providing visual hierarchy and giving visual cu
 
 The Helsinki Design system colour tokens are based on the City of Helsinki brand colour palette. More information on using and combining the brand colours in the <ExternalLink href="https://www.hel.fi/en/decision-making/information-on-helsinki/design-and-digitalisation/helsinki-brand-and-visual-identity/visual-identity-guidelines/use-basic-elements#colours">City of Helsinki Visual Identity Guidelines - Colours</ExternalLink>.
 
-Also see visual "Do and Don't" example images in the <ExternalLink href="https://share.goabstract.com/30c40134-681b-4f96-9dfc-ee6d32c2f1eb">Colour usage examples - Abstract collection</ExternalLink>. These images will help you understand where brand colours and their variants can be used.
+Also see more colour documentation and visual "Do and Don't" example images in the <ExternalLink href="https://www.figma.com/design/Kxwg3R0zNRHj55nQqFu6VS/HDS-Design-Kit-v4?m=auto&node-id=4568-32587&t=RCKXKNovoD7YlPd5-1">Colour usage examples - Figma Design kit</ExternalLink>. These images will help you understand where brand colours and their variants can be used.
 
 ### Principles
 

--- a/site/src/docs/getting-started/designer.mdx
+++ b/site/src/docs/getting-started/designer.mdx
@@ -24,7 +24,7 @@ Always keep these core principles in mind when making design decisions:
 ## Getting started
 1. Explore the City of Helsinki <ExternalLink href="https://www.hel.fi/en/decision-making/information-on-helsinki/design-and-digitalisation/helsinki-brand-and-visual-identity/visual-identity-guidelines">Visual Identity Guidelines</ExternalLink> to learn the design principles of the brand.
 2. Take a look at the <InternalLink href="/components">Components documentation</InternalLink> to see what is available and how you can incorporate those into your designs.
-3. The design assets are available either via direct design kit download or via the City of Helsinki Figma. To access HDS libraries, you will need to use Figma. See more on downloading and setting up the libraries below.
+3. The design assets are available either via direct design kit download or via the City of Helsinki Figma, or via <ExternalLink href="https://www.figma.com/community/file/1441694909662533693/helsinki-design-system-4-0-0">Community file</ExternalLink>. To access HDS libraries, you will need to use Figma. See more on downloading and setting up the libraries below.
 4. If you have an idea for improvements or a component that could be a useful addition to the Design System, see the <InternalLink href="/getting-started/contributing/how-to-contribute">Contributing</InternalLink> page for more information.
 
 ## Setting up
@@ -38,7 +38,9 @@ If you are a newcomer to Figma,  there are great tutorials and help over at:
 - <InternalLink href="/getting-started/tutorials/figma-tutorial">HDS Figma tutorial</InternalLink>
 - <ExternalLink href="https://help.figma.com/hc/">Figma help center</ExternalLink>
 
-**You do not necessarily need access to Helsinki city organisation to use HDS design library.** We offer a downloadable HDS design Kit alongside Git releases. <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/latest/download/hds-design-kit.zip">Download the latest HDS Design kit from the HDS GitHub repository</ExternalLink>. Please note that if you use the design kit outside of Helsinki organisation, you need to manually download the kit again to gain access to the newest updates. We are working toward releasing the design kit as a community file that receives updates automatically when we have a release.  
+**You do not necessarily need access to Helsinki city organisation to use HDS design library.** We offer a downloadable HDS design Kit alongside Git releases. <ExternalLink href="https://github.com/City-of-Helsinki/helsinki-design-system/releases/latest/download/hds-design-kit.zip">Download the latest HDS Design kit from the HDS GitHub repository</ExternalLink>. Please note that if you use the design kit outside of Helsinki organisation, you need to manually download the kit again to gain access to the newest updates. 
+
+HDS Design kit is also now available as a <ExternalLink href="https://www.figma.com/community/file/1441694909662533693/helsinki-design-system-4-0-0">Figma Community file</ExternalLink>. The Community file receives major updates only.
 
 
 ### Install fonts

--- a/site/src/docs/getting-started/index.mdx
+++ b/site/src/docs/getting-started/index.mdx
@@ -15,7 +15,7 @@ The system provides working code, design resources, and guidelines that bring pr
 <Image size="M" src="/images/getting-started/structure-graph.svg" alt="Helsinki Design System structure graph" style={{ display: 'block', width: '100%', minWidth: 600, maxWidth: 915, margin: '0 auto' }} />
 
 The Helsinki Design System consists of several parts:
-- **For designers**, HDS offers a Figma library and a downloadable design kit. Both include the main design file of all components in the HDS component library. They help designers create beautiful, usable, and accessible user experiences that follow the City of Helsinki brand guidelines.
+- **For designers**, HDS offers a Figma library on the organization level and as a <ExternalLink href="https://www.figma.com/community/file/1441694909662533693/helsinki-design-system-4-0-0">Community file</ExternalLink>, alongside a downloadable design kit with Github releases. All include the main design file consisting of all components in the HDS component library. They help designers create beautiful, usable, and accessible user experiences that follow the City of Helsinki brand guidelines.
 - **For developers**, HDS offers component libraries (Core and React) that provide modular, accessible components for building scalable digital services efficiently.
 - **For all**, HDS offers visual assets like icons and logos to help keep the visual language consistent.
 - **For all**, HDS offers a documentation site that collects detailed information on how to use the HDS components, design tokens, and visual assets in practice, including design principles, accessibility and usage guidelines, examples, interactive demos, and API descriptions.


### PR DESCRIPTION
## Description

fix links to Figma colour examples and and added links to Community file

## Related Issue

Closes [HDS-2655](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2655)


## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog



[HDS-2655]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ