### PR TITLE
ci: code check fetch-depth to 0 Refs: KEH-187

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Read .nvmrc
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
Noticed warnings on shallow clone from coming for SonarCloud:

- <img width="692" height="324" alt="Screenshot 2026-04-23 at 16 14 35" src="https://github.com/user-attachments/assets/6ec53095-f1b4-4635-856b-4b12bde59518" />
- https://github.com/City-of-Helsinki/helsinki-design-system/actions/runs/24836003396/job/72696396943#step:13:222

Sonar needs the entire history to proper scanning. Setting `fetch-depth: 0` on checkout stage should fix the issue.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [KEH-187](https://helsinkisolutionoffice.atlassian.net/browse/KEH-187)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[KEH-187]: https://helsinkisolutionoffice.atlassian.net/browse/KEH-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ