### PR TITLE
ci: add sonarcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,17 @@ jobs:
         working-directory: ./packages/react
 
       - name: test react package
-        run: yarn test
+        run: yarn test:coverage
         working-directory: ./packages/react
+
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        continue-on-error: true
+        with:
+          projectBaseDir: ./packages/react
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: build hds-js package
         run: yarn build:hds-js

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,6 +42,7 @@
     "storybook": "yarn ts-check-storybook && yarn start-storybook -p 6006 --quiet",
     "build-storybook": "yarn ts-check-storybook && build-storybook --loglevel error",
     "test": "jest --env=jest-environment-jsdom-sixteen",
+    "test:coverage": "jest --env=jest-environment-jsdom-sixteen --coverage",
     "prepublishOnly": "cp -r ./lib/. ."
   },
   "devDependencies": {

--- a/packages/react/sonar-project.properties
+++ b/packages/react/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=City-of-Helsinki_helsinki-design-system
+sonar.organization=city-of-helsinki
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.projectBaseDir=.
+sonar.sources=src
+sonar.exclusions=**/__tests__/**,**/test*.*,**/*.test.tsx,**/*.test.ts,**/*.stories.tsx

--- a/packages/react/sonar-project.properties
+++ b/packages/react/sonar-project.properties
@@ -26,6 +26,7 @@ sonar.coverage.exclusions= \
   **/examples/**/*, \
   **/storybookStatic/**/*, \
   **/batch.options.ts, \
+  **/testUtils/**/*, \
   **/testUtil.tsx, \
   src/components/cookieConsent/components/StoryComponent.tsx, \
   src/components/cookieConsentCore/storyComponents/**/*, \

--- a/packages/react/sonar-project.properties
+++ b/packages/react/sonar-project.properties
@@ -1,6 +1,38 @@
+# Base SonarQube configuration for City of Helsinki Frontend projects
 sonar.projectKey=City-of-Helsinki_helsinki-design-system
 sonar.organization=city-of-helsinki
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.projectBaseDir=.
+sonar.sourceEncoding=UTF-8
 sonar.sources=src
-sonar.exclusions=**/__tests__/**,**/test*.*,**/*.test.tsx,**/*.test.ts,**/*.stories.tsx
+
+sonar.exclusions= \
+  **/__mocks__/**/*, \
+  **/__snapshots__/*, \
+  **/*.d.ts, \
+  **/*.png, \
+  **/*.jpg, \
+  **/*.zip
+
+sonar.test.inclusions= \
+  **/__tests__/**/*, \
+  **/*.test.js, \
+  **/*.test.ts, \
+  **/*.test.jsx, \
+  **/*.test.tsx
+
+sonar.coverage.exclusions= \
+  **/*.stories.tsx, \
+  **/example/**/*, \
+  **/examples/**/*, \
+  **/storybookStatic/**/*, \
+  **/batch.options.ts, \
+  **/testUtil.tsx, \
+  src/components/cookieConsent/components/StoryComponent.tsx, \
+  src/components/cookieConsentCore/storyComponents/**/*, \
+  src/components/login/graphQLModule/demoData/MyProfileQuery.ts, \
+  src/internal/**/*, \
+  src/utils/PlayWrightComponentHandler.tsx, \
+  src/utils/playWrightHelpers.ts, \
+  src/utils/mockWindowLocation.ts
+
+sonar.cpd.exclusions= src/icons/**/*

--- a/packages/react/sonar-project.properties
+++ b/packages/react/sonar-project.properties
@@ -21,19 +21,24 @@ sonar.test.inclusions= \
   **/*.test.tsx
 
 sonar.coverage.exclusions= \
+  **/*.stories.js, \
+  **/*.stories.ts, \
+  **/*.stories.jsx, \
   **/*.stories.tsx, \
   **/example/**/*, \
   **/examples/**/*, \
   **/storybookStatic/**/*, \
   **/batch.options.ts, \
   **/testUtils/**/*, \
-  **/testUtil.tsx, \
+  **/*testUtil.tsx, \
+  **/*.testUtil.tsx, \
   src/components/cookieConsent/components/StoryComponent.tsx, \
   src/components/cookieConsentCore/storyComponents/**/*, \
   src/components/login/graphQLModule/demoData/MyProfileQuery.ts, \
   src/internal/**/*, \
   src/utils/PlayWrightComponentHandler.tsx, \
   src/utils/playWrightHelpers.ts, \
-  src/utils/mockWindowLocation.ts
+  src/utils/mockWindowLocation.ts, \
+  src/utils/testHelpers.ts
 
 sonar.cpd.exclusions= src/icons/**/*

--- a/packages/react/src/components/dropdownComponents/modularOptionList/texts.ts
+++ b/packages/react/src/components/dropdownComponents/modularOptionList/texts.ts
@@ -59,7 +59,7 @@ export const defaultTexts: Record<SupportedLanguage, Texts> = {
 };
 
 const interpolate = (template: string, contents: TextInterpolationContent) => {
-  return template.replace(/\{{(.*?)}}/g, (match, p1) => {
+  return template.replace(/\{{([^{}]*)}}/g, (match, p1) => {
     const key = p1 ? p1.trim() : '';
     return key ? contents[key] : '';
   });

--- a/packages/react/src/components/dropdownComponents/search/texts.ts
+++ b/packages/react/src/components/dropdownComponents/search/texts.ts
@@ -109,7 +109,7 @@ export const defaultTexts: Record<SupportedLanguage, Texts> = {
 };
 
 const interpolate = (template: string, contents: TextInterpolationContent) => {
-  return template.replace(/\{{(.*?)}}/g, (match, p1) => {
+  return template.replace(/\{{([^{}]*)}}/g, (match, p1) => {
     const key = p1 ? p1.trim() : '';
     return key ? contents[key] : '';
   });

--- a/packages/react/src/components/dropdownComponents/select/texts.ts
+++ b/packages/react/src/components/dropdownComponents/select/texts.ts
@@ -163,7 +163,7 @@ export const defaultTexts: Record<SupportedLanguage, Texts> = {
 };
 
 const interpolate = (template: string, contents: TextInterpolationContent) => {
-  return template.replace(/\{{(.*?)}}/g, (match, p1) => {
+  return template.replace(/\{{([^{}]*)}}/g, (match, p1) => {
     const key = p1 ? p1.trim() : '';
     return key ? contents[key] : '';
   });


### PR DESCRIPTION
Generate coverage from react package jest tests and upload them to sonarcloud.

refs: RATY-222, KEH-187