### PR TITLE
chore(ci): deploy site from clean state every time, discard old ones

### DIFF
--- a/.github/workflows/publish-site-with-storybooks.yml
+++ b/.github/workflows/publish-site-with-storybooks.yml
@@ -73,14 +73,10 @@ jobs:
       - name: move react storybook under site
         run: mv ./packages/react/storybook-static ./site/public/storybook/react
 
-      - name: Deploy
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./site/public
-          SCRIPT_MODE: true
-        run: |
-          wget https://raw.githubusercontent.com/peaceiris/actions-gh-pages/v2.5.0/entrypoint.sh
-          bash ./entrypoint.sh
-          # with:
-          # keepFiles: true
+      - name: Deploy site
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
+          publish_dir: ./site/public
+          force_orphan: true


### PR DESCRIPTION
Refs: HDS-2717

## Description

Deploys the site from clean state instead of accumulating all files & commits which bloat the repo.

## Related Issue

Closes [HDS-2717](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2717)

## How Has This Been Tested?

- not yet in any way, we need to test this during next release

## Demos:

Links to demos are in the comments (although nothing to demo :D )

## Screenshots (if appropriate):

## Add to changelog

- Not needed


[HDS-2717]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ