### PR TITLE
fix: header search margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
+- [Header] Header Search margins in mobile screen sizes
 
 ### Core
 

--- a/packages/react/src/components/header/components/headerSearch/HeaderSearch.module.scss
+++ b/packages/react/src/components/header/components/headerSearch/HeaderSearch.module.scss
@@ -85,6 +85,6 @@
 }
 
 // Increase specificity to override HeaderActionBarItem dropdown styles
-:global([class*="HeaderActionBarItem_dropdown"]) ul > .searchContainer {
-  padding: var(--spacing-2-xl) var(--spacing-m);
+:global([class*="HeaderActionBarItem_dropdown"]) ul .searchContainer {
+  padding: var(--spacing-2-xl) var(--header-margin);
 }


### PR DESCRIPTION
## Description

Header Search didn't have margins on mobile screen sizes, now fixed

## Related Issue

Closes [HDS-2933](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2933)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments. Go to React Storybook in Header -> With Search story, open search dropdown and narrow the screen to mobile width. It has now margins. 

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2933]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ