### PR TITLE
chore: (HDS-2693) date picker aria notification timeout

### DIFF
--- a/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
+++ b/packages/react/src/components/dateInput/components/datePicker/DatePicker.tsx
@@ -214,7 +214,10 @@ export const DatePicker = (providedProps: DayPickerProps) => {
       onMonthChange(nextMonth, event);
     }
 
-    setIsAriaNotificationActive(true);
+    // Close and open notification to make screen readers to understand
+    // that it have changed
+    setIsAriaNotificationActive(false);
+    setTimeout(() => setIsAriaNotificationActive(true), 1);
   };
 
   const findNextAvailableDate = (days: number, nextDate: Date) => {
@@ -434,7 +437,7 @@ export const DatePicker = (providedProps: DayPickerProps) => {
           position="top-left"
           invisible
           autoClose
-          autoCloseDuration={10000}
+          autoCloseDuration={5000}
           displayAutoCloseProgress={false}
           onClose={() => setIsAriaNotificationActive(false)}
           notificationAriaLabel={getMonthChangeMessage(currentMonth, language)}


### PR DESCRIPTION
## Description

Changed timeout of aria notification smaller (to 5000ms) and forced notification close and open everytime notification text change (at least macos voice over didn't say changed notification text if user clicked month change button too fast)

## Related Issue

Closes [HDS-2693](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2693)

## How Has This Been Tested?

Manually with screen reader. This is just small tuning for original fix.

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2693]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ