### PR TITLE
fix: (HDS-2700) tabs should have tabindex 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes that are not related to specific components
 - [Component] What bugs/typos are fixed?
 - [Select] Mounting & unmounting sometimes prevented opening the dropdown.
 - [Select] Search cleared or messed up the previous selections made.
+- [Tabs] Tabs has tabindex=0 to allow keyboard navigation
 
 ### Core
 

--- a/packages/react/src/components/tabs/TabPanel.tsx
+++ b/packages/react/src/components/tabs/TabPanel.tsx
@@ -26,6 +26,7 @@ export const TabPanel = ({ children, className, index, style }: TabPanelProps) =
       aria-labelledby={`tab-${index}-button`}
       className={className}
       style={style}
+      tabIndex={0}
     >
       {children}
     </div>

--- a/packages/react/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/__snapshots__/Tabs.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`<Tabs /> spec renders the component 1`] = `
       aria-labelledby="tab-0-button"
       id="tab-0-panel"
       role="tabpanel"
+      tabindex="0"
     >
       Fizz
     </div>


### PR DESCRIPTION
## Description

Tabs should have tabindex 0 to allow keyboard navigation

## Related Issue

Closes [HDS-2700](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2700)

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2700]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ