### PR TITLE
chore: (HDS-2669) disable hds-demo workflows concurrency

### DIFF
--- a/.github/workflows/hds-demo-preview-clean.yml
+++ b/.github/workflows/hds-demo-preview-clean.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - development
       - release-*
-      - 'feature/*'
     types:
       - closed
 
@@ -13,6 +12,9 @@ jobs:
   build_and_publish_demo:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    concurrency:
+      group: hds-demo
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code hds-demo
@@ -42,5 +44,6 @@ jobs:
           git status
           git add .
           git commit -m "Updated pr ${{ github.event.number }}"
+          git pull --rebase || (sleep 20 && git pull --rebase)
           git push
         working-directory: ./hds-demo

--- a/.github/workflows/hds-demo-preview.yml
+++ b/.github/workflows/hds-demo-preview.yml
@@ -5,17 +5,18 @@ on:
     branches:
       - development
       - release-*
-      - 'feature/*'
   push:
     branches:
       - development
       - release-*
-      - 'feature/*'
 
 jobs:
   build_and_publish_demo:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    concurrency:
+      group: hds-demo
+      cancel-in-progress: false
 
     env:
       PATH_PREFIX: "/hds-demo/preview_${{ github.event.number != '' && github.event.number || github.ref_name }}"
@@ -124,7 +125,7 @@ jobs:
           git add .
           git commit -m "Updated preview to $DEMO_NAME"
           git status
-          git pull --rebase
+          git pull --rebase || (sleep 20 && git pull --rebase)
           git push
         working-directory: ./hds-demo
 


### PR DESCRIPTION
Disable concurrency on workflows because
it will cause trouble when multiple PR´s are
created and/or closed at the same time.

Hard to test so this is the test when it gets merged and ran next time :D

Refs: HDS-2669

Closes [HDS-2669](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2669)

## Add to changelog

- not needed


[HDS-2669]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ