### PR TITLE
chore: add coverage to gitignore

### DIFF
--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -3,3 +3,4 @@ storybook-static/
 lib/
 _bundles/
 *.css.d.ts
+coverage/


### PR DESCRIPTION
## Description

Adds `/coverage` in react-package to .gitignore (test coverage report dir)
