### PR TITLE
fix: (HDS-2693) use Notification component for aria-live notifications

### DIFF
--- a/packages/react/src/components/dateInput/DateInput.test.tsx
+++ b/packages/react/src/components/dateInput/DateInput.test.tsx
@@ -2,12 +2,31 @@
 /* eslint-disable max-classes-per-file */
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import { axe } from 'jest-axe';
 
 import { DateInput } from './DateInput';
+
+// Mock the Notification component to be able to test aria-live announcements
+jest.mock('../notification', () => ({
+  Notification: (props: any) => {
+    const React = require('react');
+    if (props.invisible && props.notificationAriaLabel) {
+      return React.createElement(
+        'div', 
+        { 
+          'data-testid': 'notification', 
+          'aria-live': props['aria-live'] || 'polite',
+          role: 'status'
+        }, 
+        props.notificationAriaLabel
+      );
+    }
+    return null;
+  },
+}));
 
 describe('<DateInput /> spec', () => {
   const RealDate = Date;
@@ -55,5 +74,62 @@ describe('<DateInput /> spec', () => {
     const { container } = render(<DateInput id="date" label="Foo" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('informs screen reader users when month is changed', async () => {
+    const testCases = [
+      {
+        language: 'en' as const,
+        expectedTextPattern: /Calendar page has changed to/,
+        expectedMonth: 'February 2021', // Next month from January 2021
+        nextMonthLabel: 'Next month'
+      },
+      {
+        language: 'fi' as const,
+        expectedTextPattern: /Kalenterisivu on vaihtunut kuukauteen/,
+        expectedMonth: 'helmikuu 2021', // Finnish for February 2021
+        nextMonthLabel: 'Seuraava kuukausi'
+      },
+      {
+        language: 'sv' as const,
+        expectedTextPattern: /Kalendersidan har ändrats till/,
+        expectedMonth: 'februari 2021', // Swedish for February 2021
+        nextMonthLabel: 'Nästa månad'
+      }
+    ];
+
+    for (const testCase of testCases) {
+      const { rerender } = render(<DateInput id="date" label="Date" language={testCase.language} />);
+      
+      // Open the date picker
+      await act(async () => {
+        userEvent.click(screen.getByLabelText(
+          testCase.language === 'en' ? 'Choose date' :
+          testCase.language === 'fi' ? 'Valitse päivämäärä' :
+          'Välj datum'
+        ));
+      });
+
+      // Wait for the date picker to be visible
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      // Click the next month button to change the month
+      const nextMonthButton = screen.getByLabelText(testCase.nextMonthLabel);
+      await act(async () => {
+        userEvent.click(nextMonthButton);
+      });
+
+      // Wait for and check that an aria-live notification appears with the correct language message and month/year
+      await waitFor(() => {
+        const notification = screen.getByTestId('notification');
+        expect(notification).toBeInTheDocument();
+        expect(notification).toHaveAttribute('aria-live', 'polite');
+        expect(notification.textContent).toMatch(testCase.expectedTextPattern);
+        expect(notification.textContent).toContain(testCase.expectedMonth);
+      });
+
+      // Clean up for next iteration
+      rerender(<div />);
+    }
   });
 });

--- a/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/react/src/components/dateInput/__snapshots__/DateInput.test.tsx.snap
@@ -73,7 +73,6 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                 >
                   <select
                     aria-label="Month"
-                    aria-live="polite"
                   >
                     <option
                       value="0"
@@ -167,7 +166,6 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                 >
                   <select
                     aria-label="Year"
-                    aria-live="polite"
                   >
                     <option
                       value="2011"
@@ -351,7 +349,6 @@ exports[`<DateInput /> spec renders the component with additional props 1`] = `
                 </div>
               </div>
               <table
-                aria-live="polite"
                 class="hds-datepicker__month-table"
               >
                 <thead>
@@ -1534,7 +1531,6 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                 >
                   <select
                     aria-label="Month"
-                    aria-live="polite"
                   >
                     <option
                       value="0"
@@ -1628,7 +1624,6 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                 >
                   <select
                     aria-label="Year"
-                    aria-live="polite"
                   >
                     <option
                       value="2011"
@@ -1812,7 +1807,6 @@ exports[`<DateInput /> spec renders the component with default props 1`] = `
                 </div>
               </div>
               <table
-                aria-live="polite"
                 class="hds-datepicker__month-table"
               >
                 <thead>

--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
@@ -20,6 +20,7 @@ import { DayPickerProps } from './types';
 import { MonthTable } from '../monthTable';
 import { Legend } from '../legend';
 import { Button, ButtonSize, ButtonVariant } from '../../../button';
+import { Notification } from '../../../notification';
 import { IconCheck, IconCross } from '../../../../icons';
 import classNames from '../../../../utils/classNames';
 import { scrollIntoViewIfNeeded } from '../../../../utils/scrollIntoViewIfNeeded';
@@ -82,6 +83,11 @@ export const DatePicker = (providedProps: DayPickerProps) => {
   const [selectedDate, setSelectedDate] = useState<Date>(selected || null);
 
   const [isPopperReady, setIsPopperReady] = useState<boolean>(false);
+
+  /**
+   * For invisible aria-live notifications
+   */
+  const [isAriaNotificationActive, setIsAriaNotificationActive] = useState<boolean>(false);
 
   /**
    * Update the selected date from props
@@ -208,6 +214,8 @@ export const DatePicker = (providedProps: DayPickerProps) => {
     if (typeof onMonthChange === 'function') {
       onMonthChange(nextMonth, event);
     }
+
+    setIsAriaNotificationActive(true);
   };
 
   const findNextAvailableDate = (days: number, nextDate: Date) => {
@@ -347,6 +355,18 @@ export const DatePicker = (providedProps: DayPickerProps) => {
     },
   );
 
+  const getMonthChangeMessage = (month: Date, language: 'en' | 'fi' | 'sv') => {
+    const formattedMonth = format(month, 'LLLL yyyy', { locale: getLocaleByLanguage(language) });
+
+    const messages = {
+      en: `Calendar page has changed to ${formattedMonth}`,
+      fi: `Kalenterisivu on vaihtunut kuukauteen ${formattedMonth}`,
+      sv: `Kalendersidan har ändrats till ${formattedMonth}`
+    };
+
+    return messages[language];
+  };
+
   return (
     <div
       id={id}
@@ -410,6 +430,19 @@ export const DatePicker = (providedProps: DayPickerProps) => {
           </div>
         </div>
       </DatePickerContext.Provider>
+      {isAriaNotificationActive && (
+        <Notification
+          position="top-left"
+          invisible
+          autoClose
+          autoCloseDuration={10000}
+          displayAutoCloseProgress={false}
+          onClose={() => setIsAriaNotificationActive(false)}
+          notificationAriaLabel={getMonthChangeMessage(currentMonth, language)}
+          aria-live="polite"
+        />
+      )}
+
     </div>
   );
 };

--- a/packages/react/src/components/dateInput/components/monthNavigation/MonthNavigation.tsx
+++ b/packages/react/src/components/dateInput/components/monthNavigation/MonthNavigation.tsx
@@ -95,7 +95,7 @@ export const MonthNavigation = ({ month }: MonthCaptionProps) => {
   return (
     <div className={styles['hds-datepicker__navigation']}>
       <div className={styles['hds-datepicker__navigation__select']}>
-        <select aria-label={getMonthAriaLabel()} aria-live="polite" onChange={onMonthChange} value={month.getMonth()}>
+        <select aria-label={getMonthAriaLabel()} onChange={onMonthChange} value={month.getMonth()}>
           {eachMonthOfInterval({ start: new Date(selectedYear, 0, 1), end: new Date(selectedYear, 11, 31) }).map(
             (monthDate) => {
               const monthNumber = monthDate.getMonth();
@@ -116,7 +116,7 @@ export const MonthNavigation = ({ month }: MonthCaptionProps) => {
         </div>
       </div>
       <div className={styles['hds-datepicker__navigation__select']}>
-        <select aria-label={getYearAriaLabel()} aria-live="polite" onChange={onYearChange} value={selectedYear}>
+        <select aria-label={getYearAriaLabel()} onChange={onYearChange} value={selectedYear}>
           {eachYearOfInterval({ start: startOfYear(minDate), end: endOfYear(maxDate) }).map((yearDate) => {
             const year = yearDate.getFullYear();
             return (

--- a/packages/react/src/components/dateInput/components/monthTable/MonthTable.tsx
+++ b/packages/react/src/components/dateInput/components/monthTable/MonthTable.tsx
@@ -37,7 +37,7 @@ export const MonthTable = (props: MonthTableProps) => {
   return (
     <div>
       <MonthNavigation month={month} />
-      <table className={styles['hds-datepicker__month-table']} aria-live="polite">
+      <table className={styles['hds-datepicker__month-table']}>
         <Head locale={locale} />
         <tbody>
           {weeks.map((week) => (


### PR DESCRIPTION
## Description

Changed aria-live notification to use `HDS Notification` component in `invisible` -mode. Also wrote simple test to verify aria-live notification message.

## Related Issue

Closes [HDS-2693](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2693)

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->
