### PR TITLE
fix: (HDS-2763) Select accepts options with an empty string value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Select] Select accepts options with an empty string value
 
 ### Core
 

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -1326,6 +1326,39 @@ export const WithExternalLabel = () => {
   );
 };
 
+export const WithEmptyStringValue = () => {
+  const [selectedValue, setSelectedValue] = useState<OptionInProps | undefined>(undefined);
+
+  const onChange: SelectProps['onChange'] = useCallback((selectedOptions) => {
+    setSelectedValue(selectedOptions[0]);
+  }, []);
+
+  const options = [{ value: '', label: 'None (empty string)' }, ...getOptionLabels(5)];
+
+  return (
+    <div>
+      <Select
+        options={options}
+        onChange={onChange}
+        texts={{ ...defaultTexts, label: 'Select with empty string value option' }}
+        id="hds-select-empty-value"
+        clearable
+      />
+      <div style={{ marginTop: '20px', padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '4px' }}>
+        <p>
+          <strong>Selected value:</strong> &quot;{selectedValue?.value}&quot;
+        </p>
+        <p>
+          <strong>Value type:</strong> {typeof selectedValue?.value}
+        </p>
+        <p>
+          <strong>Selected label:</strong> {selectedValue?.label || 'None'}
+        </p>
+      </div>
+    </div>
+  );
+};
+
 export const WithCustomTheme = (args: SelectProps) => {
   const groups: SelectProps['groups'] = [
     {

--- a/packages/react/src/components/select/utils.ts
+++ b/packages/react/src/components/select/utils.ts
@@ -114,7 +114,7 @@ function mutateGroupsWithOptions(
   isMultiSelect: boolean,
 ) {
   partialOptionsToUpdate.forEach((partial) => {
-    if (!partial.value) {
+    if (partial.value == null) {
       return;
     }
     const groupIndex = getOptionGroupIndex(groups, { ...partial, isGroupLabel: !!partial.isGroupLabel });
@@ -222,7 +222,8 @@ export function validateOption(option: OptionInProps | string): Option {
   }
 
   const label = option.label || option.value || '';
-  const value = option.value || label;
+  // Use label as fallback for value only if value is undefined, but allow empty string
+  const value = option.value !== undefined ? option.value : label;
 
   return {
     label,
@@ -525,7 +526,7 @@ export function convertPropsToGroups({
 }: Pick<SelectProps, 'groups' | 'options' | 'value' | 'children'>): Group[] {
   const fromGroupsAndOptions = propsToGroups({ options, groups });
   if (fromGroupsAndOptions) {
-    if (value) {
+    if (value != null) {
       const selectedOptions = getSelectedOptions(fromGroupsAndOptions);
       if (selectedOptions.length > 0) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

Empty string value should be a valid option in Select (it wasn't)

## Related Issue

Closes [HDS-2763](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2763)

## How Has This Been Tested?

- New story in Storybook
- 6 tests to verify correct logic

## Demos:

Links to demos are in the comments.

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2763]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ