### PR TITLE
fix: footer logo href and tabIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes that are not related to specific components
 - [Component] What bugs/typos are fixed?
 - [FileInput] `defaultValue` triggered the `onChange` prop function
 - [FileInput] display the "No file selected" only when `required` prop is given and no file(s) selected
+- [Footer] fix `Footer.Base` logo tabIndex issue, it was falsely given zero which prevented focus
 
 ### Core
 
@@ -69,6 +70,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - Bug of anchor links on the documentation page
+- Page footer Helsinki logo link
 
 ### Figma
 

--- a/packages/react/src/components/footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/react/src/components/footer/__snapshots__/Footer.test.tsx.snap
@@ -61,7 +61,6 @@ exports[`<Footer /> spec renders the component 1`] = `
           >
             <a
               class="link link-medium item"
-              tabindex="0"
             >
               <img
                 alt="Helsingin kaupunki"

--- a/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
+++ b/packages/react/src/components/footer/components/footerBase/FooterBase.tsx
@@ -87,7 +87,7 @@ export const FooterBase = ({
     <div {...rest} className={classNames(styles.base, className)}>
       <hr className={styles.divider} aria-hidden />
       <div className={styles.logoWrapper}>
-        <FooterLink tabIndex={0} icon={logo} href={logoHref} onClick={handleLogoClick} />
+        <FooterLink icon={logo} href={logoHref} onClick={handleLogoClick} />
       </div>
       {(copyrightHolder || copyrightText) && (
         <div className={styles.copyright}>

--- a/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
+++ b/packages/react/src/components/footer/components/footerBase/__snapshots__/FooterBase.test.tsx.snap
@@ -61,7 +61,6 @@ exports[`<Footer.Base /> spec renders the component 1`] = `
           >
             <a
               class="link link-medium item"
-              tabindex="0"
             >
               <img
                 alt="Helsingin kaupunki"

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -300,7 +300,8 @@ const Layout = ({ location, children, pageContext }) => {
           <Footer.Base
             copyrightHolder="Copyright"
             backToTopLabel="Back to top"
-            logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" logoHref="https://hel.fi"/>}
+            logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
+            logoHref="https://hel.fi"
           >
             <Footer.Link
               label="Contribution"


### PR DESCRIPTION
- remove tabIndex 0 from FooterBase logo
- move falsely positioned logoHref prop in site layout
- update jest snapshots

Refs: HDS-2653

## Description

The Footer logo link did not work since the logoHref was given to wrong component, remove tabIndex 0 from it too which prevented focus

## Related Issue

Closes [HDS-2653](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2653)

## How Has This Been Tested?

- running tests locally

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog


[HDS-2653]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ