### PR TITLE
fix: docsite code example text contrast HDS-2628

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Foundation] Alert-dark color changed from #d18200->#c27900 
+- Code example syntax highlighting colors to meet WCAG AA contrast requirements
+
+- [Component] What bugs/typos are fixed?
 
 ### Figma
 

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -4,7 +4,7 @@ import { useMDXComponents } from '@mdx-js/react';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
 import sanitizeHtml from 'sanitize-html';
 import { Notification, Tabs, TabList, TabPanel, Tab, Button, IconArrowUndo } from 'hds-react';
-import theme from 'prism-react-renderer/themes/github';
+import theme from './codeTheme';
 
 import './Playground.scss';
 import LiveErrorCore from './LiveErrorCore';

--- a/site/src/components/SyntaxHighlighter.js
+++ b/site/src/components/SyntaxHighlighter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Highlight, { defaultProps } from 'prism-react-renderer';
-import theme from 'prism-react-renderer/themes/github';
+import theme from './codeTheme';
 
 import './SyntaxHighlighter.scss';
 

--- a/site/src/components/codeTheme.js
+++ b/site/src/components/codeTheme.js
@@ -1,22 +1,22 @@
 /**
  * Accessible light syntax highlighting theme for prism-react-renderer.
  * Based on the github theme but with all colors meeting WCAG AA (4.5:1)
- * contrast ratio against the background color #f6f8fa.
+ * contrast ratio against the background color #f2f2f2.
  *
- * Contrast ratios verified against #f6f8fa:
- *   #393A34 — 13.1:1  (plain text, punctuation)
- *   #57606a —  5.4:1  (comments)     was #999988 at ~2.5:1
+ * Contrast ratios verified against #f2f2f2:
+ *   #393A34 — 10.3:1  (plain text, punctuation)
+ *   #57606a —  5.7:1  (comments)     was #999988 at ~2.5:1
  *   #CE007A —  4.8:1  (strings)      was #e3116c at ~4.2:1
  *   #007A64 —  4.7:1  (numbers, variables, booleans) was #36acaa at ~2.4:1
  *   #006CCD —  4.7:1  (keywords)     was #00a4db at ~2.6:1
  *   #CD2900 —  4.8:1  (functions, tags) was #d73a49 at ~4.0:1
- *   #6f42c1 —  5.4:1  (function-variable) unchanged
- *   #00009f — 13.0:1  (tag, selector, keyword override) unchanged
+ *   #6f42c1 —  5.8:1  (function-variable) unchanged
+ *   #00009f — 12.5:1  (tag, selector, keyword override) unchanged
  */
 const accessibleLightTheme = {
   plain: {
     color: '#393A34',
-    backgroundColor: '#f6f8fa',
+    backgroundColor: '#f2f2f2',
   },
   styles: [
     {
@@ -36,7 +36,7 @@ const accessibleLightTheme = {
     {
       types: ['string', 'attr-value'],
       style: {
-        color: '#c41a7f',
+        color: '#CE007A',
       },
     },
     {
@@ -48,19 +48,19 @@ const accessibleLightTheme = {
     {
       types: ['entity', 'url', 'symbol', 'number', 'boolean', 'variable', 'constant', 'property', 'regex', 'inserted'],
       style: {
-        color: '#116329',
+        color: '#007A64',
       },
     },
     {
       types: ['atrule', 'keyword', 'attr-name', 'selector'],
       style: {
-        color: '#005cc5',
+        color: '#006CCD',
       },
     },
     {
       types: ['function', 'deleted', 'tag'],
       style: {
-        color: '#b31d28',
+        color: '#CD2900',
       },
     },
     {

--- a/site/src/components/codeTheme.js
+++ b/site/src/components/codeTheme.js
@@ -10,8 +10,8 @@
  *   #007A64 —  4.7:1  (numbers, variables, booleans) was #36acaa at ~2.4:1
  *   #006CCD —  4.7:1  (keywords)     was #00a4db at ~2.6:1
  *   #CD2900 —  4.8:1  (functions, tags) was #d73a49 at ~4.0:1
- *   #6f42c1 —  5.4:1  (function-variable) unchanged ✅
- *   #00009f — 13.0:1  (tag, selector, keyword override) unchanged ✅
+ *   #6f42c1 —  5.4:1  (function-variable) unchanged
+ *   #00009f — 13.0:1  (tag, selector, keyword override) unchanged
  */
 const accessibleLightTheme = {
   plain: {

--- a/site/src/components/codeTheme.js
+++ b/site/src/components/codeTheme.js
@@ -6,10 +6,10 @@
  * Contrast ratios verified against #f6f8fa:
  *   #393A34 — 13.1:1  (plain text, punctuation)
  *   #57606a —  5.4:1  (comments)     was #999988 at ~2.5:1
- *   #c41a7f —  4.9:1  (strings)      was #e3116c at ~4.2:1
- *   #116329 —  6.5:1  (numbers, variables, booleans) was #36acaa at ~2.4:1
- *   #005cc5 —  5.4:1  (keywords)     was #00a4db at ~2.6:1
- *   #b31d28 —  5.9:1  (functions, tags) was #d73a49 at ~4.0:1
+ *   #CE007A —  4.8:1  (strings)      was #e3116c at ~4.2:1
+ *   #007A64 —  4.7:1  (numbers, variables, booleans) was #36acaa at ~2.4:1
+ *   #006CCD —  4.7:1  (keywords)     was #00a4db at ~2.6:1
+ *   #CD2900 —  4.8:1  (functions, tags) was #d73a49 at ~4.0:1
  *   #6f42c1 —  5.4:1  (function-variable) unchanged ✅
  *   #00009f — 13.0:1  (tag, selector, keyword override) unchanged ✅
  */

--- a/site/src/components/codeTheme.js
+++ b/site/src/components/codeTheme.js
@@ -1,0 +1,81 @@
+/**
+ * Accessible light syntax highlighting theme for prism-react-renderer.
+ * Based on the github theme but with all colors meeting WCAG AA (4.5:1)
+ * contrast ratio against the background color #f6f8fa.
+ *
+ * Contrast ratios verified against #f6f8fa:
+ *   #393A34 — 13.1:1  (plain text, punctuation)
+ *   #57606a —  5.4:1  (comments)     was #999988 at ~2.5:1
+ *   #c41a7f —  4.9:1  (strings)      was #e3116c at ~4.2:1
+ *   #116329 —  6.5:1  (numbers, variables, booleans) was #36acaa at ~2.4:1
+ *   #005cc5 —  5.4:1  (keywords)     was #00a4db at ~2.6:1
+ *   #b31d28 —  5.9:1  (functions, tags) was #d73a49 at ~4.0:1
+ *   #6f42c1 —  5.4:1  (function-variable) unchanged ✅
+ *   #00009f — 13.0:1  (tag, selector, keyword override) unchanged ✅
+ */
+const accessibleLightTheme = {
+  plain: {
+    color: '#393A34',
+    backgroundColor: '#f6f8fa',
+  },
+  styles: [
+    {
+      types: ['comment', 'prolog', 'doctype', 'cdata'],
+      style: {
+        color: '#57606a',
+        fontStyle: 'italic',
+      },
+    },
+    {
+      // Removed opacity-based style to avoid contrast failures on blended colors.
+      types: ['namespace'],
+      style: {
+        color: '#393A34',
+      },
+    },
+    {
+      types: ['string', 'attr-value'],
+      style: {
+        color: '#c41a7f',
+      },
+    },
+    {
+      types: ['punctuation', 'operator'],
+      style: {
+        color: '#393A34',
+      },
+    },
+    {
+      types: ['entity', 'url', 'symbol', 'number', 'boolean', 'variable', 'constant', 'property', 'regex', 'inserted'],
+      style: {
+        color: '#116329',
+      },
+    },
+    {
+      types: ['atrule', 'keyword', 'attr-name', 'selector'],
+      style: {
+        color: '#005cc5',
+      },
+    },
+    {
+      types: ['function', 'deleted', 'tag'],
+      style: {
+        color: '#b31d28',
+      },
+    },
+    {
+      types: ['function-variable'],
+      style: {
+        color: '#6f42c1',
+      },
+    },
+    {
+      types: ['tag', 'selector', 'keyword'],
+      style: {
+        color: '#00009f',
+      },
+    },
+  ],
+};
+
+export default accessibleLightTheme;


### PR DESCRIPTION
## Description

Code example syntax highlighting colors to meet WCAG AA contrast requirements.
Modified the theme that is used for code. Another idea was to adjust the background color, but that would not have been enough.

Ref: HDS-2628

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2628](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2628)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

Old:
<img width="742" height="936" alt="Screenshot 2026-03-26 at 11 04 11" src="https://github.com/user-attachments/assets/ab34df26-ffde-47e8-bf4c-266004dfe871" />
New:
<img width="728" height="938" alt="Screenshot 2026-03-26 at 11 04 30" src="https://github.com/user-attachments/assets/a3535bd4-e4ea-45e9-ae5e-6d995901a4d8" />



## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2628]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ