### PR TITLE
Fix visited link styles HDS-2993

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Changes that are not related to specific components
 
 #### Fixed
 
-- [Component] What bugs/typos are fixed?
+- [Link] Fixed `.hds-link--disable-visited-styles` using a hardcoded color instead of the `--link-color` custom property, causing visited links to revert to the default color when a custom link color was set.
 
 ### Documentation
 

--- a/packages/core/src/components/link/link.css
+++ b/packages/core/src/components/link/link.css
@@ -31,7 +31,11 @@
 }
 
 .hds-link--disable-visited-styles:visited {
-  color: var(--color-bus);
+  color: var(--link-color);
+}
+
+.hds-link--disable-visited-styles:visited svg g path {
+  fill: var(--link-color);
 }
 
 .hds-link--small {


### PR DESCRIPTION
Refs: HDS-2993

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes [HDS-2993](https://helsinkisolutionoffice.atlassian.net/browse/HDS-2993)

## How Has This Been Tested?

## Demos:

Links to demos are in the comments

## Screenshots (if appropriate):

## Add to changelog

- [x] Added needed line to changelog
<!-- Or comment here why it is not relevant in the change log -->

## If applicable, also apply this fix/feature to the previous major version

<!-- Take the latest release of previous major as base -->
<!-- make a release-X.x branch of it (if not already made) -->
<!-- make the changes in another branch and make a PR against the release-X.x -->

[HDS-2993]: https://helsinkisolutionoffice.atlassian.net/browse/HDS-2993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed links with disabled visited styles to retain their configured custom color after being visited.
  * Updated visited link icons to match the custom link color instead of reverting to the default color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->