### PR TITLE
fix: (HDS-2470) Use English on footer examples when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Footer] Code examples now consistently use English
 
 ### Figma
 

--- a/packages/react/src/components/footer/Footer.stories.tsx
+++ b/packages/react/src/components/footer/Footer.stories.tsx
@@ -81,7 +81,7 @@ const Base = () => (
     copyrightHolder="Copyright"
     copyrightText="All rights reserved"
     backToTopLabel="Back to top"
-    logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+    logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
   >
     {createArray(5).map((index) => (
       <Footer.Link
@@ -389,7 +389,7 @@ export const Minimal = (args: FooterProps) => (
   <Footer {...args}>
     <Footer.Base
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     />
   </Footer>
 );

--- a/site/src/docs/components/footer/code.mdx
+++ b/site/src/docs/components/footer/code.mdx
@@ -56,11 +56,11 @@ import {
     </Footer.Navigation>
     <Footer.Utilities
       soMeLinks={[
-        <Footer.Link title="Helsingin kaupungin Facebook-tili" icon={<IconFacebook />} />,
-        <Footer.Link title="Helsingin kaupungin Twitter-tili" icon={<IconTwitter />} />,
-        <Footer.Link title="Helsingin kaupungin Instagram-tili" icon={<IconInstagram />} />,
-        <Footer.Link title="Helsingin kaupungin Youtube-tili" icon={<IconYoutube />} />,
-        <Footer.Link title="Helsingin kaupungin Tiktok-tili" icon={<IconTiktok />} />,
+        <Footer.Link title="City of Helsinki on Facebook" icon={<IconFacebook />} />,
+        <Footer.Link title="City of Helsinki on Twitter" icon={<IconTwitter />} />,
+        <Footer.Link title="City of Helsinki on Instagram" icon={<IconInstagram />} />,
+        <Footer.Link title="City of Helsinki on Youtube" icon={<IconYoutube />} />,
+        <Footer.Link title="City of Helsinki on Tiktok" icon={<IconTiktok />} />,
       ]}
     >
       <Footer.Link label="Contact us" />
@@ -70,7 +70,7 @@ import {
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
       logoHref="https://hel.fi"
       onLogoClick={(event) => event.preventDefault()}
     >
@@ -108,7 +108,7 @@ import { Footer, Logo, LogoSize, logoFi, logoFiDark } from 'hds-react';
         copyrightHolder="Copyright"
         copyrightText="All rights reserved"
         backToTopLabel="Back to top"
-        logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+        logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
       >
         <Footer.Link label="Link" />
         <Footer.Link label="Link" />
@@ -129,7 +129,7 @@ import { Footer, Logo, LogoSize, logoFi, logoFiDark } from 'hds-react';
         copyrightHolder="Copyright"
         copyrightText="All rights reserved"
         backToTopLabel="Back to top"
-        logo={<Logo src={logoFiDark} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+        logo={<Logo src={logoFiDark} size={LogoSize.Medium} alt="City of Helsinki" />}
       >
         <Footer.Link label="Link" />
         <Footer.Link label="Link" />
@@ -201,40 +201,40 @@ import { Footer, IconFacebook, IconTwitter, IconInstagram, IconYoutube, IconTikt
       <Footer.Utilities
         soMeLinks={[
           <Footer.Link
-            title="Helsingin kaupungin Facebook-tili"
-            aria-label="Helsingin kaupungin Facebook-tili"
+            title="City of Helsinki on Facebook"
+            aria-label="City of Helsinki on Facebook"
             external
             openInNewTab
             icon={<IconFacebook />}
             href="https://facebook.com"
           />,
           <Footer.Link
-            title="Helsingin kaupungin Twitter-tili"
-            aria-label="Helsingin kaupungin Twitter-tili"
+            title="City of Helsinki on Twitter"
+            aria-label="City of Helsinki on Twitter"
             external
             openInNewTab
             icon={<IconTwitter />}
             href="https://twitter.com"
           />,
           <Footer.Link
-            title="Helsingin kaupungin Instagram-tili"
-            aria-label="Helsingin kaupungin Instagram-tili"
+            title="City of Helsinki on Instagram"
+            aria-label="City of Helsinki on Instagram"
             external
             openInNewTab
             icon={<IconInstagram />}
             href="https://instagram.com"
           />,
           <Link
-            title="Helsingin kaupungin Youtube-tili"
-            aria-label="Helsingin kaupungin Youtube-tili"
+            title="City of Helsinki on Youtube"
+            aria-label="City of Helsinki on Youtube"
             external
             openInNewTab
             icon={<IconYoutube />}
             href="https://youtube.com"
           />,
           <Footer.Link
-            title="Helsingin kaupungin Tiktok-tili"
-            aria-label="Helsingin kaupungin Tiktok-tili"
+            title="City of Helsinki on Tiktok"
+            aria-label="City of Helsinki on Tiktok"
             external
             openInNewTab
             icon={<IconTiktok />}
@@ -304,11 +304,11 @@ import { Link } from 'gatsby';
     </Footer.Navigation>
     <Footer.Utilities
       soMeLinks={[
-        <Footer.Link as={Link} title="Helsingin kaupungin Facebook-tili" icon={<IconFacebook />} />,
-        <Footer.Link as={Link} title="Helsingin kaupungin Twitter-tili" icon={<IconTwitter />} />,
-        <Footer.Link as={Link} title="Helsingin kaupungin Instagram-tili" icon={<IconInstagram />} />,
-        <Footer.Link as={Link} title="Helsingin kaupungin Youtube-tili" icon={<IconYoutube />} />,
-        <Footer.Link as={Link} title="Helsingin kaupungin Tiktok-tili" icon={<IconTiktok />} />,
+        <Footer.Link as={Link} title="City of Helsinki on Facebook" icon={<IconFacebook />} />,
+        <Footer.Link as={Link} title="City of Helsinki on Twitter" icon={<IconTwitter />} />,
+        <Footer.Link as={Link} title="City of Helsinki on Instagram" icon={<IconInstagram />} />,
+        <Footer.Link as={Link} title="City of Helsinki on Youtube" icon={<IconYoutube />} />,
+        <Footer.Link as={Link} title="City of Helsinki on Tiktok" icon={<IconTiktok />} />,
       ]}
     >
       <Footer.Link as={Link} label="Contact us" />
@@ -318,7 +318,7 @@ import { Link } from 'gatsby';
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link as={Link} label="Link" />
       <Footer.Link as={Link} label="Link" />

--- a/site/src/docs/components/footer/customisation.mdx
+++ b/site/src/docs/components/footer/customisation.mdx
@@ -50,7 +50,7 @@ import { Footer, Logo, LogoSize, logoFi } from 'hds-react';
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link label="Link" />
       <Footer.Link label="Link" />
@@ -88,7 +88,7 @@ import { Footer, Logo, LogoSize, logoFi } from 'hds-react';
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link label="Link" />
       <Footer.Link label="Link" />

--- a/site/src/docs/components/footer/index.mdx
+++ b/site/src/docs/components/footer/index.mdx
@@ -41,7 +41,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link label="Link" />
       <Footer.Link label="Link" />
@@ -92,11 +92,11 @@ The default footer uses the black text colour variant and includes three section
     </Footer.Navigation>
     <Footer.Utilities
       soMeLinks={[
-        <Footer.Link title="Helsingin kaupungin Facebook-tili" icon={<IconFacebook />} />,
-        <Footer.Link title="Helsingin kaupungin Twitter-tili" icon={<IconTwitter />} />,
-        <Footer.Link title="Helsingin kaupungin Instagram-tili" icon={<IconInstagram />} />,
-        <Footer.Link title="Helsingin kaupungin Youtube-tili" icon={<IconYoutube />} />,
-        <Footer.Link title="Helsingin kaupungin Tiktok-tili" icon={<IconTiktok />} />,
+        <Footer.Link title="City of Helsinki on Facebook" icon={<IconFacebook />} />,
+        <Footer.Link title="City of Helsinki on Twitter" icon={<IconTwitter />} />,
+        <Footer.Link title="City of Helsinki on Instagram" icon={<IconInstagram />} />,
+        <Footer.Link title="City of Helsinki on Youtube" icon={<IconYoutube />} />,
+        <Footer.Link title="City of Helsinki on Tiktok" icon={<IconTiktok />} />,
       ]}
     >
       <Footer.Link label="Contact us" />
@@ -106,7 +106,7 @@ The default footer uses the black text colour variant and includes three section
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link label="Link" />
       <Footer.Link label="Link" />
@@ -133,7 +133,7 @@ The Footer component supports light and dark themes.
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFi} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link label="Link" />
       <Footer.Link label="Link" />
@@ -154,7 +154,7 @@ The Footer component supports light and dark themes.
       copyrightHolder="Copyright"
       copyrightText="All rights reserved"
       backToTopLabel="Back to top"
-      logo={<Logo src={logoFiDark} size={LogoSize.Medium} alt="Helsingin kaupunki" />}
+      logo={<Logo src={logoFiDark} size={LogoSize.Medium} alt="City of Helsinki" />}
     >
       <Footer.Link label="Link" />
       <Footer.Link label="Link" />
@@ -215,40 +215,40 @@ Utility section has two different layout options:
   <Footer title="Default" footerAriaLabel="HDS Footer">
     <Footer.Utilities soMeLinks={[
       <Footer.Link
-        title="Helsingin kaupungin Facebook-tili"
-        aria-label="Helsingin kaupungin Facebook-tili"
+        title="City of Helsinki on Facebook"
+        aria-label="City of Helsinki on Facebook"
         external
         openInNewTab
         icon={<IconFacebook />}
         href="https://facebook.com"
       />,
       <Footer.Link
-        title="Helsingin kaupungin Twitter-tili"
-        aria-label="Helsingin kaupungin Twitter-tili"
+        title="City of Helsinki on Twitter"
+        aria-label="City of Helsinki on Twitter"
         external
         openInNewTab
         icon={<IconTwitter />}
         href="https://twitter.com"
       />,
       <Footer.Link
-        title="Helsingin kaupungin Instagram-tili"
-        aria-label="Helsingin kaupungin Instagram-tili"
+        title="City of Helsinki on Instagram"
+        aria-label="City of Helsinki on Instagram"
         external
         openInNewTab
         icon={<IconInstagram />}
         href="https://instagram.com"
       />,
       <Footer.Link
-        title="Helsingin kaupungin Youtube-tili"
-        aria-label="Helsingin kaupungin Youtube-tili"
+        title="City of Helsinki on Youtube"
+        aria-label="City of Helsinki on Youtube"
         external
         openInNewTab
         icon={<IconYoutube />}
         href="https://youtube.com"
       />,
       <Footer.Link
-        title="Helsingin kaupungin Tiktok-tili"
-        aria-label="Helsingin kaupungin Tiktok-tili"
+        title="City of Helsinki on Tiktok"
+        aria-label="City of Helsinki on Tiktok"
         external
         openInNewTab
         icon={<IconTiktok />}
@@ -290,38 +290,38 @@ Utility section has two different layout options:
       ))}
       <Footer.UtilityGroup key={6} headingLink={<Footer.GroupHeading label="Social media" />}>
         <Footer.Link
-          title="Helsingin kaupungin Facebook-tili"
+          title="City of Helsinki on Facebook"
           label="Facebook"
-          aria-label="Helsingin kaupungin Facebook-tili"
-          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
-          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          aria-label="City of Helsinki on Facebook"
+          openInNewTabAriaLabel="Opens in a new tab."
+          openInExternalDomainAriaLabel="Directs to another site."
           icon={<IconFacebook />}
           href="https://facebook.com/helsinginkaupunki/"
         />
         <Footer.Link
-          title="Helsingin kaupungin Facebook-tili"
+          title="City of Helsinki on Facebook"
           label="Facebook"
-          aria-label="Helsingin kaupungin Facebook-tili"
-          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
-          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          aria-label="City of Helsinki on Facebook"
+          openInNewTabAriaLabel="Opens in a new tab."
+          openInExternalDomainAriaLabel="Directs to another site."
           icon={<IconFacebook />}
           href="https://facebook.com/helsinginkaupunki/"
         />
         <Footer.Link
-          title="Helsingin kaupungin Twitter-tili"
+          title="City of Helsinki on Twitter"
           label="Twitter"
-          aria-label="Helsingin kaupungin Twitter-tili"
-          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
-          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          aria-label="City of Helsinki on Twitter"
+          openInNewTabAriaLabel="Opens in a new tab."
+          openInExternalDomainAriaLabel="Directs to another site."
           icon={<IconTwitter />}
           href="https://twitter.com/helsinki"
         />
         <Footer.Link
-          title="Helsingin kaupungin Instagram-tili"
+          title="City of Helsinki on Instagram"
           label="Instagram"
-          aria-label="Helsingin kaupungin Instagram-tili"
-          openInNewTabAriaLabel="Avautuu uudessa välilehdessä."
-          openInExternalDomainAriaLabel="Siirtyy toiseen sivustoon."
+          aria-label="City of Helsinki on Instagram"
+          openInNewTabAriaLabel="Opens in a new tab."
+          openInExternalDomainAriaLabel="Directs to another site."
           icon={<IconInstagram />}
           href="https://instagram.com/helsinki/"
         />


### PR DESCRIPTION
## Description

Footer code examples now consistently use English
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

Main part of this issue has been already fixed on https://github.com/City-of-Helsinki/helsinki-design-system/pull/1498

Only thing left was to change some Finnish language logo alt texts in the code examples to English. 
There was also some strings that were in Finnish so I changed them also.

Closes [HDS-2470](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2470)


## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2470]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ