### PR TITLE
fix: select onClose not triggering with keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Select] Select accepts options with an empty string value
+- [Select] onClose was not triggered when navigating away with keyboard
 
 ### Core
 

--- a/packages/react/src/components/select/dataUpdater.ts
+++ b/packages/react/src/components/select/dataUpdater.ts
@@ -320,6 +320,7 @@ const isCloseTriggerEvent = (event: ChangeEvent) => {
     'tag',
     'selectedOptions',
     'focusMovedToNonListElement',
+    'blur',
   ];
 
   return onCloseTriggerEvents.includes(event.type || '') || onCloseTriggerEvents.includes(event.id || '');


### PR DESCRIPTION
## Description

Fixes Select's multiselect onClose not triggering when navigating away with keyboard.

## Related Issue

Closes [HDS-2812](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2812)

## How Has This Been Tested?

- running all tests

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog


[HDS-2812]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ