### PR TITLE
chore: fixed Search example to use correct way for texts prop

### DIFF
--- a/packages/react/src/components/header/Header.stories.tsx
+++ b/packages/react/src/components/header/Header.stories.tsx
@@ -802,13 +802,22 @@ export const WithCustomMenu = (args: HeaderProps) => {
   );
 };
 
+const withSearchServiceTitle = 'Helsingin kaupunki';
+
+const withSearchTexts = {
+  heading: `Hae palvelusta: ${withSearchServiceTitle}`,
+  label: 'Mitä etsit?',
+  buttonLabel: 'Hae',
+  closeLabel: 'Sulje',
+  placeholder: 'Anna teksti hakua varten',
+  assistive: 'Avustava teksti',
+};
+
 export const WithSearch = (args: HeaderProps) => {
   const lang = 'fi';
   const I18n = translations[lang];
   const versions = ['Version 4.0.0', 'Version 3.11.0', 'Version 2.17.1'];
   const selectedVersion = 'Version 3.11.0';
-  const serviceTitle = 'Helsingin kaupunki';
-
   const handleSearch: SearchFunction = useCallback((searchValue /* , lastClickedOption, data */) => {
     if (searchValue === 'error') {
       return Promise.reject(new Error('Simulated error'));
@@ -829,11 +838,11 @@ export const WithSearch = (args: HeaderProps) => {
         <Header.SkipLink skipTo="#content" label={I18n.skipToContent} />
         <Header.ActionBar
           frontPageLabel={I18n.frontPage}
-          title={serviceTitle}
+          title={withSearchServiceTitle}
           titleHref="https://hel.fi"
           logoAriaLabel="Service logo"
           logoHref="https://hel.fi"
-          logo={<Logo src={logoFi} alt="Helsingin kaupunki" />}
+          logo={<Logo src={logoFi} alt={withSearchServiceTitle} />}
           menuButtonAriaLabel="Menu"
           onMenuClick={(e) => e.stopPropagation()}
         >
@@ -842,19 +851,7 @@ export const WithSearch = (args: HeaderProps) => {
               <Header.ActionBarSubItem label={version} selected={version === selectedVersion} href="/" />
             ))}
           </Header.ActionBarItem>
-          <Header.Search
-            texts={{
-              heading: `Hae palvelusta: ${serviceTitle}`,
-              label: 'Mitä etsit?',
-              buttonLabel: 'Hae',
-              closeLabel: 'Sulje',
-              placeholder: 'Anna teksti hakua varten',
-              assistive: 'Avustava teksti',
-            }}
-            onChange={() => {}}
-            onSubmit={() => {}}
-            onSearch={handleSearch}
-          />
+          <Header.Search texts={withSearchTexts} onChange={() => {}} onSubmit={() => {}} onSearch={handleSearch} />
         </Header.ActionBar>
       </Header>
       <div id="content" />

--- a/site/src/docs/components/header/code.mdx
+++ b/site/src/docs/components/header/code.mdx
@@ -290,6 +290,14 @@ import { Header, IconSignout, Logo, logoFi, logoSv, logoSvDark } from 'hds-react
     setI18n(translations[lang]);
   }, [lang]);
 
+  const searchTexts = React.useMemo(() => ({
+    heading: `Hae palvelusta: ${I18n.headerTitle}`,
+    label: I18n.headerSearch,
+    buttonLabel: I18n.headerSearch,
+    closeLabel: I18n.close,
+    placeholder: 'Anna teksti hakua varten',
+  }), [I18n]);
+
   return (
     <>
       <Header onDidChangeLanguage={languageChangedStateAction} languages={languages}>
@@ -326,13 +334,7 @@ import { Header, IconSignout, Logo, logoFi, logoSv, logoSvDark } from 'hds-react
             </Header.ActionBarSubItemGroup>
           </Header.LanguageSelector>
           <Header.Search
-            texts={{
-              heading: `Hae palvelusta: ${I18n.headerTitle}`,
-              label: I18n.headerSearch,
-              buttonLabel: I18n.headerSearch,
-              closeLabel: I18n.close,
-              placeholder: 'Anna teksti hakua varten',
-            }}
+            texts={searchTexts}
             onSubmit={(value) => console.log('Search submitted:', value)}
             onSearch={(searchValue) => {
               return Promise.resolve({

--- a/site/src/docs/components/search/index.mdx
+++ b/site/src/docs/components/search/index.mdx
@@ -27,6 +27,10 @@ export const handleSearch = (searchValue) => {
   });
 };
 
+export const searchFruitsTexts = { label: 'Search for fruits', language: 'en' };
+export const searchHistoryTexts = { label: 'Search with history', language: 'en' };
+export const simpleSearchTexts = { label: 'Simple search', language: 'en' };
+
 export const SearchExample = () => {
   const [showNotification, setShowNotification] = React.useState(false);
   const [notificationMessage, setNotificationMessage] = React.useState('');
@@ -39,7 +43,7 @@ export const SearchExample = () => {
       )}
       <Search
         id="search-usage-example"
-        texts={{ label: 'Search for fruits', language: 'en' }}
+        texts={searchFruitsTexts}
         onSearch={handleSearch}
         onSend={(value) => { setNotificationMessage(`Search submitted: "${value}"`); setShowNotification(true); }}
       />
@@ -59,7 +63,7 @@ export const SearchWithSuggestionsExample = () => {
       )}
       <Search
         id="search-with-suggestions"
-        texts={{ label: 'Search for fruits', language: 'en' }}
+        texts={searchFruitsTexts}
         onSearch={(searchValue) => Promise.resolve({ groups: [{ label: '', options: fruits.filter((s) => s.toLowerCase().indexOf(searchValue.toLowerCase()) >= 0).map((s) => ({ label: s, value: s })) }] })}
         onSend={(value) => { setNotificationMessage(`Search submitted: "${value}"`); setShowNotification(true); }}
       />
@@ -80,7 +84,7 @@ export const SearchWithHistoryExample = () => {
       <Search
         id="search-with-history"
         historyId="docs-search-history"
-        texts={{ label: 'Search with history', language: 'en' }}
+        texts={searchHistoryTexts}
         onSearch={handleSearch}
         onSend={(value) => { setNotificationMessage(`Search submitted: "${value}"`); setShowNotification(true); }}
       />
@@ -100,7 +104,7 @@ export const SimpleSearchExample = () => {
       )}
       <Search
         id="search-simple"
-        texts={{ label: 'Simple search', language: 'en' }}
+        texts={simpleSearchTexts}
         onSend={(value) => { setNotificationMessage(`Search submitted: "${value}"`); setShowNotification(true); }}
       />
     </>
@@ -128,7 +132,7 @@ export const ExternalButtonExample = () => {
             id="search-external-button"
             hideSubmitButton
             ref={searchRef}
-            texts={{ label: 'Search for fruits', language: 'en' }}
+            texts={searchFruitsTexts}
             onSearch={handleSearch}
             onSend={onSend}
           />


### PR DESCRIPTION
## Description

All Search code examples were standardized to comply with the guidelines in the Search documentation
The guidelines about texts prop use: https://hds.hel.fi/components/search/code/#texts

For a reference, code example in https://hds.hel.fi/components/search/code/ was already done correctly

## Related Issue

Closes [HDS-2935](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2935)

## How Has This Been Tested?

Check code examples:
- Header.Search in the Storybook
- Header.Search in the documentation site
- Search in the documentation site 

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2935]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ