### PR TITLE
fix: askem not asking again on page change

### DIFF
--- a/site/src/components/AskemWidget.js
+++ b/site/src/components/AskemWidget.js
@@ -11,12 +11,14 @@ const ASKEM_SCRIPT_URL = 'https://cdn.askem.com/plugin/askem.js';
  * Askem feedback widget. Shown only on non-frontpage pages.
  * On production (hds.hel.fi) and test (city-of-helsinki.github.io) loads the real widget (when statistics consent is given);
  * on other hosts shows a dummy placeholder.
+ * Pass `routeKey` (e.g. path without version) so `window.askem.reset()` runs on SPA navigation.
  */
-const AskemWidget = ({ enabled, apiKey }) => {
+const AskemWidget = ({ enabled, apiKey, routeKey }) => {
   const hasStatisticsConsent = useGroupConsent('statistics');
   const [mounted, setMounted] = useState(false);
   const [askemTitle, setAskemTitle] = useState('');
   const scriptInjected = useRef(false);
+  const prevRouteKeyRef = useRef(undefined);
 
   useEffect(() => {
     if (globalThis.window === undefined) {
@@ -55,12 +57,37 @@ const AskemWidget = ({ enabled, apiKey }) => {
     document.body.appendChild(s);
   }, [clientReady, hasStatisticsConsent, apiKey, askemTitle]);
 
+  // Askem SPA: reset widget state on client-side route changes (see Askem docs).
+  useEffect(() => {
+    if (!clientReady || !apiKey || !hasStatisticsConsent || routeKey === undefined) {
+      return;
+    }
+
+    const prev = prevRouteKeyRef.current;
+    if (prev !== undefined && prev !== routeKey) {
+      const tryReset = () => {
+        const reset = globalThis.window?.askem?.reset;
+        if (typeof reset === 'function') {
+          reset();
+          return true;
+        }
+        return false;
+      };
+      if (!tryReset()) {
+        requestAnimationFrame(() => {
+          tryReset();
+        });
+      }
+    }
+    prevRouteKeyRef.current = routeKey;
+  }, [routeKey, clientReady, apiKey, hasStatisticsConsent]);
+
   if (!clientReady) {
     return null;
   }
 
   if (!apiKey) {
-    return <AskemWidgetMockup />;
+    return <AskemWidgetMockup routeKey={routeKey} />;
   }
   return <div className="askem askem-hds-overrides" />;
 };
@@ -68,6 +95,7 @@ const AskemWidget = ({ enabled, apiKey }) => {
 AskemWidget.propTypes = {
   enabled: PropTypes.bool.isRequired,
   apiKey: PropTypes.string,
+  routeKey: PropTypes.string,
 };
 
 export default AskemWidget;

--- a/site/src/components/AskemWidgetMockup.js
+++ b/site/src/components/AskemWidgetMockup.js
@@ -1,13 +1,28 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 
 import { askemPluginCoreCss, askemPluginThemeCss } from './askemMockPluginStyles/injectedCss';
 
 /**
  * DOM mock of Askem stages. Injects the same CSS the real plugin adds (core + theme), not HDS overrides.
+ * Pass `routeKey` so mock UI resets on SPA navigation (mirrors `window.askem.reset()`).
  */
-const AskemWidgetMockup = () => {
+const AskemWidgetMockup = ({ routeKey }) => {
   const [selectedReaction, setSelectedReaction] = useState(null);
   const [submitted, setSubmitted] = useState(false);
+  const prevRouteKeyRef = useRef(undefined);
+
+  useEffect(() => {
+    if (routeKey === undefined) {
+      return;
+    }
+    const prev = prevRouteKeyRef.current;
+    if (prev !== undefined && prev !== routeKey) {
+      setSelectedReaction(null);
+      setSubmitted(false);
+    }
+    prevRouteKeyRef.current = routeKey;
+  }, [routeKey]);
 
   const showForm = selectedReaction !== null && !submitted;
   const showReactions = selectedReaction === null || submitted;
@@ -135,6 +150,10 @@ const AskemWidgetMockup = () => {
       </div>
     </>
   );
+};
+
+AskemWidgetMockup.propTypes = {
+  routeKey: PropTypes.string,
 };
 
 export default AskemWidgetMockup;

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -339,6 +339,7 @@ const Layout = ({ location, children, pageContext }) => {
               <AskemWidget
                 enabled={showAskem}
                 apiKey={site?.siteMetadata?.askemApiKey}
+                routeKey={locationWithoutVersion}
               />
             </main>
           ) : (
@@ -347,6 +348,7 @@ const Layout = ({ location, children, pageContext }) => {
               <AskemWidget
                 enabled={showAskem}
                 apiKey={site?.siteMetadata?.askemApiKey}
+                routeKey={locationWithoutVersion}
               />
             </main>
           )}


### PR DESCRIPTION
- also make the same behaviour to mockup

Refs: HDS-2938

## Description

Askem should ask feedback on every page change, not only once

## Related Issue

Closes [HDS-2938](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2938)

## How Has This Been Tested?

- only with mockup, but logic should be fine (we still need to make sure in prod)

## Demos:

Links to demos are in the comments

## Add to changelog

- not needed, a fix

[HDS-2938]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ