### PR TITLE
fix: iconkit build type export

### DIFF
--- a/.github/workflows/update-icon-library.yml
+++ b/.github/workflows/update-icon-library.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Append React interface into index file
         if: steps.build_checker.outputs.SKIP_REST_STEPS != 'true'
         run: |
-          echo -e "export { IconProps, IconSize } from './Icon.interface';\n" | \
+          echo -e "export type { IconProps } from './Icon.interface';\nexport { IconSize } from './Icon.interface';\n" | \
           cat - ./icon-library/react/tsx/index.ts > temp && mv temp ./icon-library/react/tsx/index.ts
 
       - name: Bump version in Changelog


### PR DESCRIPTION
Refs: HDS-2953

## Description

Fix iconkit build type export since the file gets created in the build and had wrong export now when build has changed

## Related Issue

Closes [HDS-2953](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2953)

## How Has This Been Tested?

- gets tested when release-build is done

## Add to changelog

- no need

[HDS-2953]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ