### PR TITLE
fix: (FileInput) defaultValue typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [FileInput] `defaultValue` was wrongly typed (TypeScript)
 
 ### Core
 

--- a/packages/react/src/components/fileInput/FileInput.tsx
+++ b/packages/react/src/components/fileInput/FileInput.tsx
@@ -11,7 +11,7 @@ import { InputWrapper, InputWrapperProps } from '../../internal/input-wrapper/In
 
 type Language = 'en' | 'fi' | 'sv';
 
-export type FileInputProps = Omit<InputWrapperProps, 'onChange'> & {
+export type FileInputProps = Omit<InputWrapperProps, 'onChange' | 'defaultValue'> & {
   /**
    * A comma-separated list of unique file type specifiers describing file types to allow. If present, the filename extension or filetype property is validated against the list. If the file(s) do not match the acceptance criteria, the component will not add the file(s), and it will show an error message with the file name.
    */


### PR DESCRIPTION
## Description

There was an error when importing and using `hds-react` in other projects with error:

```shell
Type error: Type 'File[]' is not assignable to type '((string | number | readonly string[]) & File[]) | undefined'.
  Type 'File[]' is not assignable to type 'readonly string[] & File[]'.
    Type 'File[]' is not assignable to type 'readonly string[]'.
      Type 'File' is not assignable to type 'string'.
``` 

## How Has This Been Tested?

- importing and using in `hds-next`

## Add to changelog

- [x] Added needed line to changelog
