### PR TITLE
chore: add more workers to speed up e2e-tests

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  workers: 2,
+  workers: 4,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['junit', { outputFile: 'report/e2e-junit-results.xml' }],


### PR DESCRIPTION
## Description

Double the e2e test workers from 2 -> 4 to speed up tests
