### PR TITLE
fix: links to storybook HDS-2997

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Changes that are not related to specific components
 
 - Fixed pages with broken code examples
 - Fixed anchor links in documentation site
+- Links to form validation pattern code examples
 
 ### Figma
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Changes that are not related to specific components
 - Fixed pages with broken code examples
 - Fixed anchor links in documentation site
 - Links to form validation pattern code examples
+- Fixed links to form validation pattern Storybook examples
 
 ### Figma
 

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -231,7 +231,7 @@ described to the user from where the information is coming from.
 
 **When using static or hybrid validation methods, HDS recommends using a validation summary to clearly list errors found during the form submit**. Validation summary pattern uses the Notification component (with `type="error"`) which is provided by HDS. The error notification lists all errors (and their descriptions) found in the form and provides anchor links to each erroneous input for easy access.
 
-You can learn more about the Notification component in <Link href="/storybook/react/?path=/story/components-notification--playground" external openInNewTab openInNewTabLabel="Opens in a new tab">HDS React Storybook.</Link>.
+You can learn more about the Notification component in <Link href="/storybook/react/?path=/story/components-notification--playground" external openInNewTab openInNewTabLabel="Opens in a new tab">HDS React Storybook</Link>.
 
 <Image
   src="/images/patterns/form/validation/error-summary@2x.png"

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -61,9 +61,9 @@ In dynamic form validation the user input is **validated immediately after the f
 
 **Dynamic form validation is recommended way to do input validation in the City of Helsinki services**. The method allows the user to fix the error immediately rather than after the form has been submitted. This can greatly reduce cognitive load of the user since they neither do have to locate the erroneous input nor switch their context to the next input before fixing the error.
 
-<Link href="/storybook/react/iframe.html?id=patterns-form-validation--dynamic&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive dynamic form validation example in HDS Storybook</Link>
+<Link href="/storybook/react/iframe.html?id=examples-forms-validationdynamic--dynamic&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive dynamic form validation example in HDS Storybook</Link>
 
-<Link href="/storybook/react/?path=/docs/patterns-form-validation--static#dynamic" external openInNewTab openInNewTabLabel="Opens in new tab">See dynamic form validation code example in HDS Storybook</Link>
+<Link href="/storybook/react/?path=/docs/examples-forms-validationdynamic--dynamic" external openInNewTab openInNewTabLabel="Opens in new tab">See dynamic form validation code example in HDS Storybook</Link>
 
 ### Static validation
 
@@ -71,9 +71,9 @@ In static form validation the validation is done when the form is submitted or t
 
 The general issue of static validation is that it is possible that there are multiple erroneous inputs after the validation. To make it easier for the user to go through the errors, **HDS recommends using validation summary pattern** in which all errors are gathered to one list on top of the form. The list contains all errors found the the form and an anchor link to each form control. You can read more about the [validation summary pattern in its own section](#validation-summary-pattern).
 
-<Link href="/storybook/react/iframe.html?id=patterns-form-validation--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive static form validation example in HDS Storybook</Link>
+<Link href="/storybook/react/iframe.html?id=examples-forms-validationstatic--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive static form validation example in HDS Storybook</Link>
 
-<Link href="/storybook/react/?path=/docs/patterns-form-validation--static#static" external openInNewTab openInNewTabLabel="Opens in new tab">See static form validation code example in HDS Storybook</Link>
+<Link href="/storybook/react/?path=/docs/examples-forms-validationstatic--static" external openInNewTab openInNewTabLabel="Opens in new tab">See static form validation code example in HDS Storybook</Link>
 
 
 ### Hybrid validation
@@ -82,9 +82,9 @@ Dynamic and static validation methods can be also used in parallel. This is part
 
 The advantage of hybrid validation is that because form controls are validated dynamically, the user generally receives less errors after the form submit. **It is always recommended to use dynamic validation approach first** but if some static validation is required, the hybrid validation approach can be used.
 
-<Link href="/storybook/react/iframe.html?id=patterns-form-validation--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive hybrid form validation example in HDS Storybook</Link>
+<Link href="/storybook/react/iframe.html?id=examples-forms-validationhybrid--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive hybrid form validation example in HDS Storybook</Link>
 
-<Link href="/storybook/react/?path=/docs/patterns-form-validation--static#hybrid" external openInNewTab openInNewTabLabel="Opens in new tab">See hybrid form validation code example in HDS Storybook</Link>
+<Link href="/storybook/react/?path=/docs/examples-forms-validationhybrid--hybrid" external openInNewTab openInNewTabLabel="Opens in new tab">See hybrid form validation code example in HDS Storybook</Link>
 
 ---
 
@@ -334,7 +334,7 @@ import { Button, Notification, TextInput } from 'hds-react';
 
 </Playground>
 
-You can see the validation summary pattern in action in HDS Storybook <Link href="/storybook/react/iframe.html?id=patterns-form-validation--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">static validation example</Link> and <Link href="/storybook/react/iframe.html?id=patterns-form-validation--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">hybrid validation example</Link>.
+You can see the validation summary pattern in action in HDS Storybook <Link href="/storybook/react/iframe.html?id=examples-forms-validationstatic--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">static validation example</Link> and <Link href="/storybook/react/iframe.html?id=examples-forms-validationhybrid--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">hybrid validation example</Link>.
 
 ### Validation of multiple input fields
 

--- a/site/src/docs/patterns/forms/form-validation.mdx
+++ b/site/src/docs/patterns/forms/form-validation.mdx
@@ -61,9 +61,9 @@ In dynamic form validation the user input is **validated immediately after the f
 
 **Dynamic form validation is recommended way to do input validation in the City of Helsinki services**. The method allows the user to fix the error immediately rather than after the form has been submitted. This can greatly reduce cognitive load of the user since they neither do have to locate the erroneous input nor switch their context to the next input before fixing the error.
 
-<Link href="/storybook/react/iframe.html?id=examples-forms-validationdynamic--dynamic&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive dynamic form validation example in HDS Storybook</Link>
+<Link href="/storybook/react/iframe.html?id=examples-forms-validationdynamic--dynamic&viewMode=story" external openInNewTab openInNewTabLabel="Opens in a new tab">See interactive dynamic form validation example in HDS Storybook</Link>
 
-<Link href="/storybook/react/?path=/docs/examples-forms-validationdynamic--dynamic" external openInNewTab openInNewTabLabel="Opens in new tab">See dynamic form validation code example in HDS Storybook</Link>
+<Link href="/storybook/react/?path=/docs/examples-forms-validationdynamic--dynamic" external openInNewTab openInNewTabLabel="Opens in a new tab">See dynamic form validation code example in HDS Storybook</Link>
 
 ### Static validation
 
@@ -71,9 +71,9 @@ In static form validation the validation is done when the form is submitted or t
 
 The general issue of static validation is that it is possible that there are multiple erroneous inputs after the validation. To make it easier for the user to go through the errors, **HDS recommends using validation summary pattern** in which all errors are gathered to one list on top of the form. The list contains all errors found the the form and an anchor link to each form control. You can read more about the [validation summary pattern in its own section](#validation-summary-pattern).
 
-<Link href="/storybook/react/iframe.html?id=examples-forms-validationstatic--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive static form validation example in HDS Storybook</Link>
+<Link href="/storybook/react/iframe.html?id=examples-forms-validationstatic--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in a new tab">See interactive static form validation example in HDS Storybook</Link>
 
-<Link href="/storybook/react/?path=/docs/examples-forms-validationstatic--static" external openInNewTab openInNewTabLabel="Opens in new tab">See static form validation code example in HDS Storybook</Link>
+<Link href="/storybook/react/?path=/docs/examples-forms-validationstatic--static" external openInNewTab openInNewTabLabel="Opens in a new tab">See static form validation code example in HDS Storybook</Link>
 
 
 ### Hybrid validation
@@ -82,9 +82,9 @@ Dynamic and static validation methods can be also used in parallel. This is part
 
 The advantage of hybrid validation is that because form controls are validated dynamically, the user generally receives less errors after the form submit. **It is always recommended to use dynamic validation approach first** but if some static validation is required, the hybrid validation approach can be used.
 
-<Link href="/storybook/react/iframe.html?id=examples-forms-validationhybrid--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">See interactive hybrid form validation example in HDS Storybook</Link>
+<Link href="/storybook/react/iframe.html?id=examples-forms-validationhybrid--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in a new tab">See interactive hybrid form validation example in HDS Storybook</Link>
 
-<Link href="/storybook/react/?path=/docs/examples-forms-validationhybrid--hybrid" external openInNewTab openInNewTabLabel="Opens in new tab">See hybrid form validation code example in HDS Storybook</Link>
+<Link href="/storybook/react/?path=/docs/examples-forms-validationhybrid--hybrid" external openInNewTab openInNewTabLabel="Opens in a new tab">See hybrid form validation code example in HDS Storybook</Link>
 
 ---
 
@@ -231,7 +231,7 @@ described to the user from where the information is coming from.
 
 **When using static or hybrid validation methods, HDS recommends using a validation summary to clearly list errors found during the form submit**. Validation summary pattern uses the Notification component (with `type="error"`) which is provided by HDS. The error notification lists all errors (and their descriptions) found in the form and provides anchor links to each erroneous input for easy access.
 
-You can learn more about the Notification component in <Link href="/storybook/react/?path=/story/components-notification--playground" external openInNewTab openInNewTabLabel="Opens in new tab">HDS React Storybook.</Link>.
+You can learn more about the Notification component in <Link href="/storybook/react/?path=/story/components-notification--playground" external openInNewTab openInNewTabLabel="Opens in a new tab">HDS React Storybook.</Link>.
 
 <Image
   src="/images/patterns/form/validation/error-summary@2x.png"
@@ -334,7 +334,7 @@ import { Button, Notification, TextInput } from 'hds-react';
 
 </Playground>
 
-You can see the validation summary pattern in action in HDS Storybook <Link href="/storybook/react/iframe.html?id=examples-forms-validationstatic--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">static validation example</Link> and <Link href="/storybook/react/iframe.html?id=examples-forms-validationhybrid--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in new tab">hybrid validation example</Link>.
+You can see the validation summary pattern in action in HDS Storybook <Link href="/storybook/react/iframe.html?id=examples-forms-validationstatic--static&viewMode=story" external openInNewTab openInNewTabLabel="Opens in a new tab">static validation example</Link> and <Link href="/storybook/react/iframe.html?id=examples-forms-validationhybrid--hybrid&viewMode=story" external openInNewTab openInNewTabLabel="Opens in a new tab">hybrid validation example</Link>.
 
 ### Validation of multiple input fields
 


### PR DESCRIPTION
Refs: HDS-2997

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2997](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2997)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2997]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed Storybook links for form validation patterns, including dynamic, static, hybrid, and validation summary examples.
  * Standardized link labels to “Opens in a new tab.”
  * Updated the changelog to reflect these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->