### PR TITLE
HDS-2914 fix: changed alert-dark hex from #d18200 to #c27900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Foundation] Alert-dark color changed from #d18200->#c27900 
 
 ### Figma
 

--- a/site/src/docs/foundation/design-tokens/colour/tokens.mdx
+++ b/site/src/docs/foundation/design-tokens/colour/tokens.mdx
@@ -83,7 +83,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 | `--color-info-light`   | `$color-info-light`   | `#e5eff8` | <TextAndColorExample color="var(--color-info-light)" name="Info light variant example" />       |
 | `--color-success-dark` | `$color-success-dark` | `#006250` | <TextAndColorExample color="var(--color-success-dark)" name="Success dark variant example" />   |
 | `--color-success-light`| `$color-success-light`| `#e2f5f3` | <TextAndColorExample color="var(--color-success-light)" name="Success light variant example" /> |
-| `--color-alert-dark`   | `$color-alert-dark`   | `#d18200` | <TextAndColorExample color="var(--color-alert-dark)" name="Alert dark variant example" />       |
+| `--color-alert-dark`   | `$color-alert-dark`   | `#c27900` | <TextAndColorExample color="var(--color-alert-dark)" name="Alert dark variant example" />       |
 | `--color-alert-light`  | `$color-alert-light`  | `#fff4b4` | <TextAndColorExample color="var(--color-alert-light)" name="Alert light variant example" />     |
 | `--color-error-dark`   | `$color-error-dark`   | `#8d0d2d` | <TextAndColorExample color="var(--color-error-dark)" name="Error dark variant example" />       |
 | `--color-error-light`  | `$color-error-light`  | `#f6e2e6` | <TextAndColorExample color="var(--color-error-light)" name="Error light variant example" />     |


### PR DESCRIPTION
## Description

Fix alert-dark colour value in the token table from `#d18200` to `#c27900` under [DocSite > Foundation > Colour > Tokens](https://hds.hel.fi/foundation/design-tokens/colour/tokens/#:~:text=Table%204%3A%20UI%20colour%20variation%20tokens)

## Related Issue

Closes [HDS-2914](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2914)

## Motivation and Context

Alert-dark colour token HEX value was updated for HDS v5.0 release, but documentation table value was not updated.

## How Has This Been Tested?

Screenshot

<img width="1908" height="1282" alt="hex_fix" src="https://github.com/user-attachments/assets/3511f1df-9422-4fc7-865b-fb7a4f256110" />

## Add to changelog

- [x] Added needed line to changelog


[HDS-2914]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ