### PR TITLE
fix: core and site styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.X.X] - Month, XX, 202X
-
-### Workspace
-
-#### Changed
-
-- [Dependencies] Monorepo-level dependency or tooling changes (resolutions, security patches, CI, etc.).
+## [6.0.1] - May, X, 2026
 
 ### React
 
@@ -51,7 +45,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- Renamed a style file to process it properly in build-process (css -> scss).
 
 ### Documentation
 
@@ -71,7 +65,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- Code area font was changed in version update -> changed to monospace to match previous styling and be more clear.
 
 ### Figma
 

--- a/packages/core/src/components/all.scss
+++ b/packages/core/src/components/all.scss
@@ -3,7 +3,6 @@
 @use './checkbox/checkbox.scss';
 @use './status-label/status-label.scss';
 @use './table/table.scss';
-
 @import url('./card/card.css');
 @import url('./container/container.css');
 @import url('./fieldset/fieldset.css');

--- a/site/src/components/Playground.scss
+++ b/site/src/components/Playground.scss
@@ -56,6 +56,7 @@
   textarea,
   pre {
     border: 3px solid transparent !important;
+    font-family: monospace !important;
     line-height: 24px !important;
     padding: 0 var(--spacing-s) var(--spacing-s) !important;
     vertical-align: middle !important;


### PR DESCRIPTION
- rename core all.css -> .scss for proper processing
- add monostyle font to site code area

Refs: HDS-2956

## Description

Core style processing did not work properly since css was not processed properly -> renaming to .scss does the job. This was discovered when site table styles were broken.

Also site code area font was changed during site update -> set font to monospaced to look like it used to and to be clearer to read.

## Related Issue

Closes [HDS-2956](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2956)

## Can be tested like this
- compare demo site https://city-of-helsinki.github.io/hds-demo/preview_1664/components/button/code/ with current production site https://hds.hel.fi/components/button/code/

## How Has This Been Tested?

- running all tests to make sure nothing is broken, tested site manually to see the difference vs. not fixed.

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog

## If applicable, also apply this fix/feature to the previous major version

- not needed since it worked before

[HDS-2956]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ