### PR TITLE
fix: (HDS-2762) select keyboard navigation with virtualized mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Select] Jumping to the end of Virtualized lists with END press.
 
 ### Core
 

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -641,9 +641,10 @@ export const VirtualizedMultiselectWithGroups = () => {
     },
     {
       label: 'More healthy choices',
-      options: getLargeBatchOfUniqueValues(1000),
+      options: getLargeBatchOfUniqueValues(1000, 1000),
     },
   ];
+
   const onChange: SelectProps['onChange'] = useCallback((selectedOptions, lastClickedOption, props) => {
     // track changes here
     genericOnChangeCallback(selectedOptions, lastClickedOption, props);
@@ -668,7 +669,7 @@ export const VirtualizedSingleselectWithGroups = () => {
     },
     {
       label: 'More healthy choices',
-      options: getLargeBatchOfUniqueValues(1000),
+      options: getLargeBatchOfUniqueValues(1000, 1000),
     },
   ];
   const onChange: SelectProps['onChange'] = useCallback((selectedOptions, lastClickedOption, props) => {

--- a/packages/react/src/components/select/batch.options.ts
+++ b/packages/react/src/components/select/batch.options.ts
@@ -535,22 +535,22 @@ export const getOptions = (count = 20): OptionInProps[] => {
   });
 };
 
-export const getLargeBatchOfUniqueValues = (count: number): OptionInProps[] => {
+export const getLargeBatchOfUniqueValues = (count: number, startIndex = 0): OptionInProps[] => {
   const maxNow = optionLabels.length;
   const batch: OptionInProps[] = [];
 
-  let uid = 0;
+  let uid = startIndex;
   const makeUniqueOption = (label: string) => {
     uid += 1;
     const value = `${label} ${uid}`;
     return {
-      label,
+      label: `${label} ${uid}`,
       value,
     };
   };
 
   for (let i = 0; i < count; i += 1) {
-    const arrIndex = i % maxNow;
+    const arrIndex = (startIndex + i) % maxNow;
     batch.push(makeUniqueOption(optionLabels[arrIndex]));
   }
   return batch;

--- a/packages/react/src/components/select/components/list/SingleSelectAndGrouplessList.tsx
+++ b/packages/react/src/components/select/components/list/SingleSelectAndGrouplessList.tsx
@@ -26,7 +26,7 @@ export const createOptionElements = ({
       const props: SelectItemProps & { key: string } = {
         option,
         trigger,
-        key: option.value,
+        key: getOptionId(option),
         getOptionId,
       };
       if (multiSelect) {

--- a/packages/react/src/components/select/components/list/VirtualizedLists.tsx
+++ b/packages/react/src/components/select/components/list/VirtualizedLists.tsx
@@ -4,7 +4,7 @@ import { useRenderChildrenInChunks } from '../../hooks/useRenderChildrenInChunks
 import { createContainerProps, createGroups } from './MultiSelectListWithGroups';
 import { Group } from '../../types';
 import { useSelectDataHandlers } from '../../hooks/useSelectDataHandlers';
-import { getAllOptions } from '../../utils';
+import { getAllOptions, getVisibleGroupLabels } from '../../utils';
 import { createListElementProps, createOptionElements } from './SingleSelectAndGrouplessList';
 
 export const VirtualizedLists = ({ forMultiSelectWithGroups }: { forMultiSelectWithGroups: boolean }) => {
@@ -13,7 +13,12 @@ export const VirtualizedLists = ({ forMultiSelectWithGroups }: { forMultiSelectW
   const { open, groups, multiSelect } = getData();
   const { isSearching, getOptionId, refs, elementIds } = getMetaData();
 
-  const allOptions = getAllOptions(groups);
+  // In multiselect with groups, group labels are rendered, so include them in the count
+  // For single select with groups, group labels are also rendered, so include them
+  // Otherwise, exclude them as they're not focusable/rendered
+  const hasVisibleGroupLabels = getVisibleGroupLabels(groups).length > 0;
+  const filterOutGroupLabels = !(forMultiSelectWithGroups || (!multiSelect && hasVisibleGroupLabels));
+  const allOptions = getAllOptions(groups, filterOutGroupLabels);
   const shouldRenderOptions = open && !isSearching;
   const currentChildren = useRenderChildrenInChunks(shouldRenderOptions ? allOptions : []);
 
@@ -23,7 +28,10 @@ export const VirtualizedLists = ({ forMultiSelectWithGroups }: { forMultiSelectW
       return [];
     }
     return groups.map((group) => {
+      // Filter visible options (this includes group label if visible)
       const options = group.options.filter((opt) => opt.visible);
+      // Calculate how many items we can render from this group
+      // The options array already includes the group label as first element if visible
       const allowedLength = Math.min(options.length, childrenLeft);
       childrenLeft -= allowedLength;
       return {


### PR DESCRIPTION
## Description

Jumping to the end of the option list didn't work whenever the Select component was used in virtualized mode. The last option is to read from the data, not from the rendered DOM items. So, as the component is rendered in chunks, it retries scrolling to the end until the last item is there.

## Related Issue

Closes [HDS-2762](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2762)


[HDS-2762]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ