### PR TITLE
Hds 2624 table of contents should move focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Changes that are not related to specific components
 
 - Bug of anchor links on the documentation page
 - Page footer Helsinki logo link
+- Focus follows anchor links
+- Permalinks of headings are fixed better for screen readers
 
 ### Figma
 

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -168,9 +168,7 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              icon: `<span class="hds-anchor-icon hds-icon hds-icon--link hds-icon--size-xs" aria-hidden="true" style="vertical-align: middle"></span>`,
-              isIconAfterHeader: true,
-              className: `header-anchor`,
+              icon: false
             },
           },
         ],

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -91,12 +91,10 @@ const headingWrapper = (props) => {
   return (
     <a href={`#${props.id}`} aria-label={`${props.id} permalink`}>
       {props.children}
-      <span className="hds-anchor-icon hds-icon hds-icon--link hds-icon--size-s header-anchor after" aria-hidden="true" style={{verticalAlign: "middle"}} />
+      <span className="anchor-link" aria-hidden="true"><span className="hds-anchor-icon hds-icon hds-icon--link" /></span>
     </a>
   );
 }
-
-
 
 const components = (version) => ({
   IconCheckCircleFill,

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -153,6 +153,7 @@ const Layout = ({ location, children, pageContext }) => {
   const locationWithoutVersion = hrefWithoutVersion(pathName, version);
   const versionNumber = version ? version.replace('release-', '') : documentationVersion;
   const versionLabel = `Version ${versionNumber}`;
+  const hash = location.hash;
 
   // Some hrefs of internal links can't be replaced with MDXProvider's replace component logic.
   // this code will take care of those
@@ -169,7 +170,21 @@ const Layout = ({ location, children, pageContext }) => {
         }
       }
     }
-  }, [version, pathName]);
+
+    // Move focus to anchor if it is specified
+    if (hash) {
+      const timeout = setTimeout(() => {
+        const anchor = document.querySelector(`a[href='${hash}']`);
+        if (anchor) {
+          anchor.focus();
+        }
+      }, 0);
+
+      return () => clearTimeout(timeout);
+    }
+
+
+  }, [version, pathName, hash]);
 
   const siteData = pageContext.siteData;
 

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -87,6 +87,17 @@ const hrefWithoutVersion = (href, version) => {
   return href.replace(`/${version}`, '');
 };
 
+const headingWrapper = (props) => {
+  return (
+    <a href={`#${props.id}`} aria-label={`${props.id} permalink`}>
+      {props.children}
+      <span className="hds-anchor-icon hds-icon hds-icon--link hds-icon--size-s header-anchor after" aria-hidden="true" style={{verticalAlign: "middle"}} />
+    </a>
+  );
+}
+
+
+
 const components = (version) => ({
   IconCheckCircleFill,
   IconCrossCircle,
@@ -101,34 +112,34 @@ const components = (version) => ({
   thead: Table.Head,
   tbody: Table.Body,
   th: Table.Th,
-  h1: (props) => (
+  h1: (props) => {console.log(props); return (
     <h1 {...props} className={classNames('page-heading-1 heading-xl-mobile', props.className)}>
-      {props.children}
+      {headingWrapper(props)}
     </h1>
-  ),
+  )},
   h2: (props) => (
     <h2 {...props} className={classNames('page-heading-2 heading-l', props.className)}>
-      {props.children}
+      {headingWrapper(props)}
     </h2>
   ),
   h3: (props) => (
     <h3 {...props} className={classNames('page-heading-3 heading-m', props.className)}>
-      {props.children}
+      {headingWrapper(props)}
     </h3>
   ),
   h4: (props) => (
     <h4 {...props} className={classNames('page-heading-4 heading-s', props.className)}>
-      {props.children}
+      {headingWrapper(props)}
     </h4>
   ),
   h5: (props) => (
     <h5 {...props} className={classNames('page-heading-5 heading-xs', props.className)}>
-      {props.children}
+      {headingWrapper(props)}
     </h5>
   ),
   h6: (props) => (
     <h6 {...props} className={classNames('page-heading-6 heading-xxs', props.className)}>
-      {props.children}
+      {headingWrapper(props)}
     </h6>
   ),
 });

--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -238,15 +238,16 @@ h2,
 h3,
 h4,
 h5 {
+  & a {
+    color: var(--color-black-90);
+    text-decoration: none;
+    outline: none;
+  }
+
   &:hover {
     .hds-anchor-icon {
       visibility: visible;
-    }
-  }
-
-  &:focus {
-    .hds-anchor-icon {
-      visibility: visible;
+      color: var(--color-black-50);
     }
   }
 }
@@ -259,8 +260,6 @@ h5 {
   vertical-align: middle;
 
   &:focus {
-    outline: 3px solid var(--color-coat-of-arms);
-
     .hds-anchor-icon {
       visibility: visible;
     }

--- a/site/src/components/layout.scss
+++ b/site/src/components/layout.scss
@@ -238,22 +238,44 @@ h2,
 h3,
 h4,
 h5 {
-  & a {
-    color: var(--color-black-90);
-    text-decoration: none;
-    outline: none;
-  }
-
   &:hover {
     .hds-anchor-icon {
       visibility: visible;
+    }
+  }
+
+  & a {
+    color: var(--color-black-90);
+    outline: none;
+    text-decoration: none;
+
+    & .anchor-link {
       color: var(--color-black-50);
+      display: inline-block;
+      height: var(--fontsize-heading-m);
+      margin-left: var(--spacing-2-xs);
+      vertical-align: middle;
+
+      & .hds-anchor-icon {
+        height: var(--fontsize-heading-m);
+        vertical-align: top;
+        width: var(--fontsize-heading-m);
+      }
+    }
+
+    &:focus {
+      & .anchor-link {
+        outline: 3px solid var(--color-focus-outline);
+      }
+
+      & .hds-anchor-icon {
+        visibility: visible;
+      }
     }
   }
 }
 
 .header-anchor {
-  color: var(--color-black-90);
   font-size: 0;
   margin-left: var(--spacing-2-xs);
   padding-left: 0 !important;

--- a/site/src/docs/about/accessibility/statement.mdx
+++ b/site/src/docs/about/accessibility/statement.mdx
@@ -25,8 +25,6 @@ Issues with keyboards and navigation:
 
 - Code area cannot be scrolled with keyboard 
 
-- Table of Contents links do not work properly with keyboard and screen readers 
-
 Issues with contrast on code blocks: 
 
 - Code blocks don’t meet all contrast requirements 
@@ -69,6 +67,6 @@ Telephone number: 029 534 5000 (Switchboard)
 
 This website was published on 28.11.2019. 
 
-This accessibility statement was last reviewed on 7.2.2025. 
+This accessibility statement was last reviewed on 2.4.2025. 
 
 <ExternalLink openInNewTab openInNewTabAriaLabel="Opens in a new tab" href="https://www.finlex.fi/fi/laki/alkup/2019/20190306">Act on the Provision of Digital Services (306/2019) </ExternalLink>


### PR DESCRIPTION
## Description

- If a user navigates to an anchor link (like form table of contents) focus moves to the linked heading
- HDS-2639 (second commit) heading text is inside of an anchor element, so the whole heading is a link
- No need to set tabIndex for headings because those are links and are keyboard-navigable 

- Note: Navigation or Side navigation should not move focus (other than to the beginning of the document)


## Related Issue

Closes [HDS-2624](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2624)
Closes [HDS-2627](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2627)
Closes [HDS-2639](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2639)

## Motivation and Context

- Accessibility improvements

## How Has This Been Tested?

- /components/login/ has a good table of contents to test this

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2624]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-2627]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDS-2639]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ