### PR TITLE
feat: use figure html tag for code examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Changes that are not related to specific components
 
 Changes that are not related to specific components
 
+- All code examples are now separated by the `<figure> element to improve the screen reader experience.
+
 - [Component] What has been changed
 
 #### Fixed

--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -132,7 +132,10 @@ const PlaygroundPreviewComponent = ({ children, className, clipped, ...props }) 
 };
 
 export const PlaygroundPreview = ({ ...props }) => (
-  <PlaygroundPreviewComponent className="playground-block-preview-light" {...props} />
+  <figure className="playground-preview-figure">
+    <figcaption className="playground-block-caption">Component example</figcaption>
+    <PlaygroundPreviewComponent className="playground-block-preview-light" {...props} />
+  </figure>
 );
 
 const clearSelection = () => {
@@ -405,7 +408,8 @@ export const PlaygroundBlock = ({ children, scope }) => {
       };
     });
   return (
-    <div className="playground-block">
+    <figure className="playground-block">
+      <figcaption className="playground-block-caption">Code example</figcaption>
       <Tabs>
         <TabList className="playground-block-tabs">
           {codeBlocks.map(({ language }) => (
@@ -429,7 +433,7 @@ export const PlaygroundBlock = ({ children, scope }) => {
           );
         })}
       </Tabs>
-    </div>
+    </figure>
   );
 };
 

--- a/site/src/components/Playground.scss
+++ b/site/src/components/Playground.scss
@@ -9,6 +9,27 @@
   margin: var(--spacing-l) 0;
 }
 
+// The example wrappers are <figure> elements; reset the default UA figure margin
+// so the layout is unchanged while keeping the semantic grouping for screen readers.
+.playground-preview-figure {
+  margin: 0;
+}
+
+// Caption that names each example for assistive technology. The examples are already
+// separated visually by a border, so the caption is hidden from sighted users.
+.playground-block-caption {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .playground-block-tabs {
   --tablist-border-color: transparent;
 


### PR DESCRIPTION
## Description

Use Figure html tag to separate code examples in documentation site to improve screen reader user experience.

## Related Issue

Closes [HDS-2637](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2637)

## How Has This Been Tested?

Open documentation site and some code example and look dom in developer tools. All examples should be wrapped with <figure> and have a caption done with <figcaption>

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2637]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Unreleased documentation changelog to note that code examples are now wrapped in `<figure>` elements to improve screen reader support.

- **New Features**
  - Enhanced playground example semantics by adding `<figcaption>` labels (“Component example” and “Code example”) to improve accessibility.

- **Bug Fixes**
  - Updated styles to align with the new markup, including consistent `<figure>` layout and visually hidden captions that remain available to assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->