### PR TITLE
fix: missing export for SupportedLanguage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes that are not related to specific components
 #### Fixed
 
 - [Component] What bugs/typos are fixed?
+- [Select][Search] Restored public export of the `SupportedLanguage` type (`'fi' | 'sv' | 'en'`) from `hds-react`
 
 ### Core
 

--- a/packages/react/src/components/dropdownComponents/modularOptionList/index.ts
+++ b/packages/react/src/components/dropdownComponents/modularOptionList/index.ts
@@ -15,4 +15,4 @@ export {
   updateSelectedOptionsInGroups,
 } from './utils';
 
-export type { Option, OptionInProps, Group, GroupInProps } from './types';
+export type { Option, OptionInProps, Group, GroupInProps, SupportedLanguage } from './types';


### PR DESCRIPTION
Refs: HDS-2946

## Description

Fix dropped out export for `SupportedLanguage`

## Related Issue

Closes [HDS-2946](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2946)

## How Has This Been Tested?

- locally

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog


[HDS-2946]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ