### PR TITLE
fix: (HDS-2699) use link role only when the Header logo has a href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - [FileInput] `defaultValue` was wrongly typed (TypeScript)
+- [Header] Header logo had `role='link'` always, but now only when the logo is set as a link.
 
 ### Documentation
 

--- a/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
+++ b/packages/react/src/components/header/components/headerActionBar/HeaderActionBar.tsx
@@ -227,8 +227,8 @@ export const HeaderActionBar = ({
 
   const logoProps: LinkProps = {
     'aria-label': logoAriaLabel,
-    role: 'link',
     href: logoHref,
+    ...(logoHref ? { role: 'link' } : {}),
     className: classNames(styles.titleAndLogoContainer, styles.logo),
     onClick: handleLogoClick,
     onKeyPress: handleLogoKeyPress,

--- a/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBar.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerActionBar/__snapshots__/HeaderActionBar.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`<HeaderActionBar /> spec renders the component 1`] = `
         >
           <span
             class="titleAndLogoContainer logo"
-            role="link"
           >
             <span
               class="logoWrapper"

--- a/packages/react/src/components/header/components/headerLanguageSelector/__snapshots__/HeaderLanguageSelector.test.tsx.snap
+++ b/packages/react/src/components/header/components/headerLanguageSelector/__snapshots__/HeaderLanguageSelector.test.tsx.snap
@@ -151,7 +151,6 @@ exports[`<Header.LanguageSelector /> spec renders the consumer component with pr
     >
       <span
         class="titleAndLogoContainer logo"
-        role="link"
       >
         <span
           class="logoWrapper"


### PR DESCRIPTION
## Description

The Header logo had `role='link'` always, but should have it only when the logo is set as a link.
  
## Related Issue

Closes [HDS-2699](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2699)

## How Has This Been Tested?

Manually in the Header story in Storybook

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog


[HDS-2699]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ