### PR TITLE
fix: removed multiselect prop from the Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes that are not related to specific components
 
 - [CookieConsent] Gracefully handle error when sessionStorage or localStorage is inaccessible
 - [Header] Header Search margins in mobile screen sizes
+- [Search] Removed accidentally added `multiSelect` -prop, which doesn't have any functionality
 
 ### Core
 

--- a/packages/react/src/components/dropdownComponents/search/dataUpdater.ts
+++ b/packages/react/src/components/dropdownComponents/search/dataUpdater.ts
@@ -150,7 +150,7 @@ const dataUpdater = (
   };
 
   if (didModularOptionListChange) {
-    if (id === eventIds.listItem && !current.multiSelect) {
+    if (id === eventIds.listItem) {
       // Announce option selection for accessibility
       const { lastClickedOption } = dataHandlers.getMetaData();
       if (lastClickedOption && lastClickedOption.label) {

--- a/packages/react/src/components/dropdownComponents/search/types.ts
+++ b/packages/react/src/components/dropdownComponents/search/types.ts
@@ -34,7 +34,6 @@ export type SearchProps<P = ReactElement<HTMLOptGroupElement | HTMLOptionElement
   icon?: ReactNode;
   id?: string;
   invalid?: boolean;
-  multiSelect?: boolean;
   onBlur?: () => void;
   onClose?: (
     selectedOptions: Option[],
@@ -64,15 +63,7 @@ export type SearchData = ModularOptionListData &
   Required<
     Pick<
       SearchProps,
-      | 'open'
-      | 'required'
-      | 'invalid'
-      | 'onChange'
-      | 'disabled'
-      | 'multiSelect'
-      | 'visibleOptions'
-      | 'virtualize'
-      | 'clearable'
+      'open' | 'required' | 'invalid' | 'onChange' | 'disabled' | 'visibleOptions' | 'virtualize' | 'clearable'
     >
   > & {
     initialOpenValue?: boolean;


### PR DESCRIPTION
## Description

There is a `multiSelect`-prop in the `Search` component. That’s a bug; there is no functionality for that prop, and there shouldn't be. The `Search` is based on the `Select` component, which has multi-select functionality, which is why this prop has accidentally made its way into the `Search` component's code.

So, let's remove it to avoid any confusion.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2934](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2934)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2934]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ