### PR TITLE
fix: keyboard scrolling on code blocks HDS-2625

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,7 @@ Changes that are not related to specific components
 
 - [Foundation] Alert-dark color changed from #d18200->#c27900 
 - Code example syntax highlighting colors to meet WCAG AA contrast requirements
-
-- [Component] What bugs/typos are fixed?
+- Code blocks are now scrollable using keyboard arrow keys
 
 ### Figma
 

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -138,6 +138,7 @@ const HtmlLivePreview = ({ code }) => {
 
 const Editor = ({ onChange, initialCode, code, language }) => {
   const viewPortRef = useRef();
+  const scrollboxRef = useRef();
   const copyButtonRef = useRef();
   const [resetCount, setResetCount] = useState(0);
   const copySuccessState = 'COPY_SUCCESS';
@@ -149,10 +150,18 @@ const Editor = ({ onChange, initialCode, code, language }) => {
 
   const onFocusKeyDown = useCallback(
     (event) => {
-      if (event.key === 'Enter' && viewPortRef.current && event.target === viewPortRef.current) {
-        event.preventDefault();
-        const textArea = getTextArea(viewPortRef.current);
-        textArea.focus();
+      if (viewPortRef.current && event.target === viewPortRef.current) {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          const textArea = getTextArea(viewPortRef.current);
+          textArea.focus();
+        } else if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+          if (scrollboxRef.current) {
+            event.preventDefault();
+            const scrollAmount = event.key === 'ArrowLeft' ? -40 : 40;
+            scrollboxRef.current.scrollLeft += scrollAmount;
+          }
+        }
       }
     },
     [getTextArea],
@@ -215,7 +224,7 @@ const Editor = ({ onChange, initialCode, code, language }) => {
                 Press Enter to start editing. Press Esc to stop editing.
               </span>
             </div>
-            <div className="playground-block-editor-scrollbox" tabIndex={-1}>
+            <div className="playground-block-editor-scrollbox" tabIndex={-1} ref={scrollboxRef}>
               <LiveEditor
                 key={resetCount}
                 onChange={onChange}


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Enable scrolling the document site example code areas with keyboard. 
Add custom key handling so the focus order doesn't change.

## Related Issue

https://helsinkisolutionoffice.atlassian.net/browse/HDS-2625

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->