### PR TITLE
ci: if clean has started, kill the possible started build & deploy

### DIFF
--- a/.github/workflows/hds-demo-preview-clean.yml
+++ b/.github/workflows/hds-demo-preview-clean.yml
@@ -13,8 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     concurrency:
-      group: hds-demo
-      cancel-in-progress: false
+      group: hds-demo-${{ github.ref }}
 
     steps:
       - name: Checkout code hds-demo

--- a/.github/workflows/hds-demo-preview.yml
+++ b/.github/workflows/hds-demo-preview.yml
@@ -15,8 +15,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     concurrency:
-      group: hds-demo
-      cancel-in-progress: false
+      group: hds-demo-${{ github.ref }}
 
     env:
       PATH_PREFIX: "/hds-demo/preview_${{ github.event.number != '' && github.event.number || github.ref_name }}"


### PR DESCRIPTION
- only one workflow to run on one PR (if PR closed
-> start clean
-> kill the possibly ongoing build & deploy)

Refs: HDS-2679

## Related Issue

Closes [HDS-2679](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2679)

## Add to changelog

- not needed


[HDS-2679]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ