### PR TITLE
fix: cookie consent onChange-prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [CookieConsentContextProvider, useCookieConsent] Make `onChange`-prop optional (in `CookieConsentReactProps`)
 
 ### Core
 
@@ -66,6 +67,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [CookieConsent] Add `onChange` prop to Code-tab properties table.
 
 ### Figma
 

--- a/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
+++ b/packages/react/src/components/cookieConsent/hooks/useCookieConsent.ts
@@ -22,7 +22,7 @@ declare global {
 }
 
 export type CookieConsentReactProps = Omit<CreateProps, 'settingsPageSelector'> & {
-  onChange: (changeProps: CookieConsentChangeEvent) => void;
+  onChange?: (changeProps: CookieConsentChangeEvent) => void;
   settingsPageId?: string;
 };
 type GroupConsentData = { group: string; consented: boolean };
@@ -74,7 +74,7 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
 
   const onChangeListener = useCallback(
     (e: CookieConsentChangeEvent) => {
-      onChange(e);
+      onChange?.(e);
       forceRender();
     },
     [onChange, forceRender],
@@ -82,9 +82,9 @@ export function useCookieConsent(props: CookieConsentReactProps): CookieConsentR
 
   const onMonitorEvent = useCallback(
     (e: CookieConsentChangeEvent) => {
-      onChange(e);
+      onChange?.(e);
     },
-    [useCallback],
+    [onChange],
   );
 
   const onReady = useCallback(() => {

--- a/site/src/docs/components/cookie-consent/code.mdx
+++ b/site/src/docs/components/cookie-consent/code.mdx
@@ -93,4 +93,5 @@ The required javascript file can also be downloaded and placed to your server. T
 | Property          | Description                                                                                                                                               | Type     |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `siteSettingsObj` | Main configurations of the Cookie Consent. <InternalLink href="/components/cookie-consent/api#site-settings">See the detailed description.</InternalLink> | `object` |
+| `onChange`        | See <InternalLink href="/components/cookie-consent/api#callbacks">callbacks</InternalLink>.                                                               | `function` (optional)|
 | `options`         | An object representing the instance settings.<InternalLink href="/components/cookie-consent/api#options">See the detailed description.</InternalLink>     | `object` |


### PR DESCRIPTION
## Description

Fixes `CookieConsentReactProps`'s `onChange`-prop function to be optional. Will still re-render when change happens if not provided (like previously). Used to output error to console when not provided for any reason (although Typescript should have errored on it!)

`onChange`-prop
- make optional
- call only if provided
- React still forcefully re-renders even if not provided as intended

## Related Issue

Closes [HDS-2814](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2814)

## How Has This Been Tested?

- running all the tests

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog


[HDS-2814]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ