### PR TITLE
docs: fix site examples props from values to types

### DIFF
--- a/site/src/docs/components/button/code.mdx
+++ b/site/src/docs/components/button/code.mdx
@@ -5,6 +5,7 @@ title: 'Button - Code'
 
 import {
   Button,
+  ButtonSize,
   ButtonVariant,
   LoadingSpinner,
   IconTrash,
@@ -39,12 +40,12 @@ import { Button } from 'hds-react';
 
 #### Secondary
 
-<Playground scope={{ Button }}>
+<Playground scope={{ Button, ButtonVariant }}>
 
 ```jsx
-import { Button } from 'hds-react';
+import { Button, ButtonVariant } from 'hds-react';
 
-() => <Button variant="secondary">Secondary</Button>;
+() => <Button variant={ButtonVariant.Secondary}>Secondary</Button>;
 ```
 
 ```html
@@ -55,13 +56,13 @@ import { Button } from 'hds-react';
 
 #### Supplementary
 
-<Playground scope={{ Button, IconTrash }}>
+<Playground scope={{ Button, ButtonVariant, IconTrash }}>
 
 ```jsx
-import { Button, IconTrash } from 'hds-react';
+import { Button, ButtonVariant, IconTrash } from 'hds-react';
 
 () => (
-  <Button variant="supplementary" iconStart={<IconTrash />}>
+  <Button variant={ButtonVariant.Supplementary} iconStart={<IconTrash />}>
     Supplementary
   </Button>
 );
@@ -112,18 +113,18 @@ import { Button, IconShare, IconAngleRight } from 'hds-react';
 
 #### Small button
 
-<Playground scope={{ Button }}>
+<Playground scope={{ Button, ButtonSize, ButtonVariant }}>
 
 ```jsx
-import { Button } from 'hds-react';
+import { Button, ButtonSize, ButtonVariant } from 'hds-react';
 
 () => (
   <div style={{ display: 'flex', gap: '12px' }}>
-    <Button size="small">Primary</Button>
-    <Button variant="secondary" size="small">
+    <Button size={ButtonSize.Small}>Primary</Button>
+    <Button variant={ButtonVariant.Secondary} size={ButtonSize.Small}>
       Secondary
     </Button>
-    <Button variant="supplementary" size="small">
+    <Button variant={ButtonVariant.Supplementary} size={ButtonSize.Small}>
       Supplementary
     </Button>
   </div>
@@ -148,17 +149,17 @@ import { Button } from 'hds-react';
 
 #### Utility button
 
-<Playground scope={{ Button, IconSaveDisketteFill, IconTrash }}>
+<Playground scope={{ Button, ButtonVariant, IconSaveDisketteFill, IconTrash }}>
 
 ```jsx
-import { Button, IconSaveDisketteFill, IconTrash } from 'hds-react';
+import { Button, ButtonVariant, IconSaveDisketteFill, IconTrash } from 'hds-react';
 
 () => (
   <div style={{ display: 'flex', gap: '12px' }}>
-    <Button variant="success" iconStart={<IconSaveDisketteFill />}>
+    <Button variant={ButtonVariant.Success} iconStart={<IconSaveDisketteFill />}>
       Save
     </Button>
-    <Button variant="danger" iconStart={<IconTrash />}>
+    <Button variant={ButtonVariant.Danger} iconStart={<IconTrash />}>
       Delete
     </Button>
   </div>

--- a/site/src/docs/components/card/code.mdx
+++ b/site/src/docs/components/card/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/card/code'
 title: 'Card - Code'
 ---
 
-import { Button, Card } from 'hds-react';
+import { Button, ButtonPresetTheme, ButtonVariant, Card } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
@@ -89,18 +89,18 @@ import { Card } from 'hds-react';
 
 #### Using with other HDS components
 
-<Playground scope={{ Card, Button }}>
+<Playground scope={{ Card, Button, ButtonPresetTheme, ButtonVariant }}>
 
 
 ```jsx
-import { Card, Button } from 'hds-react';
+import { Card, Button, ButtonPresetTheme, ButtonVariant } from 'hds-react';
 
 () => (<>
   <Card
     heading="Card"
     text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
   >
-    <Button variant="secondary" theme="black" role="link">
+    <Button variant={ButtonVariant.Secondary} theme={ButtonPresetTheme.Black} role="link">
       Button
     </Button>
   </Card>
@@ -109,7 +109,7 @@ import { Card, Button } from 'hds-react';
     heading="Card"
     text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
   >
-    <Button variant="secondary" theme="black" role="link">
+    <Button variant={ButtonVariant.Secondary} theme={ButtonPresetTheme.Black} role="link">
       Button
     </Button>
   </Card>

--- a/site/src/docs/components/checkbox/code.mdx
+++ b/site/src/docs/components/checkbox/code.mdx
@@ -18,7 +18,7 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 <Playground scope={{ Checkbox, Tooltip }}>
 
 ```jsx
-import { Checkbox } from 'hds-react';
+import { Checkbox, Tooltip } from 'hds-react';
 
 () => {
   const [checkedItems, setCheckedItems] = React.useState({ "checkbox-checked": true, "checkbox-checked-disabled": true });

--- a/site/src/docs/components/date-input/code.mdx
+++ b/site/src/docs/components/date-input/code.mdx
@@ -139,7 +139,7 @@ import { DateInput } from 'hds-react';
 Selectable dates can be filtered and disabled with the `isDateDisabledBy` property. The component's invalid state can be set with the `invalid` property, and an error can be shown with the `errorText` property.
 DateInput also has some built-in validations, such as checking that the date is in the correct format and that the date is in the given range. However, if you want to add custom validation, you can do so by using the `onChange` prop to set the already mentioned `invalid` state and `errorText`.
 
-<Playground scope={{ DateInput,parse, isWeekend }}>
+<Playground scope={{ DateInput, parse, isWeekend }}>
 
 ```jsx
 import { DateInput } from 'hds-react';

--- a/site/src/docs/components/dialog/code.mdx
+++ b/site/src/docs/components/dialog/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/dialog/code'
 title: 'Dialog - Code'
 ---
 
-import { Dialog, Button, IconAlertCircle, IconInfoCircle, IconQuestionCircle, IconTrash, TextArea, TextInput } from 'hds-react';
+import { Dialog, Button, ButtonPresetTheme, ButtonVariant, IconAlertCircle, IconInfoCircle, IconQuestionCircle, IconTrash, TextArea, TextInput } from 'hds-react';
 import ExternalLink from '../../../components/ExternalLink';
 import TabsLayout from './tabs.mdx';
 import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
@@ -16,10 +16,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ### Code examples 
 
 #### Info dialog
-<Playground scope={{ Dialog, Button, IconInfoCircle }}>
+<Playground scope={{ Dialog, Button, ButtonVariant, IconInfoCircle }}>
 
 ```jsx
-import { Dialog, Button, IconInfoCircle } from 'hds-react';
+import { Dialog, Button, ButtonVariant, IconInfoCircle } from 'hds-react';
 
 () => {
   const dialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
@@ -67,10 +67,10 @@ import { Dialog, Button, IconInfoCircle } from 'hds-react';
 </Playground>
 
 ### Confirm dialog
-<Playground scope={{ Dialog, Button, IconQuestionCircle }}>
+<Playground scope={{ Dialog, Button, ButtonVariant, IconQuestionCircle }}>
 
 ```jsx
-import { Dialog, Button, IconQuestionCircle } from 'hds-react';
+import { Dialog, Button, ButtonVariant, IconQuestionCircle } from 'hds-react';
 
 () => {
   const confirmationDialogTarget = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
@@ -107,7 +107,7 @@ import { Dialog, Button, IconQuestionCircle } from 'hds-react';
           <Button onClick={close}>
             Continue
           </Button>
-          <Button onClick={close} variant="secondary">
+          <Button onClick={close} variant={ButtonVariant.Secondary}>
             Cancel
           </Button>
         </Dialog.ActionButtons>
@@ -120,10 +120,10 @@ import { Dialog, Button, IconQuestionCircle } from 'hds-react';
 </Playground>
 
 ### Danger dialog
-<Playground scope={{ Dialog, Button, IconAlertCircle, IconTrash }}>
+<Playground scope={{ Dialog, Button, ButtonPresetTheme, ButtonVariant, IconAlertCircle, IconTrash }}>
 
 ```jsx
-import { Dialog, Button, IconAlertCircle, IconTrash } from 'hds-react';
+import { Dialog, Button, ButtonPresetTheme, ButtonVariant, IconAlertCircle, IconTrash } from 'hds-react';
 
 () => {
   const dangerDialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
@@ -158,11 +158,11 @@ import { Dialog, Button, IconAlertCircle, IconTrash } from 'hds-react';
           </p>
         </Dialog.Content>
         <Dialog.ActionButtons>
-          <Button onClick={close} theme="black" variant="secondary">
+          <Button onClick={close} theme={ButtonPresetTheme.Black} variant={ButtonVariant.Secondary}>
             Cancel
           </Button>
           <Button
-            variant="danger"
+            variant={ButtonVariant.Danger}
             iconStart={<IconTrash />}
             onClick={() => {
               // Add confirm operations here
@@ -181,10 +181,10 @@ import { Dialog, Button, IconAlertCircle, IconTrash } from 'hds-react';
 </Playground>
 
 ### Scrollable dialog
-<Playground scope={{ Dialog, Button, IconAlertCircle }}>
+<Playground scope={{ Dialog, Button, ButtonVariant, IconAlertCircle }}>
 
 ```jsx
-import { Dialog, Button, IconAlertCircle } from 'hds-react';
+import { Dialog, Button, ButtonVariant, IconAlertCircle } from 'hds-react';
 
 () => {
   const termsDialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
@@ -275,7 +275,7 @@ import { Dialog, Button, IconAlertCircle } from 'hds-react';
           <Button onClick={close}>
             Accept terms
           </Button>
-          <Button onClick={close} variant="secondary">
+          <Button onClick={close} variant={ButtonVariant.Secondary}>
             Cancel
           </Button>
         </Dialog.ActionButtons>
@@ -288,10 +288,10 @@ import { Dialog, Button, IconAlertCircle } from 'hds-react';
 </Playground>
 
 #### Dialog with custom content
-<Playground scope={{ Dialog, Button, TextInput, TextArea }}>
+<Playground scope={{ Dialog, Button, ButtonVariant, TextInput, TextArea }}>
 
 ```jsx
-import { Dialog, Button, TextInput, TextArea } from 'hds-react';
+import { Dialog, Button, ButtonVariant, TextInput, TextArea } from 'hds-react';
 
 () => {
   const customDialogTargetRef = React.useRef(null); // We need to render the dialog into a div inside the Playground component to ensure correct dialog styles in the HDS documentation. The dialog will be rendered into the document body by default.
@@ -346,7 +346,7 @@ import { Dialog, Button, TextInput, TextArea } from 'hds-react';
         >
           Add item
         </Button>
-        <Button onClick={close} variant="secondary">
+        <Button onClick={close} variant={ButtonVariant.Secondary}>
           Cancel
         </Button>
       </Dialog.ActionButtons>

--- a/site/src/docs/components/header/code.mdx
+++ b/site/src/docs/components/header/code.mdx
@@ -125,7 +125,7 @@ export const translations = {
   },
   sv: {
     adultEducationCentres: 'Arbetarinstituten',
-    ariaLanguageSelection: 'Välja spräk',
+    ariaLanguageSelection: 'Välja språk',
     ariaLogo: 'Service logo',
     ariaMenuButton: 'Menu',
     basicEducation: 'Grundläggande utbildning',
@@ -149,7 +149,7 @@ export const translations = {
     headerMenuTitle: 'Andra språk',
     headerSearch: 'Sök',
     headerTitle: 'Helsingfors Stad',
-    healtcare: 'Hälsovärd',
+    healtcare: 'Hälsovård',
     healthAndndSocialServices: 'Social- och hälsovårdstjänster',
     infoOtherLanguages: 'information på andra språk',
     jobSeekers: 'Arbetssökande',
@@ -268,7 +268,6 @@ export const IndexLink = ({ anchor, children }) => {
 
 ```jsx
 import { Header, IconSignout, Logo, logoFi, logoSv, logoSvDark } from 'hds-react';
-
 () => {
   const languages = [
     { label: 'Suomi', value: 'fi', isPrimary: true },
@@ -811,8 +810,6 @@ The Header.ActionBarButton can be used as a plain button element without a dropd
 
 ```jsx
 import { Header, Logo, logoFi, IconSignin } from 'hds-react';
-import { Link } from 'gatsby';
-
 () => {
   return (
     <>

--- a/site/src/docs/components/hero/code.mdx
+++ b/site/src/docs/components/hero/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/hero/code'
 title: 'Hero - Code'
 ---
 
-import { Button, Hero } from 'hds-react';
+import { Button, ButtonVariant, Hero } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
@@ -17,10 +17,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 Note that in order to customise the colour of the background with `variant="diagonalKoros"`, you need to set the `--koros-color` CSS variable.
 
-<Playground scope={{ Hero, Button }}>
+<Playground scope={{ Hero, Button, ButtonVariant }}>
 
 ```jsx
-import { Fieldset, TextInput } from 'hds-react';
+import { Hero, Button, ButtonVariant } from 'hds-react';
 
 () => (
   <Hero
@@ -37,7 +37,7 @@ import { Fieldset, TextInput } from 'hds-react';
       introduction is around 230 characters, including spaces. The intro ends with a period.
     </Hero.Text>
     <Button
-      variant="secondary"
+      variant={ButtonVariant.Secondary}
       role="link"
       style={{ '--background-color': '#000', '--color': '#fff', '--border-color': '#000' }}
     >
@@ -112,10 +112,10 @@ import { Fieldset, TextInput } from 'hds-react';
 
 Hero has an option to show an arrow icon to indicate the followin content. The arrow color can also be customised with the `theme` prop by passing `--arrow-icon-color` in it.
 
-<Playground scope={{ Hero, Button }}>
+<Playground scope={{ Hero, Button, ButtonVariant }}>
 
 ```jsx
-import { Fieldset, TextInput } from 'hds-react';
+import { Hero, Button, ButtonVariant } from 'hds-react';
 
 () => (
   <Hero
@@ -133,7 +133,7 @@ import { Fieldset, TextInput } from 'hds-react';
       introduction is around 230 characters, including spaces. The intro ends with a period.
     </Hero.Text>
     <Button
-      variant="secondary"
+      variant={ButtonVariant.Secondary}
       role="link"
       style={{ '--background-color': '#000', '--color': '#fff', '--border-color': '#000' }}
     >
@@ -213,10 +213,10 @@ import { Fieldset, TextInput } from 'hds-react';
 
 Hero has an option to show additional information below the koros. Usually the information is photographer credit.
 
-<Playground scope={{ Hero, Button }}>
+<Playground scope={{ Hero, Button, ButtonVariant }}>
 
 ```jsx
-import { Fieldset, TextInput } from 'hds-react';
+import { Hero, Button, ButtonVariant } from 'hds-react';
 
 () => (
   <Hero
@@ -234,7 +234,7 @@ import { Fieldset, TextInput } from 'hds-react';
       introduction is around 230 characters, including spaces. The intro ends with a period.
     </Hero.Text>
     <Button
-      variant="secondary"
+      variant={ButtonVariant.Secondary}
       role="link"
       style={{ '--background-color': '#000', '--color': '#fff', '--border-color': '#000' }}
     >

--- a/site/src/docs/components/hero/customisation.mdx
+++ b/site/src/docs/components/hero/customisation.mdx
@@ -3,7 +3,7 @@ slug: '/components/hero/customisation'
 title: 'Hero - Customisation'
 ---
 
-import { Hero, Button } from 'hds-react';
+import { Hero, Button, ButtonVariant } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -45,10 +45,10 @@ You can use the same properties as the <Link href="/components/koros/customisati
 
 ### Customisation example
 
-<Playground scope={{ Hero, Button }}>
+<Playground scope={{ Hero, Button, ButtonVariant }}>
 
 ```jsx
-import { Hero } from 'hds-react';
+import { Hero, Button, ButtonVariant } from 'hds-react';
 
 () => (
   <Hero
@@ -70,7 +70,7 @@ import { Hero } from 'hds-react';
       introduction is around 230 characters, including spaces. The intro ends with a period.
     </Hero.Text>
     <Button
-      variant="secondary"
+      variant={ButtonVariant.Secondary}
       role="link"
       style={{ '--background-color': '#000', '--color': '#fff', '--border-color': '#000' }}
     >

--- a/site/src/docs/components/link/code.mdx
+++ b/site/src/docs/components/link/code.mdx
@@ -78,7 +78,7 @@ import { Link, LinkSize } from 'hds-react';
 
 
 ```jsx
-import { Link } from 'hds-react';
+import { Link, LinkSize } from 'hds-react';
 
 () => (<>
   <Link href="https://hds.hel.fi/" size={LinkSize.Medium}>

--- a/site/src/docs/components/notification/code.mdx
+++ b/site/src/docs/components/notification/code.mdx
@@ -142,7 +142,7 @@ import { Notification, Button } from 'hds-react';
 
 
 ```jsx
-import { Notification } from 'hds-react';
+import { Notification, NotificationSize } from 'hds-react';
 
 () => (
 <div style={{display: 'flex', flexDirection: 'column', gap: 'var(--spacing-s)'}}>

--- a/site/src/docs/components/password-input/code.mdx
+++ b/site/src/docs/components/password-input/code.mdx
@@ -3,7 +3,7 @@ slug: '/components/password-input/code'
 title: 'PasswordInput - Code'
 ---
 
-import { Button, PasswordInput, IconEye, IconEyeCrossed } from 'hds-react';
+import { Button, ButtonVariant, PasswordInput, IconEye, IconEyeCrossed } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
@@ -62,11 +62,11 @@ import { PasswordInput } from 'hds-react';
 </Playground>
 
 #### With an external button
-<Playground scope={{ PasswordInput, Button, IconEyeCrossed, IconEye }}>
+<Playground scope={{ PasswordInput, Button, ButtonVariant, IconEyeCrossed, IconEye }}>
 
 
 ```jsx
-import { PasswordInput, Button, IconEyeCrossed, IconEye } from 'hds-react';
+import { PasswordInput, Button, ButtonVariant, IconEyeCrossed, IconEye } from 'hds-react';
 
 () => {
   const [revealPassword, setRevealPassword] = React.useState(false);
@@ -83,7 +83,7 @@ import { PasswordInput, Button, IconEyeCrossed, IconEye } from 'hds-react';
       />
       <div style={{ display: 'flex', justifyContent: 'center', flexDirection: 'column' }}>
         <Button
-          variant="supplementary"
+          variant={ButtonVariant.Supplementary}
           onClick={() => setRevealPassword(!revealPassword)}
           iconStart={revealPassword ? <IconEyeCrossed /> : <IconEye />}
         >

--- a/site/src/docs/components/side-navigation/code.mdx
+++ b/site/src/docs/components/side-navigation/code.mdx
@@ -126,7 +126,7 @@ import { SideNavigation } from 'hds-react';
 
 
 ```jsx
-import { SideNavigation } from 'hds-react';
+import { SideNavigation, IconHome, IconMap, IconCogwheel } from 'hds-react';
 
 () => {
   const [active, setActive] = useState('/archive');

--- a/site/src/docs/components/stepper/code.mdx
+++ b/site/src/docs/components/stepper/code.mdx
@@ -4,7 +4,7 @@ title: 'Stepper - Code'
 ---
 
 import { useReducer } from 'react';
-import { Button, Stepper, StepState, IconArrowLeft, IconArrowRight } from 'hds-react';
+import { Button, ButtonVariant, Stepper, StepState, IconArrowLeft, IconArrowRight } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 
@@ -15,10 +15,10 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 ### Code examples 
 
 #### Default
-<Playground scope={{ StepState, Stepper, Button, IconArrowLeft, IconArrowRight, useReducer }}>
+<Playground scope={{ StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight, useReducer }}>
 
 ```jsx
-import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-react';
+import { StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight } from 'hds-react';
 
 () => {
   const commonReducer = (stepsTotal) => (state, action) => {
@@ -110,7 +110,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
       >
         <Button
           disabled={state.activeStepIndex === 0}
-          variant="secondary"
+          variant={ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'setActive', payload: state.activeStepIndex - 1 })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconStart={<IconArrowLeft />}
@@ -118,7 +118,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
           Previous
         </Button>
         <Button
-          variant={lastStep ? 'primary' : 'secondary'}
+          variant={lastStep ? ButtonVariant.Primary : ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'completeStep', payload: state.activeStepIndex })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconEnd={lastStep ? undefined : <IconArrowRight />}
@@ -134,11 +134,11 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
 </Playground>
 
 #### Small
-<Playground scope={{ StepState, Stepper, Button, IconArrowLeft, IconArrowRight, useReducer }}>
+<Playground scope={{ StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight, useReducer }}>
 
 
 ```jsx
-import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-react';
+import { StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight } from 'hds-react';
 
 () => {
   const commonReducer = (stepsTotal) => (state, action) => {
@@ -236,7 +236,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
       >
         <Button
           disabled={state.activeStepIndex === 0}
-          variant="secondary"
+          variant={ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'setActive', payload: state.activeStepIndex - 1 })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconStart={<IconArrowLeft />}
@@ -244,7 +244,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
           Previous
         </Button>
         <Button
-          variant={lastStep ? 'primary' : 'secondary'}
+          variant={lastStep ? ButtonVariant.Primary : ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'completeStep', payload: state.activeStepIndex })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconEnd={lastStep ? undefined : <IconArrowRight />}
@@ -260,11 +260,11 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
 </Playground>
 
 #### With a step heading
-<Playground scope={{ StepState, Stepper, Button, IconArrowLeft, IconArrowRight, useReducer }}>
+<Playground scope={{ StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight, useReducer }}>
 
 
 ```jsx
-import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-react';
+import { StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight } from 'hds-react';
 
 () => {
   const commonReducer = (stepsTotal) => (state, action) => {
@@ -358,7 +358,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
       >
         <Button
           disabled={state.activeStepIndex === 0}
-          variant="secondary"
+          variant={ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'setActive', payload: state.activeStepIndex - 1 })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconStart={<IconArrowLeft />}
@@ -366,7 +366,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
           Previous
         </Button>
         <Button
-          variant={lastStep ? 'primary' : 'secondary'}
+          variant={lastStep ? ButtonVariant.Primary : ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'completeStep', payload: state.activeStepIndex })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconEnd={lastStep ? undefined : <IconArrowRight />}
@@ -382,11 +382,11 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
 </Playground>
 
 #### Overflow
-<Playground scope={{ StepState, Stepper, Button, IconArrowLeft, IconArrowRight, useReducer }}>
+<Playground scope={{ StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight, useReducer }}>
 
 
 ```jsx
-import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-react';
+import { StepState, Stepper, Button, ButtonVariant, IconArrowLeft, IconArrowRight } from 'hds-react';
 
 () => {
   const commonReducer = (stepsTotal) => (state, action) => {
@@ -482,7 +482,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
       >
         <Button
           disabled={state.activeStepIndex === 0}
-          variant="secondary"
+          variant={ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'setActive', payload: state.activeStepIndex - 1 })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconStart={<IconArrowLeft />}
@@ -490,7 +490,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
           Previous
         </Button>
         <Button
-          variant={lastStep ? 'primary' : 'secondary'}
+          variant={lastStep ? ButtonVariant.Primary : ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'completeStep', payload: state.activeStepIndex })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconEnd={lastStep ? undefined : <IconArrowRight />}
@@ -510,7 +510,7 @@ import { StepState, Stepper, Button, IconArrowLeft, IconArrowRight } from 'hds-r
 
 
 ```jsx
-import { Stepper } from 'hds-react';
+import { Stepper, StepState } from 'hds-react';
 
 () => (
   <Stepper

--- a/site/src/docs/components/stepper/customisation.mdx
+++ b/site/src/docs/components/stepper/customisation.mdx
@@ -3,7 +3,7 @@ slug: '/components/stepper/customisation'
 title: 'Stepper - Customisation'
 ---
 
-import { Stepper, StepState, Button, IconArrowLeft, IconArrowRight } from 'hds-react';
+import { Stepper, StepState, Button, ButtonPresetTheme, ButtonVariant, IconArrowLeft, IconArrowRight } from 'hds-react';
 import { useReducer } from 'react';
 import TabsLayout from './tabs.mdx';
 
@@ -26,11 +26,11 @@ You can use the `theme` property to customise the component. See all available t
 | `--hds-stepper-focus-border-color`    | Colour of a step focus border.              |
 
 ### Customisation example
-<Playground scope={{ Stepper, StepState, Button, IconArrowLeft, IconArrowRight, useReducer }}>
+<Playground scope={{ Stepper, StepState, Button, ButtonPresetTheme, ButtonVariant, IconArrowLeft, IconArrowRight, useReducer }}>
 
 
 ```jsx
-import { Stepper } from 'hds-react';
+import { Stepper, StepState, Button, ButtonPresetTheme, ButtonVariant, IconArrowLeft, IconArrowRight } from 'hds-react';
 
 () => {
   const commonReducer = (stepsTotal) => (state, action) => {
@@ -131,20 +131,20 @@ import { Stepper } from 'hds-react';
       >
         <Button
           disabled={state.activeStepIndex === 0}
-          variant="secondary"
+          variant={ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'setActive', payload: state.activeStepIndex - 1 })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconStart={<IconArrowLeft />}
-          theme="black"
+          theme={ButtonPresetTheme.Black}
         >
           Previous
         </Button>
         <Button
-          variant={lastStep ? 'primary' : 'secondary'}
+          variant={lastStep ? ButtonVariant.Primary : ButtonVariant.Secondary}
           onClick={() => dispatch({ type: 'completeStep', payload: state.activeStepIndex })}
           style={{ height: 'fit-content', width: 'fit-content' }}
           iconEnd={lastStep ? undefined : <IconArrowRight />}
-          theme="black"
+          theme={ButtonPresetTheme.Black}
         >
           {lastStep ? 'Send' : 'Next'}
         </Button>

--- a/site/src/docs/components/tag/code.mdx
+++ b/site/src/docs/components/tag/code.mdx
@@ -211,7 +211,7 @@ import { Tag, IconGlobe, IconDocument, IconZoomIn, IconZoomOut } from 'hds-react
 <Playground scope={{ Tag, IconLinkExternal }}>
 
 ```jsx
-import { Tag } from 'hds-react';
+import { Tag, IconLinkExternal } from 'hds-react';
 
 () => (
   <div style={{display: 'flex', gap: 'var(--spacing-s)'}}>


### PR DESCRIPTION
- for example Button size from "small" to ButtonSize.Small enum
- for the components I found, not much have enum typed  props yet

Refs: HDS-2926

## Description

Fix missing enum props for few components which support it

## Related Issue

Closes [HDS-2926](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2926)

## How Has This Been Tested?

- locally

## Add to changelog

- not needed

[HDS-2926]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ