### PR TITLE
[DRAFT] HDS-2726: OidcClient renew user if refresh_token exists

### DIFF
--- a/packages/react/src/components/login/Login.stories.tsx
+++ b/packages/react/src/components/login/Login.stories.tsx
@@ -117,20 +117,20 @@ const loginProviderProps: LoginProviderProps = {
 
 const loginProviderPropsForKeycloak: LoginProviderProps = {
   userManagerSettings: {
-    authority: 'https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus',
-    client_id: 'exampleapp-ui-test',
-    scope: 'openid profile',
+    authority: 'https://tunnistus.dev.hel.ninja/auth/realms/helsinki-tunnistus',
+    client_id: 'exampleapp-ui-dev',
+    scope: 'openid profile email',
     redirect_uri: `${window.origin}/static-login/callback_kc.html`,
     silent_redirect_uri: `${window.origin}/static-login/silent_renew.html`,
     post_logout_redirect_uri: `${window.origin}/static-login/logout.html`,
   },
   apiTokensClientSettings: {
-    url: 'https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect/token',
+    url: 'https://tunnistus.dev.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect/token',
     queryProps: {
       grantType: 'urn:ietf:params:oauth:grant-type:uma-ticket',
       permission: '#access',
     },
-    audiences: ['exampleapp-api-test', 'profile-api-test'],
+    audiences: ['exampleapp-api-dev', 'profile-api-dev'],
   },
   sessionPollerSettings: { pollIntervalInMs: 10000 },
 };
@@ -629,6 +629,7 @@ export const ExampleApplication = (args: StoryArgs) => {
   // The following lines are not needed when only one oidc server is used.
   // HDS uses both Tunnistamo and Helsinki Profile (Keycloak) and uses Storybook args to define which is used.
   const isUsingKeycloak = shouldUseKeycloakServer(args);
+
   const loginProps = isUsingKeycloak ? loginProviderPropsForKeycloak : loginProviderProps;
 
   const AuthenticatedContent = ({ user }: { user: User }) => {

--- a/packages/react/src/components/login/client/hooks.test.tsx
+++ b/packages/react/src/components/login/client/hooks.test.tsx
@@ -44,7 +44,7 @@ describe('Client hooks', () => {
     });
     it('Returns null, if a valid user is not found', async () => {
       init({
-        invalidUser: false,
+        invalidUser: true,
         expiredUser: true,
       });
       expect(getUser()).toBeNull();

--- a/packages/react/src/components/login/client/hooks.tsx
+++ b/packages/react/src/components/login/client/hooks.tsx
@@ -14,7 +14,13 @@ export const useOidcClient = (): OidcClient => {
 
 export const useAuthenticatedUser = (): UserReturnType => {
   const client = useOidcClient();
+
   const user = client.getUser();
+
+  if (client.isRenewing() && user && user.refresh_token) {
+    return user;
+  }
+
   if (!isValidUser(user)) {
     return null;
   }

--- a/packages/react/src/components/login/client/oidcClient.test.ts
+++ b/packages/react/src/components/login/client/oidcClient.test.ts
@@ -636,7 +636,7 @@ describe('oidcClient', () => {
       return beaconModule;
     };
 
-    const initRenewalTests = async (validResponse = true, createListeningModules = false) => {
+    const initRenewalTests = async (validResponse = true, createListeningModules = false, userPropsOverrides = {}) => {
       const modules = createListeningModules
         ? moduleNamespaces.map((namespace) => {
             return createModule(namespace);
@@ -664,7 +664,7 @@ describe('oidcClient', () => {
         : new Error('Failed');
       const clientData = await initTests({
         modules: createListeningModules ? [reEmitListeningModule, ...modules] : undefined,
-        userProps: { signInResponseProps: { refresh_token: refreshTokens.initial } },
+        userProps: { signInResponseProps: { ...userPropsOverrides, refresh_token: refreshTokens.initial } },
       });
       const renewalFunctions = init({ userManager: clientData.userManager });
 
@@ -779,6 +779,17 @@ describe('oidcClient', () => {
           expect(oidcClient.isRenewing()).toBeFalsy();
         });
         expect(oidcClient.getUser()).toMatchObject(initialUser);
+        expect(oidcClient.isAuthenticated()).toBeTruthy();
+      });
+      it('Renewal when access_token has expired', async () => {
+        const { oidcClient, waitForRefreshToEnd } = await initRenewalTests(true, true, { access_token: null });
+        expect(oidcClient.isRenewing()).toBeTruthy();
+
+        await waitForRefreshToEnd();
+        await waitFor(() => {
+          expect(oidcClient.isRenewing()).toBeFalsy();
+        });
+
         expect(oidcClient.isAuthenticated()).toBeTruthy();
       });
     });

--- a/packages/react/src/components/login/client/oidcClient.ts
+++ b/packages/react/src/components/login/client/oidcClient.ts
@@ -232,8 +232,17 @@ export function createOidcClient(props: OidcClientProps): OidcClient {
     emitEvent(oidcClientEvents.USER_REMOVED);
   });
 
-  if (isValidUser(getUserFromStorageSyncronously())) {
+  const storedUser = getUserFromStorageSyncronously();
+
+  if (isValidUser(storedUser)) {
     state = oidcClientStates.VALID_SESSION;
+  } else if (storedUser && storedUser.refresh_token) {
+    // If user has a refresh token but expired access token, try to renew on initialization
+    handleUserRenewal({ triggerSigninSilent: true }).then(([, renewedUser]) => {
+      if (renewedUser && isValidUser(renewedUser)) {
+        emitStateChange(oidcClientStates.VALID_SESSION);
+      }
+    });
   }
 
   const oidcClient: OidcClient = {


### PR DESCRIPTION
## Description
OIDC should try to renew user if access_token has expired, but refresh_token is available.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2726](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2726)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->
