### PR TITLE
ci: skip test result publishing for dependabot

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
+        if: always() && github.actor != 'dependabot[bot]'
         with:
           files: |
             e2e/report/**/*.xml


### PR DESCRIPTION
- since bot does not have permissions

Refs: HDS-2927

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2927](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2927)

[HDS-2927]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ