### PR TITLE
chore: add dummy workflows for next stage new workflows (HDS-2332)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - development
+      - master
+      - release-*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4

--- a/.github/workflows/loki-tests.yml
+++ b/.github/workflows/loki-tests.yml
@@ -1,0 +1,17 @@
+name: loki-tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - development
+      - master
+      - release-*
+
+jobs:
+  run-loki-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4


### PR DESCRIPTION
Refs: HDS-2332

## Description

These are needed to be able to test the new workflows without merging to `development` first (workflows need to exist in base branch to be able to run them on other branches).