### PR TITLE
[Feature]: Add optional date format prop to DateInput component

### DIFF
--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -74,6 +74,10 @@ export type DateInputProps = Omit<TextInputProps, 'onChange'> & {
    * Function to set aria-describedby for dates.
    */
   setDateAriaDescribedBy?: (date: Date) => string | undefined;
+  /**
+   * Date format for the input value.
+   * */
+  format?: string;
 };
 
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
@@ -94,11 +98,11 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       setDateClassName,
       legend,
       setDateAriaDescribedBy,
+      format: dateFormat = 'd.M.yyyy',
       ...textInputProps
     }: DateInputProps,
     ref?: React.Ref<HTMLInputElement>,
   ) => {
-    const dateFormat = 'd.M.yyyy';
     const inputRef = useRef<HTMLInputElement>();
     const didMount = useRef(false);
     const [inputValue, setInputValue] = useState<string>(providedValue || defaultValue || '');


### PR DESCRIPTION
## Description
adding the ability to pass the format of the date

## Related Issue
We use this library as part of our project, and we need a different format (`mm.dd.yyyy`), maybe other users will find it useful too.
[previous pr](https://github.com/City-of-Helsinki/helsinki-design-system/pull/1488) was closed accidentally by mistake (I deleted the remote branch which closed the pr)
