### PR TITLE
fix: (HDS-2671) internal documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- Bug of anchor links on the documentation page
 
 ### Figma
 

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -57,6 +57,7 @@ const hrefWithVersion = (href, version, withoutPrefix = false) => {
   if (!version || hrefWithFixedExceptions === ''
     || hrefWithFixedExceptions.startsWith('mailto:')
     || hrefWithFixedExceptions.startsWith('#')
+    || hrefWithFixedExceptions.startsWith('/#')
     || hrefWithFixedExceptions.startsWith('http'))
     return hrefWithFixedExceptions;
 


### PR DESCRIPTION
## Description

The documentation site's internal documentation links (anchor links) didn't work (on historical documentation versions). For example, links on page [https://hds.hel.fi/release-3.12.0/components/login/usage/](https://hds.hel.fi/release-3.12.0/components/login/usage/
) 

## Related Issue

Closes [HDS-2671](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2671)

## How Has This Been Tested?

Manually. As historical documentation versions are not anymore available on development build, run `yarn build; yarn serve` on documentation site for production build. Go to [http://localhost:9000/release-3.12.0/components/login/usage/](http://localhost:9000/release-3.12.0/components/login/usage/) try anchor links on Table of contents

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2671]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ