### PR TITLE
fix: add aria-label to main navigation HDS-2654

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Changes that are not related to specific components
 - [Foundation] Alert-dark color changed from #d18200->#c27900 
 - Code example syntax highlighting colors to meet WCAG AA contrast requirements
 - Code blocks are now scrollable using keyboard arrow keys
+- Added aria-label for main navigation
 
 ### Figma
 

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -274,7 +274,7 @@ const Layout = ({ location, children, pageContext }) => {
               ))}
             </Header.ActionBarItem>
           </Header.ActionBar>
-          <Header.NavigationMenu>
+          <Header.NavigationMenu aria-label="Main">
             {uiMenuLinks.map(({ name, link, uiId }) => (
               <Header.Link
                 active={hrefWithVersion(currentMenuItem?.link || '', version) === hrefWithVersion(link, version)}


### PR DESCRIPTION
Refs: HDS-2654

## Description

Added `aria-label="Main"` to main navigation as it was instructed in the jira ticket. 
I didn't notice any difference how voiceover handles this, but might me that this is orignally tested with windows. 


## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2654](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2654)

## How Has This Been Tested?

MacOs + VoiceOver

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2654]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ