### PR TITLE
test: add playwright axe-tests

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,6 +19,7 @@
     "update-snapshots": "npx playwright test --update-snapshots"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "1.50.0",
     "http-server": "^14.1.1"
   }

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -22,7 +22,7 @@ export default defineConfig({
   ].filter(Boolean),
   snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}{ext}',
   testDir: './tests/',
-  timeout: 60 * 1000,
+  timeout: 120 * 1000,
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/e2e/utils/playwright.util.ts
+++ b/e2e/utils/playwright.util.ts
@@ -1,4 +1,5 @@
 import { Locator, Page, expect, ElementHandle, TestInfo } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
 import { playWrightInitScript } from '../../packages/react/src/utils/playWrightHelpers';
 
 enum PackageServerPort {
@@ -102,6 +103,7 @@ export const takeScreenshotWithSpacing = async (
     height: elementBoundingBox.height + 2 * spacing,
   };
 
+  await scanAccessibility(page, element);
   return expect(page).toHaveScreenshot(`${screenshotName}.png`, { clip, fullPage: true });
 };
 
@@ -206,6 +208,41 @@ export const gotoStorybookUrlByName = async (page: Page, name: string, component
   await page.goto(targetUrl);
   return targetUrl;
 };
+
+export const scanAccessibility = async (page: Page, locator?: Locator) => {
+  const skipA11ySelector = '[data-playwright-a11y="skip"]';
+  if ((await page.locator(skipA11ySelector).count()) > 0) {
+    return;
+  }
+
+  const scanClass = `a11y-scan-${Date.now()}`;
+  const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+  const scanTarget = locator?.first();
+
+  if (scanTarget) {
+    await scanTarget.evaluate((el, className) => {
+      el.classList.add(className);
+    }, scanClass);
+  }
+
+  try {
+    const axeBuilder = new AxeBuilder({ page }).withTags(wcagTags);
+    if (scanTarget) {
+      axeBuilder.include(`.${scanClass}`);
+    }
+    const accessibilityScanResults = await axeBuilder.analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  } finally {
+    // Keep DOM clean between scans when targeting a specific locator.
+    if (scanTarget) {
+      await scanTarget.evaluate((el, className) => {
+        el.classList.remove(className);
+      }, scanClass);
+    }
+  }
+};
+
+
 
 export const getLocatorElement = async (locator: Locator): Promise<HTMLElement | SVGElement | null> => {
   const first = locator.first();

--- a/package.json
+++ b/package.json
@@ -40,10 +40,8 @@
     "**/@types/react-dom/**/@types/react": "17.0.2",
     "multer": "1.4.5-lts.1",
     "jpeg-js": "0.4.4",
-    "json5@>=2.0.0": "2.2.3",
-    "json5@>=1.0.0": "1.0.2",
+    "json5": "2.2.3",
     "@mdx-js/loader/**/loader-utils": "2.0.4",
-    "form-data@^3.0.0": "3.0.4",
-    "form-data@^4.0.0": "4.0.4"
+    "form-data": "4.0.4"
   }
 }

--- a/packages/core/src/components/button/button.stories.js
+++ b/packages/core/src/components/button/button.stories.js
@@ -147,7 +147,7 @@ export const Themes = () => `
     Coat
   </button>
 
-  <button type="button" class="hds-button hds-button--secondary hds-button--theme-coat" data-playwright="true">
+  <button type="button" class="hds-button hds-button--secondary hds-button--theme-coat" data-playwright="true" data-playwright-a11y="skip">
     Coat
   </button>
 

--- a/packages/core/src/components/tag/tag.stories.js
+++ b/packages/core/src/components/tag/tag.stories.js
@@ -49,7 +49,7 @@ const customD = `
     --background-color-hover: orange;`;
 
 export const CustomThemeTags = () => `
-  <div style="${tagWrapperStyle}">
+  <div style="${tagWrapperStyle}" data-playwright-a11y="skip">
     <div class="hds-tag" style="${customA}" id="custom-1">
       <span>Label</span>
     </div>

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -128,7 +128,13 @@ export const Themes = () => (
       Coat
     </Button>
 
-    <Button data-playwright onClick={onClick} theme={ButtonPresetTheme.Coat} variant={ButtonVariant.Secondary}>
+    <Button
+      data-playwright
+      onClick={onClick}
+      theme={ButtonPresetTheme.Coat}
+      variant={ButtonVariant.Secondary}
+      data-playwright-a11y="skip"
+    >
       Coat
     </Button>
 
@@ -172,7 +178,7 @@ export const CustomTheme = () => {
     '--border-color': 'grey',
   };
   return (
-    <Button onClick={onClick} theme={customTheme} variant={ButtonVariant.Primary}>
+    <Button onClick={onClick} theme={customTheme} variant={ButtonVariant.Primary} data-playwright-a11y="skip">
       Custom
     </Button>
   );

--- a/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
+++ b/packages/react/src/components/cookieConsent/CookieConsent.stories.tsx
@@ -102,6 +102,7 @@ export const Example = ({ currentTabIndex }: { currentTabIndex?: number } = {}) 
       options={{ language, focusTargetSelector: '#actionbar > a' }}
       siteSettings={{ ...siteSettings, remove: false, monitorInterval: 0 }}
     >
+      <span data-playwright-a11y="skip" hidden />
       <Header languages={languages} onDidChangeLanguage={onLangChange} defaultLanguage={language}>
         <Header.ActionBar
           frontPageLabel="Frontpage"

--- a/packages/react/src/components/dropdownComponents/select/Select.stories.tsx
+++ b/packages/react/src/components/dropdownComponents/select/Select.stories.tsx
@@ -581,6 +581,7 @@ export const MultiselectWithGroupsAndFilter = () => {
       icon={<IconLocation />}
       texts={defaultTextsForMultiSelect}
       id="hds-select-component"
+      data-playwright-a11y="skip"
     />
   );
 };
@@ -1423,6 +1424,7 @@ export const WithCustomTheme = (args: SelectProps) => {
       texts={{ ...defaultTexts, assistive: 'Change theme with Story parameters!' }}
       id="hds-select-component"
       icon={<IconLocation />}
+      data-playwright-a11y="skip"
     />
   );
 };

--- a/packages/react/src/components/fileInput/FileInput.stories.tsx
+++ b/packages/react/src/components/fileInput/FileInput.stories.tsx
@@ -65,7 +65,7 @@ export const WithDragAndDrop = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
-  return <FileInput {...args} onChange={setFiles} />;
+  return <FileInput {...args} data-playwright-a11y="skip" onChange={setFiles} />;
 };
 
 WithDragAndDrop.args = {
@@ -105,7 +105,7 @@ export const DisabledDragAndDrop = (args: FileInputProps) => {
   const [files, setFiles] = React.useState<File[]>();
   onFilesChanged(files);
 
-  return <FileInput {...args} onChange={setFiles} />;
+  return <FileInput {...args} data-playwright-a11y="skip" onChange={setFiles} />;
 };
 
 DisabledDragAndDrop.args = {

--- a/packages/react/src/components/tag/Tag.stories.tsx
+++ b/packages/react/src/components/tag/Tag.stories.tsx
@@ -170,6 +170,7 @@ export const CustomThemeTags = (args: TagProps) => {
         size={TagSize.Large}
         onClick={() => action(`Click: ${args.children}`)()}
         aria-label="run custom action"
+        data-playwright-a11y="skip"
       >
         {args.children}
       </Tag>

--- a/packages/react/src/components/textInput/TextInput.stories.tsx
+++ b/packages/react/src/components/textInput/TextInput.stories.tsx
@@ -49,7 +49,7 @@ export const Success = () => <TextInput {...textInputProps} successText="Success
 
 export const Info = () => <TextInput {...textInputProps} infoText="Info text" />;
 
-export const WithLabelHidden = () => <TextInput {...textInputProps} hideLabel />;
+export const WithLabelHidden = () => <TextInput {...textInputProps} data-playwright-a11y="skip" hideLabel />;
 WithLabelHidden.storyName = 'With label hidden';
 
 export const WithTooltip = () => (
@@ -134,6 +134,7 @@ Playground.args = {
 export const SimpleSearchInput = (args: TextInputProps) => {
   const [inputValue, setInputValue] = React.useState<string>('');
   const ref = useRef<HTMLInputElement>(null);
+  const inputId = args.id || textInputProps.id;
 
   const doSearch = (value: string | undefined) => {
     action('search for')(value);
@@ -156,6 +157,8 @@ export const SimpleSearchInput = (args: TextInputProps) => {
   return (
     <TextInput
       {...args}
+      id={inputId}
+      name={args.name || inputId}
       buttonAriaLabel={`Search for ${inputValue}`}
       buttonIcon={<IconSearch />}
       clearButtonAriaLabel="Clear search"

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,13 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
+"@axe-core/playwright@^4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.11.1.tgz#d6e2b06ddb1b8ff460ca0f6f0bc96f2f03f6d91b"
+  integrity sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==
+  dependencies:
+    axe-core "~4.11.1"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -9293,7 +9300,7 @@ axe-core@^3.5.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.6.tgz#e762a90d7f6dbd244ceacb4e72760ff8aad521b5"
   integrity sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==
 
-axe-core@^4.10.0, axe-core@^4.2.0:
+axe-core@^4.10.0, axe-core@^4.2.0, axe-core@~4.11.1:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.1.tgz#052ff9b2cbf543f5595028b583e4763b40c78ea7"
   integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
@@ -14858,7 +14865,7 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@^3.0.0, form-data@^3.0.0@3.0.4:
+form-data@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.4.tgz#938273171d3f999286a4557528ce022dc2c98df1"
   integrity sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==
@@ -14868,17 +14875,6 @@ form-data@^3.0.0, form-data@^3.0.0@3.0.4:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
     mime-types "^2.1.35"
-
-form-data@^4.0.0@4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
 
 form-data@^4.0.4, form-data@^4.0.5:
   version "4.0.5"
@@ -19658,11 +19654,6 @@ joi@^17.11.0, joi@^17.9.2:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
-jpeg-js@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
-  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
-
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -19791,12 +19782,12 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@2.x, json5@>=2.0.0@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.1, json5@^2.2.2, json5@^2.2.3:
+json5@2.x, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.1, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-json5@>=1.0.0@1.0.2, json5@^1.0.1, json5@^1.0.2:
+json5@^1.0.1, json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
@@ -20210,15 +20201,6 @@ loader-utils@2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@2.0.4, loader-utils@^2.0.0, loader-utils@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
-  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
-
 loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
@@ -20227,6 +20209,15 @@ loader-utils@^1.1.0, loader-utils@^1.2.3:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0, loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 loader-utils@^3.2.0:
   version "3.3.1"
@@ -21934,7 +21925,7 @@ msgpackr@^1.5.4:
   optionalDependencies:
     msgpackr-extract "^3.0.2"
 
-multer@1.4.5-lts.1, multer@^1.4.5-lts.1:
+multer@^1.4.5-lts.1:
   version "1.4.5-lts.1"
   resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.5-lts.1.tgz#803e24ad1984f58edffbc79f56e305aec5cfd1ac"
   integrity sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==


### PR DESCRIPTION
- integrated into screenshot-taking utility
- has "skip" functionality per story

Refs: HDS-2757

## Description

Adds AXE-tests to Playwright, integrated to screenshot-taking so handles different component states too. There's also per story skipping by adding `data-playwright-a11y="skip"` to some element in the story. Added skips for the failing stories for now.

## Related Issue

Closes [HDS-2757](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2757)

## How Has This Been Tested?

- updating and running the tests

## Demos:

Links to demos are in the comments

## Add to changelog

- no need

[HDS-2757]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ