### PR TITLE
docs: remove and replace deprecated props in doc site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Multiple components] Removed already obsolete props from component props tables.
 
 ### Figma
 

--- a/site/src/docs/components/checkbox/code.mdx
+++ b/site/src/docs/components/checkbox/code.mdx
@@ -278,9 +278,6 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `label`                    | A text label for the checkbox.                                             | `string`    | -             |
 | `errorText`                | The error text content that will be shown below the checkbox.              | `string`    | -             |
 | `helperText`               | The helper text content that will be shown below the checkbox.             | `string`    | -             |
-| `tooltipLabel`             | The aria-label text for the tooltip. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipButtonLabel`       | The aria-label text for the tooltip trigger button. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipText`              | The text content of the tooltip. **Deprecated, will be removed in next major release**   | `string`    | -             |
 | `tooltip`                  | The tooltip component.                                                     | <Link openInNewTab openInNewTabLabel="Opens in a new tab" href="/components/tooltip/">`Tooltip`</Link> | -             |
 | `onChange`                 | Callback fired when the state is changed.                                  | `function`  | -             |
 

--- a/site/src/docs/components/fieldset/code.mdx
+++ b/site/src/docs/components/fieldset/code.mdx
@@ -15,11 +15,11 @@ export default ({ children, pageContext }) => <TabsLayout pageContext={pageConte
 
 #### Default
 
-<Playground scope={{ Fieldset, TextInput }}>
+<Playground scope={{ Fieldset, TextInput, Tooltip }}>
 
 
 ```jsx
-import { Fieldset, TextInput } from 'hds-react';
+import { Fieldset, TextInput, Tooltip } from 'hds-react';
 
 () => (<>
   <Fieldset heading="Child information" style={{ maxWidth: '400px' }} helperText='Assistive text'>
@@ -48,7 +48,15 @@ import { Fieldset, TextInput } from 'hds-react';
     />
   </Fieldset>
 
-  <Fieldset heading="Applicant information" style={{ maxWidth: '400px' }} tooltipText="tooltip text" tooltipLabel="tooltip text aria label" tooltipButtonLabel="tooltip button aria label">
+  <Fieldset
+    heading="Applicant information"
+    style={{ maxWidth: '400px' }}
+    tooltip={
+      <Tooltip tooltipLabel="tooltip text aria label" buttonLabel="tooltip button aria label">
+        tooltip text
+      </Tooltip>
+    }
+  >
     <TextInput id="first-name-1" name="first-name" label="First name" />
     <TextInput id="last-name-1" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
     <TextInput
@@ -240,9 +248,6 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `heading`             | Heading of the fieldset element.                                     | `string`  | -             |
 | `border`              | If set to true, a border is drawn around the fieldset.               | `boolean` | false         |
 | `helperText`          | The help text content that will be shown below the fieldset content. | `string`  | -             |
-| `tooltipLabel`        | The aria-label text for the tooltip. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipButtonLabel`  | The aria-label text for the tooltip trigger button. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipText`         | The text content of the tooltip. **Deprecated, will be removed in next major release** | `string`    | -             |
 | `tooltip`             | The tooltip component.                                               | <Link openInNewTab openInNewTabLabel="Opens in a new tab" href="/components/tooltip/">`Tooltip`</Link> | -             |
 
 <NativeElementPropsInfo nodeName="fieldset" />

--- a/site/src/docs/components/fieldset/index.mdx
+++ b/site/src/docs/components/fieldset/index.mdx
@@ -4,7 +4,7 @@ title: 'Fieldset'
 navTitle: 'Fieldset'
 ---
 
-import { Fieldset, TextInput } from 'hds-react';
+import { Fieldset, TextInput, Tooltip } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -84,7 +84,15 @@ Border variant is also useful when the form contains multiple form elements with
 A Fieldset can be provided with additional tooltip. Tooltip information should be considered as extra information, for example, why this information is gathered or how is it used. You can find more information about Tooltips how they are used from the <InternalLink href="/components/tooltip">Tooltip documentation page</InternalLink>.
 
 <PlaygroundPreview>
-  <Fieldset heading="Applicant information" style={{ maxWidth: '400px' }} tooltipText="tooltip text" tooltipLabel="tooltip text aria label" tooltipButtonLabel="tooltip button aria label">
+  <Fieldset
+    heading="Applicant information"
+    style={{ maxWidth: '400px' }}
+    tooltip={
+      <Tooltip tooltipLabel="tooltip text aria label" buttonLabel="tooltip button aria label">
+        tooltip text
+      </Tooltip>
+    }
+  >
     <TextInput id="first-name-1" name="first-name" label="First name" />
     <TextInput id="last-name-1" name="last-name" label="Last name" style={{ marginTop: '12px' }} />
     <TextInput

--- a/site/src/docs/components/footer/code.mdx
+++ b/site/src/docs/components/footer/code.mdx
@@ -5,6 +5,8 @@ title: 'Footer - Code'
 
 import {
   Footer,
+  IconCheckCircleFill,
+  IconCrossCircle,
   IconFacebook,
   IconTwitter,
   IconInstagram,

--- a/site/src/docs/components/text-area/code.mdx
+++ b/site/src/docs/components/text-area/code.mdx
@@ -121,9 +121,6 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `invalid`            | If set to true, the input will be displayed in an invalid state. | `boolean`   | false         |
 | `successText`        | The success text content that will be shown below the input.     | `string`    | -             |
 | `infoText`           | The info text content that will be shown below the input.        | `string`    | -             |
-| `tooltipLabel`       | The aria-label text for the tooltip. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipButtonLabel` | The aria-label text for the tooltip trigger button. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipText`        | The text content of the tooltip. **Deprecated, will be removed in next major release**   | `string`    | -             |
 | `tooltip`            | The tooltip component.                                           | <Link openInNewTab openInNewTabLabel="Opens in a new tab" href="/components/tooltip/">`Tooltip`</Link> | -             |
 [Table 1:TextArea properties]|
 

--- a/site/src/docs/components/text-input/code.mdx
+++ b/site/src/docs/components/text-input/code.mdx
@@ -151,9 +151,6 @@ Note! You can find the full list of properties in the <Link openInNewTab openInN
 | `invalid`            | If set to true, the input will be displayed in an invalid state. | `boolean`   | false         |
 | `successText`        | The success text content that will be shown below the input.     | `string`    | -             |
 | `infoText`           | The info text content that will be shown below the input.        | `string`    | -             |
-| `tooltipLabel`       | The aria-label text for the tooltip. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipButtonLabel` | The aria-label text for the tooltip trigger button. **Deprecated, will be removed in next major release** | `string`    | -             |
-| `tooltipText`        | The text content of the tooltip. **Deprecated, will be removed in next major release**   | `string`    | -             |
 | `tooltip`            | The tooltip component.                                           | <Link openInNewTab openInNewTabLabel="Opens in a new tab" href="/components/tooltip/">`Tooltip`</Link> | -             |
 | `buttonIcon`         | Button icon.                                                     | `ReactNode` | -             |
 | `buttonAriaLabel`    | The aria-label for the button.                                   | `string`    | -             |

--- a/site/src/docs/components/text-input/index.mdx
+++ b/site/src/docs/components/text-input/index.mdx
@@ -4,7 +4,7 @@ title: 'TextInput'
 navTitle: 'TextInput'
 ---
 
-import { TextInput } from 'hds-react';
+import { TextInput, Tooltip } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 
 export default ({ children, pageContext }) => <TabsLayout pageContext={pageContext}>{children}</TabsLayout>;
@@ -76,9 +76,12 @@ A text input can be provided with additional tooltip. Tooltip information should
     id="textinput-tooltip"
     label="Label"
     placeholder="Placeholder"
-    tooltipLabel="Tooltip label"
-    tooltipButtonLabel="Tooltip button label"
-    tooltipText='Tooltips contain "nice to have" information. Default Tooltip contents should not be longer than two to three sentences. For longer descriptions, provide a link to a separate page.'
+    tooltip={
+      <Tooltip tooltipLabel="Tooltip label" buttonLabel="Tooltip button label">
+        Tooltips contain &quot;nice to have&quot; information. Default Tooltip contents should not be longer than two to
+        three sentences. For longer descriptions, provide a link to a separate page.
+      </Tooltip>
+    }
     style={{ maxWidth: '320px' }}
   />
 </PlaygroundPreview>


### PR DESCRIPTION
Refs: HDS-2982

## Description

Removed deprecated and removed props from documentation site. Also tried to go through all the react-components props too and check if some more exist -> did not.

Also changed some examples to use the newer prop -> tooltip vs. the old ones.

## Related Issue

Closes [HDS-2982](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2982)

## How Has This Been Tested?

- locally

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog


[HDS-2982]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ