### PR TITLE
fix: component typescript typings output

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -147,7 +147,13 @@ const getConfig = (format, extractCSS) => ({
   plugins: [
     includePaths({ paths: ['src'], extensions }),
     resolve(),
-    typescript(),
+    typescript({
+      clean: true,
+      useTsconfigDeclarationDir: true,
+      tsconfigOverride: {
+        exclude: ['**/*.test.tsx', '**/*.test.ts', '**/*.stories.tsx', 'node_modules'],
+      },
+    }),
     isEsmOutputFormat(format) &&
       babel({
         babelHelpers: 'runtime',

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,6 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "declaration": true,
+    "declarationDir": "lib",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "jsx": "react",


### PR DESCRIPTION
Tsconfig & rollup-plugin-typescript2 config to output correct typings for all components.

Refs: HDS-2820

## Description

Not all components' typings were created in the previous build system due to change in the rollup-plugin-typescript -> rollup-plugin-typescript2 transition.

## Related Issue

Closes [HDS-2820](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2820)

## How Has This Been Tested?

- can be tested in some project using hds-react and try to import for example reported:

`import { LoginCallbackHandler } from "hds-react";`

which caused an error, not finding it exported at all.

## Demos:

Links to demos are in the comments

## Add to changelog

Not needed since it's a build-system fix.


[HDS-2820]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ