### PR TITLE
fix: helsinki grotesk pro font italics v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.X.X] - Month, XX, 202X
+
+### Core
+
+#### Fixed
+
+- [Typography] Fixed italic rendering for Helsinki Grotesk Pro.
+
 ## [5.2.0] - May, 7, 2026
 
 ### Workspace

--- a/packages/core/scripts/fonts.template
+++ b/packages/core/scripts/fonts.template
@@ -2,86 +2,29 @@
 
 /*
  * HelsinkiGroteskPro variable font (font file served from CDN).
- * Regular (400), Medium (500), Bold (700), Black (900), each normal and italic.
- * Font axes (fvar): wght 200–900, ital 0–1.
+ * Single woff2 with wght (200–900) and ital (0–1) axes.
+ *
+ * Use one @font-face so font-family matching never falls through to Arial.
+ * Italic uses the ital axis via font-variation-settings (font-style alone is
+ * not reliable for variable fonts).
  */
 
-/* Webfont: HelsinkiGroteskPro-Regular */
 @font-face {
   font-display: swap;
   font-family: HelsinkiGroteskPro;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 200 900;
   src: url("") format("woff2");
   text-rendering: optimizelegibility;
 }
 
-/* Webfont: HelsinkiGroteskPro-RegularItalic */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: italic;
-  font-weight: 400;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
-}
-
-/* Webfont: HelsinkiGroteskPro-Medium */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: normal;
-  font-weight: 500;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
-}
-
-/* Webfont: HelsinkiGroteskPro-MediumItalic */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: italic;
-  font-weight: 500;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
-}
-
-/* Webfont: HelsinkiGroteskPro-Bold */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: normal;
-  font-weight: 700;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
-}
-
-/* Webfont: HelsinkiGroteskPro-BoldItalic */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: italic;
-  font-weight: 700;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
-}
-
-/* Webfont: HelsinkiGroteskPro-Black */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: normal;
-  font-weight: 900;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
-}
-
-/* Webfont: HelsinkiGroteskPro-BlackItalic */
-@font-face {
-  font-display: swap;
-  font-family: HelsinkiGroteskPro;
-  font-style: italic;
-  font-weight: 900;
-  src: url("") format("woff2");
-  text-rendering: optimizelegibility;
+em,
+i,
+cite,
+var,
+dfn,
+[style*="font-style: italic"],
+[style*="font-style:italic"] {
+  font-synthesis: none;
+  font-variation-settings: "ital" 1;
 }

--- a/packages/react/src/components/sideNavigation/_sideNavigation.common.scss
+++ b/packages/react/src/components/sideNavigation/_sideNavigation.common.scss
@@ -43,7 +43,7 @@
     background-color: var(--side-navigation-level-background-color-active);
     border-color: var(--side-navigation-level-background-color-active);
     color: var(--side-navigation-level-color-active);
-    font-weight: 600;
+    font-weight: 700;
     position: relative;
 
     &:before {


### PR DESCRIPTION
Refs: HDS-2992

## Description

Fix Helsinki Grotesk Pro italics not working, also spotted wrong font-weight in Sidenavigation

## Related Issue

Closes [HDS-2992](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2992)

## How Has This Been Tested?

- running all tests

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog


[HDS-2992]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ