### PR TITLE
fix: (HDS-2748) select virtualize mode rendered wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes that are not related to specific components
 - [Component] What bugs/typos are fixed?
 - [Select] Mounting & unmounting sometimes prevented opening the dropdown.
 - [Select] Search cleared or messed up the previous selections made.
+- [Select] Select component didn't render last option on virtualize -mode.
 
 ### Core
 

--- a/packages/react/src/components/select/components/list/VirtualizedLists.tsx
+++ b/packages/react/src/components/select/components/list/VirtualizedLists.tsx
@@ -27,7 +27,7 @@ export const VirtualizedLists = ({ forMultiSelectWithGroups }: { forMultiSelectW
       const allowedLength = Math.min(options.length, childrenLeft);
       childrenLeft -= allowedLength;
       return {
-        options: allowedLength > 0 ? options.slice(0, allowedLength - 1) : [],
+        options: allowedLength > 0 ? options.slice(0, allowedLength) : [],
       };
     });
   };


### PR DESCRIPTION
## Description

Select component didn't render the last option if the `virtualize` argument was set. There was a simple bug that sliced the options wrong.

## Related Issue

Closes [HDS-2748](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2748)

## How Has This Been Tested?

It's easy to test in document site or storybook. Just add the `virtualize` argument to any Select example, and then the last option is dropped from the list. Test the same on fixed code — it works.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2748]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ