### PR TITLE
fix: esm and cjs builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.2] - July, 1, 2026
+
+### React
+
+#### Fixed
+
+- [Package] Restored dual ESM and CommonJS package output. Added conditional `exports` for `import` and `require` resolution, and corrected Rollup Babel runtime configuration so CommonJS bundles no longer emit broken helper imports.
+
+### Core
+
+#### Fixed
+
+- [Build] CSS-to-JS build step now writes separate ESM (`.js`), CommonJS (`.cjs`), and TypeScript (`.ts`) modules with correct file paths, and exposes conditional `exports` so bundlers and Node resolve the right format.
+
+### Hds-js
+
+#### Fixed
+
+- [Package] Added conditional `exports` mapping `import` and `require` to the ESM and CommonJS entry points, fixing broken module resolution in mixed ESM/CJS toolchains.
+
 ## [5.2.1] - June, 16, 2026
 
 ### Core

--- a/packages/core/cssToImportableString.js
+++ b/packages/core/cssToImportableString.js
@@ -19,15 +19,18 @@ function isMatchingFile(targetFiles, fullFilePath) {
 }
 
 /**
- * Changes path/to/file/with.any.ext to path/to/file/with.newExt
+ * Changes path/to/file/with.min.css to path/to/file/with (drops .min.css suffix).
  */
-function createNewFileExt(file, ext) {
-  const baseBeforeDots = file.split('.')[0];
-  return `${baseBeforeDots}${ext}`;
+function createOutputPath(file) {
+  return file.replace(/\.min\.css$/, '');
 }
 
 function cssToExportedString(css) {
   return `export default \`${css}\`;`;
+}
+
+function cssToCommonJsString(css) {
+  return `module.exports = \`${css}\`;`;
 }
 
 /**
@@ -57,18 +60,22 @@ async function save(path, contents) {
 }
 
 /**
- * Reads a file and writes its contents with "export default" prefix to a new file.
+ * Reads a css file and writes ESM (.js), CJS (.cjs), and TypeScript (.ts) variants.
  */
 async function createNewFile(path) {
   const readResult = await getFileContent(path);
   if (readResult.error) {
     return Promise.resolve(readResult.error);
   }
-  const exportContents = cssToExportedString(readResult);
-  const newFileName = createNewFileExt(path, '.ts');
-  const writeResult = save(newFileName, exportContents);
-  if (writeResult.error) {
-    return Promise.resolve(writeResult.error);
+  const basePath = createOutputPath(path);
+  const writeResults = await Promise.all([
+    save(`${basePath}.js`, cssToExportedString(readResult)),
+    save(`${basePath}.cjs`, cssToCommonJsString(readResult)),
+    save(`${basePath}.ts`, cssToExportedString(readResult)),
+  ]);
+  const writeError = writeResults.find((result) => result && result.error);
+  if (writeError) {
+    return Promise.resolve(writeError.error);
   }
   return Promise.resolve();
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,16 @@
   },
   "browserslist": "> 0.2%, not iOS < 15, not Safari < 14.5, not dead, not op_mini all, not Android >= 0, not and_uc >= 0",
   "main": "lib/base.min.css",
+  "exports": {
+    ".": "./lib/base.min.css",
+    "./lib/*": "./lib/*",
+    "./lib/components/cookie-consent/cookieConsent": {
+      "types": "./lib/components/cookie-consent/cookieConsent.ts",
+      "import": "./lib/components/cookie-consent/cookieConsent.js",
+      "require": "./lib/components/cookie-consent/cookieConsent.cjs",
+      "default": "./lib/components/cookie-consent/cookieConsent.js"
+    }
+  },
   "files": [
     "lib"
   ],

--- a/packages/hds-js/package.json
+++ b/packages/hds-js/package.json
@@ -15,6 +15,14 @@
   "module": "./index.js",
   "esnext": "./index.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./cjs/index.js"
+    },
+    "./standalone/*": "./standalone/*"
+  },
   "dependencies": {
     "@apollo/client": "^3.10.1",
     "@babel/runtime": "^7.26.10",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,6 +15,25 @@
   "module": "./lib/index.js",
   "esnext": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./components": {
+      "types": "./lib/components/index.d.ts",
+      "import": "./lib/components/index.js"
+    },
+    "./components/index": {
+      "types": "./lib/components/index.d.ts",
+      "import": "./lib/components/index.js"
+    },
+    "./components/*": {
+      "types": "./lib/components/*/index.d.ts",
+      "import": "./lib/components/*/index.js"
+    }
+  },
   "files": [
     "lib"
   ],

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -30,8 +30,23 @@ const hdsJsEsmOutput = 'hds-js-esm';
 const hdsJsCommonJsOutput = 'hds-js-cjs';
 const hdsStandAloneOutput = 'hds-js-standalone';
 
+const isCjsFormat = (format) => format === reactCommonJsOutputFormat || format === hdsJsCommonJsOutput;
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const hdsJsPackageJSON = require('../hds-js/package.json');
+
+const babelPresets = [
+  ['@babel/preset-env', { targets: '>1%, not dead, not ie 11, not op_mini all' }],
+  '@babel/preset-react',
+  '@babel/preset-typescript',
+];
+
+const babelPlugins = (useESModules) => [
+  ['@babel/plugin-transform-runtime', { useESModules }],
+  ['@babel/plugin-proposal-class-properties', { loose: true }],
+  ['@babel/plugin-proposal-private-methods', { loose: true }],
+  ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+];
 
 /** Match hds-core postcss.config.js (calc/svgo off for predictable output). */
 const cssnanoOptions = {
@@ -98,7 +113,6 @@ const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 const externals = [...Object.keys(packageJSON.dependencies), ...Object.keys(packageJSON.peerDependencies)];
 
 // Match resolved paths under node_modules/@babel/runtime (string "@babel/runtime" alone does not).
-// Babel runs for all formats (incl. react-cjs); runtime helpers must stay external for every bundle.
 const getExternal = () => [...externals, /@babel\/runtime/];
 
 const checkModule = (forHdsJs) => {
@@ -186,6 +200,10 @@ const getConfig = (format, extractCSS) => ({
       babelHelpers: 'runtime',
       exclude: 'node_modules/**',
       extensions,
+      babelrc: false,
+      configFile: false,
+      presets: babelPresets,
+      plugins: babelPlugins(!isCjsFormat(format)),
     }),
     commonjs({
       include: ['../../node_modules/**', 'node_modules/**'],


### PR DESCRIPTION
- so outputs are usable again

Refs: HDS-3000

## Description

The ESM / CJS outputs where broken in previous 5.x version, this one fixes it. Same fix is coming to v6 also

## Related Issue

Closes [HDS-3000](https://helsinkisolutionoffice.atlassian.net/browse/HDS-3000)

## How Has This Been Tested?

- running builds and analyzing vs older version

## Demos:

Links to demos are in the comments

## Add to changelog

- [x] Added needed line to changelog

[HDS-3000]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ