### PR TITLE
fix:  cookie banner issue HDS-2913

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
+- [Component] What bugs/typos are fixed?
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
 
 ### Hds-js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
 
 ### Core
 
@@ -45,7 +45,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
 
 ### Documentation
 

--- a/packages/react/src/components/cookieConsentCore/CookieConsentCore.test.ts
+++ b/packages/react/src/components/cookieConsentCore/CookieConsentCore.test.ts
@@ -1710,4 +1710,70 @@ describe('cookieConsentCore', () => {
       window.removeEventListener(cookieEventType.CHANGE, changeSpy);
     });
   });
+
+  describe('when localStorage and sessionStorage are blocked by the browser (SecurityError)', () => {
+    let localStorageDescriptor: PropertyDescriptor | undefined;
+    let sessionStorageDescriptor: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      localStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+      sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+
+      const throwSecurityError = () => {
+        throw new DOMException('Storage access blocked', 'SecurityError');
+      };
+
+      Object.defineProperty(window, 'localStorage', { get: throwSecurityError, configurable: true });
+      Object.defineProperty(window, 'sessionStorage', { get: throwSecurityError, configurable: true });
+    });
+
+    afterEach(() => {
+      if (localStorageDescriptor) {
+        Object.defineProperty(window, 'localStorage', localStorageDescriptor);
+      }
+      if (sessionStorageDescriptor) {
+        Object.defineProperty(window, 'sessionStorage', sessionStorageDescriptor);
+      }
+    });
+
+    it('should initialize without throwing when storage is blocked', async () => {
+      await expect(CookieConsentCore.create(urls.siteSettingsJsonUrl, optionsEvent)).resolves.toBeDefined();
+    });
+
+    it('should not log errors during monitor intervals when storage is blocked', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error');
+
+      instance = await CookieConsentCore.create(urls.siteSettingsJsonUrl, optionsEvent);
+      await waitForRoot();
+
+      // Clear calls accumulated from initialization and prior tests
+      consoleErrorSpy.mockClear();
+
+      // Advance through several monitor intervals
+      jest.advanceTimersByTime(testTimeout * 5);
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not attempt removal after a failed removeItem when storage is blocked', async () => {
+      const consoleLogSpy = jest.spyOn(console, 'log');
+
+      instance = await CookieConsentCore.create({ ...siteSettingsObj, remove: true }, optionsEvent);
+      await waitForRoot();
+
+      // Clear calls accumulated from initialization and prior tests
+      consoleLogSpy.mockClear();
+
+      jest.advanceTimersByTime(testTimeout * 5);
+
+      // No "will delete" log should appear for localStorage or sessionStorage
+      const deletionLogCalls = consoleLogSpy.mock.calls.filter(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.includes('Cookie consent: will delete') &&
+          (msg.includes('localStorage') || msg.includes('sessionStorage')),
+      );
+      expect(deletionLogCalls).toHaveLength(0);
+    });
+  });
 });

--- a/packages/react/src/components/cookieConsentCore/monitorAndCleanBrowserStorages.js
+++ b/packages/react/src/components/cookieConsentCore/monitorAndCleanBrowserStorages.js
@@ -61,13 +61,13 @@ export default class MonitorAndCleanBrowserStorages {
           try {
             localStorage.removeItem(key);
           } catch (e) {
-            // Storage access blocked by browser
+            this.#removalFailedKeys.localStorage.push(key);
           }
         } else if (storageTypeString === 'sessionStorage') {
           try {
             sessionStorage.removeItem(key);
           } catch (e) {
-            // Storage access blocked by browser
+            this.#removalFailedKeys.sessionStorage.push(key);
           }
         } else if (storageTypeString === 'indexedDB') {
           const request = indexedDB.deleteDatabase(key);

--- a/packages/react/src/components/cookieConsentCore/monitorAndCleanBrowserStorages.js
+++ b/packages/react/src/components/cookieConsentCore/monitorAndCleanBrowserStorages.js
@@ -58,9 +58,17 @@ export default class MonitorAndCleanBrowserStorages {
             this.#removalFailedKeys.cookie.push(key);
           }
         } else if (storageTypeString === 'localStorage') {
-          localStorage.removeItem(key);
+          try {
+            localStorage.removeItem(key);
+          } catch (e) {
+            // Storage access blocked by browser
+          }
         } else if (storageTypeString === 'sessionStorage') {
-          sessionStorage.removeItem(key);
+          try {
+            sessionStorage.removeItem(key);
+          } catch (e) {
+            // Storage access blocked by browser
+          }
         } else if (storageTypeString === 'indexedDB') {
           const request = indexedDB.deleteDatabase(key);
           request.onsuccess = () => {
@@ -230,9 +238,17 @@ export default class MonitorAndCleanBrowserStorages {
       case 'cookie':
         return this.#getCookieNamesArray();
       case 'localStorage':
-        return Object.keys(localStorage);
+        try {
+          return Object.keys(localStorage);
+        } catch (e) {
+          return [];
+        }
       case 'sessionStorage':
-        return Object.keys(sessionStorage);
+        try {
+          return Object.keys(sessionStorage);
+        } catch (e) {
+          return [];
+        }
       case 'indexedDB':
         return this.#getIndexedDBNamesArray();
       case 'cacheStorage':


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

If a user has somehow blocked webite from using localStorage or sessionStorage with some settings or plugin, cookie banner and cookie settings spam issues to sentry. 

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2913](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2913)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally

## Demos:

To demo the unfixed issue. 

With incognito or with cleared storage go to simulate the situation:
https://hds.hel.fi/storybook/react/?path=/story/components-cookieconsent--banner
or 
https://hds.hel.fi/storybook/react/static-cookie-consent/standaloneBanner.html

Paste this into browser console
```
Object.defineProperty(window, 'sessionStorage', {
  get() {
    throw new DOMException(
      "Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.",
      'SecurityError'
    );
  }
});
```
click accept required cookies --> should throw an error

<img width="1714" height="712" alt="Screenshot 2026-03-24 at 17 05 40" src="https://github.com/user-attachments/assets/47c71706-5649-4654-b415-b2afa52e5fd1" />

And with this fix there should be no error.

Fixed demo: 
https://city-of-helsinki.github.io/hds-demo/preview_1612/storybook/react/?path=/story/components-cookieconsent--banner

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->


[HDS-2913]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ