### PR TITLE
fix: routes in docsite HDS-2990

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- Fixed pages with broken code examples
 
 ### Figma
 

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -182,6 +182,21 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
         }
       }
     ),
+    // Redirect '@reach/router' imports from .previous-versions/ to '@gatsbyjs/reach-router'.
+    // Archived AnchorLink.js calls useLocation() from '@reach/router', but Gatsby 5 provides its
+    // LocationContext.Provider via '@gatsbyjs/reach-router' — a different context object. Reading
+    // from the wrong package finds no provider and throws "useLocation hook was used but a
+    // LocationContext.Provider was not found", crashing every archived page that renders AnchorLink.
+    // The two packages are API-compatible; only applies when the importer is inside .previous-versions/.
+    new webpack.NormalModuleReplacementPlugin(
+      /^@reach\/router$/,
+      resource => {
+        const normalizedContext = resource.context.split(path.sep).join('/');
+        if (normalizedContext.includes('.previous-versions/')) {
+          resource.request = '@gatsbyjs/reach-router';
+        }
+      }
+    ),
     new webpack.NormalModuleReplacementPlugin(
       /(~?hds-core|hds-react|~?hds-design-tokens)/,
       resource => {

--- a/site/src/docs/components/fieldset/code.mdx
+++ b/site/src/docs/components/fieldset/code.mdx
@@ -2,7 +2,7 @@
 slug: '/components/fieldset/code'
 title: 'Fieldset - Code'
 ---
-import { Fieldset, TextInput } from 'hds-react';
+import { Fieldset, TextInput, Tooltip } from 'hds-react';
 import TabsLayout from './tabs.mdx';
 import NativeElementPropsInfo from '../../../components/NativeElementPropsInfo';
 


### PR DESCRIPTION
## Description

Fixes two different issues with code examples in documentation.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2990](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2990)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2990]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed broken code examples in documentation pages.
  - Corrected archived documentation pages so router-dependent examples load properly.
  - Resolved an issue that prevented certain interactive documentation examples from rendering correctly.

- **Documentation**
  - Updated Fieldset examples to include the required Tooltip component, ensuring they render correctly in the interactive playground.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->