### PR TITLE
fix: (HDS-2693) date picker aria-live and aria-controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - [Component] What is added?
+- [DateInput] aria-live, aria-controls and aria-expanded -attributes.
 
 #### Changed
 

--- a/packages/react/src/components/dateInput/DateInput.tsx
+++ b/packages/react/src/components/dateInput/DateInput.tsx
@@ -284,6 +284,8 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           {...textInputProps}
           buttonIcon={disableDatePicker ? undefined : <IconCalendar />}
           buttonAriaLabel={disableDatePicker ? undefined : getOpenButtonLabel()}
+          buttonAriaControlsId="hds-date-picker"
+          buttonAriaExpanded={showPicker}
           onButtonClick={disableDatePicker ? undefined : onOpenButtonClick}
           onChange={handleInputChange}
           onBlur={(e) => handleBlur(e.target.value, e)}
@@ -301,6 +303,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         >
           {disableDatePicker === false && showPicker && (
             <DatePicker
+              id="hds-date-picker"
               language={language}
               disableConfirmation={disableConfirmation}
               selected={selected}

--- a/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
@@ -28,6 +28,8 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
           class="buttonWrapper"
         >
           <button
+            aria-controls="hds-date-picker"
+            aria-expanded="true"
             aria-label="Choose date"
             class="button"
             type="button"
@@ -55,6 +57,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
           data-popper-escaped="true"
           data-popper-placement="bottom-end"
           data-popper-reference-hidden="true"
+          id="hds-date-picker"
           role="dialog"
           style="position: absolute; left: 0px; top: 0px; right: 0px; transform: translate(0px, 5px);"
         >
@@ -70,6 +73,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                 >
                   <select
                     aria-label="Month"
+                    aria-live="polite"
                   >
                     <option
                       value="0"
@@ -163,6 +167,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                 >
                   <select
                     aria-label="Year"
+                    aria-live="polite"
                   >
                     <option
                       value="2011"
@@ -346,6 +351,7 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                 </div>
               </div>
               <table
+                aria-live="polite"
                 class="hds-datepicker__month-table"
               >
                 <thead>
@@ -1483,6 +1489,8 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
           class="buttonWrapper"
         >
           <button
+            aria-controls="hds-date-picker"
+            aria-expanded="true"
             aria-label="Choose date"
             class="button"
             type="button"
@@ -1510,6 +1518,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
           data-popper-escaped="true"
           data-popper-placement="bottom-end"
           data-popper-reference-hidden="true"
+          id="hds-date-picker"
           role="dialog"
           style="position: absolute; left: 0px; top: 0px; right: 0px; transform: translate(0px, 5px);"
         >
@@ -1525,6 +1534,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                 >
                   <select
                     aria-label="Month"
+                    aria-live="polite"
                   >
                     <option
                       value="0"
@@ -1618,6 +1628,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                 >
                   <select
                     aria-label="Year"
+                    aria-live="polite"
                   >
                     <option
                       value="2011"
@@ -1801,6 +1812,7 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                 </div>
               </div>
               <table
+                aria-live="polite"
                 class="hds-datepicker__month-table"
               >
                 <thead>

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
@@ -36,6 +36,7 @@ const keyCode = {
 
 export const DatePicker = (providedProps: DayPickerProps) => {
   const {
+    id,
     initialMonth = new Date(),
     onMonthChange,
     onDaySelect,
@@ -348,6 +349,7 @@ export const DatePicker = (providedProps: DayPickerProps) => {
 
   return (
     <div
+      id={id}
       ref={pickerWrapperRef}
       className={classNames(styles.pickerWrapper, isPopperReady && styles.isVisible)}
       role="dialog"

--- a/packages/react/src/components/dateInput/components/datePicker/defaults/defaultProps.ts
+++ b/packages/react/src/components/dateInput/components/datePicker/defaults/defaultProps.ts
@@ -6,6 +6,7 @@ import { DayPickerProps } from '../types';
  * List the default props used by the [[DayPicker]] component.
  */
 export const defaultProps: DayPickerProps = {
+  id: 'hds-date-picker',
   className: '',
   style: {},
   language: 'en',

--- a/packages/react/src/components/dateInput/components/datePicker/types/DayPickerProps.ts
+++ b/packages/react/src/components/dateInput/components/datePicker/types/DayPickerProps.ts
@@ -27,6 +27,10 @@ export type LegendItem = {
  */
 export interface DayPickerProps {
   /**
+   * Unique element id.
+   */
+  id?: string;
+  /**
    * CSS class to add to the root element.
    */
   className?: string;

--- a/packages/react/src/components/dateInput/components/monthNavigation/MonthNavigation.tsx
+++ b/packages/react/src/components/dateInput/components/monthNavigation/MonthNavigation.tsx
@@ -95,7 +95,7 @@ export const MonthNavigation = ({ month }: MonthCaptionProps) => {
   return (
     <div className={styles['hds-datepicker__navigation']}>
       <div className={styles['hds-datepicker__navigation__select']}>
-        <select aria-label={getMonthAriaLabel()} onChange={onMonthChange} value={month.getMonth()}>
+        <select aria-label={getMonthAriaLabel()} aria-live="polite" onChange={onMonthChange} value={month.getMonth()}>
           {eachMonthOfInterval({ start: new Date(selectedYear, 0, 1), end: new Date(selectedYear, 11, 31) }).map(
             (monthDate) => {
               const monthNumber = monthDate.getMonth();
@@ -116,7 +116,7 @@ export const MonthNavigation = ({ month }: MonthCaptionProps) => {
         </div>
       </div>
       <div className={styles['hds-datepicker__navigation__select']}>
-        <select aria-label={getYearAriaLabel()} onChange={onYearChange} value={selectedYear}>
+        <select aria-label={getYearAriaLabel()} aria-live="polite" onChange={onYearChange} value={selectedYear}>
           {eachYearOfInterval({ start: startOfYear(minDate), end: endOfYear(maxDate) }).map((yearDate) => {
             const year = yearDate.getFullYear();
             return (

--- a/packages/react/src/components/dateInput/components/monthTable/MonthTable.tsx
+++ b/packages/react/src/components/dateInput/components/monthTable/MonthTable.tsx
@@ -37,7 +37,7 @@ export const MonthTable = (props: MonthTableProps) => {
   return (
     <div>
       <MonthNavigation month={month} />
-      <table className={styles['hds-datepicker__month-table']}>
+      <table className={styles['hds-datepicker__month-table']} aria-live="polite">
         <Head locale={locale} />
         <tbody>
           {weeks.map((week) => (

--- a/packages/react/src/components/textInput/TextInput.tsx
+++ b/packages/react/src/components/textInput/TextInput.tsx
@@ -60,6 +60,14 @@ export type TextInputProps = MergeAndOverrideProps<
      * Button aria-label
      */
     buttonAriaLabel?: string;
+    /**
+     * ID of the element controlled by the button (e.g., dropdown, dialog)
+     */
+    buttonAriaControlsId?: string;
+    /**
+     * Whether the controlled element is expanded/visible
+     */
+    buttonAriaExpanded?: boolean;
   }
 >;
 
@@ -67,6 +75,8 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   (
     {
       buttonAriaLabel,
+      buttonAriaControlsId,
+      buttonAriaExpanded,
       buttonIcon,
       children,
       className = '',
@@ -179,6 +189,12 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
                 disabled={disabled}
                 onClick={onButtonClick}
                 type="button"
+                {...(buttonAriaControlsId
+                  ? {
+                      'aria-controls': buttonAriaControlsId,
+                      'aria-expanded': buttonAriaExpanded,
+                    }
+                  : {})}
               >
                 {buttonIcon}
               </button>


### PR DESCRIPTION
## Description

DateInput -component should have `aria-live` -attribute on date picker, year and month -elements. Date picker opening button should have `aria-controls` and `aria-expanded` -attributes 

## Related Issue

Closes [HDS-2693](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2693)

## How Has This Been Tested?

Open demo and check that aria-live and aria-controls are in place. aria-expanded should show if the date-picker dialog is open or not
 
## Demos:

Links to demos are in the comments.

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2693]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ