### PR TITLE
fix: stricter yarn + CODEOWNERS file

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @City-of-Helsinki/ratkaisutoimiston-frontend


### PR DESCRIPTION
Quite simple .yarnrc change to prevent unmanaged package upgrades through dependencies.
Added CODEOWNERS file as is practice in Ratkis projects.